### PR TITLE
In travis, don't build Simbody examples, and build clang first.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 language: cpp
 
 compiler:
-  - gcc
   - clang
+  - gcc
 
 before_install:
   ## Get Simbody and its dependencies.


### PR DESCRIPTION
b/c clang is faster.
