### PR TITLE
Fix conectee typo.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -326,7 +326,7 @@ public:
 		// get the Connector and check if it is connected.
 		const AbstractConnector& connector = getConnector<T>(name);
 		if (connector.isConnected()){
-			return (Connector<T>::downcast(connector)).getConectee();
+			return (Connector<T>::downcast(connector)).getConnectee();
 		}
 		else{
 			std::stringstream msg;

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -118,7 +118,7 @@ public:
 	virtual std::string getConnectedToTypeName() const = 0;
 
 	/** Connect this Connector to the provided connectee object */
-	virtual void connect(const Object& conectee) = 0;
+	virtual void connect(const Object& connectee) = 0;
 
 	/** Disconnect this Connector from the connectee object */
 	virtual void disconnect() = 0;
@@ -154,14 +154,14 @@ public:
 		return !connectee.empty();
 	}
 
-	/** Temporary access to the conectee for testing purposes. Real useage
+	/** Temporary access to the connectee for testing purposes. Real useage
 	    will be through the Connector (and Input) interfaces. 
 		For example, Input should short circuit to its Output's getValue()
 		once it is connected.
 	Return a const reference to the object connected to this Connector */
 	const T& getConnectee() const { return connectee.getRef(); }
 
-	/** Connect this Connector to the provided conectee object */
+	/** Connect this Connector to the provided connectee object */
 	void connect(const Object& object) override{
 		const T* objT = dynamic_cast<const T*>(&object);
 		if (objT) {

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -482,6 +482,10 @@ int main() {
 		TheWorld *world2 = new TheWorld(modelFile);
 		
 		world2->updComponent("Bar").getConnector<Foo>("childFoo");
+        // We haven't called connect yet, so this connection isn't made yet.
+		ASSERT_THROW(OpenSim::Exception,
+                world2->updComponent("Bar").getConnectee<Foo>("childFoo");
+                );
 
 		ASSERT(theWorld == *world2, __FILE__, __LINE__,
 			"Model serialization->deserialization FAILED");
@@ -490,6 +494,8 @@ int main() {
 		world2->connect();
 
 		world2->updComponent("Bar").getConnector<Foo>("childFoo");
+        ASSERT("Foo2" ==
+                world2->updComponent("Bar").getConnectee<Foo>("childFoo").getName());
 
 		world2->buildUpSystem(system2);
 		s = system2.realizeTopology();
@@ -500,6 +506,7 @@ int main() {
 		TheWorld world3;
 		world3= *world2;
 		world3.getComponent("Bar").getConnector<Foo>("parentFoo");
+
 		ASSERT(world3 == (*world2), __FILE__, __LINE__, 
 			"Model copy assignment FAILED");
 


### PR DESCRIPTION
Added to the testComponentInterface to test that getConnectee() now works.

Fixes #165.
