### PR TITLE
Clean up MuscleFirstOrderActivationDynamicModel and make into a property of Thelen2003Muscle

### DIFF
--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -198,7 +198,7 @@ void Millard2012AccelerationMuscle::buildMuscle()
     fcphi.setName(tmp);
 
      //Ensure all sub objects are up to date with properties;
-    actMdl.ensureModelUpToDate();
+    actMdl.finalizeFromProperties();
     m_penMdl.ensureModelUpToDate();
 
     falCurve.ensureCurveUpToDate();

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -81,8 +81,8 @@ void Millard2012AccelerationMuscle::constructProperties()
 
         MuscleFirstOrderActivationDynamicModel defaultActMdl = 
             MuscleFirstOrderActivationDynamicModel();
-        double tauAct = defaultActMdl.getActivationTimeConstant();
-        double tauDact= defaultActMdl.getDeactivationTimeConstant();
+        double tauAct = defaultActMdl.get_activation_time_constant();
+        double tauDact= defaultActMdl.get_deactivation_time_constant();
 
     //Ensure the minimum allowed activation is 0.     
     constructProperty_MuscleFirstOrderActivationDynamicModel(

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -198,7 +198,8 @@ void Millard2012AccelerationMuscle::buildMuscle()
     fcphi.setName(tmp);
 
      //Ensure all sub objects are up to date with properties;
-    actMdl.finalizeFromProperties();
+    actMdl.finalizeFromProperties(); //TODO: Remove this once the activation
+                                     //model has been made into a property.
     m_penMdl.ensureModelUpToDate();
 
     falCurve.ensureCurveUpToDate();

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -102,12 +102,14 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
         " MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties";
 
     // Ensure property values are within appropriate ranges.
-    SimTK_VALUECHECK_ALWAYS(SimTK::SignificantReal,
-        get_activation_time_constant(), SimTK::Infinity,
-        "activation_time_constant", errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(SimTK::SignificantReal,
-        get_deactivation_time_constant(), SimTK::Infinity,
-        "deactivation_time_constant", errorLocation.c_str());
+    SimTK_ERRCHK1_ALWAYS(get_activation_time_constant() > SimTK::SignificantReal,
+        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
+        "%s: Activation time constant must be greater than zero",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_deactivation_time_constant() > SimTK::SignificantReal,
+        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
+        "%s: Deactivation time constant must be greater than zero",
+        getName().c_str());
     SimTK_VALUECHECK_ALWAYS(0.0, get_minimum_activation(),
         1.0-SimTK::SignificantReal, "minimum_activation",
         errorLocation.c_str());

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -108,7 +108,7 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
     SimTK_VALUECHECK_ALWAYS(SimTK::SignificantReal,
         get_deactivation_time_constant(), SimTK::Infinity,
         "deactivation_time_constant", errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_deactivation_time_constant(),
-        1.0-SimTK::SignificantReal, "deactivation_time_constant",
+    SimTK_VALUECHECK_ALWAYS(0.0, get_minimum_activation(),
+        1.0-SimTK::SignificantReal, "minimum_activation",
         errorLocation.c_str());
 }

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -34,7 +34,6 @@ MuscleFirstOrderActivationDynamicModel::MuscleFirstOrderActivationDynamicModel()
     setNull();
     constructProperties();
     setName("default_MuscleFirstOrderActivationDynamicModel");
-    extendFinalizeFromProperties();
 }
 
 MuscleFirstOrderActivationDynamicModel::
@@ -52,7 +51,6 @@ MuscleFirstOrderActivationDynamicModel(double tauActivation,
     set_activation_time_constant(tauActivation);
     set_deactivation_time_constant(tauDeactivation);
     set_minimum_activation(minActivation);
-    extendFinalizeFromProperties();
 }
 
 void MuscleFirstOrderActivationDynamicModel::setNull()
@@ -104,15 +102,15 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
     SimTK_ERRCHK1_ALWAYS(get_activation_time_constant() >= SimTK::SignificantReal,
         "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
         "%s: Activation time constant can be no smaller than SimTK::SignificantReal",
-        getName());
+        getName().c_str());
     SimTK_ERRCHK1_ALWAYS(get_deactivation_time_constant() >= SimTK::SignificantReal,
         "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
         "%s: Deactivation time constant can be no smaller than SimTK::SignificantReal",
-        getName());
+        getName().c_str());
     SimTK_ERRCHK1_ALWAYS(get_minimum_activation() >= 0.0
         && get_minimum_activation() <= 1.0-SimTK::SignificantReal,
         "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Minimum activation must be in the range [0,1)", getName());
+        "%s: Minimum activation must be in the range [0,1)", getName().c_str());
 
     setObjectIsUpToDateWithProperties();
 }

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -67,18 +67,6 @@ void MuscleFirstOrderActivationDynamicModel::constructProperties()
     constructProperty_minimum_activation(0.01);
 }
 
-void MuscleFirstOrderActivationDynamicModel::ensureModelUpToDate()
-{
-    if(!isObjectUpToDateWithProperties()) {
-        extendFinalizeFromProperties();
-    }
-
-    // The name is not counted as a property but it can change, so it must be
-    // updated as well.
-    std::string name = getName();
-    setName(name);
-}
-
 //==============================================================================
 // SERVICES
 //==============================================================================

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -98,19 +98,17 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-    // Ensure property values are within appropriate ranges.
-    SimTK_ERRCHK1_ALWAYS(get_activation_time_constant() >= SimTK::SignificantReal,
-        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Activation time constant can be no smaller than SimTK::SignificantReal",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_deactivation_time_constant() >= SimTK::SignificantReal,
-        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Deactivation time constant can be no smaller than SimTK::SignificantReal",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_minimum_activation() >= 0.0
-        && get_minimum_activation() <= 1.0-SimTK::SignificantReal,
-        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Minimum activation must be in the range [0,1)", getName().c_str());
+    std::string errorLocation = getName() + 
+        " MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties";
 
-    setObjectIsUpToDateWithProperties();
+    // Ensure property values are within appropriate ranges.
+    SimTK_VALUECHECK_ALWAYS(SimTK::SignificantReal,
+        get_activation_time_constant(), SimTK::Infinity,
+        "activation_time_constant", errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(SimTK::SignificantReal,
+        get_deactivation_time_constant(), SimTK::Infinity,
+        "deactivation_time_constant", errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(0.0, get_deactivation_time_constant(),
+        1.0-SimTK::SignificantReal, "deactivation_time_constant",
+        errorLocation.c_str());
 }

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
@@ -110,8 +110,6 @@ public:
                                            double minActivation,
                                            const std::string& muscleName);
 
-    void ensureModelUpToDate();
-
     /**
     @returns Activation clamped to the range [minActivation, 1.0].
     */

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
@@ -26,7 +26,7 @@
 // INCLUDES
 #include "Simbody.h"
 #include <OpenSim/Actuators/osimActuatorsDLL.h>
-#include <OpenSim/Common/Object.h>
+#include <OpenSim/Simulation/Model/ModelComponent.h>
 
 namespace OpenSim {
 /** This is a muscle modeling utility class that computes the time derivative of
@@ -69,12 +69,6 @@ namespace OpenSim {
     minActivation ...... 0.01
     \endverbatim
 
-    Note that this object should be updated through the set methods provided.
-    These set methods will take care of rebuilding the object correctly. If you
-    modify the properties directly, the object will not be rebuilt, and upon
-    calling any function, an exception will be thrown because the object is
-    out-of-date with its properties.
-
     <B>References</B>
     \li Thelen, D.G. (2003) Adjustment of muscle mechanics model parameters to
         simulate dynamic contractions in older adults. ASME Journal of
@@ -85,8 +79,8 @@ namespace OpenSim {
 
     @author Matt Millard
 */
-class OSIMACTUATORS_API MuscleFirstOrderActivationDynamicModel : public Object{
-OpenSim_DECLARE_CONCRETE_OBJECT(MuscleFirstOrderActivationDynamicModel, Object);
+class OSIMACTUATORS_API MuscleFirstOrderActivationDynamicModel : public ModelComponent{
+OpenSim_DECLARE_CONCRETE_OBJECT(MuscleFirstOrderActivationDynamicModel, ModelComponent);
 public:
 
 //==============================================================================
@@ -118,36 +112,6 @@ public:
 
     void ensureModelUpToDate();
 
-    /** @returns The activation time constant (in seconds). */
-    double getActivationTimeConstant() const;
-
-    /** @returns The deactivation time constant (in seconds). */
-    double getDeactivationTimeConstant() const;
-
-    /** @returns The lower bound on activation. */
-    double getMinimumActivation() const;
-
-    /** @returns The upper bound on activation. */
-    double getMaximumActivation() const;
-
-    /**
-    @param activationTimeConstant The activation time constant (in seconds).
-    @returns A boolean indicating whether the value was set.
-    */
-    bool setActivationTimeConstant(double activationTimeConstant);
-
-    /**
-    @param deactivationTimeConstant The deactivation time constant (in seconds).
-    @returns A boolean indicating whether the value was set.
-    */
-    bool setDeactivationTimeConstant(double deactivationTimeConstant);
-        
-    /**
-    @param minimumActivation The lower bound on activation.
-    @returns A boolean indicating whether the value was set.
-    */
-    bool setMinimumActivation(double minimumActivation);
-
     /**
     @returns Activation clamped to the range [minActivation, 1.0].
     */
@@ -156,11 +120,13 @@ public:
     /** Calculates the time derivative of activation. */
     double calcDerivative(double activation, double excitation) const;
 
+protected:
+    // Component interface.
+    void extendFinalizeFromProperties() override;
 
 private:
     void setNull();
     void constructProperties();
-    void buildModel();
 
 };
 

--- a/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
@@ -100,9 +100,9 @@ int main(int argc, char* argv[])
             MuscleFirstOrderActivationDynamicModel actMdl;
 
             MuscleFirstOrderActivationDynamicModel actMdl2;
-            actMdl2.setActivationTimeConstant(2*tauA);
-            actMdl2.setDeactivationTimeConstant(2*tauD);
-            actMdl2.setMinimumActivation(2*amin);
+            actMdl2.set_activation_time_constant(2*tauA);
+            actMdl2.set_deactivation_time_constant(2*tauD);
+            actMdl2.set_minimum_activation(2*amin);
 
             cout << endl;
             cout<<"*****************************************************"<<endl;
@@ -266,7 +266,7 @@ int main(int argc, char* argv[])
 
             //Generate a range of activation values
             actV.resize(100);
-            amin = actMdl.getMinimumActivation();
+            amin = actMdl.get_minimum_activation();
             for(int i=0; i<actV.size(); i++){
                 actV(i) = (1-amin)*((double)i)/((double)actV.size()-1.0) + amin;
             }

--- a/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
@@ -63,25 +63,25 @@ int main(int argc, char* argv[])
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_activation_time_constant(-0.32);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    SimTK::Exception::ValueOutOfRange);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_deactivation_time_constant(-0.81);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    SimTK::Exception::ValueOutOfRange);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_minimum_activation(-0.05);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    SimTK::Exception::ValueOutOfRange);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_minimum_activation(1.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    SimTK::Exception::ValueOutOfRange);
         }
 
         /*

--- a/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
@@ -61,19 +61,19 @@ int main(int argc, char* argv[])
         // Test property bounds.
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
-            actMdl.set_activation_time_constant(-0.32);
+            actMdl.set_activation_time_constant(0.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ValueOutOfRange);
+                    SimTK::Exception::ErrorCheck);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
-            actMdl.set_deactivation_time_constant(-0.81);
+            actMdl.set_deactivation_time_constant(0.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ValueOutOfRange);
+                    SimTK::Exception::ErrorCheck);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
-            actMdl.set_minimum_activation(-0.05);
+            actMdl.set_minimum_activation(-SimTK::SignificantReal);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
                     SimTK::Exception::ValueOutOfRange);
         }

--- a/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
@@ -35,285 +35,311 @@ using namespace SimTK;
 void printMatrixToFile( const SimTK::Matrix& data, const std::string& filename);
 
 SimTK::Vector calcCentralDifference(const SimTK::Vector& x, 
-                                 const SimTK::Vector& y, bool extrap_endpoints);
+        const SimTK::Vector& y, bool extrap_endpoints);
 
 bool isFunctionContinuous(const SimTK::Vector& xV, const SimTK::Vector& yV,
-    const SimTK::Vector& dydxV, const SimTK::Vector& d2ydx2V, double minTol,
-                                                    double taylorErrorMult);
+        const SimTK::Vector& dydxV, const SimTK::Vector& d2ydx2V, double minTol,
+        double taylorErrorMult);
 
 SimTK::Matrix calcFunctionTimeIntegral( 
-                                const SimTK::Vector& timeV, 
-                                const SimTK::Matrix& xM, 
-                                const MuscleFirstOrderActivationDynamicModel& yF,
-                                double ic, 
-                                int dim, 
-                                double startTime, 
-                                double endTime,
-                                double intAcc);
-                                        
+        const SimTK::Vector& timeV, 
+        const SimTK::Matrix& xM, 
+        const MuscleFirstOrderActivationDynamicModel& yF,
+        double ic, 
+        int dim, 
+        double startTime, 
+        double endTime,
+        double intAcc);
+
 int main(int argc, char* argv[])
 {
-    
+
 
     try {
-            SimTK_START_TEST("Testing MuscleFirstOrderDynamicModel");
+        SimTK_START_TEST("Testing MuscleFirstOrderDynamicModel");
 
-            /*
-            Test conditions:
-
-            1. Generate the step response and make sure that it stays between
-               the minimum activation and the maximum (amin, and 1)
-            2. Ensure that the derivative function is continuous
-            3. Ensure that the 10%-90% rise time is about 3 time constants
-               Ensure that the fall time is about 2.25 time constants.
-            */
-
-
-            int pts = 100;
-            double stepStart = 0.2;
-            double stepEnd   = 0.5;
-            double amin = 0.01;
-
-            double tauA   = 0.01;
-            double tauD   = 0.04;
-
-
-
-            ////////////////////////////
-            //generate a step input
-            ////////////////////////////
-            
-            SimTK::Vector timeV(pts);
-            SimTK::Matrix xM(pts,2);
-
-            for(int i=0; i<pts; i++){
-                timeV(i) = ((double)i)/((double)pts-1.0);
-                xM(i,0) = amin;
-                if( timeV(i)<=stepStart || timeV(i)>=stepEnd ){
-                    xM(i,1) = 0;
-                }else{
-                    xM(i,1) = 1;
-                }                 
-            }
-
-
+        // Test property bounds.
+        {
             MuscleFirstOrderActivationDynamicModel actMdl;
+            actMdl.set_activation_time_constant(-0.32);
+            SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
+                    SimTK::Exception::ErrorCheck);
+        }
+        {
+            MuscleFirstOrderActivationDynamicModel actMdl;
+            actMdl.set_deactivation_time_constant(-0.81);
+            SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
+                    SimTK::Exception::ErrorCheck);
+        }
+        {
+            MuscleFirstOrderActivationDynamicModel actMdl;
+            actMdl.set_minimum_activation(-0.05);
+            SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
+                    SimTK::Exception::ErrorCheck);
+        }
+        {
+            MuscleFirstOrderActivationDynamicModel actMdl;
+            actMdl.set_minimum_activation(1.0);
+            SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
+                    SimTK::Exception::ErrorCheck);
+        }
 
