### PR TITLE
Remove automatically-created Output for StateVariables

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -367,23 +367,9 @@ void Component::addStateVariable(Component::StateVariable*  stateVariable) const
     // assign a "slot" for a state variable by name
     // state variable index will be invalid by default
     // upon allocation during realizeTopology the index will be set
-    _namedStateVariableInfo[stateVariableName] = StateVariableInfo(stateVariable, order);
+    _namedStateVariableInfo[stateVariableName] =
+        StateVariableInfo(stateVariable, order);
 
-    // If the StateVariable is not hidden, create an Output for this
-    // StateVariable's value. We do this with an AddedStateVariable since
-    // only AddedStateVariable's have a stage.
-    if(!stateVariable->isHidden()){
-        // StateVariable values are of type double. Also, StateVariable's
-        // always have a value after they've been created, and they don't
-        // depend on anything. So, their dependsOn Stage is Model.
-        const_cast<Component*>(this)->constructOutput<double>(
-                stateVariableName,
-                std::bind(&Component::StateVariable::getValue,
-                    stateVariable,
-                    std::placeholders::_1),
-                Stage::Model);
-    }
-                
     const AddedStateVariable* asv =
         dynamic_cast<const Component::AddedStateVariable *>(stateVariable);
     // Now automatically add a cache variable to hold the derivative
@@ -808,6 +794,13 @@ void Component::addOutput(const std::string& name,
                     const std::function<T(const SimTK::State&)> outputFunction,
                     const SimTK::Stage& dependsOn)
 */
+
+void Component::constructOutputForStateVariable(const std::string& name) {
+    constructOutput<double>(name,
+            std::bind(&Component::getStateVariableValue,
+                this, std::placeholders::_1, name),
+            SimTK::Stage::Model);
+}
 
 // Include another Component as a subcomponent of this one. If already a
 // subcomponent, it is not added to the list again.

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1227,7 +1227,12 @@ template <class T> friend class ComponentMeasure;
                 Output<T>(name, outputFunction, dependsOn));
     }
 
-    /** Construct an Output for a StateVariable.
+    /** Construct an Output for a StateVariable. While this method is a
+     * convenient way to construct an Output for a StateVariable, it is
+     * inefficient because it uses a string lookup. To create a more efficient
+     * Output, create a member variable that returns the state variable
+     * directly; see the implementations of Coordinate::getValue() or
+     * Muscle::getActivation() for examples.
      *
      * @param name Name of the output, which must be the same as the name of
      * the corresponding state variable.
@@ -1235,11 +1240,12 @@ template <class T> friend class ComponentMeasure;
     void constructOutputForStateVariable(const std::string& name);
     
     /**
-     * Add another Component as a subcomponent of this Component.
-     * Component methods (e.g. addToSystem(), initStateFromProperties(), ...) are 
-     * therefore invoked on subcomponents when called on this Component. Realization is 
-     * also performed automatically on subcomponents. This Component does not take 
-     * ownership of designated subcomponents and does not destroy them when the Component.
+     * Add another Component as a subcomponent of this Component.  Component
+     * methods (e.g. addToSystem(), initStateFromProperties(), ...) are
+     * therefore invoked on subcomponents when called on this Component.
+     * Realization is also performed automatically on subcomponents. This
+     * Component does not take ownership of designated subcomponents and does
+     * not destroy them when the Component.
      */
     void addComponent(Component *aComponent);
 
@@ -1273,9 +1279,13 @@ template <class T> friend class ComponentMeasure;
     indices are automatically determined using this interface. As an advanced
     option you may choose to hide the state variable from being accessed outside
     of this component, in which case it is considered to be "hidden". 
-    You may also want to create an Output for this state variable using
-    constructOutputForStateVariable(); Reporters should use this Output to get
-    the StateVariable's value (instead of using getStateVariableValue()).
+    You may also want to create an Output for this state variable; see
+    constructOutputForStateVariable() for more information. Reporters should
+    use such an Output to get the StateVariable's value (instead of using
+    getStateVariableValue()).
+
+    @see constructOutputForStateVariable()
+
     @param[in] stateVariableName     string value to access variable by name
     @param[in] invalidatesStage      the system realization stage that is
                                      invalidated when variable value is changed
@@ -1293,10 +1303,13 @@ template <class T> friend class ComponentMeasure;
     add/expose state variables that are allocated by underlying Simbody
     components and specify how the state variable value is accessed by
     implementing a concrete StateVariable and adding it to the component using
