### PR TITLE
Remove osimInstantiator class from OpenSim.h

### DIFF
--- a/OpenSim/OpenSim.h
+++ b/OpenSim/OpenSim.h
@@ -29,17 +29,4 @@
 #include "Analyses/osimAnalyses.h"
 #include "Tools/osimTools.h"
 
-class osimInstantiator
-{
-public:
-    osimInstantiator() {
-        RegisterTypes_osimCommon();
-        RegisterTypes_osimSimulation();
-        RegisterTypes_osimActuators();
-        RegisterTypes_osimAnalyses();
-        RegisterTypes_osimTools();
-    }
-};
-
-static osimInstantiator instantiator;
 #endif // _opensim_h_


### PR DESCRIPTION
This singleton class in OpenSim.h shouldn't be necessary; each library takes care of its own registering. If the tests pass I think we should be able to merge this.

Ajay suggested that plugins or client main programs might make use of this singleton. @aymanhab  doesn't think it should be necessary. @msdemers do you know about this?