### PR TITLE
Cleaned up MuscleFixedWidthPennationModel

### DIFF
--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -154,8 +154,9 @@ void Millard2012AccelerationMuscle::buildMuscle()
     caller.append(".buildMuscle()");
 
 
-    m_penMdl = MuscleFixedWidthPennationModel(optFibLen, optPenAng,
-                    SimTK::Pi/2.0-SimTK::SignificantReal);
+    m_penMdl = MuscleFixedWidthPennationModel(  optFibLen,
+                                                optPenAng, 
+                                                SimTK::Pi/2.0);
    
     std::string aName = getName();
 

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -200,7 +200,9 @@ void Millard2012AccelerationMuscle::buildMuscle()
      //Ensure all sub objects are up to date with properties;
     actMdl.finalizeFromProperties(); //TODO: Remove this once the activation
                                      //model has been made into a property.
-    m_penMdl.ensureModelUpToDate();
+    // TODO: Remove this once MuscleFixedWidthPennationModel has been made into
+    //       a property.
+    m_penMdl.finalizeFromProperties();
 
     falCurve.ensureCurveUpToDate();
     fvCurve.ensureCurveUpToDate();

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -764,7 +764,7 @@ void Millard2012AccelerationMuscle::
             case 2: //Maximum number of iterations exceeded.
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,m_penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
                 setFiberVelocity(s,0.0);
 
                 std::string muscleName = getName();
@@ -789,7 +789,7 @@ void Millard2012AccelerationMuscle::
                         "        Whole muscle length : %f \n\n", 
                         muscleName.c_str(),
                         fcnName.c_str(), 
-                        m_penMdl.get_optimal_fiber_length(),
+                        get_optimal_fiber_length(),
                         abs(solnErr),
                         tol,
                         iterations,
@@ -811,7 +811,7 @@ void Millard2012AccelerationMuscle::
                         muscleName.c_str());
 
                 setActuation(s, 0.0);
-                setFiberLength(s,m_penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
                 setFiberVelocity(s,0.0);
         }
     }catch (const std::exception& e) { 

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -154,9 +154,8 @@ void Millard2012AccelerationMuscle::buildMuscle()
     caller.append(".buildMuscle()");
 
 
-    m_penMdl = MuscleFixedWidthPennationModel(  optFibLen,
-                                                optPenAng, 
-                                                SimTK::Pi/2.0);
+    m_penMdl = MuscleFixedWidthPennationModel(optFibLen, optPenAng,
+                    SimTK::Pi/2.0-SimTK::SignificantReal);
    
     std::string aName = getName();
 
@@ -762,7 +761,7 @@ void Millard2012AccelerationMuscle::
             case 2: //Maximum number of iterations exceeded.
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,m_penMdl.getOptimalFiberLength());
+                setFiberLength(s,m_penMdl.get_optimal_fiber_length());
                 setFiberVelocity(s,0.0);
 
                 std::string muscleName = getName();
@@ -787,7 +786,7 @@ void Millard2012AccelerationMuscle::
                         "        Whole muscle length : %f \n\n", 
                         muscleName.c_str(),
                         fcnName.c_str(), 
-                        m_penMdl.getOptimalFiberLength(),
+                        m_penMdl.get_optimal_fiber_length(),
                         abs(solnErr),
                         tol,
                         iterations,
@@ -809,7 +808,7 @@ void Millard2012AccelerationMuscle::
                         muscleName.c_str());
 
                 setActuation(s, 0.0);
