### PR TITLE
addresses testAssemblySolver failure issue #7

### DIFF
--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -193,9 +193,10 @@ void AssemblySolver::updateGoals(const SimTK::State &s)
  */
 void AssemblySolver::assemble(SimTK::State &state)
 {
-	// Make a working copy of the state that will be used to set the internal state of the solver
-	// This is necessary because we may wish to disable redundant constraints, but do not want this
-	// to effect the state of constraints the user expects
+	// Make a working copy of the state that will be used to set the internal 
+	// state of the solver. This is necessary because we may wish to disable 
+	// redundant constraints, but do not want this  to effect the state of 
+	// constraints the user expects
 	SimTK::State s = state;
 	
 	// Make sure goals are up-to-date.
@@ -203,12 +204,13 @@ void AssemblySolver::assemble(SimTK::State &state)
 
 	// Let assembler perform some internal setup
 	_assembler->initialize(s);
-
-	/*
-	printf("UNASSEMBLED CONFIGURATION (err=%g, cost=%g, qerr=%g)\n",
-        _assembler->calcCurrentErrorNorm(), _assembler->calcCurrentGoal(), max(abs(_assembler->getInternalState().getQErr())));
-	cout << "Model numQs: " << _assembler->getInternalState().getNQ() << " Assembler num freeQs: " << _assembler->getNumFreeQs() << endl;
-	*/
+	
+	printf("UNASSEMBLED CONFIGURATION (normerr=%g, maxerr=%g, cost=%g)\n",
+        _assembler->calcCurrentErrorNorm(),
+		max(abs(_assembler->getInternalState().getQErr())),
+		_assembler->calcCurrentGoal());
+	cout << "Model numQs: " << _assembler->getInternalState().getNQ() 
+		<< " Assembler num freeQs: " << _assembler->getNumFreeQs() << endl;
 
 	try{
 		// Now do the assembly and return the updated state.
@@ -226,18 +228,16 @@ void AssemblySolver::assemble(SimTK::State &state)
 			if(isLocked)
 				modelCoordSet[i].setLocked(state, isLocked);
 		}
-
-		/*
-		printf("ASSEMBLED CONFIGURATION (acc=%g tol=%g err=%g, cost=%g, qerr=%g)\n",
+	
+		printf("ASSEMBLED CONFIGURATION (acc=%g tol=%g normerr=%g, maxerr=%g, cost=%g)\n",
 			_assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
-			_assembler->calcCurrentErrorNorm(), _assembler->calcCurrentGoal(),
-			max(abs(_assembler->getInternalState().getQErr())));
+			_assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
+			_assembler->calcCurrentGoal());
 		printf("# initializations=%d\n", _assembler->getNumInitializations());
 		printf("# assembly steps: %d\n", _assembler->getNumAssemblySteps());
 		printf(" evals: goal=%d grad=%d error=%d jac=%d\n",
 			_assembler->getNumGoalEvals(), _assembler->getNumGoalGradientEvals(),
 			_assembler->getNumErrorEvals(), _assembler->getNumErrorJacobianEvals());
-		*/
 	}
 	catch (const std::exception& ex)
     {
@@ -263,8 +263,17 @@ void AssemblySolver::track(SimTK::State &s)
 		updateGoals(s);
 	}
 	else{
-		throw Exception("AssemblySolver::track() failed: assemble() must be called first.");
+		throw Exception(
+			"AssemblySolver::track() failed: assemble() must be called first.");
 	}