-            MuscleFirstOrderActivationDynamicModel actMdl2;
-            actMdl2.set_activation_time_constant(2*tauA);
-            actMdl2.set_deactivation_time_constant(2*tauD);
-            actMdl2.set_minimum_activation(2*amin);
+        /*
+           Test conditions:
 
-            cout << endl;
-            cout<<"*****************************************************"<<endl;
-            cout << "TEST: Serialization"<<endl;
-            cout << endl;
+           1. Generate the step response and make sure that it stays between
+           the minimum activation and the maximum (amin, and 1)
+           2. Ensure that the derivative function is continuous
+           3. Ensure that the 10%-90% rise time is about 3 time constants
+           Ensure that the fall time is about 2.25 time constants.
+           */
 
-            actMdl.print("default_MuscleFirstOrderActivationDynamicModel.xml");
-       
+
+        int pts = 100;
+        double stepStart = 0.2;
+        double stepEnd   = 0.5;
+        double amin = 0.01;
+
+        double tauA   = 0.01;
+        double tauD   = 0.04;
+
+
+
+        ////////////////////////////
+        //generate a step input
+        ////////////////////////////
+
+        SimTK::Vector timeV(pts);
+        SimTK::Matrix xM(pts,2);
+
+        for(int i=0; i<pts; i++){
+            timeV(i) = ((double)i)/((double)pts-1.0);
+            xM(i,0) = amin;
+            if( timeV(i)<=stepStart || timeV(i)>=stepEnd ){
+                xM(i,1) = 0;
+            }else{
+                xM(i,1) = 1;
+            }                 
+        }
+
+
+        MuscleFirstOrderActivationDynamicModel actMdl;
+
+        MuscleFirstOrderActivationDynamicModel actMdl2;
+        actMdl2.set_activation_time_constant(2*tauA);
+        actMdl2.set_deactivation_time_constant(2*tauD);
+        actMdl2.set_minimum_activation(2*amin);
+
+        cout << endl;
+        cout<<"*****************************************************"<<endl;
+        cout << "TEST: Serialization"<<endl;
+        cout << endl;
+
+        actMdl.print("default_MuscleFirstOrderActivationDynamicModel.xml");
+
         Object* tmpObj = Object::
-        makeObjectFromFile("default_MuscleFirstOrderActivationDynamicModel.xml");
+            makeObjectFromFile("default_MuscleFirstOrderActivationDynamicModel.xml");
         actMdl2 = *dynamic_cast<MuscleFirstOrderActivationDynamicModel*>(tmpObj);
         delete tmpObj;
-       
-            SimTK_TEST(actMdl ==actMdl2);
-            remove("default_MuscleFirstOrderActivationDynamicModel.xml");
 
-            cout << endl;
-            cout<<"*****************************************************"<<endl;
-            printf("TEST: Actvation bounds %f and 1 \n",amin);
-            cout<<"       respected during step response"<<endl;
-            cout << endl;
+        SimTK_TEST(actMdl ==actMdl2);
+        remove("default_MuscleFirstOrderActivationDynamicModel.xml");
 
