### PR TITLE
Travis gcc crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   # Build OpenSim.
   # gcc is crashing when building osimJavaJNI with other targets (_opensim?).
   # gcc does not crash if we build _opensim separately.
-  - if [ "$CXX" = "g++-4.8" ]; then make -j8 osimJavaJNI PyWrap; fi
+  - if [ "$CXX" = "g++-4.8" ]; then make -j8 osimJavaJNI; fi
   - make -j8 # This'll build _opensim and the tests.
 
 script:


### PR DESCRIPTION
Addresses #132 by preventing gcc from building osimJavaJNI and _opensim at the same time. We should revisit this in the future. Gcc will still periodically crash, but at least it won't do it every time now.