-                setFiberLength(s,m_penMdl.getOptimalFiberLength());
+                setFiberLength(s,m_penMdl.get_optimal_fiber_length());
                 setFiberVelocity(s,0.0);
         }
     }catch (const std::exception& e) { 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -114,9 +114,9 @@ void Millard2012EquilibriumMuscle::buildMuscle()
             if(falCurve.getMinValue() < 0.1) {
                 falCurve.setMinValue(0.1);
             }
-            if(cos(penMdl.getMaximumPennationAngle()) < SimTK::SignificantReal)
+            if(cos(penMdl.get_maximum_pennation_angle()) < SimTK::SignificantReal)
             {
-                penMdl.setMaximumPennationAngle(maxPennationAngle);
+                penMdl.set_maximum_pennation_angle(maxPennationAngle);
             }
             if(conSlopeAtVmax < 0.1 || eccSlopeAtVmax < 0.1) {
                 fvCurve.setCurveShape(0.1, conSlopeNearVmax, isometricSlope,
@@ -243,7 +243,7 @@ getPennationModel() const
 {   return penMdl; }
 
 double Millard2012EquilibriumMuscle::getMaximumPennationAngle() const
-{   return penMdl.getMaximumPennationAngle(); }
+{   return penMdl.get_maximum_pennation_angle(); }
 double Millard2012EquilibriumMuscle::getMinimumFiberLength() const
 {   return m_minimumFiberLength; }
 double Millard2012EquilibriumMuscle::getMinimumFiberLengthAlongTendon() const
@@ -458,7 +458,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
             case 2: //maximum number of iterations reached
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
 
                 char msgBuffer[1000];
                 int n = sprintf(msgBuffer,
@@ -476,7 +476,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
                     "   Activation:      %f\n"
                     "   Actuator length: %f\n\n",
                     getName().c_str(),
-                    penMdl.getOptimalFiberLength(),
+                    penMdl.get_optimal_fiber_length(),
                     abs(solnErr), tol,
                     iterations, maxIter,
                     clampedActivation,
@@ -492,7 +492,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
                        "optimal fiber length.",
                        getName().c_str());
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
         }
 
     } catch (const std::exception& e) {
@@ -571,7 +571,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
             case 2: //maximum number of iterations reached
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
 
                 char msgBuffer[1000];
                 int n = sprintf(msgBuffer,
@@ -589,7 +589,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
                     "   Activation:      %f\n"
                     "   Actuator length: %f\n\n",
                     getName().c_str(),
-                    penMdl.getOptimalFiberLength(),
+                    penMdl.get_optimal_fiber_length(),
                     abs(solnErr), tol,
                     iterations, maxIter,
                     activation,
@@ -605,7 +605,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
                        "optimal fiber length.",
                        getName().c_str());
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
         }
 
     } catch (const std::exception& e) {

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -114,7 +114,8 @@ void Millard2012EquilibriumMuscle::buildMuscle()
             if(falCurve.getMinValue() < 0.1) {
                 falCurve.setMinValue(0.1);
             }
-            if(cos(penMdl.get_maximum_pennation_angle()) < SimTK::SignificantReal)
+            if(cos(penMdl.get_maximum_pennation_angle())
+                < SimTK::SignificantReal)
             {
                 penMdl.set_maximum_pennation_angle(maxPennationAngle);
             }

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -461,7 +461,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
             case 2: //maximum number of iterations reached
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
 
                 char msgBuffer[1000];
                 int n = sprintf(msgBuffer,
@@ -479,7 +479,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
                     "   Activation:      %f\n"
                     "   Actuator length: %f\n\n",
                     getName().c_str(),
-                    penMdl.get_optimal_fiber_length(),
+                    get_optimal_fiber_length(),
                     abs(solnErr), tol,
                     iterations, maxIter,
                     clampedActivation,
@@ -495,7 +495,7 @@ computeInitialFiberEquilibrium(SimTK::State& s) const
                        "optimal fiber length.",
                        getName().c_str());
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
         }
 
     } catch (const std::exception& e) {
@@ -574,7 +574,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
             case 2: //maximum number of iterations reached
             {
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
 
                 char msgBuffer[1000];
                 int n = sprintf(msgBuffer,
@@ -592,7 +592,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
                     "   Activation:      %f\n"
                     "   Actuator length: %f\n\n",
                     getName().c_str(),
-                    penMdl.get_optimal_fiber_length(),
+                    get_optimal_fiber_length(),
                     abs(solnErr), tol,
                     iterations, maxIter,
                     activation,
@@ -608,7 +608,7 @@ computeFiberEquilibriumAtZeroVelocity(SimTK::State& s) const
                        "optimal fiber length.",
                        getName().c_str());
                 setActuation(s, 0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setFiberLength(s, get_optimal_fiber_length());
         }
 
     } catch (const std::exception& e) {

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -144,7 +144,10 @@ void Millard2012EquilibriumMuscle::buildMuscle()
                                                eccCurviness);
 
         // Ensure all sub-objects are up-to-date
-        penMdl.ensureModelUpToDate();
+        // TODO: Remove this once MuscleFixedWidthPennationModel has been made
+        //       into a property.
+        penMdl.finalizeFromProperties();
+
         falCurve.ensureCurveUpToDate();
         fvCurve.ensureCurveUpToDate();
         fvInvCurve.ensureCurveUpToDate();

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
@@ -22,8 +22,6 @@
  * See the License for the specific language governing permissions and        *
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
-
-// INCLUDES
 #include "Simbody.h"
 #include <OpenSim/Actuators/osimActuatorsDLL.h>
 #include <OpenSim/Simulation/Model/ModelComponent.h>

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -71,9 +71,9 @@ MuscleFixedWidthPennationModel(double optimalFiberLength,
     setNull();
     constructProperties();
 
-    setOptimalFiberLength(optimalFiberLength);
-    setOptimalPennationAngle(optimalPennationAngle);
-    setMaximumPennationAngle(maximumPennationAngle);
+    set_optimal_fiber_length(optimalFiberLength);
+    set_optimal_pennation_angle(optimalPennationAngle);
+    set_maximum_pennation_angle(maximumPennationAngle);
 
     ensureModelUpToDate();
 }
@@ -81,20 +81,20 @@ MuscleFixedWidthPennationModel(double optimalFiberLength,
 void MuscleFixedWidthPennationModel::buildModel()
 {
     // Compute quantities that are used often.
-    m_parallelogramHeight = getOptimalFiberLength()
-                            * sin(getOptimalPennationAngle());
-    m_maximumSinPennation = sin(getMaximumPennationAngle());
+    m_parallelogramHeight = get_optimal_fiber_length()
+                            * sin(get_optimal_pennation_angle());
+    m_maximumSinPennation = sin(get_maximum_pennation_angle());
 
     // Compute the minimum fiber length:
     // - pennated: the length of the fiber when at its maximum pennation angle
     // - straight: 1% of the optimal fiber length
-    if(getMaximumPennationAngle() > SimTK::SignificantReal) {
+    if(get_maximum_pennation_angle() > SimTK::SignificantReal) {
         m_minimumFiberLength = m_parallelogramHeight / m_maximumSinPennation;
     } else {
-        m_minimumFiberLength = getOptimalFiberLength()*0.01;
+        m_minimumFiberLength = get_optimal_fiber_length()*0.01;
     }
     m_minimumFiberLengthAlongTendon = m_minimumFiberLength
-                                      * cos(getMaximumPennationAngle());
+                                      * cos(get_maximum_pennation_angle());
 
     // Mark model as being up-to-date with its properties
     setObjectIsUpToDateWithProperties();
@@ -110,9 +110,9 @@ void MuscleFixedWidthPennationModel::ensureModelUpToDate()
 
 void MuscleFixedWidthPennationModel::ensurePropertiesSet() const
 {
-    SimTK_ERRCHK1_ALWAYS(!isNaN(getOptimalFiberLength())
-                         && !isNaN(getOptimalPennationAngle())
-                         && !isNaN(getMaximumPennationAngle()),
+    SimTK_ERRCHK1_ALWAYS(!isNaN(get_optimal_fiber_length())
+                         && !isNaN(get_optimal_pennation_angle())
+                         && !isNaN(get_maximum_pennation_angle()),
                          "MuscleFixedWidthPennationModel",
                          "%s: Properties have not been set.",
                          getName().c_str());
@@ -120,54 +120,38 @@ void MuscleFixedWidthPennationModel::ensurePropertiesSet() const
 
 double MuscleFixedWidthPennationModel::getParallelogramHeight() const
 {   return m_parallelogramHeight; }
-double MuscleFixedWidthPennationModel::getOptimalFiberLength() const
-{   return get_optimal_fiber_length(); }
 double MuscleFixedWidthPennationModel::getMinimumFiberLength() const
 {   return m_minimumFiberLength; }
 double MuscleFixedWidthPennationModel::getMinimumFiberLengthAlongTendon() const
 {   return m_minimumFiberLengthAlongTendon; }
-double MuscleFixedWidthPennationModel::getOptimalPennationAngle() const
-{   return get_optimal_pennation_angle(); }
-double MuscleFixedWidthPennationModel::getMaximumPennationAngle() const
-{   return get_maximum_pennation_angle(); }
-
-bool MuscleFixedWidthPennationModel::
-setOptimalFiberLength(double aOptimalFiberLength)
-{
-    if(aOptimalFiberLength > SimTK::SignificantReal) {
-        set_optimal_fiber_length(aOptimalFiberLength);
-        ensureModelUpToDate();
-        return true;
-    }
-    return false;
-}
-
-bool MuscleFixedWidthPennationModel::
-setOptimalPennationAngle(double aOptimalPennationAngle)
-{
-    if(aOptimalPennationAngle >= 0 && aOptimalPennationAngle < SimTK::Pi/2) {
-        set_optimal_pennation_angle(aOptimalPennationAngle);
-        ensureModelUpToDate();
-        return true;
-    }
-    return false;
-}
-
-bool MuscleFixedWidthPennationModel::
-setMaximumPennationAngle(double aMaximumPennationAngle)
-{
-    if(aMaximumPennationAngle >= 0 && aMaximumPennationAngle < SimTK::Pi/2) {
-        set_maximum_pennation_angle(aMaximumPennationAngle);
-        ensureModelUpToDate();
-        return true;
-    }
-    return false;
-}
 
 double MuscleFixedWidthPennationModel::
 clampFiberLength(double fiberLength) const
 {
     return max(m_minimumFiberLength, fiberLength);
+}
+
+//==============================================================================
+// COMPONENT INTERFACE
+//==============================================================================
+void MuscleFixedWidthPennationModel::extendFinalizeFromProperties()
+{
+    Super::extendFinalizeFromProperties();
+
+    std::string errorLocation = getName() +
+        " MuscleFixedWidthPennationModel::extendFinalizeFromProperties";
+
+    // Ensure property values are within appropriate ranges.
+    SimTK_ERRCHK1_ALWAYS(get_optimal_fiber_length() > SimTK::SignificantReal,
+        "MuscleFixedWidthPennationModel::extendFinalizeFromProperties",
+        "%s: Optimal fiber length must be greater than zero",
+        getName().c_str());
+    SimTK_VALUECHECK_ALWAYS(0.0, get_optimal_pennation_angle(),
+        SimTK::Pi/2.0-SimTK::SignificantReal, "optimal_pennation_angle",
+        errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(0.0, get_maximum_pennation_angle(),
+        SimTK::Pi/2.0-SimTK::SignificantReal, "maximum_pennation_angle",
+        errorLocation.c_str());
 }
 
 //==============================================================================
@@ -177,16 +161,16 @@ double MuscleFixedWidthPennationModel::
 calcPennationAngle(double fiberLength) const
 {
     double phi = 0;
-    double optimalPennationAngle = getOptimalPennationAngle();
+    double optimalPennationAngle = get_optimal_pennation_angle();
 
     // This computation is only worth performing on pennated muscles.
     if(optimalPennationAngle > SimTK::Eps) {
         if(fiberLength > m_minimumFiberLength) {
             double sin_phi = m_parallelogramHeight/fiberLength;
             phi = (sin_phi < m_maximumSinPennation) ?
-                  asin(sin_phi) : getMaximumPennationAngle();
+                  asin(sin_phi) : get_maximum_pennation_angle();
         } else {
-            phi = getMaximumPennationAngle();
+            phi = get_maximum_pennation_angle();
         }
     }
     return phi;
@@ -211,7 +195,7 @@ double MuscleFixedWidthPennationModel::calcPennationAngularVelocity(
     double tanPennationAngle, double fiberLength, double fiberVelocity) const
 {
     double dphi = 0;
-    double optimalPennationAngle = getOptimalPennationAngle();
+    double optimalPennationAngle = get_optimal_pennation_angle();
 
     if(optimalPennationAngle > SimTK::Eps) {
         SimTK_ERRCHK_ALWAYS(fiberLength > 0,

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -146,12 +146,10 @@ void MuscleFixedWidthPennationModel::extendFinalizeFromProperties()
         "MuscleFixedWidthPennationModel::extendFinalizeFromProperties",
         "%s: Optimal fiber length must be greater than zero",
         getName().c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_optimal_pennation_angle(),
-        SimTK::Pi/2.0-SimTK::SignificantReal, "optimal_pennation_angle",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_maximum_pennation_angle(),
-        SimTK::Pi/2.0-SimTK::SignificantReal, "maximum_pennation_angle",
-        errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(0.0, get_optimal_pennation_angle(), SimTK::Pi/2.0,
+        "optimal_pennation_angle", errorLocation.c_str());
+    SimTK_VALUECHECK_ALWAYS(0.0, get_maximum_pennation_angle(), SimTK::Pi/2.0,
+        "maximum_pennation_angle", errorLocation.c_str());
 }
 
 //==============================================================================

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -63,6 +63,10 @@ MuscleFixedWidthPennationModel(double optimalFiberLength,
     set_maximum_pennation_angle(maximumPennationAngle);
 }
 
+double MuscleFixedWidthPennationModel::getOptimalFiberLength() const
+{   return m_optimalFiberLength; }
+double MuscleFixedWidthPennationModel::getPennationAngleAtOptimal() const
+{   return m_pennationAngleAtOptimal; }
 double MuscleFixedWidthPennationModel::getParallelogramHeight() const
 {   return m_parallelogramHeight; }
 double MuscleFixedWidthPennationModel::getMinimumFiberLength() const

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -131,10 +131,6 @@ public:
     /** @returns The minimum possible fiber length along the tendon. */
     double getMinimumFiberLengthAlongTendon() const;
 
-    /** Enforces a lower bound on the fiber length to avoid a numerical
-    singularity as the fiber length approaches zero. */
-    double clampFiberLength(double fiberLength) const;
-
     /** Calculates the pennation angle (the orientation of the parallelogram)
     given the fiber length. */
     double calcPennationAngle(double fiberLength) const;
@@ -342,6 +338,14 @@ private:
     double m_minimumFiberLength;
     double m_minimumFiberLengthAlongTendon;
 
+    // Enforces a lower bound on the fiber length to avoid a numerical
+    // singularity as the fiber length approaches zero.
+    double clampFiberLength(double fiberLength) const;
+
+    // These classes are friends because they call clampFiberLength().
+    friend class Thelen2003Muscle;
+    friend class Millard2012EquilibriumMuscle;
+    friend class Millard2012AccelerationMuscle;
 };
 
 }

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -24,7 +24,7 @@
  * -------------------------------------------------------------------------- */
 #include "Simbody.h"
 #include <OpenSim/Actuators/osimActuatorsDLL.h>
-#include <OpenSim/Common/Object.h>
+#include <OpenSim/Simulation/Model/ModelComponent.h>
 
 namespace OpenSim {
 /** This is a muscle modeling utility class containing kinematic equations that
@@ -91,8 +91,8 @@ namespace OpenSim {
 
     @author Matt Millard
 */
-class OSIMACTUATORS_API MuscleFixedWidthPennationModel: public Object{
-OpenSim_DECLARE_CONCRETE_OBJECT(MuscleFixedWidthPennationModel, Object);
+class OSIMACTUATORS_API MuscleFixedWidthPennationModel : public ModelComponent{
+OpenSim_DECLARE_CONCRETE_OBJECT(MuscleFixedWidthPennationModel, ModelComponent);
 
 public:
 //==============================================================================
@@ -125,24 +125,11 @@ public:
     /** @returns The height of the fixed-width paralleogram. */
     double getParallelogramHeight() const;
 
-    /** @returns The optimal fiber length. */
-    double getOptimalFiberLength() const;
-
     /** @returns The minimum possible fiber length. */
     double getMinimumFiberLength() const;
 
     /** @returns The minimum possible fiber length along the tendon. */
     double getMinimumFiberLengthAlongTendon() const;
-
-    /** @returns The optimal pennation angle (radians). */
-    double getOptimalPennationAngle() const;
-
-    /** @returns The maximum permissible pennation angle. */
-    double getMaximumPennationAngle() const;
-
-    bool setOptimalFiberLength(double aOptimalFiberLength);
-    bool setOptimalPennationAngle(double aOptimalPennationAngle);
-    bool setMaximumPennationAngle(double aMaximumPennationAngle);
 
     /** Enforces a lower bound on the fiber length to avoid a numerical
     singularity as the fiber length approaches zero. */
@@ -343,6 +330,10 @@ public:
                              double tendonVelocity) const;
 
     void ensureModelUpToDate();
+
+protected:
+    // Component interface.
+    void extendFinalizeFromProperties() override;
 
 private:
     void setNull();

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -101,6 +101,10 @@ public:
     /** @name Property declarations
         These are the serializable properties associated with this class. **/
     /**@{**/
+    OpenSim_DECLARE_PROPERTY(optimal_fiber_length, double,
+        "Optimal length of the muscle fibers (overridden when this is a subcomponent of Muscle)");
+    OpenSim_DECLARE_PROPERTY(pennation_angle_at_optimal, double,
+        "Angle between tendon and fibers at optimal fiber length expressed in radians (overridden when this is a subcomponent of Muscle)");
     OpenSim_DECLARE_PROPERTY(maximum_pennation_angle, double,
         "Maximum pennation angle (radians)");
     /**@}**/
@@ -338,10 +342,6 @@ protected:
 private:
     void setNull();
     void constructProperties();
-
-    // Two properties of Muscle are stored here.
-    double m_optimalFiberLength;
-    double m_pennationAngleAtOptimal;
 
     double m_parallelogramHeight;
     double m_maximumSinPennation;

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -122,12 +122,6 @@ public:
                                    double optimalPennationAngle,
                                    double maximumPennationAngle);
 
-    /** @returns The optimal fiber length. */
-    double getOptimalFiberLength() const;
-
-    /** @returns The pennation angle at optimal fiber length. */
-    double getPennationAngleAtOptimal() const;
-
     /** @returns The height of the fixed-width paralleogram. */
     double getParallelogramHeight() const;
 

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -329,8 +329,6 @@ public:
                              double muscleVelocity,
                              double tendonVelocity) const;
 
-    void ensureModelUpToDate();
-
 protected:
     // Component interface.
     void extendFinalizeFromProperties() override;
@@ -338,8 +336,6 @@ protected:
 private:
     void setNull();
     void constructProperties();
-    void buildModel();
-    void ensurePropertiesSet() const;
 
     double m_parallelogramHeight;
     double m_maximumSinPennation;

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -101,10 +101,6 @@ public:
     /** @name Property declarations
         These are the serializable properties associated with this class. **/
     /**@{**/
-    OpenSim_DECLARE_PROPERTY(optimal_fiber_length, double,
-        "Optimal length of the muscle fibers (meters)");
-    OpenSim_DECLARE_PROPERTY(optimal_pennation_angle, double,
-        "Angle between tendon and fibers at optimal fiber length (radians)");
     OpenSim_DECLARE_PROPERTY(maximum_pennation_angle, double,
         "Maximum pennation angle (radians)");
     /**@}**/
@@ -336,6 +332,10 @@ protected:
 private:
     void setNull();
     void constructProperties();
+
+    // Two properties of Muscle are stored here.
+    double m_optimalFiberLength;
+    double m_pennationAngleAtOptimal;
 
     double m_parallelogramHeight;
     double m_maximumSinPennation;

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -118,6 +118,12 @@ public:
                                    double optimalPennationAngle,
                                    double maximumPennationAngle);
 
+    /** @returns The optimal fiber length. */
+    double getOptimalFiberLength() const;
+
+    /** @returns The pennation angle at optimal fiber length. */
+    double getPennationAngleAtOptimal() const;
+
     /** @returns The height of the fixed-width paralleogram. */
     double getParallelogramHeight() const;
 

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -798,16 +798,20 @@ int main(int argc, char* argv[])
 
         // Test property bounds.
         {
-            MuscleFixedWidthPennationModel fibKinEX;
-            fibKinEX.set_optimal_fiber_length(0.0);
-            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+            // TODO: Uncomment and refine when MuscleFixedWidthPennationModel is
+            //       a property of Thelen2003Muscle.
+            //Thelen2003Muscle mcl;
+            //mcl.set_optimal_fiber_length(0.0);
+            //SimTK_TEST_MUST_THROW_EXC(mcl.get_MuscleFixedWidthPennationModel.finalizeFromProperties(),
+            //    SimTK::Exception::ErrorCheck);
         }
         {
-            MuscleFixedWidthPennationModel fibKinEX;
-            fibKinEX.set_optimal_pennation_angle(SimTK::Pi/2.0);
-            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+            // TODO: Uncomment and refine when MuscleFixedWidthPennationModel is
+            //       a property of Thelen2003Muscle.
+            //MuscleFixedWidthPennationModel fibKinEX;
+            //fibKinEX.set_optimal_pennation_angle(SimTK::Pi/2.0);
+            //SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
+            //    SimTK::Exception::ValueOutOfRange);
         }
         {
             MuscleFixedWidthPennationModel fibKinEX;

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -864,7 +864,7 @@ int main(int argc, char* argv[])
 
         double maxPenAngle = SimTK::Pi/2.0 * (7.0/8.0);
 
-        fibKin.setMaximumPennationAngle(maxPenAngle);
+        fibKin.set_maximum_pennation_angle(maxPenAngle);
 
         //printf("Clamped Angle %f, expected %f\n",
         //    fibKin.calcPennationAngle(0,caller),

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
 
         MuscleFixedWidthPennationModel fibKin(  optFibLen, 
                                                 optPenAng,
-                                                SimTK::Pi/2.0);
+                                                SimTK::Pi/2.0 - SimTK::SignificantReal);
 
         MuscleFixedWidthPennationModel fibKin2( optFibLen*2, 
                                                 optPenAng,

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -326,6 +326,7 @@ int main(int argc, char* argv[])
         MuscleFixedWidthPennationModel fibKin(  optFibLen, 
                                                 optPenAng,
                                                 SimTK::Pi/2.0 - SimTK::SignificantReal);
+        fibKin.finalizeFromProperties();
 
         MuscleFixedWidthPennationModel fibKin2( optFibLen*2, 
                                                 optPenAng,
@@ -795,13 +796,26 @@ int main(int argc, char* argv[])
         cout << "**************************************************" << endl;
         cout << "TEST: Exception Handling" << endl;
 
-        //constructor
-        SimTK_TEST_MUST_THROW(MuscleFixedWidthPennationModel fibKinEX = 
-            MuscleFixedWidthPennationModel(0, optPenAng, SimTK::Pi/2.0));
-        SimTK_TEST_MUST_THROW(MuscleFixedWidthPennationModel fibKinEX = 
-            MuscleFixedWidthPennationModel(optFibLen, -0.01, SimTK::Pi/2.0));
-        SimTK_TEST_MUST_THROW(MuscleFixedWidthPennationModel fibKinEX = 
-            MuscleFixedWidthPennationModel(optFibLen, SimTK::Pi/2, SimTK::Pi/2.0));
+        // Test property bounds.
+        {
+            MuscleFixedWidthPennationModel fibKinEX;
+            fibKinEX.set_optimal_fiber_length(0.0);
+            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
+        }
+        {
+            MuscleFixedWidthPennationModel fibKinEX;
+            fibKinEX.set_optimal_pennation_angle(SimTK::Pi/2.0);
+            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
+                SimTK::Exception::ValueOutOfRange);
+        }
+        {
+            MuscleFixedWidthPennationModel fibKinEX;
+            fibKinEX.set_maximum_pennation_angle(SimTK::Pi/2.0
+                                                 + SimTK::SignificantReal);
+            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
+                SimTK::Exception::ValueOutOfRange);
+        }
 
         //Unset properties
         MuscleFixedWidthPennationModel fibKinDirty;

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -798,26 +798,34 @@ int main(int argc, char* argv[])
 
         // Test property bounds.
         {
-            // TODO: Uncomment and refine when MuscleFixedWidthPennationModel is
-            //       a property of Thelen2003Muscle.
-            //Thelen2003Muscle mcl;
-            //mcl.set_optimal_fiber_length(0.0);
-            //SimTK_TEST_MUST_THROW_EXC(mcl.get_MuscleFixedWidthPennationModel.finalizeFromProperties(),
-            //    SimTK::Exception::ErrorCheck);
+            MuscleFixedWidthPennationModel mfwpm;
+            mfwpm.set_optimal_fiber_length(0.0);
+            SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
+                SimTK::Exception::ErrorCheck);
         }
         {
-            // TODO: Uncomment and refine when MuscleFixedWidthPennationModel is
-            //       a property of Thelen2003Muscle.
-            //MuscleFixedWidthPennationModel fibKinEX;
-            //fibKinEX.set_optimal_pennation_angle(SimTK::Pi/2.0);
-            //SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
-            //    SimTK::Exception::ValueOutOfRange);
+            MuscleFixedWidthPennationModel mfwpm;
+            mfwpm.set_pennation_angle_at_optimal(-SimTK::SignificantReal);
+            SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
+                SimTK::Exception::ValueOutOfRange);
         }
         {
-            MuscleFixedWidthPennationModel fibKinEX;
-            fibKinEX.set_maximum_pennation_angle(SimTK::Pi/2.0
-                                                 + SimTK::SignificantReal);
-            SimTK_TEST_MUST_THROW_EXC(fibKinEX.finalizeFromProperties(),
+            MuscleFixedWidthPennationModel mfwpm;
+            mfwpm.set_pennation_angle_at_optimal(SimTK::Pi/2.0);
+            SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
+                SimTK::Exception::ValueOutOfRange);
+        }
+        {
+            MuscleFixedWidthPennationModel mfwpm;
+            mfwpm.set_maximum_pennation_angle(-SimTK::SignificantReal);
+            SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
+                SimTK::Exception::ValueOutOfRange);
+        }
+        {
+            MuscleFixedWidthPennationModel mfwpm;
+            mfwpm.set_maximum_pennation_angle(SimTK::Pi/2.0
+                                              + SimTK::SignificantReal);
+            SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
                 SimTK::Exception::ValueOutOfRange);
         }
 

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -109,10 +109,15 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
 
     // Ensure optimal fiber length and pennation angle at optimal fiber length
     // are up to date in the pennation model.
-    MuscleFixedWidthPennationModel tempPennMdl(getOptimalFiberLength(),
-        getPennationAngleAtOptimalFiberLength(),
-        pennMdl.get_maximum_pennation_angle());
-    pennMdl = tempPennMdl;
+    if (pennMdl.getOptimalFiberLength() != getOptimalFiberLength() ||
+        pennMdl.getPennationAngleAtOptimal() !=
+        getPennationAngleAtOptimalFiberLength())
+    {
+        MuscleFixedWidthPennationModel tempPennMdl(getOptimalFiberLength(),
+            getPennationAngleAtOptimalFiberLength(),
+            pennMdl.get_maximum_pennation_angle());
+        pennMdl = tempPennMdl;
+    }
 }
 
 //====================================================================

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -109,15 +109,9 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
 
     // Ensure optimal fiber length and pennation angle at optimal fiber length
     // are up to date in the pennation model.
-    if (pennMdl.getOptimalFiberLength() != getOptimalFiberLength() ||
-        pennMdl.getPennationAngleAtOptimal() !=
-        getPennationAngleAtOptimalFiberLength())
-    {
-        MuscleFixedWidthPennationModel tempPennMdl(getOptimalFiberLength(),
-            getPennationAngleAtOptimalFiberLength(),
-            pennMdl.get_maximum_pennation_angle());
-        pennMdl = tempPennMdl;
-    }
+    pennMdl.set_optimal_fiber_length(getOptimalFiberLength());
+    pennMdl.set_pennation_angle_at_optimal(
+        getPennationAngleAtOptimalFiberLength());
 }
 
 //====================================================================

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -221,7 +221,7 @@ const MuscleFixedWidthPennationModel& Thelen2003Muscle::
 
 double Thelen2003Muscle::getMaximumPennationAngle() const
 {
-    return penMdl.getMaximumPennationAngle();
+    return penMdl.get_maximum_pennation_angle();
 }
 
 //=============================================================================
@@ -420,7 +420,7 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
             case 2: //Maximum number of iterations exceeded.
             {
                 setActuation(s,0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
 
                 std::string muscleName = getName();
                 std::string fcnName = "\n\nWARNING: Thelen2003Muscle::"
@@ -444,7 +444,7 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
                         "        Whole muscle length : %f \n\n", 
                         muscleName.c_str(),
                         fcnName.c_str(), 
-                        penMdl.getOptimalFiberLength(),
+                        penMdl.get_optimal_fiber_length(),
                         abs(solnErr),
                         tol,
                         iterations,
@@ -465,7 +465,7 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
                         muscleName.c_str());
 
                 setActuation(s,0.0);
-                setFiberLength(s,penMdl.getOptimalFiberLength());
+                setFiberLength(s,penMdl.get_optimal_fiber_length());
         }
  
 
@@ -482,7 +482,7 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
              << endl;
 
         setActuation(s,0.0);
-        setFiberLength(s,penMdl.getOptimalFiberLength());
+        setFiberLength(s,penMdl.get_optimal_fiber_length());
 
     }
 }

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -154,6 +154,10 @@ void Thelen2003Muscle::constructProperties()
 
     constructProperty_MuscleFixedWidthPennationModel(
         MuscleFixedWidthPennationModel());
