### PR TITLE
Suppress AssemblySolver debug output. Addresses comment in PR#34 by @sherm1

### DIFF
--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -205,13 +205,14 @@ void AssemblySolver::assemble(SimTK::State &state)
 	// Let assembler perform some internal setup
 	_assembler->initialize(s);
 	
+	/* TODO: Useful to include through debug message/log in the future
 	printf("UNASSEMBLED CONFIGURATION (normerr=%g, maxerr=%g, cost=%g)\n",
         _assembler->calcCurrentErrorNorm(),
 		max(abs(_assembler->getInternalState().getQErr())),
 		_assembler->calcCurrentGoal());
 	cout << "Model numQs: " << _assembler->getInternalState().getNQ() 
 		<< " Assembler num freeQs: " << _assembler->getNumFreeQs() << endl;
-
+    */
 	try{
 		// Now do the assembly and return the updated state.
 		_assembler->assemble();
@@ -228,7 +229,7 @@ void AssemblySolver::assemble(SimTK::State &state)
 			if(isLocked)
 				modelCoordSet[i].setLocked(state, isLocked);
 		}
-	
+		/* TODO: Useful to include through debug message/log in the future
 		printf("ASSEMBLED CONFIGURATION (acc=%g tol=%g normerr=%g, maxerr=%g, cost=%g)\n",
 			_assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
 			_assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
@@ -238,6 +239,7 @@ void AssemblySolver::assemble(SimTK::State &state)
 		printf(" evals: goal=%d grad=%d error=%d jac=%d\n",
 			_assembler->getNumGoalEvals(), _assembler->getNumGoalGradientEvals(),
 			_assembler->getNumErrorEvals(), _assembler->getNumErrorJacobianEvals());
+		*/
 	}
 	catch (const std::exception& ex)
     {
@@ -267,13 +269,14 @@ void AssemblySolver::track(SimTK::State &s)
 			"AssemblySolver::track() failed: assemble() must be called first.");
 	}
 
+	/* TODO: Useful to include through debug message/log in the future
 	printf("UNASSEMBLED(track) CONFIGURATION (normerr=%g, maxerr=%g, cost=%g)\n",
 		_assembler->calcCurrentErrorNorm(), 
 		max(abs(_assembler->getInternalState().getQErr())), 
 		_assembler->calcCurrentGoal() );
 	cout << "Model numQs: " << _assembler->getInternalState().getNQ() 
 		<< " Assembler num freeQs: " << _assembler->getNumFreeQs() << endl;
-
+    */
 
 	try{
 		// Now do the assembly and return the updated state.
@@ -282,11 +285,13 @@ void AssemblySolver::track(SimTK::State &s)
 		// update the state from the result of the assembler 
 		_assembler->updateFromInternalState(s);
 		
+		/* TODO: Useful to include through debug message/log in the future
 		printf("Tracking: t= %f (acc=%g tol=%g normerr=%g, maxerr=%g, cost=%g)\n", 
 			s.getTime(),
 			_assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
 			_assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
 			_assembler->calcCurrentGoal());	
+		*/
 	}
 	catch (const std::exception& ex)
     {


### PR DESCRIPTION
Currently debug output commented out with the hopes of enabling message handling/logging to provide user control of the level of detail in debug messages that are provided.
