### PR TITLE
OpenSimConfig.cmake does not contain hardcoded abs paths.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
     - OPENSIM_HOME=~/opensim-install SWIG=swig-2.0.10
 
 before_install:
+  ## Install CMake 2.8.8 (for CMakePackageConfigHelpers).
+  - sudo add-apt-repository ppa:kalakris/cmake -y
+  - sudo apt-get update -qq
+  - sudo apt-get install cmake
   ## Get Simbody and its dependencies.
   - sudo apt-get update -qq
   - sudo apt-get install -qq liblapack-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT (OpenSim)
 #
 #----------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 2.8.8)
 if(COMMAND cmake_policy)
         cmake_policy(SET CMP0003 NEW)
         cmake_policy(SET CMP0005 NEW)

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ On Windows using Visual Studio
 
 * **operating system**: Windows 7 or 8.
 * **cross-platform build system**:
-  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.6
+  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8
 * **compiler / IDE**: Visual Studio 2013. We recommended either:
     * *Visual Studio Express 2013 for Windows Desktop*, which is free, or
     * *Visual Studio Professional 2013* through
@@ -227,7 +227,7 @@ On Mac using Xcode
 
 * **operating system**: OS X 10.8 or later.
 * **cross-platform build system**:
-  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.6
+  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8
 * **compiler / IDE**: [Xcode](https://developer.apple.com/xcode/) >= 5, through
   the Mac App Store.
 * **physics engine**:
@@ -351,8 +351,10 @@ line below, we show the corresponding package.
 
 * **operating system**: Ubuntu 13.10 or later.
 * **cross-platform build system**:
-  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.6;
-  `cmake-gui`.
+  [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8;
+  `cmake-gui`. Ubuntu 12.04 only has 2.8.6 available; download from the website
+  or from this [third party
+  PPA](https://launchpad.net/~robotology/+archive/ubuntu/ppa).
 * **compiler**: [gcc](http://gcc.gnu.org) >= 4.8; `g++-4.8`, or
       [Clang](http://clang.llvm.org) >= 3.4; `clang-3.4`.
 * **physics engine**:

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,13 +1,24 @@
 # CMake packaging so people can use OpenSim.
 # ------------------------------------------
 
+# Requires CMake 2.8.8.
+INCLUDE(CMakePackageConfigHelpers)
+
 SET(OPENSIM_INSTALL_CMAKE_DIR cmake)
 
 CONFIGURE_FILE(OpenSimConfig.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfig.cmake" @ONLY)
 
+CONFIGURE_PACKAGE_CONFIG_FILE(
+    OpenSimConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfig.cmake
+    INSTALL_DESTINATION "${OPENSIM_INSTALL_CMAKE_DIR}"
+    PATH_VARS # Variables to edit in OpenSimConfig.cmake.in.
+        CMAKE_INSTALL_PREFIX
+        OPENSIM_INSTALL_CMAKE_DIR
+    )
+
 # Version file.
-include(WriteBasicConfigVersionFile)
 WRITE_BASIC_CONFIG_VERSION_FILE(
     "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfigVersion.cmake"
     VERSION "${OPENSIM_VERSION}"
@@ -22,4 +33,4 @@ INSTALL(
         "${OPENSIM_INSTALL_CMAKE_DIR}"
         )
 
-install(EXPORT OpenSimTargets DESTINATION "${OPENSIM_INSTALL_CMAKE_DIR}")
+INSTALL(EXPORT OpenSimTargets DESTINATION "${OPENSIM_INSTALL_CMAKE_DIR}")

--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -16,7 +16,10 @@
 # Adapted from SimbodyConfig.cmake
 #
 
-list(APPEND @CMAKE_PROJECT_NAME@_ROOT_DIR "@CMAKE_INSTALL_PREFIX@")
+# To make the OpenSim installation relocatable:
+@PACKAGE_INIT@
+
+set_and_check(@CMAKE_PROJECT_NAME@_ROOT_DIR "@PACKAGE_CMAKE_INSTALL_PREFIX@")
 
 if(WIN32)
     set(_OPENSIM_LIB_RELPATH "sdk/lib")
@@ -24,7 +27,8 @@ else()
     set(_OPENSIM_LIB_RELPATH "lib")
 endif()
 
-list(APPEND @CMAKE_PROJECT_NAME@_LIB_DIR "@CMAKE_INSTALL_PREFIX@/${_OPENSIM_LIB_RELPATH}")
+set_and_check(@CMAKE_PROJECT_NAME@_LIB_DIR
+    "@PACKAGE_CMAKE_INSTALL_PREFIX@/${_OPENSIM_LIB_RELPATH}")
 
 if(WIN32)
     set(_SIMBODY_INCLUDE_RELPATH "include")
@@ -33,13 +37,15 @@ else()
 endif()
 
 list(APPEND @CMAKE_PROJECT_NAME@_INCLUDE_DIRS
-    "@CMAKE_INSTALL_PREFIX@/sdk/include"
-    "@CMAKE_INSTALL_PREFIX@/sdk/include/Vendors/Lepton/include"
-    "@CMAKE_INSTALL_PREFIX@/sdk/include/SimTK/${_SIMBODY_INCLUDE_RELPATH}"
+    "@PACKAGE_CMAKE_INSTALL_PREFIX@/sdk/include"
+    "@PACKAGE_CMAKE_INSTALL_PREFIX@/sdk/include/Vendors/Lepton/include"
+    "@PACKAGE_CMAKE_INSTALL_PREFIX@/sdk/include/SimTK/${_SIMBODY_INCLUDE_RELPATH}"
     )
 
-include("@CMAKE_INSTALL_PREFIX@/@OPENSIM_INSTALL_CMAKE_DIR@/@CMAKE_PROJECT_NAME@Targets.cmake")
+include("@PACKAGE_OPENSIM_INSTALL_CMAKE_DIR@/@CMAKE_PROJECT_NAME@Targets.cmake")
 
 # The osimTools target uses all the other targets.
 # TODO Does this handle both release and debug libraries?
 list(APPEND @CMAKE_PROJECT_NAME@_LIBRARIES osimTools)
+
+check_required_components(OpenSim)


### PR DESCRIPTION
Fixes #323. See https://github.com/simbody/simbody/pull/339 for discussion.