### PR TITLE
Coordinate ctor now calls constructInfrastructure.

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -90,7 +90,7 @@ private:
  */
 Coordinate::Coordinate() 
 {
-    constructProperties();
+    constructInfrastructure();
 }
 
 //_____________________________________________________________________________
@@ -98,9 +98,9 @@ Coordinate::Coordinate()
  * Constructor.
  */
 Coordinate::Coordinate(const std::string &aName, MotionType aMotionType,
-        double defaultValue, double aRangeMin, double aRangeMax)
+        double defaultValue, double aRangeMin, double aRangeMax) :
+    Coordinate()
 {
-    constructProperties();
     setName(aName);
     setMotionType(aMotionType);
     setDefaultValue(defaultValue);


### PR DESCRIPTION
Before, it was only calling constructProperties, despite the existence of a
constructOutputs method.

Also making use of delegating constructors.