-
-            SimTK::Matrix stepResponse = calcFunctionTimeIntegral(  timeV, 
-                                                                    xM, 
-                                                                    actMdl,
-                                                                    amin, 
-                                                                    0, 
-                                                                    0, 
-                                                                    1,
-                                                                    1e-12);
-
-            //printMatrixToFile( stepResponse, "stepResponse.csv");
-
-            //TEST 1: Check bounds on the step response
-            bool boundsRespected= true;
-
-            for(int i=0; i<stepResponse.nrow(); i++){
-                if(stepResponse(i,1) < amin-SimTK::Eps)
-                    boundsRespected = false;
-
-                if(stepResponse(i,1) > 1+SimTK::Eps)
-                    boundsRespected = false;
-
-            }
-            SimTK_TEST(boundsRespected);
-            printf("PASSED to a tol of %fe-16",SimTK::Eps*1e16);
-
-            cout << endl;
-
-            cout<<"*****************************************************"<<endl;
-            cout<<"TEST: 10%-90% Rise time 3*tau_act +/- 10%"<<endl;
-            cout<<"      90%-10% Fall time 2.17*tau_dact  +/- 10%" <<endl;
-            cout<<"      And causality" << endl;
-            cout << endl;
-
-            double rt10 = 0;
-            double rt90 = 0;
-            double ft90 = 0;
-            double ft10 = 0;
-
-            double v10 = (1-amin)*0.10 + amin;
-            double v90 = (1-amin)*0.90 + amin;
-
-            for(int i=0; i<stepResponse.nrow()-1; i++){
-                if(stepResponse(i,1) <= v10 && stepResponse(i+1,1) > v10)
-                    rt10 = stepResponse(i+1,0);
-
-                if(stepResponse(i,1) <= v90 && stepResponse(i+1,1) > v90)
-                    rt90 = stepResponse(i+1,0);
-
-                if(stepResponse(i,1) > v10 && stepResponse(i+1,1) <= v10)
-                    ft10 = stepResponse(i+1,0);
-
-                if(stepResponse(i,1) > v90 && stepResponse(i+1,1) <= v90)
-                    ft90 = stepResponse(i+1,0);
-            }
-
-            double normRiseTime = (rt90-rt10)/tauA;
-            double normFallTime = (ft10-ft90)/tauD;
-
-            //Checking for causality
-            SimTK_TEST(  (rt10>stepStart) && (rt90>rt10) 
-                       && (ft90>rt90) && (ft90>stepEnd) && (ft10>ft90)); 
-            SimTK_TEST_EQ_TOL(normRiseTime,3,0.3);
-            SimTK_TEST_EQ_TOL(normFallTime,2.17,0.2);
-
-            printf("PASSED: with a normalized 10-90 percent rise time of %f\n"
-                   "         and a normalized 90-10 percent fall time of %f\n",
-                   normRiseTime,normFallTime);
-
-            cout<<"*****************************************************"<<endl;
-            cout<<"TEST: Continuity of d/dt activation w.r.t. excitation"<<endl;
-            cout<<"       and constant activation" <<endl;
-            cout << endl;
-            //Generate a range of activation values
-            SimTK::Vector actV(10);
-            for(int i=0; i<actV.size(); i++){
-                actV(i) = (1-amin)*((double)i)/((double)actV.size()-1.0) + amin;
-            }
-
-            //Generate a detailed range of excitations
-            SimTK::Vector uV(100);
-            for(int i=0; i<uV.size(); i++){
-                uV(i) = ((double)i)/((double)uV.size()-1.0);
-            }
-
-            //For each activation value, generate the derivative curve, and
-            //check its continuity
-            SimTK::Vector dx(uV.size()), d2x(uV.size()), d3x(uV.size());
-            dx = 0;
-            d2x = 0;
-            d3x = 0;
-            xM.resize(uV.size(),2);
-
-            /*
-            calcCentralDifference(const SimTK::Matrix& xM,
-                                    const SimTK::Function& yF,
-                                    int dim,int order)
-                                    */
-
-            bool continuous = false;
-            double tmp = 0;
-            double maxDxDiff = 0;
-            double minTol = 0.5;
-            double taylorMult = 2.0000001;
+        cout << endl;
+        cout<<"*****************************************************"<<endl;
+        printf("TEST: Actvation bounds %f and 1 \n",amin);
+        cout<<"       respected during step response"<<endl;
+        cout << endl;
 
 
-            for(int i=0;i<actV.size();i++){
-            
-                for(int j=0; j<uV.size(); j++){
-                    xM(j,0) = actV(i);
-                    xM(j,1) = uV(j);
-                    dx(j) = actMdl.calcDerivative(actV(i), uV(j));
-                }
-                d2x = calcCentralDifference(xM(1), dx,true);                  
-                
-                for(int j=1;j<uV.size();j++){
-                    tmp = abs(d2x(j)-d2x(j-1));
-                    if( tmp > maxDxDiff)
-                        maxDxDiff = tmp;
-                }
-                
-                d3x = calcCentralDifference(xM(1), d2x, true);  
+        SimTK::Matrix stepResponse = calcFunctionTimeIntegral(  timeV, 
+                xM, 
+                actMdl,
+                amin, 
+                0, 
+                0, 
+                1,
+                1e-12);
 
-                continuous = isFunctionContinuous(xM(1), dx, d2x, d3x, 
-                                                       minTol,taylorMult);
-                SimTK_TEST(continuous);
-            }
-            printf("PASSED: with an allowable error of minTol of %f\n"
-                   "    or %f x the next Taylor series term. These values\n"
-                   "    are reasonable given the elbow in the function and\n"
-                   "    the maximum difference in slope of %f\n"
-                   ,minTol,taylorMult,maxDxDiff);
+        //printMatrixToFile( stepResponse, "stepResponse.csv");
 
-            cout << endl;
-            cout<<"*****************************************************"<<endl;
-            cout<<"TEST: Continuity of d/dt activation w.r.t. activation"<<endl;
-            cout<<"       and constant excitation" <<endl;
-            cout << endl;
+        //TEST 1: Check bounds on the step response
+        bool boundsRespected= true;
 
-            //Generate a range of activation values
-            actV.resize(100);
-            amin = actMdl.get_minimum_activation();
-            for(int i=0; i<actV.size(); i++){
-                actV(i) = (1-amin)*((double)i)/((double)actV.size()-1.0) + amin;
-            }
+        for(int i=0; i<stepResponse.nrow(); i++){
+            if(stepResponse(i,1) < amin-SimTK::Eps)
+                boundsRespected = false;
 
-            //Generate a detailed range of excitations
-            uV.resize(10);
-            for(int i=0; i<uV.size(); i++){
-                uV(i) = ((double)i)/((double)uV.size()-1.0);
-            }
+            if(stepResponse(i,1) > 1+SimTK::Eps)
+                boundsRespected = false;
 
-            maxDxDiff = 0;
-            for(int i=0;i<uV.size();i++){
-            
-                for(int j=0; j<actV.size(); j++){
-                    xM(j,0) = actV(j);
-                    xM(j,1) = uV(i);
-                    dx(j) = actMdl.calcDerivative(actV(j), uV(i));
-                }                
-             
-                d2x = calcCentralDifference(xM(0), dx,true);                  
-                
-
-
-                for(int j=1;j<uV.size();j++){
-                    tmp = abs(d2x(j)-d2x(j-1));
-                    if( tmp > maxDxDiff)
-                        maxDxDiff = tmp;
-                }
-                
-                d3x = calcCentralDifference(xM(0), d2x, true);  
-
-                continuous = isFunctionContinuous(xM(0), dx, d2x, d3x, 
-                                                       minTol,taylorMult);
-                SimTK_TEST(continuous);
-            }
-            printf("PASSED: with an allowable error of minTol of %f\n"
-                   "    or %f x the next Taylor series term. These values\n"
-                   "    are reasonable given the elbow in the function and\n"
-                   "    the maximum difference in slope of %f\n"
-                   ,minTol,taylorMult,maxDxDiff);
-
-            cout<<"*****************************************************"<<endl;
-            cout<<"TEST: Exceptions thrown correctly.                   "<<endl;           
-            cout << endl;
-           
-            SimTK_END_TEST();
         }
