### PR TITLE
[WIP] Clarify nonzero mass/inertia message and behavior.

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -173,9 +173,13 @@ const SimTK::Inertia& Body::getInertia() const
 		const double& m = getMass();
 		// if mass is zero, non-zero inertia makes no sense
 		if (-SimTK::Eps <= m && m <= SimTK::Eps){
-			// force zero intertia
-			cout<<"Body '"<<getName()<<"' is massless but nonzero inertia provided.";
-			cout<<" Inertia reset to zero. "<<"Otherwise provide nonzero mass."<< endl;
+		    // if inertia is non-zero.
+		    if (!(-SimTK::Eps <= get_inertia() && get_inertia() <= SimTK::Eps)) {
+    			cout<<"Body '"<<getName()<<"' is massless but nonzero inertia provided.";
+    			cout<<" Inertia reset to zero. "<<"Otherwise provide nonzero mass."<< endl;
+    			upd_inertia().setToZero();
+		    }
+		    // force zero intertia
 			_inertia = SimTK::Inertia(0);
 		}
 		else{

--- a/OpenSim/Simulation/SimbodyEngine/Body.h
+++ b/OpenSim/Simulation/SimbodyEngine/Body.h
@@ -153,8 +153,7 @@ private:
 	void updateFromXMLNode(SimTK::Xml::Element& aNode,
 		int versionNumber = -1) override;
 
-	// mutable because fist get constructs tensor from properties
-	mutable SimTK::Inertia _inertia;
+	SimTK::Inertia _inertia;
 
 	SimTK::Array_<Body*> _slaves;
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testBody.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testBody.cpp
@@ -1,0 +1,52 @@
+/* -------------------------------------------------------------------------- *
+ *                          OpenSim:  testBody.cpp                            *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2014 Stanford University and the Authors                *
+ * Author(s): Chris Dembia                                                    *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/SimbodyEngine/WeldJoint.h>
+
+using namespace OpenSim;
+
+int main() {
+
+    // Make sure that zero mass with nonzero inertia gives an error message,
+    // and the inertia is changed to zero.
+    // The check is done in Body::finalizeFromProperties(), which gets invoked
+    // from Model::initSystem().
+    // It should also be invoked by copy construction, but this didn't work for
+    // me. -chrisdembia
+    Model model;
+    Body * b1 = new Body();
+    b1->setName("body1");
+    b1->set_mass(0);
+    b1->set_inertia(SimTK::Vec6(1, 0, 0, 0, 0, 0));
+    SimTK::Vec3 v(0);
+    WeldJoint* joint = new WeldJoint("joint", model.getGroundBody(), v, v,
+            *b1, v, v);
+    model.addBody(b1);
+    model.addJoint(joint);
+    SimTK::State& s = model.initSystem();
+    SimTK_TEST_EQ(model.updBodySet().get("body1").get_inertia(),
+            SimTK::Vec6(0));
+    return 0;
+}
+


### PR DESCRIPTION
Running this code:

``` cpp
Model model;
State state = model.initSystem();
model.printDetailedInfo(state, std::cout);
```

produces an unnecessary warning message:

```
MODEL: 

ANALYSES (0)

BODIES (1)
body[0] = ground (mass: 0)Body 'ground' is massless but nonzero inertia provided. Iner
tia reset to zero. Otherwise provide nonzero mass.
 (inertia: [~[0,0,0]  ~[0,0,0]])

ACTUATORS (0)
numStates = 0
numCoordinates = 0
numSpeeds = 0
numActuators = 0
numBodies = 1
numConstraints = 0
numProbes = 0

STATES (0)
```

[Here](https://github.com/opensim-org/opensim-core/blob/20beb87ef317c69a4a1d11d4f12d18dcfc0e68ae/OpenSim/Simulation/SimbodyEngine/Body.cpp#L177) is where the message is generated. 

This PR only emits that message if the inertia property was indeed set to nonzero, and also modifies the inertia property.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/225)

<!-- Reviewable:end -->
