### PR TITLE
Remove stale Mtx link.

### DIFF
--- a/OpenSim/OpenSimDoxygenMain.h
+++ b/OpenSim/OpenSimDoxygenMain.h
@@ -178,27 +178,29 @@ For example, you can click on the "Model Component" block to see a list of model
 	</tr>
 </table>
 <!-- End ImageReady Slices -->
-<br/>
-<b>Other specific classes of interest:</b>
-<br/>
-<a href = "classOpenSim_1_1Actuator.html">OpenSim::Actuator</a> <br/>
-<a href = "classOpenSim_1_1Body.html">OpenSim::Body</a> <br/>
-<a href = "classOpenSim_1_1Force.html">OpenSim::Force</a> <br/>
-<a href = "classOpenSim_1_1Function.html">OpenSim::Function</a> <br/>
-<a href = "classOpenSim_1_1Joint.html">OpenSim::Joint</a> <br/>
-<a href = "classOpenSim_1_1Mtx.html">OpenSim::Mtx</a> <br/>
-<a href = "classOpenSim_1_1Muscle.html">OpenSim::Muscle</a> <br/>
-<br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1Matrix__.html">SimTK::Matrix</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1Vector__.html">SimTK::Vector</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1Vec.html">SimTK::Vec</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1UnitVec.html">SimTK::UnitVec</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1Rotation__.html">SimTK::Rotation</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1MobilizedBody.html">SimTK::MobilizedBody</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1SimbodyMatterSubsystem.html">SimTK::SimbodyMatterSubsystem</a> <br/>
-<a href = "https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1State.html">SimTK::State</a> <br/>
 
 \endhtmlonly
+
+<b>Other specific classes of interest in OpenSim:</b>
+
+- OpenSim::Actuator
+- OpenSim::Body
+- OpenSim::Force
+- OpenSim::Function
+- OpenSim::Joint
+- OpenSim::Muscle
+
+<b>Classes of interest in Simbody:</b>
+
+- SimTK::Matrix_
+- SimTK::Vector_
+- SimTK::Vec
+- SimTK::UnitVec
+- SimTK::Rotation
+- SimTK::MobilizedBody
+- SimTK::SimbodyMatterSubsystem
+- SimTK::State
+
 **/
 
 /** @page OpenSim_license_page  OpenSim Copyright and License


### PR DESCRIPTION
Also, clean up links to Simbody, now that we are using a Simbody tag file. That is, those Simbody links at the bottom do not link to Simbody documentation online; they link to the user's local copy of Simbody. Maybe that is not a good idea, because the person might not have built Simbody documentation locally?

See the new front page:
![screenshot from 2014-08-04 15 26 24](https://cloud.githubusercontent.com/assets/846001/3804460/9d5af06c-1c26-11e4-82d7-7e6575023385.png)