+        SimTK_TEST(boundsRespected);
+        printf("PASSED to a tol of %fe-16",SimTK::Eps*1e16);
+
+        cout << endl;
+
+        cout<<"*****************************************************"<<endl;
+        cout<<"TEST: 10%-90% Rise time 3*tau_act +/- 10%"<<endl;
+        cout<<"      90%-10% Fall time 2.17*tau_dact  +/- 10%" <<endl;
+        cout<<"      And causality" << endl;
+        cout << endl;
+
+        double rt10 = 0;
+        double rt90 = 0;
+        double ft90 = 0;
+        double ft10 = 0;
+
+        double v10 = (1-amin)*0.10 + amin;
+        double v90 = (1-amin)*0.90 + amin;
+
+        for(int i=0; i<stepResponse.nrow()-1; i++){
+            if(stepResponse(i,1) <= v10 && stepResponse(i+1,1) > v10)
+                rt10 = stepResponse(i+1,0);
+
+            if(stepResponse(i,1) <= v90 && stepResponse(i+1,1) > v90)
+                rt90 = stepResponse(i+1,0);
+
+            if(stepResponse(i,1) > v10 && stepResponse(i+1,1) <= v10)
+                ft10 = stepResponse(i+1,0);
+
+            if(stepResponse(i,1) > v90 && stepResponse(i+1,1) <= v90)
+                ft90 = stepResponse(i+1,0);
+        }
+
+        double normRiseTime = (rt90-rt10)/tauA;
+        double normFallTime = (ft10-ft90)/tauD;
+
+        //Checking for causality
+        SimTK_TEST(  (rt10>stepStart) && (rt90>rt10) 
+                && (ft90>rt90) && (ft90>stepEnd) && (ft10>ft90)); 
+        SimTK_TEST_EQ_TOL(normRiseTime,3,0.3);
+        SimTK_TEST_EQ_TOL(normFallTime,2.17,0.2);
+
+        printf("PASSED: with a normalized 10-90 percent rise time of %f\n"
+                "         and a normalized 90-10 percent fall time of %f\n",
+                normRiseTime,normFallTime);
+
+        cout<<"*****************************************************"<<endl;
+        cout<<"TEST: Continuity of d/dt activation w.r.t. excitation"<<endl;
+        cout<<"       and constant activation" <<endl;
+        cout << endl;
+        //Generate a range of activation values
+        SimTK::Vector actV(10);
+        for(int i=0; i<actV.size(); i++){
+            actV(i) = (1-amin)*((double)i)/((double)actV.size()-1.0) + amin;
+        }
+
+        //Generate a detailed range of excitations
+        SimTK::Vector uV(100);
+        for(int i=0; i<uV.size(); i++){
+            uV(i) = ((double)i)/((double)uV.size()-1.0);
+        }
+
+        //For each activation value, generate the derivative curve, and
+        //check its continuity
+        SimTK::Vector dx(uV.size()), d2x(uV.size()), d3x(uV.size());
+        dx = 0;
+        d2x = 0;
+        d3x = 0;
+        xM.resize(uV.size(),2);
+
+        /*
+           calcCentralDifference(const SimTK::Matrix& xM,
+           const SimTK::Function& yF,
+           int dim,int order)
+           */
+
+        bool continuous = false;
+        double tmp = 0;
+        double maxDxDiff = 0;
+        double minTol = 0.5;
+        double taylorMult = 2.0000001;
+
+
+        for(int i=0;i<actV.size();i++){
+
+            for(int j=0; j<uV.size(); j++){
+                xM(j,0) = actV(i);
+                xM(j,1) = uV(j);
+                dx(j) = actMdl.calcDerivative(actV(i), uV(j));
+            }
+            d2x = calcCentralDifference(xM(1), dx,true);                  
+
+            for(int j=1;j<uV.size();j++){
+                tmp = abs(d2x(j)-d2x(j-1));
+                if( tmp > maxDxDiff)
+                    maxDxDiff = tmp;
+            }
+
+            d3x = calcCentralDifference(xM(1), d2x, true);  
+
+            continuous = isFunctionContinuous(xM(1), dx, d2x, d3x, 
+                    minTol,taylorMult);
+            SimTK_TEST(continuous);
+        }
+        printf("PASSED: with an allowable error of minTol of %f\n"
+                "    or %f x the next Taylor series term. These values\n"
+                "    are reasonable given the elbow in the function and\n"
+                "    the maximum difference in slope of %f\n"
+                ,minTol,taylorMult,maxDxDiff);
+
+        cout << endl;
+        cout<<"*****************************************************"<<endl;
+        cout<<"TEST: Continuity of d/dt activation w.r.t. activation"<<endl;
+        cout<<"       and constant excitation" <<endl;
+        cout << endl;
+
+        //Generate a range of activation values
+        actV.resize(100);
+        amin = actMdl.get_minimum_activation();
+        for(int i=0; i<actV.size(); i++){
+            actV(i) = (1-amin)*((double)i)/((double)actV.size()-1.0) + amin;
+        }
+
+        //Generate a detailed range of excitations
+        uV.resize(10);
+        for(int i=0; i<uV.size(); i++){
+            uV(i) = ((double)i)/((double)uV.size()-1.0);
+        }
+
+        maxDxDiff = 0;
+        for(int i=0;i<uV.size();i++){
+
+            for(int j=0; j<actV.size(); j++){
+                xM(j,0) = actV(j);
+                xM(j,1) = uV(i);
+                dx(j) = actMdl.calcDerivative(actV(j), uV(i));
+            }                
+
+            d2x = calcCentralDifference(xM(0), dx,true);                  
+
+
+
+            for(int j=1;j<uV.size();j++){
+                tmp = abs(d2x(j)-d2x(j-1));
+                if( tmp > maxDxDiff)
+                    maxDxDiff = tmp;
+            }
+
+            d3x = calcCentralDifference(xM(0), d2x, true);  
+
+            continuous = isFunctionContinuous(xM(0), dx, d2x, d3x, 
+                    minTol,taylorMult);
+            SimTK_TEST(continuous);
+        }
+        printf("PASSED: with an allowable error of minTol of %f\n"
+                "    or %f x the next Taylor series term. These values\n"
+                "    are reasonable given the elbow in the function and\n"
+                "    the maximum difference in slope of %f\n"
+                ,minTol,taylorMult,maxDxDiff);
+
+        cout<<"*****************************************************"<<endl;
+        cout<<"TEST: Exceptions thrown correctly.                   "<<endl;           
+        cout << endl;
+
+        SimTK_END_TEST();
+    }
     catch (const OpenSim::Exception& ex)
     {
         cout << ex.getMessage() << endl;
@@ -333,19 +359,19 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    
+
 
     cout << "\ntestMuscleFirstOrderDynamicModel completed successfully .\n";
     return 0;
 }
 
 /**
-This function will print cvs file of the matrix 
- data
+  This function will print cvs file of the matrix 
+  data
 
-@params data: A matrix of data
-@params filename: The name of the file to print
-*/
+  @params data: A matrix of data
+  @params filename: The name of the file to print
+  */
 void printMatrixToFile( const SimTK::Matrix& data, const std::string& filename)
 {
     ofstream datafile;
@@ -363,36 +389,36 @@ void printMatrixToFile( const SimTK::Matrix& data, const std::string& filename)
 }
 
 /**
-    This function tests numerically for continuity of a curve. The test is 
-    performed by taking a point on the curve, and then two points (called the 
-    shoulder points) to the left and right of the point in question. The value
-    of the functions derivative is evaluated at each of the shoulder points and
-    used to linearly extrapolate from the shoulder points back to the original 
-    point. If the original point and the linear extrapolations of each of the 
-    shoulder points agree within tol, then the curve is assumed to be 
-    continuous.
+  This function tests numerically for continuity of a curve. The test is 
+  performed by taking a point on the curve, and then two points (called the 
+  shoulder points) to the left and right of the point in question. The value
+  of the functions derivative is evaluated at each of the shoulder points and
+  used to linearly extrapolate from the shoulder points back to the original 
+  point. If the original point and the linear extrapolations of each of the 
+  shoulder points agree within tol, then the curve is assumed to be 
+  continuous.
 
 
-    @param xV       Values to test for continuity, note that the first and last
-                    points cannot be tested
+  @param xV       Values to test for continuity, note that the first and last
+  points cannot be tested
 
-    @param yV       Function values at the test points
+  @param yV       Function values at the test points
 
-    @param dydxV    Function derivative values evaluated at xV
+  @param dydxV    Function derivative values evaluated at xV
 
-    @param d2ydx2V  Function 2nd derivative values (or estimates) evaluated at
-                    xV
+  @param d2ydx2V  Function 2nd derivative values (or estimates) evaluated at
+  xV
 
-    @param minTol   The minimum error allowed - this prevents the second order
-                    error term from going to zero
+  @param minTol   The minimum error allowed - this prevents the second order
+  error term from going to zero
 
-    @param taylorErrorMult  This scales the error tolerance. The default error
-                            tolerance is the the 2nd order Taylor series
-                            term.
-*/
+  @param taylorErrorMult  This scales the error tolerance. The default error
+  tolerance is the the 2nd order Taylor series
+  term.
+  */
 bool isFunctionContinuous(const SimTK::Vector& xV, const SimTK::Vector& yV,
-                       const SimTK::Vector& dydxV, const SimTK::Vector& d2ydx2V, 
-                       double minTol, double taylorErrorMult)
+        const SimTK::Vector& dydxV, const SimTK::Vector& d2ydx2V, 
+        double minTol, double taylorErrorMult)
 {
     bool flag_continuous = true;
     //double contErr = 0;
@@ -430,7 +456,7 @@ bool isFunctionContinuous(const SimTK::Vector& xV, const SimTK::Vector& yV,
         dydxL = dydxV(i-1);
         dydxR = dydxV(i+1);
 
-        
+
         yValEL = yL + dydxL*(xVal-xL);
         yValER = yR - dydxR*(xR-xVal);
 
@@ -448,17 +474,17 @@ bool isFunctionContinuous(const SimTK::Vector& xV, const SimTK::Vector& yV,
 
         if(errRMX < minTol)
             errRMX = minTol; // to accomodate numerical
-                             //error in errL
+        //error in errL
 
         if(errL > errLMX || errR > errRMX){
             /*if(errL > errR){
-                if(errL > contErr)
-                    contErr = errL;
+              if(errL > contErr)
+              contErr = errL;
 
-            }else{
-                if(errR > contErr)
-                    contErr = errR;
-            }*/
+              }else{
+              if(errR > contErr)
+              contErr = errR;
+              }*/
 
             flag_continuous = false;
         }
@@ -468,24 +494,24 @@ bool isFunctionContinuous(const SimTK::Vector& xV, const SimTK::Vector& yV,
 }
 
 /**
-    This function computes a standard central difference dy/dx. If 
-    extrap_endpoints is set to 1, then the derivative at the end points is 
-    estimated by linearly extrapolating the dy/dx values beside the end points
+  This function computes a standard central difference dy/dx. If 
+  extrap_endpoints is set to 1, then the derivative at the end points is 
+  estimated by linearly extrapolating the dy/dx values beside the end points
 
- @param x domain vector
- @param y range vector
- @param extrap_endpoints: (false)   Endpoints of the returned vector will be 
-                                    zero, because a central difference
-                                    is undefined at these endpoints
-                            (true)  Endpoints are computed by linearly 
-                                    extrapolating using a first difference from 
-                                    the neighboring 2 points
- @returns dy/dx computed using central differences
-*/
+  @param x domain vector
+  @param y range vector
+  @param extrap_endpoints: (false)   Endpoints of the returned vector will be 
+  zero, because a central difference
+  is undefined at these endpoints
+  (true)  Endpoints are computed by linearly 
+  extrapolating using a first difference from 
+  the neighboring 2 points
+  @returns dy/dx computed using central differences
+  */
 SimTK::Vector calcCentralDifference(const SimTK::Vector& x, 
-                                    const SimTK::Vector& y,                                          
-                                    bool extrap_endpoints){
- 
+        const SimTK::Vector& y,                                          
+        bool extrap_endpoints){
+
 
     SimTK::Vector dy(x.size());
     double dx1,dx2;
@@ -517,7 +543,7 @@ class FunctionData {
 public:
     const MuscleFirstOrderActivationDynamicModel& m_func;
     SimTK::Array_<SimTK::Spline_<double> > m_splinedInput;
-        
+
     double m_ic;        
     int m_intDim;
 
@@ -533,20 +559,20 @@ public:
 
 
 /**
-This is the nice user interface class to MySystemGuts, which creates a System
-object that is required to use SimTK's integrators to integrate the Bezier
-curve sets
-*/
+  This is the nice user interface class to MySystemGuts, which creates a System
+  object that is required to use SimTK's integrators to integrate the Bezier
+  curve sets
+  */
 class MySystem;
 /**
-Class that makes a system so that SimTK's integrators (which require a system)
-can be used to numerically integrate the BezierCurveSet. This class is used
-by the function calcNumIntBezierYfcnX, which evaluates the numerical integral
-of a Bezier curve set.
+  Class that makes a system so that SimTK's integrators (which require a system)
+  can be used to numerically integrate the BezierCurveSet. This class is used
+  by the function calcNumIntBezierYfcnX, which evaluates the numerical integral
+  of a Bezier curve set.
 
-A System is actually two classes: System::Guts does the work while System
-provides a pleasant veneer to make usage easier. This is the workhorse
-*/
+  A System is actually two classes: System::Guts does the work while System
+  provides a pleasant veneer to make usage easier. This is the workhorse
+  */
 class MySystemGuts : public SimTK::System::Guts {
     friend class MySystem;
 
@@ -575,9 +601,9 @@ class MySystemGuts : public SimTK::System::Guts {
         for(int i=0; i<funcData.m_tmpXV.size(); i++)
         {
             funcData.m_tmpXV(i) = funcData.m_splinedInput[i].
-                                        calcValue(SimTK::Vector(1,x));
+                calcValue(SimTK::Vector(1,x));
         }
-        
+
         //Update the dimension of the vector that we're integrating along
         funcData.m_tmpXV(funcData.m_intDim) = z;
 
@@ -585,7 +611,7 @@ class MySystemGuts : public SimTK::System::Guts {
         Real dz = funcData.m_func.calcDerivative(funcData.m_tmpXV[0], funcData.m_tmpXV[1]);
         //if(z>funcData.m_ic+SimTK::Eps)
         //    printf(" dz: %f\n",dz);
-        
+
         state.updZDot()[0] = dz;
         return 0;
     }
@@ -594,18 +620,18 @@ class MySystemGuts : public SimTK::System::Guts {
     // prescribed state variables to worry about.
     int prescribeImpl(State&, Stage) const {return 0;}
     int projectImpl(State&, Real, const Vector&, const Vector&, 
-                    Vector&, SimTK::ProjectOptions) const {return 0;}
-    private:
-        /**The Bezier curve data that is being integrated*/
-        const FunctionData funcData;
+            Vector&, SimTK::ProjectOptions) const {return 0;}
+private:
+    /**The Bezier curve data that is being integrated*/
+    const FunctionData funcData;
 };
 
 /**
-This is the implementation of the nice user interface class to MySystemGuts, 
-which creates a System object that is required to use SimTK's integrators to 
-integrate the Bezier curve sets. Used in function
-SegmentedQuinticBezierToolkit::calcNumIntBezierYfcnX
-*/
+  This is the implementation of the nice user interface class to MySystemGuts, 
+  which creates a System object that is required to use SimTK's integrators to 
+  integrate the Bezier curve sets. Used in function
+  SegmentedQuinticBezierToolkit::calcNumIntBezierYfcnX
+  */
 class MySystem : public System {
 public:
     MySystem(const FunctionData& funcData) {
@@ -615,24 +641,24 @@ public:
 };
 
 /**
-@param timeV A nx1 time vector to integrate along, which must monotonic 
-             and increasing
-@param xM    A nxm matrix of row vectors, each corresponding to the row vector
-             that should be applied to yF at time t
-@param yF    A function
-@param ic    The initial condition for the integral
-@param intAcc The accuracy of the integral
-@returns an nx2 matrix, time in column 0, integral of y in column 1
-*/
+  @param timeV A nx1 time vector to integrate along, which must monotonic 
+  and increasing
+  @param xM    A nxm matrix of row vectors, each corresponding to the row vector
+  that should be applied to yF at time t
+  @param yF    A function
+  @param ic    The initial condition for the integral
+  @param intAcc The accuracy of the integral
+  @returns an nx2 matrix, time in column 0, integral of y in column 1
+  */
 SimTK::Matrix calcFunctionTimeIntegral( 
-                                const SimTK::Vector& timeV,
-                                const SimTK::Matrix& xM, 
-                                const MuscleFirstOrderActivationDynamicModel& yF,
-                                double ic, 
-                                int dim, 
-                                double startTime, 
-                                double endTime,
-                                double intAcc)
+        const SimTK::Vector& timeV,
+        const SimTK::Matrix& xM, 
+        const MuscleFirstOrderActivationDynamicModel& yF,
+        double ic, 
+        int dim, 
+        double startTime, 
+        double endTime,
+        double intAcc)
 {
     SimTK::Matrix intXY(timeV.size(),2);
 
@@ -649,7 +675,7 @@ SimTK::Matrix calcFunctionTimeIntegral(
     for(int i=0; i<xM.ncol(); i++){        
 
         splinedInput[i] = SimTK::SplineFitter<Real>::
-               fitForSmoothingParameter(1,timeV,xM(i),0).getSpline();
+            fitForSmoothingParameter(1,timeV,xM(i),0).getSpline();
     }
     fdata.m_splinedInput = splinedInput;
     //FunctionData is now completely built
@@ -683,7 +709,7 @@ SimTK::Matrix calcFunctionTimeIntegral(
 
         if (status == Integrator::EndOfSimulation)
             break;
-        
+
         const State& state = integ.getState();
 
         intXY(idx,0) = nextTimeInterval;

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -823,8 +823,8 @@ void testMillard2012AccelerationMuscle()
     muscle.setMass(muscle.getMass()*10);
 
     MuscleFirstOrderActivationDynamicModel actMdl = muscle.getActivationModel();
-    actMdl.setActivationTimeConstant(Activation0);
-    actMdl.setDeactivationTimeConstant(Deactivation0);
+    actMdl.set_activation_time_constant(Activation0);
+    actMdl.set_deactivation_time_constant(Deactivation0);
     muscle.setActivationModel(actMdl);
 
     double x0 = 0;

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -769,6 +769,67 @@ void testThelen2003Muscle()
         CorrectnessTest,
         CorrectnessTestTolerance,
         false);
+
+    // Test property bounds.
+    {
+        Thelen2003Muscle musc;
+        musc.set_FmaxTendonStrain(-0.03);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_FmaxMuscleStrain(-0.05);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_KshapeActive(-0.15);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_KshapePassive(-0.51);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_Af(-0.13);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_Flen(1.0);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_Flen(1.3);
+        musc.finalizeFromProperties();
+    }
+    {
+        Thelen2003Muscle musc;
+        musc.set_FvExtrapolationThreshold(1.0 / 1.4);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+
+        musc.set_FvExtrapolationThreshold(1.007);
+        musc.finalizeFromProperties();
+
+        musc.set_Flen(3.0);
+
+        musc.set_FvExtrapolationThreshold(1.0 / 3.0);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+
+        musc.set_FvExtrapolationThreshold(1.001 / 3.0);
+        musc.finalizeFromProperties();
+    }
 }
 
 

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -773,46 +773,46 @@ void testThelen2003Muscle()
     // Test property bounds.
     {
         Thelen2003Muscle musc;
-        musc.set_FmaxTendonStrain(-0.03);
-        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueWasNegative);
-
         musc.set_FmaxTendonStrain(0.0);
+        SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+
+        musc.set_FmaxTendonStrain(0.1);
         musc.finalizeFromProperties();
     }
     {
         Thelen2003Muscle musc;
-        musc.set_FmaxMuscleStrain(-0.05);
+        musc.set_FmaxMuscleStrain(0.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueWasNegative);
+                SimTK::Exception::ErrorCheck);
     }
     {
         Thelen2003Muscle musc;
-        musc.set_KshapeActive(-0.15);
+        musc.set_KshapeActive(0.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueWasNegative);
+                SimTK::Exception::ErrorCheck);
     }
     {
         Thelen2003Muscle musc;
-        musc.set_KshapePassive(-0.51);
+        musc.set_KshapePassive(0.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueWasNegative);
+                SimTK::Exception::ErrorCheck);
     }
     {
         Thelen2003Muscle musc;
-        musc.set_Af(-0.13);
+        musc.set_Af(0.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueWasNegative);
+                SimTK::Exception::ErrorCheck);
     }
     {
         Thelen2003Muscle musc;
+        musc.set_Flen(1.001);
         musc.set_fv_linear_extrap_threshold(5.0);
-        musc.set_Flen(1.0);
         musc.finalizeFromProperties();
 
-        musc.set_Flen(0.8);
+        musc.set_Flen(1.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+                SimTK::Exception::ErrorCheck);
     }
     {
         Thelen2003Muscle musc;

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -775,37 +775,44 @@ void testThelen2003Muscle()
         Thelen2003Muscle musc;
         musc.set_FmaxTendonStrain(-0.03);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueWasNegative);
+
+        musc.set_FmaxTendonStrain(0.0);
+        musc.finalizeFromProperties();
     }
     {
         Thelen2003Muscle musc;
         musc.set_FmaxMuscleStrain(-0.05);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueWasNegative);
     }
     {
         Thelen2003Muscle musc;
         musc.set_KshapeActive(-0.15);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueWasNegative);
     }
     {
         Thelen2003Muscle musc;
         musc.set_KshapePassive(-0.51);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueWasNegative);
     }
     {
         Thelen2003Muscle musc;
         musc.set_Af(-0.13);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueWasNegative);
     }
     {
         Thelen2003Muscle musc;
+        musc.set_fv_linear_extrap_threshold(5.0);
         musc.set_Flen(1.0);
+        musc.finalizeFromProperties();
+
+        musc.set_Flen(0.8);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                SimTK::Exception::ValueOutOfRange);
     }
     {
         Thelen2003Muscle musc;
@@ -814,20 +821,20 @@ void testThelen2003Muscle()
     }
     {
         Thelen2003Muscle musc;
-        musc.set_FvExtrapolationThreshold(1.0 / 1.4);
+        musc.set_fv_linear_extrap_threshold(1.0 / 1.4);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
                 SimTK::Exception::ErrorCheck);
 