+    upd_MuscleFixedWidthPennationModel()
+        .set_optimal_fiber_length(getOptimalFiberLength());
+    upd_MuscleFixedWidthPennationModel()
+        .set_pennation_angle_at_optimal(getPennationAngleAtOptimalFiberLength());
     setMaximumPennationAngle(acos(0.1));
 
     constructProperty_FmaxTendonStrain(0.04); // was 0.033

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -48,10 +48,6 @@ Thelen2003Muscle::Thelen2003Muscle()
 {    
     setNull();
     constructInfrastructure();
-
-    // TODO: Remove this once MuscleFixedWidthPennationModel has been made into
-    //       a property.
-    buildMuscle();
 }
 
 //_____________________________________________________________________________
@@ -71,11 +67,6 @@ Thelen2003Muscle(const std::string& aName,  double aMaxIsometricForce,
     setOptimalFiberLength(aOptimalFiberLength);
     setTendonSlackLength(aTendonSlackLength);
     setPennationAngleAtOptimalFiberLength(aPennationAngle);
-
-    // TODO: Remove this once MuscleFixedWidthPennationModel has been made into
-    //       a property.
-    buildMuscle();
-
 }
 
 //==============================================================================
@@ -88,6 +79,10 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     MuscleFirstOrderActivationDynamicModel& actMdl = 
         upd_MuscleFirstOrderActivationDynamicModel();
     addComponent(&actMdl);