+
+	printf("UNASSEMBLED(track) CONFIGURATION (normerr=%g, maxerr=%g, cost=%g)\n",
+		_assembler->calcCurrentErrorNorm(), 
+		max(abs(_assembler->getInternalState().getQErr())), 
+		_assembler->calcCurrentGoal() );
+	cout << "Model numQs: " << _assembler->getInternalState().getNQ() 
+		<< " Assembler num freeQs: " << _assembler->getNumFreeQs() << endl;
+
 
 	try{
 		// Now do the assembly and return the updated state.
@@ -272,13 +281,12 @@ void AssemblySolver::track(SimTK::State &s)
 
 		// update the state from the result of the assembler 
 		_assembler->updateFromInternalState(s);
-
-		/*
-		printf("Tracking: t= %f (acc=%g tol=%g err=%g, cost=%g, qerr=%g)\n", s.getTime(),
+		
+		printf("Tracking: t= %f (acc=%g tol=%g normerr=%g, maxerr=%g, cost=%g)\n", 
+			s.getTime(),
 			_assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
-			_assembler->calcCurrentErrorNorm(), _assembler->calcCurrentGoal(),
-			max(abs(_assembler->getInternalState().getQErr())));
-		*/
+			_assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
+			_assembler->calcCurrentGoal());	
 	}
 	catch (const std::exception& ex)
     {

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -637,11 +637,6 @@ void Model::createMultibodySystem()
 	SimTK::UnitVec3 direction = magnitude==0 ? SimTK::UnitVec3(0,-1,0) : SimTK::UnitVec3(_gravity/magnitude);
 	_gravityForce = new SimTK::Force::Gravity(*_forceSubsystem, *_matter, direction, magnitude);
 
-	/*
-	cout << "**************** Graph of the Multibody Tree ****************" << endl;
-	_multibodyTree.dumpGraph(cout);
-	cout << "****************** End of the Multibody Tree ****************" << endl;
-	*/
 	addToSystem(*_system);
 }
 
@@ -770,8 +765,8 @@ void Model::connectToModel(Model &model)
 
 	// Model is connected so build the Multibody tree to represent it
 	_multibodyTree.generateGraph();
-	_multibodyTree.dumpGraph(cout);
-	cout << endl;
+	//_multibodyTree.dumpGraph(cout);
+	//cout << endl;
 
 	SimTK::Array_<Component *>::iterator it = nullptr;
 	JointSet& joints = upd_JointSet();
@@ -1737,8 +1732,7 @@ void Model::createAssemblySolver(const SimTK::State& s)
 
 void Model::updateAssemblyConditions(SimTK::State& s)
 {
-	createAssemblySolver(s);
-	
+	createAssemblySolver(s);	
 }
 //--------------------------------------------------------------------------
 // MARKERS

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -386,9 +386,11 @@ void Joint::addToSystem(SimTK::MultibodySystem& system) const
 	// add sub components (e.g. Coordinates) once we have necessary system indices
 	Super::addToSystem(system);
 
+	/* TODO: Useful to include through debug message/log in the future
 	cout << getConcreteClassName() << ":'" << getName() << "' connects parent '";
 	cout << getParentBodyName() << "'[" << getParentBody().getIndex() << "] and child '";
 	cout << getChildBodyName() << "'[" << getChildBody().getIndex() << "]" << endl;
+     */
 }
 
 void Joint::initStateFromProperties(SimTK::State& s) const


### PR DESCRIPTION
testAssemblySolver was failing because assembling from a state that already satisfied the constraints and coordinate goals was causing significant changes in the coordinates (beyond 10*accuracy). The fix on Simbody (https://github.com/simbody/simbody/issues/168 to not make the assembly solution worse) alleviated that issue for an initial check (assemble after initSystem). The other problem was that after a simulation is run, we do a similar check to assemble from the integrated state, and this time the initial goal is not zero and was requiring a big change in the q's. It seemed that the assembly's track was still targeting the pre-simulation state. A call to `Model::updateAssemblyConditions(state)` fixed that problem and the assembled q's end up being identical since the final state of integration satisfies constraints to around 1e-12. The test now checks that the q's do not change beyond the accuracy of the assembler, which seems right. The test passes for both a model that precisely satisfies the constraints initially and what that is close but well outside the tolerance.

Also the debugging output of the Multibody graph and the Joint's connections have been commented out until we have messaging system that enables us to set the level of output for error handling and debugging purposes.

All test cases should pass on VS2013.