-        musc.set_FvExtrapolationThreshold(1.007);
+        musc.set_fv_linear_extrap_threshold(1.007);
         musc.finalizeFromProperties();
 
         musc.set_Flen(3.0);
 
-        musc.set_FvExtrapolationThreshold(1.0 / 3.0);
+        musc.set_fv_linear_extrap_threshold(1.0 / 3.0);
         SimTK_TEST_MUST_THROW_EXC(musc.finalizeFromProperties(),
                 SimTK::Exception::ErrorCheck);
 
-        musc.set_FvExtrapolationThreshold(1.001 / 3.0);
+        musc.set_fv_linear_extrap_threshold(1.001 / 3.0);
         musc.finalizeFromProperties();
     }
 }

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -103,8 +103,10 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     SimTK_VALUECHECK_NONNEG_ALWAYS(get_Af(), "Af", errorLocation.c_str());
     SimTK_VALUECHECK_ALWAYS(1.0, get_Flen(), SimTK::Infinity, "Flen",
         errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(1.0/get_Flen(), get_fv_linear_extrap_threshold(),
-        SimTK::Infinity, "fv_linear_extrap_threshold", errorLocation.c_str());
+    SimTK_ERRCHK1_ALWAYS(get_fv_linear_extrap_threshold() > 1.0/get_Flen(),
+        "Thelen2003::extendFinalizeFromProperties",
+        "%s: F-v extrapolation threshold must be greater than 1.0/Flen",
+        getName().c_str());
 }
 
 //====================================================================

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -89,34 +89,22 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
         upd_MuscleFirstOrderActivationDynamicModel();
     addComponent(&actMdl);
 
