### PR TITLE
Specify version of python needed.

### DIFF
--- a/OpenSim/Wrapping/Python/CMakeLists.txt
+++ b/OpenSim/Wrapping/Python/CMakeLists.txt
@@ -3,15 +3,14 @@ SET(UKIT PYOPENSIM)
 
 IF(BUILD_PYTHON_WRAPPING)
 
-INCLUDE(${CMAKE_ROOT}/Modules/FindPythonLibs.cmake)
-INCLUDE(${CMAKE_ROOT}/Modules/FindPythonInterp.cmake)
-
+FIND_PACKAGE(PythonLibs 2.7)
+#FIND_PACKAGE(PythonInterp 2.7)
 
 IF(NOT PYTHONLIBS_FOUND)
     MESSAGE(FATAL_ERROR "Cannot build Python wrapping because "
         "Python libraries were not found. Either turn "
         "BUILD_PYTHON_WRAPPING off or install Python "
-        "libraries (on Ubuntu, apt-get install python2.7-dev).")
+        "libraries (on Ubuntu, sudo apt-get install python2.7-dev).")
 ENDIF()
 
 


### PR DESCRIPTION
This PR is in anticipation of appveyor builds. The appveyor machines have python 3 as well as python 2. This change causes opensim to use python 2, even if python 3 is present.