### PR TITLE
Fixed doxygen errors; no complaints remain.

### DIFF
--- a/OpenSim/Analyses/StaticOptimizationTarget.h
+++ b/OpenSim/Analyses/StaticOptimizationTarget.h
@@ -49,7 +49,7 @@ class OSIMANALYSES_API StaticOptimizationTarget : public SimTK::OptimizerSystem
 public:
 	/** Smallest allowable perturbation size for computing derivatives. */
 	static const double SMALLDX;
-	/** . */
+
 private:
 
 	/** Work model. */

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -424,9 +424,8 @@ public:
 	/**
 	* Get the Output provided by this Component by name.
 	*
-	* @param state		the State for which to set the value
-	* @param name		the name of the cache variable
-	* @return output	const reference to the AbstractOutput
+	* @param name   the name of the cache variable
+	* @return       const reference to the AbstractOutput
 	*/
 	const AbstractOutput& getOutput(const std::string& name) const
 	{

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -109,6 +109,7 @@ public:
 	/** Convenience constructor
 	Create a Component::Output bound to a specific method of the Component and 
 	valid at a given realization Stage.
+    @param name             The name of the output.
 	@param outputFunction	The output function to be invoked (returns Output T)
 	@param dependsOnStage	Stage at which Output can be evaluated. */
 	explicit Output(const std::string& name,

--- a/OpenSim/Common/PolynomialFunction.h
+++ b/OpenSim/Common/PolynomialFunction.h
@@ -84,7 +84,7 @@ public:
 	 * f(x) = a*x^n + b*x^(n-1) + ... + c 
 	 * The size of the coffecient vector determines the order of the polynomial.
 	 * n = size-1;
-	 * @param[in]   Vector of polynomial coefficients
+	 * @param[in] coefficients      Vector of polynomial coefficients
 	 */
 	void setCoefficients(SimTK::Vector coefficients)
 	{ set_coefficients(coefficients); }

--- a/OpenSim/Common/Property_Deprecated.h
+++ b/OpenSim/Common/Property_Deprecated.h
@@ -38,26 +38,6 @@
 #include <string>
 
 namespace OpenSim { 
-
-class Object;
-
-#ifdef SWIG
-	#ifdef OSIMCOMMON_API
-		#undef OSIMCOMMON_API
-	#endif
-    #define OSIMCOMMON_API
-	#ifdef override
-		#undef override
-	#endif
-    #define override
-	#ifdef FINAL_11
-		#undef FINAL_11
-	#endif
-    #define FINAL_11 
-#endif
-
-//=============================================================================
-//=============================================================================
 /**
  * A property consists of a type, name, and a value or an array of values.
  *
@@ -87,6 +67,24 @@ class Object;
  * @version 1.0
  * @author Frank C. Anderson
  */
+
+class Object;
+
+#ifdef SWIG
+	#ifdef OSIMCOMMON_API
+		#undef OSIMCOMMON_API
+	#endif
+    #define OSIMCOMMON_API
+	#ifdef override
+		#undef override
+	#endif
+    #define override
+	#ifdef FINAL_11
+		#undef FINAL_11
+	#endif
+    #define FINAL_11 
+#endif
+
 #ifdef WIN32
 #pragma warning( disable : 4290 )	// VC++ non-ANSI Exception handling
 #pragma warning( disable : 4251 )	// VC2010 no-dll export of std::string

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -648,9 +648,6 @@ void SmoothSegmentedFunction::printMuscleCurveToCSVFile(
 }
 /*
 This function will print cvs file of the column vector col0 and the matrix data
-
-@params data: A matrix of data
-@params filename: The name of the file to print
 */
 void SmoothSegmentedFunction::
     printMatrixToFile(SimTK::Matrix& data, SimTK::Array_<std::string>& colNames,

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -412,6 +412,7 @@ namespace OpenSim {
         matrix data
        
         @param data A matrix of data
+        @param colnames Array of column headings
         @param path The desired path to the folder to write the file
         @param filename The name of the file to print
         @throws OpenSim::Exception

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -192,14 +192,6 @@ public:
     **/
 	explicit Model(const std::string& filename, bool finalize=true) SWIG_DECLARE_EXCEPTION;
 
-//    #ifndef SWIG
-	/** Copy assignment copies model components but does not copy any run-time 
-    objects.
-	@param source   The %Model to be copied.
-	@returns        Reference to this object. **/
-//	Model& operator=(const Model& source);
-//    #endif
-
 	/**
 	 * Perform some set up functions that happen after the
 	 * object has been deserialized. TODO: this method is

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -353,15 +353,15 @@ protected:
 	                             multibody tree 
 	@param[in] outboardTransform  the transform locating the joint (mobilizer)
 	                              frame on the outboard body
-    @param[in/out] startingCoordinateIndex
+    @param[in,out] startingCoordinateIndex
 	                             the starting index of mobilities
 	                             enabled by the created MobilizedBody and used
 								 to assign mobility indices to the Joint's
 								 coordinates. It is incremented by the number of
 								 mobilities of the MobilizedBody created
-	@param[optional] associatedBody  the Body associated with the MobilizeBody.
-	                                 The MobilizedBody index is assigned to the
-									 associated Body.
+	@param[in] associatedBody    (optional) the Body associated with the
+                                 MobilizeBody. The MobilizedBody index is
+                                 assigned to the associated Body.
 	*/
 	template <typename T>
 	T createMobilizedBody(SimTK::MobilizedBody& inboard, 


### PR DESCRIPTION
There are, however, 4 warnings related to Doxyfile:

<pre>
2>CUSTOMBUILD : warning : Tag `SHOW_DIRECTORIES' at line 569 of file C:/Users/tkuchida/GitHub/opensim-core/build/Doxyfile has become obsolete.
2>  To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
2>CUSTOMBUILD : warning : Tag `HTML_ALIGN_MEMBERS' at line 1011 of file C:/Users/tkuchida/GitHub/opensim-core/build/Doxyfile has become obsolete.
2>  To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
2>CUSTOMBUILD : warning : Tag `USE_INLINE_TREES' at line 1202 of file C:/Users/tkuchida/GitHub/opensim-core/build/Doxyfile has become obsolete.
2>  To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
2>CUSTOMBUILD : warning : ignoring unsupported tag `EXTERNAL_SEARCH        =' at line 1275, file C:/Users/tkuchida/GitHub/opensim-core/build/Doxyfile
</pre>


Safe to do `doxygen -u` and clear out `EXTERNAL_SEARCH`? The former seems safe; not sure whether `EXTERNAL_SEARCH` is necessary.

Addresses @sherm1's request in #29.