-    SimTK_ERRCHK1_ALWAYS(get_FmaxTendonStrain() > 0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Tendon strain at maximum isometric force must be positive",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_FmaxMuscleStrain() > 0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Passive muscle strain at maximum isometric force must be positive",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_KshapeActive() > 0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Shape factor for active muscle f-l relationship must be positive",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_KshapePassive() > 0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Shape factor for passive muscle f-l relationship must be positive",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_Af() > 0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Force-velocity shape factor must be positive",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_Flen() > 1.0,
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: Maximum normalized lengthening force must be greater than 1.0",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_FvExtrapolationThreshold() > 1.0/get_Flen(),
-        "Thelen2003Muscle::extendFinalizeFromProperties",
-        "%s: F-v threshold must be greater than 1.0/Flen",
-        getName().c_str());
+    std::string errorLocation = getName() + 
+        " Thelen2003Muscle::extendFinalizeFromProperties";
+
+    SimTK_VALUECHECK_NONNEG_ALWAYS(get_FmaxTendonStrain(), "FmaxTendonStrain",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_NONNEG_ALWAYS(get_FmaxMuscleStrain(), "FmaxMuscleStrain",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_NONNEG_ALWAYS(get_KshapeActive(), "KshapeActive",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_NONNEG_ALWAYS(get_KshapePassive(), "KshapePassive",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_NONNEG_ALWAYS(get_Af(), "Af", errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(1.0, get_Flen(), SimTK::Infinity, "Flen",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(1.0/get_Flen(), get_fv_linear_extrap_threshold(),
+        SimTK::Infinity, "fv_linear_extrap_threshold", errorLocation.c_str());
 }
 
 //====================================================================
@@ -194,7 +182,7 @@ void Thelen2003Muscle::constructProperties()
     constructProperty_KshapePassive(5.0);   
     constructProperty_Af(0.25); 
     constructProperty_Flen(1.4);    //was 1.8, 
-    constructProperty_FvExtrapolationThreshold(0.95);
+    constructProperty_fv_linear_extrap_threshold(0.95);
     //acos(0.05) = 84.26 degrees    
 }
 
@@ -1750,7 +1738,7 @@ double Thelen2003Muscle::calcdlceN(double act,double fal,double actFalFv) const
     double Fm_asyC = 0;           //Concentric contraction asymptote
     double Fm_asyE = afl*flen;    
                                 //Eccentric contraction asymptote
-    double asyE_thresh = get_FvExtrapolationThreshold();
+    double asyE_thresh = get_fv_linear_extrap_threshold();
 
     //If fv is in the appropriate region, use 
     //Thelen 2003 Eqns 6 & 7 to compute dlceN
@@ -1835,7 +1823,7 @@ double Thelen2003Muscle::calcDdlceDaFalFv(double aAct,
     double Fm_asyC = 0;           //Concentric contraction asymptote
     double Fm_asyE = aAct*aFal*flen;    
                                 //Eccentric contraction asymptote
-    double asyE_thresh = get_FvExtrapolationThreshold();
+    double asyE_thresh = get_fv_linear_extrap_threshold();
 
     //If fv is in the appropriate region, use 
     //Thelen 2003 Eqns 6 & 7 to compute dlceN

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -48,7 +48,7 @@ Thelen2003Muscle::Thelen2003Muscle()
 {    
     setNull();
     constructInfrastructure();
-    ensureMuscleUpToDate();
+    buildMuscle();  //TODO: remove this when pennation model is a subcomponent.
 }
 
 //_____________________________________________________________________________
@@ -69,23 +69,58 @@ Thelen2003Muscle(const std::string& aName,  double aMaxIsometricForce,
     setTendonSlackLength(aTendonSlackLength);
     setPennationAngleAtOptimalFiberLength(aPennationAngle);
 
-    ensureMuscleUpToDate();
+    buildMuscle();  //TODO: remove this when pennation model is a subcomponent.
 
 }
+
+//==============================================================================
+// Component Interface
+//==============================================================================
+void Thelen2003Muscle::extendFinalizeFromProperties()
+{
+    Super::extendFinalizeFromProperties();
+
+    MuscleFirstOrderActivationDynamicModel& actMdl = 
+        upd_MuscleFirstOrderActivationDynamicModel();
+    addComponent(&actMdl);
+
+    SimTK_ERRCHK1_ALWAYS(get_FmaxTendonStrain() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Tendon strain at maximum isometric force must be positive",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_FmaxMuscleStrain() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Passive muscle strain at maximum isometric force must be positive",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_KshapeActive() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Shape factor for active muscle f-l relationship must be positive",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_KshapePassive() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Shape factor for passive muscle f-l relationship must be positive",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_Af() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Force-velocity shape factor must be positive",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_Flen() > 1.0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Maximum normalized lengthening force must be greater than 1.0",
+        getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_FvExtrapolationThreshold() > 1.0/get_Flen(),
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: F-v threshold must be greater than 1.0/Flen",
+        getName().c_str());
+}
+
 //====================================================================
 // Model Component Interface
 //====================================================================
 void Thelen2003Muscle::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
-    ensureMuscleUpToDate();
-}
-
-void Thelen2003Muscle::ensureMuscleUpToDate()
-{
-    if(isObjectUpToDateWithProperties()==false){
-        buildMuscle();
-    }
+    buildMuscle();  //TODO: remove this when pennation model is a subcomponent.
 }
 
 void Thelen2003Muscle::extendInitStateFromProperties(SimTK::State& s) const
@@ -97,26 +132,12 @@ void Thelen2003Muscle::
     extendSetPropertiesFromState(const SimTK::State& s)
 {
     Super::extendSetPropertiesFromState(s);      
-    ensureMuscleUpToDate();
+    buildMuscle();  //TODO: remove this when pennation model is a subcomponent.
       
 }
 
-void Thelen2003Muscle::buildMuscle(){
-    std::string caller(getName());
-    caller.append("_Thelen2003Muscle::buildMuscle");
-
-    //Appropriately set the properties of the activation model
-    double activationTimeConstant  = getActivationTimeConstant();
-    double deactivationTimeConstant= getDeactivationTimeConstant();
-    double activationMinValue      = getMinimumActivation();
-
-
-    MuscleFirstOrderActivationDynamicModel tmp1(activationTimeConstant, 
-                                                deactivationTimeConstant, 
-                                                activationMinValue, 
-                                                caller);
-    actMdl = tmp1; 
-
+void Thelen2003Muscle::buildMuscle()
+{
     //Appropriately set the properties of the pennation model    
     double optimalFiberLength = getOptimalFiberLength();
     double pennationAngle     = getPennationAngleAtOptimalFiberLength();
@@ -128,10 +149,8 @@ void Thelen2003Muscle::buildMuscle(){
     penMdl = tmp2;   
 
     //Ensure all sub objects are up to date with properties.
-    actMdl.finalizeFromProperties();
+    //upd_MuscleFirstOrderActivationDynamicModel().finalizeFromProperties();
     penMdl.ensureModelUpToDate();
-
-    setObjectIsUpToDateWithProperties();
 }
 //_____________________________________________________________________________
 // Set the data members of this muscle to their null values.
@@ -145,61 +164,44 @@ void Thelen2003Muscle::setNull()
 
 //_____________________________________________________________________________
 /**
- * Populate this objects properties
+ * Populate this object's properties
  */
 void Thelen2003Muscle::constructProperties()
 {
-    constructProperty_activation_time_constant(0.015);
-    constructProperty_deactivation_time_constant(0.050);
+    constructProperty_MuscleFirstOrderActivationDynamicModel(
+        MuscleFirstOrderActivationDynamicModel());
+    setActivationTimeConstant(0.015);
+    setDeactivationTimeConstant(0.050);
+
     constructProperty_FmaxTendonStrain(0.04); // was 0.033
     constructProperty_FmaxMuscleStrain(0.6);
     constructProperty_KshapeActive(0.45);   
     constructProperty_KshapePassive(5.0);   
     constructProperty_Af(0.25); 
     constructProperty_Flen(1.4);    //was 1.8, 
-    constructProperty_fv_linear_extrap_threshold(0.95);
+    constructProperty_FvExtrapolationThreshold(0.95);
     //acos(0.05) = 84.26 degrees    
 }
 
 //=============================================================================
 // GET
 //=============================================================================
-
 double Thelen2003Muscle::getActivationTimeConstant() const 
-{   return get_activation_time_constant(); }
+{   return get_MuscleFirstOrderActivationDynamicModel().
+           get_activation_time_constant(); }
 
 double Thelen2003Muscle::getDeactivationTimeConstant() const 
-{   return get_deactivation_time_constant(); }
+{   return get_MuscleFirstOrderActivationDynamicModel().
+           get_deactivation_time_constant(); }
 
 double Thelen2003Muscle::getMinimumActivation() const 
-{   return actMdl.get_minimum_activation(); }
-
-
-double Thelen2003Muscle::getFmaxTendonStrain() const 
-{   return get_FmaxTendonStrain(); }
-
-double Thelen2003Muscle::getFmaxMuscleStrain()  const 
-{   return get_FmaxMuscleStrain(); }
-
-double Thelen2003Muscle::getKshapeActive()  const 
-{   return get_KshapeActive(); }
-
-double Thelen2003Muscle::getKshapePassive() const 
-{   return get_KshapePassive(); }
-
-double Thelen2003Muscle::getAf() const 
-{   return get_Af(); }
-
-double Thelen2003Muscle::getFlen() const 
-{   return get_Flen(); }
-
-double Thelen2003Muscle::getForceVelocityExtrapolationThreshold() const 
-{   return get_fv_linear_extrap_threshold(); }
+{   return get_MuscleFirstOrderActivationDynamicModel().
+           get_minimum_activation(); }
 
 const MuscleFirstOrderActivationDynamicModel& Thelen2003Muscle::
     getActivationModel() const
 {    
-    return actMdl;
+    return get_MuscleFirstOrderActivationDynamicModel();
 }
 
 const MuscleFixedWidthPennationModel& Thelen2003Muscle::
@@ -216,124 +218,22 @@ double Thelen2003Muscle::getMaximumPennationAngle() const
 //=============================================================================
 // SET
 //=============================================================================
-
-bool Thelen2003Muscle::setActivationTimeConstant(double aActTimeConstant)
+void Thelen2003Muscle::setActivationTimeConstant(double actTimeConstant)
 {
-    if(aActTimeConstant > 0){
-        set_activation_time_constant(aActTimeConstant);    
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
+    upd_MuscleFirstOrderActivationDynamicModel().
+        set_activation_time_constant(actTimeConstant);
 }
 
-bool Thelen2003Muscle::setDeactivationTimeConstant(double aDeActTimeConstant)
+void Thelen2003Muscle::setDeactivationTimeConstant(double deactTimeConstant)
 {
-    if(aDeActTimeConstant > 0){
-        set_deactivation_time_constant(aDeActTimeConstant);       
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
+    upd_MuscleFirstOrderActivationDynamicModel().
+        set_deactivation_time_constant(deactTimeConstant);
 }
 
-bool Thelen2003Muscle::setFmaxTendonStrain(double aFmaxTendonStrain)
+void Thelen2003Muscle::setMinimumActivation(double minimumActivation)
 {
-    if(aFmaxTendonStrain > 0){
-        set_FmaxTendonStrain(aFmaxTendonStrain);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-
-bool Thelen2003Muscle::setFmaxFiberStrain(double aFmaxMuscleStrain)
-{
-    if(aFmaxMuscleStrain > 0){
-        set_FmaxMuscleStrain(aFmaxMuscleStrain);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-
-bool Thelen2003Muscle::setKshapeActive(double aKShapeActive)
-{
-    if(aKShapeActive > 0){
-        set_KshapeActive(aKShapeActive);
-        ensureMuscleUpToDate();
-        return true; 
-    }
-    return false;
-}
-
-bool Thelen2003Muscle::setKshapePassive(double aKshapePassive)
-{
-    if(aKshapePassive > 0){
-        set_KshapePassive(aKshapePassive);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-
-
-bool Thelen2003Muscle::setAf(double aAf)
-{
-    if(aAf > 0){
-        set_Af(aAf);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-
-bool Thelen2003Muscle::setFlen(double aFlen)
-{
-    if(aFlen > 1.0){
-        set_Flen(aFlen);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-  
-
-
-bool Thelen2003Muscle::
-                 setForceVelocityExtrapolationThreshold(double aFvThresh)
-{
-    if(aFvThresh > 1.0/getFlen()){
-        set_fv_linear_extrap_threshold(aFvThresh);
-        ensureMuscleUpToDate();
-        return true;
-    }
-    return false;
-}
-
-/*bool Thelen2003Muscle::
-    setMaximumPennationAngle(double maxPennationAngle) 
-{
-    if(maxPennationAngle > 0.0 &&
-       maxPennationAngle < acos(0.001)){    
-           penMdl.setMaximumPennationAngle(maxPennationAngle);
-           ensureMuscleUpToDate();
-           return true;
-    }
-
-    return false;
-}*/
-
-bool Thelen2003Muscle::setMinimumActivation(double aActivationMinValue)
-{
-    if(aActivationMinValue > 0.001){        
-        actMdl.set_minimum_activation(aActivationMinValue);     
-        ensureMuscleUpToDate();
-        return true;
-    }else{
-        return false;
-    }
-
+    upd_MuscleFirstOrderActivationDynamicModel().
+        set_minimum_activation(minimumActivation);
 }
 
 //==============================================================================
@@ -395,8 +295,9 @@ double Thelen2003Muscle::
     //If the fiber is in a legal range, compute the force its generating
     if(fiberLength > penMdl.getMinimumFiberLength()){
 
-        //Clamp activation to a legal range        
-        double clampedActivation = actMdl.clampActivation(activation);
+        //Clamp activation to a legal range
+        double clampedActivation = get_MuscleFirstOrderActivationDynamicModel()
+                                   .clampActivation(activation);
 
         //Normalize fiber length and velocity
         double normFiberLength    = clampedFiberLength/getOptimalFiberLength();
@@ -682,8 +583,8 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
         //1. Get fiber/tendon kinematic information
 
         //clamp activation to a legal range
-        double a = actMdl.clampActivation(
-                                getStateVariableValue(s, STATE_ACTIVATION_NAME));
+        double a = get_MuscleFirstOrderActivationDynamicModel()
+            .clampActivation(getStateVariableValue(s, STATE_ACTIVATION_NAME));
    
 
         double lce  = mli.fiberLength;   
@@ -826,8 +727,8 @@ void Thelen2003Muscle::calcMuscleDynamicsInfo(const SimTK::State& s,
         //=========================================================================
 
         //1. Get fiber/tendon kinematic information
-        double a    = actMdl.clampActivation(
-                                getStateVariableValue(s, STATE_ACTIVATION_NAME));
+        double a = get_MuscleFirstOrderActivationDynamicModel()
+            .clampActivation(getStateVariableValue(s, STATE_ACTIVATION_NAME));
 
         double lce      = mli.fiberLength;
         double fiberStateClamped = mvi.userDefinedVelocityExtras[1];
@@ -987,7 +888,8 @@ double Thelen2003Muscle::calcActivationRate(const SimTK::State& s) const
 {    
     double excitation = getExcitation(s);
     double activation = getActivation(s);
-    double dadt = actMdl.calcDerivative(activation,excitation);
+    double dadt = get_MuscleFirstOrderActivationDynamicModel()
+                  .calcDerivative(activation,excitation);
     return dadt;
 }  
 
@@ -1341,7 +1243,7 @@ double Thelen2003Muscle::calcDFseDtl(double tl, double fiso, double tsl) const
 void Thelen2003Muscle::printCurveToCSVFile(const CurveType ctype, 
                                            const std::string&path)
 {
-    ensureMuscleUpToDate();
+    //ensureMuscleUpToDate();
     /*
         //Only compute up to the 2nd derivative
     SimTK::Matrix results = calcSampledMuscleCurve(2);
@@ -1578,7 +1480,7 @@ void Thelen2003Muscle::
 double Thelen2003Muscle::calcfse(const double tlN) const 
 {
     double x = tlN-1;
-    double e0 = getFmaxTendonStrain();
+    double e0 = get_FmaxTendonStrain();
     
     /*The paper reports etoe = 0.609e0, however, this is a severely rounded off
         The exact answer, to SimTK::Eps is   
@@ -1609,7 +1511,7 @@ double Thelen2003Muscle::calcfse(const double tlN) const
 
 double Thelen2003Muscle::calcDfseDtlN(const double tlN) const {
     double x = tlN-1;
-    double e0 = getFmaxTendonStrain();
+    double e0 = get_FmaxTendonStrain();
     
     /*The paper reports etoe = 0.609e0, however, this is a severely rounded off
     result of the exact answer:    
@@ -1647,7 +1549,7 @@ double Thelen2003Muscle::calcfsefisoPE(double tendonStrain) const
 {
 
     double tendon_strain =  tendonStrain;
-    double fmaxTendonStrain = getFmaxTendonStrain();       
+    double fmaxTendonStrain = get_FmaxTendonStrain();       
 
     //Future optimization opportunity: precompute kToe, fToe, eToe and klin
     //when the muscle is initialized. Store these values rather than 
@@ -1722,13 +1624,13 @@ double Thelen2003Muscle::calcfsefisoPE(double tendonStrain) const
 //
 //==============================================================================
 double Thelen2003Muscle::calcfal(const double lceN) const{       
-    double kShapeActive = getKshapeActive();   
+    double kShapeActive = get_KshapeActive();   
     double x=(lceN-1.)*(lceN-1.);
     double fal = exp(-x/kShapeActive);
     return fal;
 }
 double Thelen2003Muscle::calcDfalDlceN(const double lceN) const {
-    double kShapeActive = getKshapeActive();   
+    double kShapeActive = get_KshapeActive();   
     double t1 = lceN - 0.10e1;
     double t2 = 0.1e1 / kShapeActive;
     double t4 = t1 * t1;
@@ -1744,8 +1646,8 @@ double Thelen2003Muscle::calcDfalDlceN(const double lceN) const {
 //=============================================================================
 double Thelen2003Muscle::calcfpe(const double lceN) const {
     double fpe = 0;
-    double e0 = getFmaxMuscleStrain();
-    double kpe = getKshapePassive();
+    double e0 = get_FmaxMuscleStrain();
+    double kpe = get_KshapePassive();
 
     //Compute the passive force developed by the muscle
     if(lceN > 1.0){
@@ -1758,8 +1660,8 @@ double Thelen2003Muscle::calcfpe(const double lceN) const {
 
 double Thelen2003Muscle::calcDfpeDlceN(const double lceN) const {
     double dfpe_d_lceN = 0;
-    double e0 = getFmaxMuscleStrain();
-    double kpe = getKshapePassive();
+    double e0 = get_FmaxMuscleStrain();
+    double kpe = get_KshapePassive();
 
     if(lceN > 1.0){
         double t1 = 0.1e1 / e0;
@@ -1772,8 +1674,8 @@ double Thelen2003Muscle::calcDfpeDlceN(const double lceN) const {
 
 double Thelen2003Muscle::calcfpefisoPE(double lceN) const
 {
-    double fmaxMuscleStrain = getFmaxMuscleStrain();
-    double kShapePassive = getKshapePassive();
+    double fmaxMuscleStrain = get_FmaxMuscleStrain();
+    double kShapePassive = get_KshapePassive();
 
     double musclePE = 0.0;
     //Compute the potential energy stored in the muscle
@@ -1816,12 +1718,12 @@ double Thelen2003Muscle::calcdlceN(double act,double fal,double actFalFv) const
     //The variable names have all been switched to closely match 
     //with the notation in Thelen 2003.
     double dlceN = 0.0;      //contractile element velocity    
-    double af   = getAf();
+    double af   = get_Af();
 
     double a    = act;
     double afl  = a*fal; //afl = a*fl
     double Fm   = actFalFv;     //Fm = a*fl*fv    
-    double flen = getFlen();
+    double flen = get_Flen();
     double Fmlen_afl = flen*afl;
 
     double dlcedFm = 0.0; //partial deriviative of contactile element
@@ -1833,7 +1735,7 @@ double Thelen2003Muscle::calcdlceN(double act,double fal,double actFalFv) const
     double Fm_asyC = 0;           //Concentric contraction asymptote
     double Fm_asyE = afl*flen;    
                                 //Eccentric contraction asymptote
-    double asyE_thresh = getForceVelocityExtrapolationThreshold();
+    double asyE_thresh = get_FvExtrapolationThreshold();
 
     //If fv is in the appropriate region, use 
     //Thelen 2003 Eqns 6 & 7 to compute dlceN
@@ -1901,12 +1803,12 @@ double Thelen2003Muscle::calcDdlceDaFalFv(double aAct,
     //The variable names have all been switched to closely match with 
     //the notation in Thelen 2003.
     double dlceN = 0.0;      //contractile element velocity    
-    double af   = getAf();
+    double af   = get_Af();
 
     double a    = aAct;
     double afl  = aAct*aFal;  //afl = a*fl
     double Fm   = aFalFv;    //Fm = a*fl*fv    
-    double flen = getFlen();
+    double flen = get_Flen();
     double Fmlen_afl = flen*aAct*aFal;
 
     double dlcedFm = 0.0; //partial derivative of contractile element 
@@ -1918,7 +1820,7 @@ double Thelen2003Muscle::calcDdlceDaFalFv(double aAct,
     double Fm_asyC = 0;           //Concentric contraction asymptote
     double Fm_asyE = aAct*aFal*flen;    
                                 //Eccentric contraction asymptote
-    double asyE_thresh = getForceVelocityExtrapolationThreshold();
+    double asyE_thresh = get_FvExtrapolationThreshold();
 
     //If fv is in the appropriate region, use 
     //Thelen 2003 Eqns 6 & 7 to compute dlceN

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -89,20 +89,24 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
         upd_MuscleFirstOrderActivationDynamicModel();
     addComponent(&actMdl);
 
-    std::string errorLocation = getName() + 
-        " Thelen2003Muscle::extendFinalizeFromProperties";
-
-    SimTK_VALUECHECK_NONNEG_ALWAYS(get_FmaxTendonStrain(), "FmaxTendonStrain",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_NONNEG_ALWAYS(get_FmaxMuscleStrain(), "FmaxMuscleStrain",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_NONNEG_ALWAYS(get_KshapeActive(), "KshapeActive",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_NONNEG_ALWAYS(get_KshapePassive(), "KshapePassive",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_NONNEG_ALWAYS(get_Af(), "Af", errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(1.0, get_Flen(), SimTK::Infinity, "Flen",
-        errorLocation.c_str());
+    SimTK_ERRCHK1_ALWAYS(get_FmaxTendonStrain() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: FmaxTendonStrain must be greater than zero", getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_FmaxMuscleStrain() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: FmaxMuscleStrain must be greater than zero", getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_KshapeActive() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: KshapeActive must be greater than zero", getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_KshapePassive() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: KshapePassive must be greater than zero", getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_Af() > 0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Af must be greater than zero", getName().c_str());
+    SimTK_ERRCHK1_ALWAYS(get_Flen() > 1.0,
+        "Thelen2003Muscle::extendFinalizeFromProperties",
+        "%s: Flen must be greater than 1.0", getName().c_str());
     SimTK_ERRCHK1_ALWAYS(get_fv_linear_extrap_threshold() > 1.0/get_Flen(),
         "Thelen2003::extendFinalizeFromProperties",
         "%s: F-v extrapolation threshold must be greater than 1.0/Flen",

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -128,7 +128,7 @@ void Thelen2003Muscle::buildMuscle(){
     penMdl = tmp2;   
 
     //Ensure all sub objects are up to date with properties.
-    actMdl.ensureModelUpToDate();
+    actMdl.finalizeFromProperties();
     penMdl.ensureModelUpToDate();
 
     setObjectIsUpToDateWithProperties();

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -172,7 +172,7 @@ double Thelen2003Muscle::getDeactivationTimeConstant() const
 {   return get_deactivation_time_constant(); }
 
 double Thelen2003Muscle::getMinimumActivation() const 
-{   return actMdl.getMinimumActivation(); }
+{   return actMdl.get_minimum_activation(); }
 
 
 double Thelen2003Muscle::getFmaxTendonStrain() const 
@@ -327,7 +327,7 @@ bool Thelen2003Muscle::
 bool Thelen2003Muscle::setMinimumActivation(double aActivationMinValue)
 {
     if(aActivationMinValue > 0.001){        
-        actMdl.setMinimumActivation(aActivationMinValue);     
+        actMdl.set_minimum_activation(aActivationMinValue);     
         ensureMuscleUpToDate();
         return true;
     }else{

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -312,7 +312,7 @@ private:
     //=====================================================================
     //bool initializedModel;
 
-    double activation_minimum_value;
+    //double activation_minimum_value;
     //Activation Dynamics
     MuscleFirstOrderActivationDynamicModel actMdl;
 

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -102,13 +102,6 @@ namespace OpenSim {
     physiologically possible (that is shorter than approximately half a 
     normalized fiber length).
 
-     <B> Usage </B>
-    This object should be updated through the set methods provided. 
-    These set methods will take care of rebuilding the object correctly. If you
-    modify the properties directly, the object will not be rebuilt, and upon
-    calling any functions an exception will be thrown because the object is out 
-    of date with its properties.
-
   <B> References </B>
 
    DG Thelen, Adjustment of muscle mechanics model parameters to simulate dynamic 
@@ -127,12 +120,6 @@ public:
     /** @name Property declarations 
     These are the serializable properties associated with this class. **/
     /**@{**/
-    OpenSim_DECLARE_PROPERTY(activation_time_constant, double,
-        "time constant for ramping up muscle activation");
-
-    OpenSim_DECLARE_PROPERTY(deactivation_time_constant, double,
-        "time constant for ramping down of muscle activation");
-
     OpenSim_DECLARE_PROPERTY(FmaxTendonStrain, double,
         "tendon strain at maximum isometric muscle force");
 
@@ -151,12 +138,11 @@ public:
     OpenSim_DECLARE_PROPERTY(Flen, double,
         "maximum normalized lengthening force");
 
-    //OpenSim_DECLARE_PROPERTY(activation_minimum_value, double,
-    //    "minimum activation value permitted");
-    
-    OpenSim_DECLARE_PROPERTY(fv_linear_extrap_threshold, double,
+    OpenSim_DECLARE_PROPERTY(FvExtrapolationThreshold, double,
         "fv threshold where linear extrapolation is used");
 
+    OpenSim_DECLARE_UNNAMED_PROPERTY(MuscleFirstOrderActivationDynamicModel,
+        "The model governing the excitation-to-activation dynamics.");
 
     /**@}**/
 
@@ -183,13 +169,6 @@ public:
     double getActivationTimeConstant() const;
     double getMinimumActivation() const;
     double getDeactivationTimeConstant() const;
-    double getFmaxTendonStrain() const;
-    double getFmaxMuscleStrain() const;
-    double getKshapeActive() const;
-    double getKshapePassive() const;
-    double getAf() const;
-    double getFlen() const;
-    double getForceVelocityExtrapolationThreshold() const;
 
     /**
      @returns the minimum fiber length, which is the maximum of two values:
@@ -205,16 +184,9 @@ public:
     */
     double getMaximumPennationAngle() const;
 
-    bool setActivationTimeConstant(double aActivationTimeConstant);   
-    bool setDeactivationTimeConstant(double aDeactivationTimeConstant);
-    bool setMinimumActivation(double aActivationMinValue);
-    bool setFmaxTendonStrain(double aFmaxTendonStrain);
-    bool setFmaxFiberStrain(double aFmaxMuscleStrain);
-    bool setKshapeActive(double aKShapeActive);
-    bool setKshapePassive(double aKshapePassive);
-    bool setAf(double aAf);
-    bool setFlen(double aFlen);
-    bool setForceVelocityExtrapolationThreshold(double aFvThresh);
+    void setActivationTimeConstant(double actTimeConstant);   
+    void setDeactivationTimeConstant(double deactTimeConstant);
+    void setMinimumActivation(double minimumActivation);
 
     /**
    @returns the MuscleFirstOrderActivationDynamicModel 
@@ -296,6 +268,9 @@ protected:
     /** Calculate activation rate */
     double calcActivationRate(const SimTK::State& s) const override; 
 
+    /** Component interface. */
+    void extendFinalizeFromProperties() override;
+
     /** Implement the ModelComponent interface */
     void extendConnectToModel(Model& aModel) override;
     void extendInitStateFromProperties(SimTK::State& s) const override;
@@ -305,16 +280,12 @@ private:
     void setNull();
     void constructProperties() override;
     void buildMuscle();
-    void ensureMuscleUpToDate();
+    //void ensureMuscleUpToDate();
     //=====================================================================
     // Private Utility Class Members
     //      -Computes activation dynamics and fiber kinematics
     //=====================================================================
     //bool initializedModel;
-
-    //double activation_minimum_value;
-    //Activation Dynamics
-    MuscleFirstOrderActivationDynamicModel actMdl;
 
     //Fiber and Tendon Kinematics
     MuscleFixedWidthPennationModel penMdl;

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -138,7 +138,7 @@ public:
     OpenSim_DECLARE_PROPERTY(Flen, double,
         "maximum normalized lengthening force");
 
-    OpenSim_DECLARE_PROPERTY(FvExtrapolationThreshold, double,
+    OpenSim_DECLARE_PROPERTY(fv_linear_extrap_threshold, double,
         "fv threshold where linear extrapolation is used");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(MuscleFirstOrderActivationDynamicModel,
@@ -165,10 +165,19 @@ public:
 //==============================================================================
 // Get and Set Properties
 //==============================================================================
-    // Properties    
+    // Properties
+
+    /** @name Convenience methods
+    These are convenience methods that get and set properties of the activation
+    model. **/
+    /**@{**/
     double getActivationTimeConstant() const;
-    double getMinimumActivation() const;
+    void setActivationTimeConstant(double actTimeConstant);
     double getDeactivationTimeConstant() const;
+    void setDeactivationTimeConstant(double deactTimeConstant);
+    double getMinimumActivation() const;
+    void setMinimumActivation(double minimumActivation);
+    /**@}**/
 
     /**
      @returns the minimum fiber length, which is the maximum of two values:
@@ -183,10 +192,6 @@ public:
     @return the maximum pennation angle allowed by this muscle model (radians)
     */
     double getMaximumPennationAngle() const;
-
-    void setActivationTimeConstant(double actTimeConstant);   
-    void setDeactivationTimeConstant(double deactTimeConstant);
-    void setMinimumActivation(double minimumActivation);
 
     /**
    @returns the MuscleFirstOrderActivationDynamicModel 

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -140,14 +140,14 @@ int main()
             countSkipComponent++;
         }
 
-        ASSERT(numComponents == 23); 
+        ASSERT(numComponents == 29); 
         ASSERT(numBodies == model.getNumBodies());
         ASSERT(numBodiesPost == numBodies);
         ASSERT(numMuscles == model.getMuscles().getSize());
         ASSERT(numJointsWithStateVariables == 2);
         ASSERT(numModelComponentsWithStateVariables == 11);
         ASSERT(numJntComponents == 2);
-        ASSERT(countSkipComponent == 12);
+        ASSERT(countSkipComponent == 15);
     }
     catch (Exception &ex) {
         ex.print(std::cout);


### PR DESCRIPTION
First half of addressing #326. Moved property value checks from setters into `extendFinalizeFromProperties()`. Removed getters and setters for properties, since these methods just called the corresponding get_ and set_ methods (which will appear in doxygen with #318). `buildModel()` still exists for now, but will disappear when MuscleFixedWidthPennationModel is changed into a property as well.