### PR TITLE
Allow OpenSim doxygen to link to Simbody doxygen.

### DIFF
--- a/ApiDoxygen.cmake
+++ b/ApiDoxygen.cmake
@@ -4,6 +4,20 @@ IF(DOXYGEN_EXECUTABLE-NOTFOUND)
 ELSE(DOXYGEN_EXECUTABLE-NOTFOUND)
     SET(DOXY_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
 
+    # Configure linking to Simbody documentation.
+    # Some of these variables are used in Doxyfile.in.
+    # This variable must be a STRING; a PATH variable resolves //'s as a single
+    # /, but we need to use double slashes for URL's.
+    SET(OPENSIM_SIMBODY_DOXYGEN_LOCATION "${Simbody_DOXYGEN_DIR}"
+        CACHE STRING
+        "The location of Simbody's doxygen documentation. By default, OpenSim's
+        Doxygen will link to the user's *local* Simbody documentation. However,
+        when the OpenSim documentation is put online, there is no local Simbody
+        Doxygen documentation. In this case, this variable can be set to a URL
+        where one can find Simbody Doxygen documentation online. Delete from
+        CMakeCache.txt to reset to default.")
+    MARK_AS_ADVANCED(OPENSIM_SIMBODY_DOXYGEN_LOCATION)
+
     CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in 
           ${DOXY_CONFIG}
           @ONLY )
@@ -40,6 +54,7 @@ ELSE(DOXYGEN_EXECUTABLE-NOTFOUND)
          DESTINATION "${PROJECT_BINARY_DIR}/")
     FILE(COPY "${CMAKE_CURRENT_SOURCE_DIR}/OpenSim/doc/images/"
          DESTINATION "${PROJECT_BINARY_DIR}/html/images/")
+
     ################
     # INSTALLATION #
     ################

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1608,7 +1608,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = 
+TAGFILES               = "@Simbody_DOXYGEN_TAGFILE@=@OPENSIM_SIMBODY_DOXYGEN_LOCATION@"
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.


### PR DESCRIPTION
When browsing your OpenSim doxygen, have you ever come upon a Simbody class, say
SimTK::MobilizedBody, and wanted to see the documentation for it? Well, now,
OpenSim doxygen will contain a link right there, as if the OpenSim and Simbody
doxygen were combined. Check out the result:
http://stanford.edu/~dembia/opensim/classOpenSim_1_1Body.html.

On your local machine, the wiring is done automatically (presuming you've built
Simbody doxygen locally). If posting the Doxygen online, one must set the
OpenSim CMake variable `OPENSIM_SIMBODY_DOXYGEN_LOCATION` to a valid URL where
Simbody doxygen exists. That's what I've done for the above URL.

This is made possible by https://github.com/simbody/simbody/pull/203.

Addresses some of #122. Our doxygen homepage still contains HTML with
hard-coded URL's to Simbody's doxygen. I don't know how to fix that, but I
think this is a first step.

This is ready to go in.

EDIT: Don't click SimTK::Vec3; that link isn't working because the version of Simbody doxygen online is older than the one I used to generate OpenSim doxygen.
