### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ We encourage everyone to contribute to the OpenSim-Core repository. This could b
 
 Even great programmers benefit from additional eyeballs on their code to catch bugs, avoid duplication and inefficiency, watch for standards violations, and to check that the code is as clear to others as it is to its author. We appreciate contributions and our development team is collaborative and constructive -- don't be shy!
 
+Thank you for contributing!
+
 
 Making a Pull Request
 ---------------------
@@ -21,8 +23,6 @@ Making a Pull Request
 6. Any other changes to the code require review by at least two members of the Dev Team. If the pull request involves adding a new class or performing a major object/algorithm refactor, one of these reviewers must be an Owner. The Owners and Dev Team are Teams within the opensim-org GitHub organization. The original author may NOT merge the pull request. 
 
 A few additional practices will help streamline the code review process. Please use tags (i.e. @user_name) and quoting to help keep the discussion organized. Please also call for a meeting or Skype call when discussions start to stagnate. In addition, we recommend getting input on your interface design before implementing a major new component or other change.
-
-Thank you for contributing!
 
 
 Checking for Memory Leaks through GitHub


### PR DESCRIPTION
GitHub suggests putting a CONTRIBUTING.md in the repository. https://github.com/blog/1184-contributing-guidelines

Currently, we have such content at Confluence. We can either just link people to Confluence, move those confluence pages to this file, or forget about making this file in the repo.
