### PR TITLE
Inputs and outputs don't deserialize; adding checks to ensure.

### DIFF
--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -481,6 +481,8 @@ int main() {
 		MultibodySystem system2;
 		TheWorld *world2 = new TheWorld(modelFile);
 		
+        world2->updComponent("Foo").getOutput("Output1");
+        world2->updComponent("Foo").getInput("input1");
 		world2->updComponent("Bar").getConnector<Foo>("childFoo");
 
 		ASSERT(theWorld == *world2, __FILE__, __LINE__,


### PR DESCRIPTION
I added a check in the tests to ensure inputs and outputs deserialize. You'll see the test fails. AFAIK, inputs and outputs do not "deserialize". I spent some time trying to look through the deserialization code and I _think_ it's b/c, during the clone operation in deserialization, the inputs and outputs maps are not being cloned. I'm not sure though. If that is the case, it would be caused by my PR TODO.

I tried switching from unique_ptr to ClonePtr, but got this error:

```
/home/fitze/simtk/simbody/include/simbody/SimTKcommon/internal/ClonePtr.h:63:11: error: multiple overloads of 'ClonePtr' instantiate to the same signature
      'void (const OpenSim::AbstractInput *)'
        explicit ClonePtr(const T* obj) : p(obj?obj->clone():0) { }
                 ^
/home/fitze/repos/simtk/opensim-core/OpenSim/Common/Component.h:352:10: note: in instantiation of template class 'SimTK::ClonePtr<const OpenSim::AbstractInput>' requested
      here
                if (it != itEnd) {
                       ^
/home/fitze/simtk/simbody/include/simbody/SimTKcommon/internal/ClonePtr.h:54:14: note: previous declaration is here
    explicit ClonePtr(T*  obj) : p(obj) { }
             ^
1 error generated.
```

Here's the relevant code:

```
        std::map<std::string, SimTK::ClonePtr<const AbstractInput>>::const_iterator                                                                                           
            it = _inputsTable.find(name);                                                                                                                                             std::map<std::string, SimTK::ClonePtr<const AbstractInput>>::const_iterator                                                                                           
            itEnd = _inputsTable.end();                                                                                                                                       

        if (it != itEnd) {
```

@sherm1 , help me!

I think one solution is using a ClonePtr. The other option is using an ArrayPtrs in conjunction with a map<string, int>, or using a private list property instead of the ArrayPtrs. I think we prefer the first, though it could lead to people accidentally making clones of the Inputs and Outputs.

Please advise.
