### PR TITLE
Fix jar contents and version compat. for MATLAB.

### DIFF
--- a/OpenSim/Wrapping/Java/CMakeLists.txt
+++ b/OpenSim/Wrapping/Java/CMakeLists.txt
@@ -23,12 +23,15 @@ IF ( JAVA_COMPILE )
   ADD_CUSTOM_TARGET ( JavaCompile
      COMMAND ${JAVA_COMPILE} 
      ${CMAKE_BINARY_DIR}/OpenSim/Wrapping/Java/OpenSimJNI/src/org/opensim/modeling/*.java 
+     -source 1.6 -target 1.6
      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/OpenSim/Wrapping/Java/OpenSimJNI/src/)
      
   ADD_CUSTOM_COMMAND(TARGET JavaCompile
                    POST_BUILD
-                   COMMAND ${JAVA_ARCHIVE} -cvf ${CMAKE_BINARY_DIR}/OpenSim/Wrapping/Java/OpenSimJNI/src/org-opensim-modeling.jar 
-				   ${CMAKE_BINARY_DIR}/OpenSim/Wrapping/Java/OpenSimJNI/src/org/opensim/modeling/*.class
+                   COMMAND ${JAVA_ARCHIVE} -cvf org-opensim-modeling.jar
+                   org/opensim/modeling/*.class
+                   WORKING_DIRECTORY
+                   ${CMAKE_BINARY_DIR}/OpenSim/Wrapping/Java/OpenSimJNI/src/
    )
 ENDIF ( JAVA_COMPILE )
 ENDIF(BUILD_JAVA_WRAPPING)


### PR DESCRIPTION
1. The java compiler builds .class files compatible with a JRE 1.6. This is
   necessary, as MATLAB uses 1.6.
2. The paths in the .jar file used to be absolute paths on the user's system.
   Now, they are relative to the Java/src/ dir.

Addresses #40.
