### PR TITLE
[appveyor] Parallelism set to 4; build 64bit.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@
   
 shallow_clone: true
 
+platform: x64
+
 init:
   # Put MSBuild on the path.
   - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
@@ -47,9 +49,9 @@ build_script:
   - mkdir build
   - cd build
   # Configure.
-  - cmake .. -DSIMBODY_HOME=C:\simbody # TODO -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DSWIG_EXECUTABLE=C:\swigwin-3.0.2\swig.exe # TODO -DBUILD_SIMM_TRANSLATOR=ON
+  - cmake .. -G"Visual Studio 12 Win64" -DSIMBODY_HOME=C:\simbody # TODO -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DSWIG_EXECUTABLE=C:\swigwin-3.0.2\swig.exe # TODO -DBUILD_SIMM_TRANSLATOR=ON
   # Build.
-  - MSBuild OpenSim.sln /target:ALL_BUILD /p:Configuration=Release /maxcpucount /verbosity:quiet
+  - MSBuild OpenSim.sln /target:ALL_BUILD /p:Configuration=Release /maxcpucount:4 /verbosity:quiet
 
 test_script:
-  - ctest --parallel 8 --build-config Release --output-on-failure
+  - ctest --parallel 4 --build-config Release --output-on-failure


### PR DESCRIPTION
Addresses the appveyor part of #287. The issue was that I changed simbody to build as 64bit, but opensim-core was still building as 32bit. I even made the change to build opensim as 32 bit, but forgot about it...silly me. The real bug was my memory.