-    this method. You may also want to create an Output for this state variable
-    using constructOutputForStateVariable(); Reporters should use this Output
-    to get the StateVariable's value (instead of using
+    this method.
+    You may also want to create an Output for this state variable; see
+    constructOutputForStateVariable() for more information. Reporters should
+    use such an Output to get the StateVariable's value (instead of using
     getStateVariableValue()).
+
+    @see constructOutputForStateVariable()
     */
     void addStateVariable(Component::StateVariable*  stateVariable) const;
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1182,6 +1182,8 @@ template <class T> friend class ComponentMeasure;
         constructOutput<SimTK::Vec3>("force", &MyComponent::calcForce,
                 SimTK::Stage::Velocity);
         @endcode
+
+       @see constructOutputForStateVariable()
      */
 #ifndef SWIG // SWIG can't parse the const at the end of the second argument.
     template <typename T, typename Class>
@@ -1214,6 +1216,8 @@ template <class T> friend class ComponentMeasure;
                std::placeholders::_1, "ankle"),
                SimTK::Stage::Position);
        @endcode
+
+      @see constructOutputForStateVariable()
     */
     template <typename T>
     void constructOutput(const std::string& name, 
@@ -1222,6 +1226,13 @@ template <class T> friend class ComponentMeasure;
         _outputsTable[name] = std::unique_ptr<const AbstractOutput>(new
                 Output<T>(name, outputFunction, dependsOn));
     }
+
+    /** Construct an Output for a StateVariable.
+     *
+     * @param name Name of the output, which must be the same as the name of
+     * the corresponding state variable.
+     */
+    void constructOutputForStateVariable(const std::string& name);
     
     /**
      * Add another Component as a subcomponent of this Component.
@@ -1262,6 +1273,9 @@ template <class T> friend class ComponentMeasure;
     indices are automatically determined using this interface. As an advanced
     option you may choose to hide the state variable from being accessed outside
     of this component, in which case it is considered to be "hidden". 
+    You may also want to create an Output for this state variable using
+    constructOutputForStateVariable(); Reporters should use this Output to get
+    the StateVariable's value (instead of using getStateVariableValue()).
     @param[in] stateVariableName     string value to access variable by name
     @param[in] invalidatesStage      the system realization stage that is
                                      invalidated when variable value is changed
@@ -1279,10 +1293,11 @@ template <class T> friend class ComponentMeasure;
     add/expose state variables that are allocated by underlying Simbody
     components and specify how the state variable value is accessed by
     implementing a concrete StateVariable and adding it to the component using
-    this method. If the StateVariable is NOT hidden, this also creates an
-    Output in this Component with the same name as the StateVariable. Reporters
-    should use this Output to get the StateVariable's value (instead of using
-    getStateVariableValue()). */
+    this method. You may also want to create an Output for this state variable
+    using constructOutputForStateVariable(); Reporters should use this Output
+    to get the StateVariable's value (instead of using
+    getStateVariableValue()).
+    */
     void addStateVariable(Component::StateVariable*  stateVariable) const;
 
     /** Add a system discrete variable belonging to this Component, give

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -304,6 +304,8 @@ private:
         constructOutput<double>("PotentialEnergy",
         std::bind(&Bar::getPotentialEnergy, this, std::placeholders::_1),
         SimTK::Stage::Velocity);
+        constructOutputForStateVariable("fiberLength");
+        constructOutputForStateVariable("activation");
     }
 
     // keep track of the force added by the component

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -636,9 +636,9 @@ void Coordinate::setClamped(SimTK::State& s, bool aLocked) const
 void Coordinate::constructOutputs()
 {
     //return the coordinate value
-    constructOutput<double>("value", &Coordinate::getValue, Stage::Position);
+    constructOutput<double>("value", &Coordinate::getValue, Stage::Model);
     //return the speed value;
-    constructOutput<double>("speed", &Coordinate::getSpeedValue, Stage::Velocity);
+    constructOutput<double>("speed", &Coordinate::getSpeedValue, Stage::Model);
     //return the acceleration value;
     constructOutput<double>("acceleration", &Coordinate::getAccelerationValue,
                              Stage::Acceleration);


### PR DESCRIPTION
I replaced the automatically created Output for StateVariables with a helper method constructOutputForStateVariable(), which creates an inefficient output because it uses a string look up. Perhaps we can revisit later and remove that additional string lookup.