### PR TITLE
Fix Clang warning about unhandled enum values.

### DIFF
--- a/Vendors/lepton/src/ParsedExpression.cpp
+++ b/Vendors/lepton/src/ParsedExpression.cpp
@@ -268,6 +268,13 @@ ExpressionTreeNode ParsedExpression::substituteSimplerExpression(const Expressio
                 return ExpressionTreeNode(new Operation::Constant(dynamic_cast<const Operation::MultiplyConstant*>(&node.getOperation())->getValue()*getConstantValue(children[0])));
             if (children[0].getOperation().getId() == Operation::NEGATE) // Combine a multiply and a negate into a single multiply
                 return ExpressionTreeNode(new Operation::MultiplyConstant(-dynamic_cast<const Operation::MultiplyConstant*>(&node.getOperation())->getValue()), children[0].getChildren()[0]);
+            break;
+        }
+        default:
+        {
+            // If operation ID is not one of the above,
+            // we don't substitute a simpler expression.
+            break;
         }
     }
     return ExpressionTreeNode(node.getOperation().clone(), children);


### PR DESCRIPTION
Currently, Clang generates the following warning:

```
/home/fitze/repos/opensim/opensim-core-feature-source/Vendors/lepton/src/ParsedExpression.cpp:123:13:
warning:
      30 enumeration values not handled in switch: 'CONSTANT', 'VARIABLE',
      'CUSTOM'...
            [-Wswitch]
                switch (node.getOperation().getId()) {
                                ^
                                1 warning generated.
```

Added a default case, which does nothing.

I'm actually not sure what the default case should do; I tried to guess based on the name of the method, and assuming the current behavior is correct. Alternative behavior would be to raise an exception. Hopefully my comment is correct as well.
