### PR TITLE
[travis] gcc uses 3 processes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - compiler: clang
       env: BUILD_WRAPPING=on NPROC=8
     - compiler: gcc
-      env: BUILD_WRAPPING=off NPROC=2
+      env: BUILD_WRAPPING=off NPROC=3
 
 env:
   global:


### PR DESCRIPTION
I used to have travis using 2 processes for building with gcc, because I thought 3 caused gcc to crash. I have tried 3 processes again (3 times), and it seems like gcc doesn't crash. This should avoid gcc from running out of time (50 minutes). I'll merge this myself once I'm rerun the gcc test a few more times and it doesn't crash.
