### PR TITLE
Remove extraneous setObjectIsUpToDateWithProperties

### DIFF
--- a/OpenSim/Analyses/StaticOptimization.cpp
+++ b/OpenSim/Analyses/StaticOptimization.cpp
@@ -486,8 +486,6 @@ record(const SimTK::State& s)
         ActivationFiberLengthMuscle *mus = dynamic_cast<ActivationFiberLengthMuscle*>(&actuators[k]);
         if(mus){
             mus->setDefaultActivation(_parameters[k]);
-            // Don't send up red flags when the def
-            mus->setObjectIsUpToDateWithProperties();
         }
     }
 

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -352,18 +352,6 @@ public:
     template <class T> Property<T>& 
     updProperty(const PropertyIndex& index);
 
-    /** When an object is initialized using the current values of its 
-    properties, it can set a flag indicating that it is up to date. This 
-    flag is automatically cleared when any property is modified. This allows 
-    objects to avoid expensive reinitialization if it is unnecessary (that is,
-    whenever this %Object hands out writable access to a property). Note
-    that use of this flag is entirely optional; most %Object classes don't
-    have any expensive initialization to worry about. 
-    
-    This flag is cleared automatically but if you want to clear it manually
-    for testing or debugging, see clearObjectIsUpToDateWithProperties(). **/
-    void setObjectIsUpToDateWithProperties()
-    {   _objectIsUpToDate = true; }
     /** Returns \c true if no property's value has changed since the last time
     setObjectIsUpToDateWithProperties() was called. **/
     bool isObjectUpToDateWithProperties() const {return _objectIsUpToDate;}
@@ -541,6 +529,28 @@ public:
     void setInlined(bool aInlined, const std::string &aFileName="");
 
 protected:
+    /** When an object is initialized using the current values of its
+    properties, it can set a flag indicating that it is up to date. This
+    flag is automatically cleared when any property is modified. This allows
+    objects to avoid expensive reinitialization if it is unnecessary (that is,
+    whenever this %Object hands out writable access to a property). Note
+    that use of this flag is entirely optional; most %Object classes don't
+    have any expensive initialization to worry about.
+
+    This flag is cleared automatically but if you want to clear it manually
+    for testing or debugging, see clearObjectIsUpToDateWithProperties(). **/
+    void setObjectIsUpToDateWithProperties() {
+        _objectIsUpToDate = true;
+    }
+
+    /** For testing or debugging purposes, manually clear the "object is up to
+    date with respect to properties" flag. This is normally done automatically
+    when a property is modified. Setting the flag is always done manually,
+    however, see setObjectIsUpToDateWithProperties(). **/
+    void clearObjectIsUpToDateWithProperties() {
+        _objectIsUpToDate = false;
+    }
+
     /** Use this method only if you're deserializing from a file and the object
     is at the top level; that is, primarily in constructors that take a file
     name as input. **/
@@ -602,13 +612,6 @@ public:
     {
         return _serializeAllDefaults;
     }
-
-    /** For testing or debugging purposes, manually clear the "object is up to 
-    date with respect to properties" flag. This is normally done automatically
-    when a property is modified. Setting the flag is always done manually,
-    however, see setObjectIsUpToDateWithProperties(). **/    
-    void clearObjectIsUpToDateWithProperties()
-    {   _objectIsUpToDate = false; }
 
     /** Returns true if the passed-in string is "Object"; each %Object-derived
     class defines a method of this name for its own class name. **/

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -794,9 +794,6 @@ void Model::extendConnectToModel(Model &model)
     //Analyses are not Components so add them after legit 
     //Components have been wired-up correctly.
     updAnalysisSet().setModel(*this);
-
-    // Connections are properties so we need to mark these changes as final.
-    setObjectIsUpToDateWithProperties();
 }
 
 


### PR DESCRIPTION
Made `Object::setObjectIsUpToDateWithProperties()` protected and removed extraneous calls from Model and StaticOptimization. Remaining uses are by Millard muscle components that are actively being fixed by @tkuchida  #366, so I've left those in, for the time being. 