### PR TITLE
Build Java and python wrapping in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   # Build Simbody.
   - make -j8
   # Test Simbody.
-  - ctest -j8
+  - ctest -j8 --output-on-failure
   # Install Simbody.
   - make -j8 install
   # Go back to the directory containing OpenSim.
@@ -50,4 +50,4 @@ install:
 
 script:
   # Install OpenSim.
-  - ctest -j8
+  - ctest -j8 --output-on-failure


### PR DESCRIPTION
This requires installing swig in travis.

Right now, the JavaWrap target only generates java sources. @aymanhab is planning to add a target to build those java files into a .jar, so that we can ensure they successfully compile. If we want, we can wait until Ayman makes those changes to merge this PR.
