### PR TITLE
Enable Markdown support in Doxygen

### DIFF
--- a/OpenSim/doc/Doxyfile.in
+++ b/OpenSim/doc/Doxyfile.in
@@ -250,17 +250,15 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 
 EXTENSION_MAPPING      = 
 
-# Doxygen 1.8.3.1 supports the markdown language, which cause problems
-# for OpenSim's doxygen documentation. Disabling here in case a newer
-# version of doxygen is used (sherm 20130418).
 # If MARKDOWN_SUPPORT is enabled (the default) then doxygen pre-processes all
 # comments according to the Markdown format, which allows for more readable
 # documentation. See http://daringfireball.net/projects/markdown/ for details.
 # The output of markdown processing is further processed by doxygen, so you
 # can mix doxygen, HTML, and XML commands with Markdown formatting.
 # Disable only in case of backward compatibilities issues.
+# (sherm 20141224) Markdown requires doxygen >= 1.8.6.
 
-MARKDOWN_SUPPORT       = NO
+MARKDOWN_SUPPORT       = YES
 
 # If you use STL classes (i.e. std::string, std::vector, etc.) but do not want 
 # to include (a tag file for) the STL sources as input, then you should 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ On Windows using Visual Studio
 * **physics engine**:
   [Simbody](https://github.com/simbody/simbody#windows-and-visual-studio) >= 3.4
 * **API documentation** (optional):
-  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8
+  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6
 * **version control** (optional): git. There are many options:
     * [Git for Windows](http://msysgit.github.io/), most advanced;
     * [TortoiseGit](https://code.google.com/p/tortoisegit/wiki/Download),
@@ -236,7 +236,7 @@ On Mac using Xcode
   CMake variable `SIMBODY_STANDARD_11` is turned on (in 3.6 and later, this variable
   is removed).
 * **API documentation** (optional):
-  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8
+  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6
 * **version control** (optional): git.
     * Xcode Command Line Tools gives you git on the command line.
     * [GitHub for Mac](https://mac.github.com), easiest.
@@ -361,7 +361,7 @@ line below, we show the corresponding package.
   CMake variable `SIMBODY_STANDARD_11` is turned on (in 3.6 and later, this variable
   is removed).
 * **API documentation** (optional):
-  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8;
+  [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6;
   `doxygen`.
 * **version control** (optional): git; `git`.
 * **Wrapping** (optional): [SWIG](http://www.swig.org/) 2.0.10 `swig`


### PR DESCRIPTION
This PR repeats Simbody's simbody/simbody#314 for OpenSim. It enables Markdown support in Doxygen, and modifies `README.md` to require Doxygen version >= 1.8.6.

See issue #305.

@jimmyDunne if the changes look OK I suggest merging this PR to the master branch, then try generating new doxygen from there to see whether anything gets messed up. If it does we can always back it out since the change is tiny.