+
+    MuscleFixedWidthPennationModel& pennMdl =
+        upd_MuscleFixedWidthPennationModel();
+    addComponent(&pennMdl);
 
     SimTK_ERRCHK1_ALWAYS(get_FmaxTendonStrain() > 0,
         "Thelen2003Muscle::extendFinalizeFromProperties",
@@ -111,6 +106,13 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
         "Thelen2003::extendFinalizeFromProperties",
         "%s: F-v extrapolation threshold must be greater than 1.0/Flen",
         getName().c_str());
+
+    // Ensure optimal fiber length and pennation angle at optimal fiber length
+    // are up to date in the pennation model.
+    MuscleFixedWidthPennationModel tempPennMdl(getOptimalFiberLength(),
+        getPennationAngleAtOptimalFiberLength(),
+        pennMdl.get_maximum_pennation_angle());
+    pennMdl = tempPennMdl;
 }
 
 //====================================================================
@@ -119,10 +121,6 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
 void Thelen2003Muscle::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
-
-    // TODO: Remove this once MuscleFixedWidthPennationModel has been made into
-    //       a property.
-    buildMuscle();
 }
 
 void Thelen2003Muscle::extendInitStateFromProperties(SimTK::State& s) const
@@ -134,36 +132,8 @@ void Thelen2003Muscle::
     extendSetPropertiesFromState(const SimTK::State& s)
 {
     Super::extendSetPropertiesFromState(s);
-
-    // TODO: Remove this once MuscleFixedWidthPennationModel has been made into
-    //       a property.
-    buildMuscle();
 }
 
