### PR TITLE
Add a convenience constructOutput; fix typos.

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -922,6 +922,7 @@ getStateVariablesNamesAddedByComponent() const
 // ComponentMeasures, so we do not need to forward to subcomponents here.
 void Component::realizeTopology(SimTK::State& s) const
 {
+
     const SimTK::Subsystem& subSys = getSystem().getDefaultSubsystem();
     
     Component *mutableThis = const_cast<Component*>(this);
@@ -1039,7 +1040,7 @@ double Component::AddedStateVariable::getValue(const SimTK::State& state) const
 	}
 
     std::stringstream msg;
-    msg << "Component::AddedStateVariable::getValue: ERR- variable name '" 
+    msg << "Component::AddedStateVariable::getValue: ERR- variable '" 
 		<< getName() << "' is invalid for component " << getOwner().getName() 
 		<< " of type " << getOwner().getConcreteClassName() <<".";
     throw Exception(msg.str(),__FILE__,__LINE__);
@@ -1056,7 +1057,7 @@ void Component::AddedStateVariable::setValue(SimTK::State& state, double value) 
 	}
 
     std::stringstream msg;
-    msg << "Component::AddedStateVariable::setValue: ERR- variable name '" 
+    msg << "Component::AddedStateVariable::setValue: ERR- variable '" 
 		<< getName() << "' is invalid for component " << getOwner().getName() 
 		<< " of type " << getOwner().getConcreteClassName() <<".";
     throw Exception(msg.str(),__FILE__,__LINE__);

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -625,7 +625,7 @@ public:
     }
 
     /**
-     * Enables the to monitor the validity of the cache variable value using the
+     * Enables the user to monitor the validity of the cache variable value using the
      * returned flag. For components performing a costly evaluation, use this 
 	 * method to force a re-evaluation cache variable value only when necessary 
 	 * (returns false).
@@ -808,8 +808,8 @@ template <class T> friend class ComponentMeasure;
 	For common Components, OpenSim base classes either provide convenience methods
 	or handle indices automatically. 
    
-    If you override this method, be sure to invoke the base class method first, 
-    using code like this:
+    If you override this method, be sure to invoke the base class method at the
+    end, using code like this:
     @code
     void MyComponent::addToSystem(SimTK::MultibodySystem& system) const {
 		// ... your code goes here
@@ -892,7 +892,6 @@ template <class T> friend class ComponentMeasure;
 
 		// Then set the derivative value by state variable name
 		setStateVariableDerivative(state, "<state_variable_name>", deriv);
-		;
     }
     @endcode
 
@@ -1016,11 +1015,43 @@ template <class T> friend class ComponentMeasure;
 		_inputsTable[name] = new Input<T>(name, requiredAtStage);
 	}
 
+    /**
+     * A convenient way to construct an Output.  Here, we assume the following
+     * about componentMemberFunction, the function that returns the output:
+     *
+     *  1. It is a member function of \a this Component.
+     *  2. It takes only one input, which is const SimTK::State&
+     *
+     * If these are not true for your case, then use the more general method
+     * Component::constructOutput(const std::string&, const std::function<T(const SimTK::State&)>, const SimTK::Stage&).
+     *
+     * Here's an example. Say your Component has a method calcForce:
+     *  @code
+     *  constructOutput<SimTK::Vec3>("force", &MyComponent::calcForce,
+     *          SimTK::Stage::Velocity);
+     *  @endcode
+     */
+    template <typename T, typename Class>
+    void constructOutput(const std::string& name,
+            T(Class::*componentMemberFunction)(const SimTK::State&),
+            const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration) {
+        constructOutput<T>(name, std::bind(componentMemberFunction,
+                    static_cast<Class*>(this),
+                    std::placeholders::_1), dependsOn);
+    }
+
 	/**
 	* Construct an Output (wire) for the Component as function of the State.
 	* Specifiy a (member) function of the state implemented by this component to
 	* be an Output and include the Stage that output is dependent on. If no
-	* Stage is specified it defaults to Acceleration.
+    * Stage is specified it defaults to Acceleration. Here's an example. Say you have a class Markers that manages markers, you have an instance of this class as a member variable in your Component, and Markers has a method `Vec3 Markers\:\:calcMarkerPos(const SimTK\:\:State& s, std\:\:string marker);` to compute
+    * motion capture marker positions, given the name of a marker.
+     *  @code
+     *  constructOutput<SimTK::Vec3>("ankleMarkerPos",
+     *          std::bind(&Markers::calcMarkerPos, _markers,
+     *          std::placeholders::_1, "ankle"),
+     *          SimTK::Stage::Position);
+	 *  @endcode
 	*/
 	template <typename T>
 	void constructOutput(const std::string& name, 
@@ -1169,13 +1200,13 @@ template <class T> friend class ComponentMeasure;
 		Coordinate component of the elbow joint that connects the forearm body in 
 		linear time (linear search for name at each component level. Whereas
 		supplying "elbow_flexion" requires a tree search.
-		returns NULL if Component of that specified name cannot be found. 
+		Returns NULL if Component of that specified name cannot be found. 
 		If the name provided is a component's state variable name and a pointer to
-		a StateVariable pointer in provided, the pointer will be set to the 
+		a StateVariable pointer is provided, the pointer will be set to the 
 		StateVariable object that was found. This facilitates the getting and setting
 		of StateVariables by name. 
 		
-		NOTE: If the a component name or the state variable name is ambiguous, the 
+		NOTE: If the component name or the state variable name is ambiguous, the 
 		 first instance found is returned. To disambiguate use the full name provided
 		 by owning component(s). */
 	const Component* findComponent(const std::string& name, 
@@ -1259,7 +1290,7 @@ protected:
 	//implement the virtual methods below. Otherwise, if the Component is adding its
 	//own state variables using the addStateVariable() helper, then an 
 	//AddedStateVariable implements the interface and automatically handles state
-	//varaible access.
+	//variable access.
 	class StateVariable {
 		friend void Component::addStateVariable(StateVariable* sv) const;
 	public:

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -108,8 +108,8 @@ public:
 	Output() : AbstractOutput(), _outputFcn(nullptr) {}   
 	/** Convenience constructor
 	Create a Component::Output bound to a specific method of the Component and 
-	valid at a givent realization Stage.
-	@param outputMethod		The output function to be invoked (returns Output T)
+	valid at a given realization Stage.
+	@param outputFunction	The output function to be invoked (returns Output T)
 	@param dependsOnStage	Stage at which Output can be evaluated. */
 	explicit Output(const std::string& name,
 		const std::function<T(const SimTK::State&)> outputFunction,

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -193,13 +193,11 @@ private:
 	}
 
 	void constructOutputs() OVERRIDE_11 {
-		constructOutput<double>("Output1",
-		std::bind(&Foo::getSomething, this, std::placeholders::_1),
-			SimTK::Stage::Time);
+		constructOutput<double>("Output1", &Foo::getSomething,
+                SimTK::Stage::Time);
 
-		constructOutput<SimTK::Vec3>("Output2",
-			std::bind(&Foo::calcSomething, this, std::placeholders::_1),
-			SimTK::Stage::Time);
+		constructOutput<SimTK::Vec3>("Output2", &Foo::calcSomething,
+                SimTK::Stage::Time);
 
 		double a = 10;
 		constructOutput<Vector>("Qs",
@@ -470,7 +468,7 @@ int main() {
 		theWorld.connect();
 
 		Bar& bar2 = *new Bar();
-		bar.setName("bar2");
+		bar2.setName("bar2");
 		CompoundFoo& compFoo = *new CompoundFoo();
 		compFoo.setName("BigFoo");
 


### PR DESCRIPTION
Added a convenience Component::constructOutput that allows the user to
avoid using std::bind or std::placeholders. Modified tests to test this.

Also fixed various typos.

May be good to get in for the hackathon, if people want to use the new convenient constructOutput.