-void Thelen2003Muscle::buildMuscle()
-{
-    if (!isObjectUpToDateWithProperties()) {
-
-        //Appropriately set the properties of the pennation model
-        double optimalFiberLength = getOptimalFiberLength();
-        double pennationAngle     = getPennationAngleAtOptimalFiberLength();
-
-        MuscleFixedWidthPennationModel tmp2( optimalFiberLength,
-                                        pennationAngle, 
-                                        acos(0.1));
-
-        penMdl = tmp2;   
-
-        //Ensure all sub objects are up to date with properties.
-        //upd_MuscleFirstOrderActivationDynamicModel().finalizeFromProperties();
-        //penMdl.ensureModelUpToDate();
-        // TODO: Remove this once MuscleFixedWidthPennationModel has been made
-        //       into a property.
-        penMdl.finalizeFromProperties();
-
-        setObjectIsUpToDateWithProperties();
-    }
-}
 //_____________________________________________________________________________
 // Set the data members of this muscle to their null values.
 void Thelen2003Muscle::setNull()
@@ -171,8 +141,6 @@ void Thelen2003Muscle::setNull()
     // no data members
     setAuthors("Matthew Millard");
 }
-
-
 
 //_____________________________________________________________________________
 /**
@@ -184,6 +152,10 @@ void Thelen2003Muscle::constructProperties()
         MuscleFirstOrderActivationDynamicModel());
     setActivationTimeConstant(0.015);
     setDeactivationTimeConstant(0.050);
+
+    constructProperty_MuscleFixedWidthPennationModel(
+        MuscleFixedWidthPennationModel());
+    setMaximumPennationAngle(acos(0.1));
 
     constructProperty_FmaxTendonStrain(0.04); // was 0.033
     constructProperty_FmaxMuscleStrain(0.6);
@@ -212,20 +184,14 @@ double Thelen2003Muscle::getMinimumActivation() const
 
 const MuscleFirstOrderActivationDynamicModel& Thelen2003Muscle::
     getActivationModel() const
-{    
-    return get_MuscleFirstOrderActivationDynamicModel();
-}
+{   return get_MuscleFirstOrderActivationDynamicModel(); }
 
 const MuscleFixedWidthPennationModel& Thelen2003Muscle::
     getPennationModel() const
-{    
-    return penMdl;
-}
+{   return get_MuscleFixedWidthPennationModel(); }
 
 double Thelen2003Muscle::getMaximumPennationAngle() const
-{
-    return penMdl.get_maximum_pennation_angle();
-}
+{   return get_MuscleFixedWidthPennationModel().get_maximum_pennation_angle(); }
 
 //=============================================================================
 // SET
@@ -246,6 +212,12 @@ void Thelen2003Muscle::setMinimumActivation(double minimumActivation)
 {
     upd_MuscleFirstOrderActivationDynamicModel().
         set_minimum_activation(minimumActivation);
+}
+
+void Thelen2003Muscle::setMaximumPennationAngle(double maximumPennationAngle)
+{
+    upd_MuscleFixedWidthPennationModel().
+        set_maximum_pennation_angle(maximumPennationAngle);
 }
 
 //==============================================================================
@@ -270,13 +242,17 @@ calcInextensibleTendonActiveFiberForce(SimTK::State& s,
         double tendonSlackLength = getTendonSlackLength();
         double tendonVelocity = 0.0; //Inextensible tendon;
 
-        double fiberLength  = penMdl.calcFiberLength(muscleLength,
+        double fiberLength  = get_MuscleFixedWidthPennationModel()
+                              .calcFiberLength(muscleLength,
                                              tendonSlackLength);
         
-        if(fiberLength > penMdl.getMinimumFiberLength()){
-            double phi      = penMdl.calcPennationAngle(fiberLength);
+        if(fiberLength > get_MuscleFixedWidthPennationModel()
+                         .getMinimumFiberLength()) {
+            double phi = get_MuscleFixedWidthPennationModel()
+                         .calcPennationAngle(fiberLength);
         
-            double fiberVelocity   = penMdl.calcFiberVelocity(cos(phi),
+            double fiberVelocity = get_MuscleFixedWidthPennationModel()
+                                   .calcFiberVelocity(cos(phi),
                                           muscleVelocity,tendonVelocity);
 
             inextensibleTendonActiveFiberForce = 
@@ -302,11 +278,13 @@ double Thelen2003Muscle::
     caller.append("::Thelen2003Muscle::calcActiveFiberForceAlongTendon");
 
     double activeFiberForce = 0;    
-    double clampedFiberLength = penMdl.clampFiberLength(fiberLength);
+    double clampedFiberLength = get_MuscleFixedWidthPennationModel()
+                                .clampFiberLength(fiberLength);
 
     //If the fiber is in a legal range, compute the force its generating
-    if(fiberLength > penMdl.getMinimumFiberLength()){
-
+    if(fiberLength > get_MuscleFixedWidthPennationModel()
+                     .getMinimumFiberLength())
+    {
         //Clamp activation to a legal range
         double clampedActivation = get_MuscleFirstOrderActivationDynamicModel()
                                    .clampActivation(activation);
@@ -336,7 +314,8 @@ double Thelen2003Muscle::
         double fiso = getMaxIsometricForce();
 
         //Evaluate the pennation angle
-        double phi = penMdl.calcPennationAngle(fiberLength);
+        double phi = get_MuscleFixedWidthPennationModel()
+                     .calcPennationAngle(fiberLength);
 
         //Compute the active fiber force 
         activeFiberForce = fiso * clampedActivation * fal * fv * cos(phi);
@@ -417,7 +396,8 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
                 std::string muscleName = getName();            
                 printf( "\n\nThelen2003Muscle Initialization Message:"
                         " %s is at its minimum length of %f",
-                        muscleName.c_str(), penMdl.getMinimumFiberLength());
+                        muscleName.c_str(), get_MuscleFixedWidthPennationModel()
+                                            .getMinimumFiberLength());
             }break;
 
             case 2: //Maximum number of iterations exceeded.
@@ -508,19 +488,21 @@ void Thelen2003Muscle::calcMuscleLengthInfo(const SimTK::State& s,
         caller.append("_Thelen2003Muscle::calcMuscleLengthInfo");
 
         //Clamp the minimum fiber length to its minimum physical value.
-        mli.fiberLength  = penMdl.clampFiberLength(
+        mli.fiberLength  = get_MuscleFixedWidthPennationModel().clampFiberLength(
                                 getStateVariableValue(s, STATE_FIBER_LENGTH_NAME));
 
-        mli.normFiberLength   = mli.fiberLength/optFiberLength;       
-        mli.pennationAngle = penMdl.calcPennationAngle(mli.fiberLength);    
+        mli.normFiberLength = mli.fiberLength/optFiberLength;       
+        mli.pennationAngle  = get_MuscleFixedWidthPennationModel()
+                              .calcPennationAngle(mli.fiberLength);    
 
         mli.cosPennationAngle = cos(mli.pennationAngle);
         mli.sinPennationAngle = sin(mli.pennationAngle);
 
         mli.fiberLengthAlongTendon = mli.fiberLength*mli.cosPennationAngle;
     
-        mli.tendonLength      = penMdl.calcTendonLength(mli.cosPennationAngle,
-                                                        mli.fiberLength,mclLength);
+        mli.tendonLength      = get_MuscleFixedWidthPennationModel()
+                                .calcTendonLength(mli.cosPennationAngle,
+                                                  mli.fiberLength,mclLength);
         mli.normTendonLength  = mli.tendonLength / tendonSlackLen;
         mli.tendonStrain      = mli.normTendonLength -  1.0;
         
@@ -642,21 +624,20 @@ void Thelen2003Muscle::calcFiberVelocityInfo(const SimTK::State& s,
         double fal  = mli.fiberActiveForceLengthMultiplier;
         double fpe  = mli.fiberPassiveForceLengthMultiplier;
 
-        double afalfv   = ((fse/cosphi)-fpe); //we can do this without fear of
+        double afalfv = ((fse/cosphi)-fpe); //we can do this without fear of
                                               //a singularity because fiber length
                                               //is clamped
-        double fv       = afalfv/(a*fal);
-
-        double dlceN    = calcdlceN(a,fal,afalfv);
-    
-        double dlce     = dlceN*getMaxContractionVelocity()*optFiberLen;
+        double fv     = afalfv/(a*fal);
+        double dlceN  = calcdlceN(a,fal,afalfv);
+        double dlce   = dlceN*getMaxContractionVelocity()*optFiberLen;
         double tanPhi = tan(phi);
-        double dphidt    = penMdl.calcPennationAngularVelocity(tanPhi,lce,dlce);
-        double dlceAT   = penMdl.calcFiberVelocityAlongTendon(lce,
-                                                        dlce,sinphi,cosphi, dphidt);
-
-        double dtl       = penMdl.calcTendonVelocity(cosphi,sinphi,dphidt,
-                                                            lce,  dlce,dmcldt);
+        double dphidt = get_MuscleFixedWidthPennationModel()
+                        .calcPennationAngularVelocity(tanPhi,lce,dlce);
+        double dlceAT = get_MuscleFixedWidthPennationModel()
+                        .calcFiberVelocityAlongTendon(lce, dlce, sinphi, cosphi,
+                                                      dphidt);
+        double dtl    = get_MuscleFixedWidthPennationModel().calcTendonVelocity(
+                            cosphi, sinphi, dphidt, lce, dlce, dmcldt);
     
     
         //Switching condition: if the fiber is clamped and the tendon and the 
@@ -724,7 +705,8 @@ void Thelen2003Muscle::calcMuscleDynamicsInfo(const SimTK::State& s,
             double tendonSlackLen = getTendonSlackLength();
             double optFiberLen    = getOptimalFiberLength();
             double fiso           = getMaxIsometricForce();
-            double penHeight      = penMdl.getParallelogramHeight();
+            double penHeight      = get_MuscleFixedWidthPennationModel()
+                                    .getParallelogramHeight();
 
         //Prep strings that will be useful to make sensible exception messages
             std::string muscleName = getName();
@@ -868,9 +850,9 @@ void Thelen2003Muscle::calcMuscleDynamicsInfo(const SimTK::State& s,
    
 }
 
-double Thelen2003Muscle:: getMinimumFiberLength() const
+double Thelen2003Muscle::getMinimumFiberLength() const
 {
-    return penMdl.getMinimumFiberLength();
+    return get_MuscleFixedWidthPennationModel().getMinimumFiberLength();
 }
 
 
@@ -963,9 +945,9 @@ SimTK::Vector Thelen2003Muscle::
     double tl  = getTendonSlackLength()*1.01;
 
    
-    lce = penMdl.calcFiberLength( ml, tl);    
+    lce = get_MuscleFixedWidthPennationModel().calcFiberLength( ml, tl);    
     
-    double phi      = penMdl.calcPennationAngle(lce);
+    double phi      = get_MuscleFixedWidthPennationModel().calcPennationAngle(lce);
     double cosphi   = cos(phi);
     double sinphi   = sin(phi);  
 
@@ -1059,16 +1041,19 @@ SimTK::Vector Thelen2003Muscle::
                     lce = lce + lengthPerturbation;
                 }
 
-                if(lce < penMdl.getMinimumFiberLength()){
+                if(lce < get_MuscleFixedWidthPennationModel()
+                         .getMinimumFiberLength())
+                {
                     minFiberLengthCtr++;
-                    lce = penMdl.getMinimumFiberLength();
+                    lce = get_MuscleFixedWidthPennationModel()
+                          .getMinimumFiberLength();
                 }
 
                 
                 //Update position level quantities, only if they won't go 
                 //singular
 
-                phi = penMdl.calcPennationAngle(lce);
+                phi = get_MuscleFixedWidthPennationModel().calcPennationAngle(lce);
                 cosphi = cos(phi);
                 tl  = ml - lce*cosphi;
                 lceN = lce/ofl;
@@ -1103,10 +1088,13 @@ SimTK::Vector Thelen2003Muscle::
                     dtl     = dml;
                 }
 
-                dlce = penMdl.calcFiberVelocity(cosphi,dml,dtl); 
+                dlce = get_MuscleFixedWidthPennationModel()
+                       .calcFiberVelocity(cosphi,dml,dtl); 
                 dlceN    = dlce/(vmax*ofl);
-                dphi = penMdl.calcPennationAngularVelocity(tan(phi),lce,dlce);
-                dlceAT = penMdl.calcFiberVelocityAlongTendon(lce,dlce,
+                dphi = get_MuscleFixedWidthPennationModel()
+                       .calcPennationAngularVelocity(tan(phi),lce,dlce);
+                dlceAT = get_MuscleFixedWidthPennationModel()
+                         .calcFiberVelocityAlongTendon(lce,dlce,
                                                     sinphi,cosphi,dphi);               
             }
         
@@ -1139,10 +1127,11 @@ SimTK::Vector Thelen2003Muscle::
         
         if(iter < aMaxIterations){ //if the fiber length hit its lower bound
 
-            lce = penMdl.getMinimumFiberLength();
-            phi = penMdl.calcPennationAngle(lce);
+            lce = get_MuscleFixedWidthPennationModel().getMinimumFiberLength();
+            phi = get_MuscleFixedWidthPennationModel().calcPennationAngle(lce);
             cosphi = cos(phi);
-            tl  = penMdl.calcTendonLength(cosphi,lce,ml);
+            tl  = get_MuscleFixedWidthPennationModel()
+                  .calcTendonLength(cosphi,lce,ml);
             lceN = lce/ofl;
             tlN  = tl/tsl;                
             fse = calcfse(tlN);

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -156,7 +156,10 @@ void Thelen2003Muscle::buildMuscle()
 
         //Ensure all sub objects are up to date with properties.
         //upd_MuscleFirstOrderActivationDynamicModel().finalizeFromProperties();
-        penMdl.ensureModelUpToDate();
+        //penMdl.ensureModelUpToDate();
+        // TODO: Remove this once MuscleFixedWidthPennationModel has been made
+        //       into a property.
+        penMdl.finalizeFromProperties();
 
         setObjectIsUpToDateWithProperties();
     }

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -422,8 +422,8 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
 
             case 2: //Maximum number of iterations exceeded.
             {
-                setActuation(s,0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setActuation(s, 0.0);
+                setFiberLength(s, get_optimal_fiber_length());
 
                 std::string muscleName = getName();
                 std::string fcnName = "\n\nWARNING: Thelen2003Muscle::"
@@ -447,7 +447,7 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
                         "        Whole muscle length : %f \n\n", 
                         muscleName.c_str(),
                         fcnName.c_str(), 
-                        penMdl.get_optimal_fiber_length(),
+                        get_optimal_fiber_length(),
                         abs(solnErr),
                         tol,
                         iterations,
@@ -467,8 +467,8 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
                         "optimal fiber length",
                         muscleName.c_str());
 
-                setActuation(s,0.0);
-                setFiberLength(s,penMdl.get_optimal_fiber_length());
+                setActuation(s, 0.0);
+                setFiberLength(s, get_optimal_fiber_length());
         }
  
 
@@ -484,8 +484,8 @@ void Thelen2003Muscle::computeInitialFiberEquilibrium(SimTK::State& s) const
         cerr << "    and a fiber length equal to the optimal fiber length ..." 
              << endl;
 
-        setActuation(s,0.0);
-        setFiberLength(s,penMdl.get_optimal_fiber_length());
+        setActuation(s, 0.0);
+        setFiberLength(s, get_optimal_fiber_length());
 
     }
 }

--- a/OpenSim/Actuators/Thelen2003Muscle.h
+++ b/OpenSim/Actuators/Thelen2003Muscle.h
@@ -144,6 +144,9 @@ public:
     OpenSim_DECLARE_UNNAMED_PROPERTY(MuscleFirstOrderActivationDynamicModel,
         "The model governing the excitation-to-activation dynamics.");
 
+    OpenSim_DECLARE_UNNAMED_PROPERTY(MuscleFixedWidthPennationModel,
+        "The model governing the fiber and tendon kinematics.");
+
     /**@}**/
 
     enum CurveType{FiberActiveForceLength,
@@ -169,7 +172,7 @@ public:
 
     /** @name Convenience methods
     These are convenience methods that get and set properties of the activation
-    model. **/
+    and pennation models. **/
     /**@{**/
     double getActivationTimeConstant() const;
     void setActivationTimeConstant(double actTimeConstant);
@@ -177,6 +180,8 @@ public:
     void setDeactivationTimeConstant(double deactTimeConstant);
     double getMinimumActivation() const;
     void setMinimumActivation(double minimumActivation);
+    double getMaximumPennationAngle() const;
+    void setMaximumPennationAngle(double maximumPennationAngle);
     /**@}**/
 
     /**
@@ -187,11 +192,6 @@ public:
         fiber velocity goes positive.
     */
     double getMinimumFiberLength() const;
-
-    /**
-    @return the maximum pennation angle allowed by this muscle model (radians)
-    */
-    double getMaximumPennationAngle() const;
 
     /**
    @returns the MuscleFirstOrderActivationDynamicModel 
@@ -284,17 +284,13 @@ protected:
 private:
     void setNull();
     void constructProperties() override;
-    void buildMuscle();
-    //void ensureMuscleUpToDate();
+
     //=====================================================================
     // Private Utility Class Members
     //      -Computes activation dynamics and fiber kinematics
     //=====================================================================
     //bool initializedModel;
 
-    //Fiber and Tendon Kinematics
-    MuscleFixedWidthPennationModel penMdl;
-    
     //=====================================================================
     // Private Accessor names
     //=====================================================================

--- a/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
+++ b/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
@@ -160,7 +160,7 @@ int main()
         //Optimizer opt(sys, InteriorPoint);
 
         // Specify settings for the optimizer
-        opt.setConvergenceTolerance(0.1);
+        opt.setConvergenceTolerance(0.11);
         opt.useNumericalGradient(true, 1e-5);
         opt.setMaxIterations(100);
         opt.setLimitedMemoryHistory(500);

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -140,14 +140,14 @@ int main()
             countSkipComponent++;
         }
 
-        ASSERT(numComponents == 29); 
+        ASSERT(numComponents == 35); 
         ASSERT(numBodies == model.getNumBodies());
         ASSERT(numBodiesPost == numBodies);
         ASSERT(numMuscles == model.getMuscles().getSize());
         ASSERT(numJointsWithStateVariables == 2);
         ASSERT(numModelComponentsWithStateVariables == 11);
         ASSERT(numJntComponents == 2);
-        ASSERT(countSkipComponent == 15);
+        ASSERT(countSkipComponent == 18);
     }
     catch (Exception &ex) {
         ex.print(std::cout);


### PR DESCRIPTION
MuscleFixedWidthPennationModel is now a property and subcomponent of Thelen2003Muscle.

Removed duplicated checks of property values; all property value checks are now performed in `MuscleFixedWidthPennationModel::extendFinalizeFromProperties()`. Removed `buildModel()` and `ensureModelUpToDate()` methods from MuscleFixedWidthPennationModel, and removed `buildMuscle()` method from Thelen2003Muscle. Fixes #326.

Analogous changes should be made to Millard2012{Equilibrium|Acceleration}Muscle. Added to #366.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/378)
<!-- Reviewable:end -->
