### PR TITLE
Knee ligament

### DIFF
--- a/OpenSim/Simulation/Model/KneeLigament.cpp
+++ b/OpenSim/Simulation/Model/KneeLigament.cpp
@@ -1,0 +1,300 @@
+/* -------------------------------------------------------------------------- *
+ *                           OpenSim:  KneeLigament.cpp                       *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2013 Stanford University and the Authors                *
+ * Author(s): Peter Loan, Dimitar Stanev                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include "KneeLigament.h"
+#include "GeometryPath.h"
+#include "PointForceDirection.h"
+
+//=============================================================================
+// STATICS
+//=============================================================================
+using namespace std;
+using namespace OpenSim;
+using SimTK::Vec3;
+
+static const Vec3 DefaultLigamentColor(.9,.9,.9); // mostly white 
+
+//=============================================================================
+// CONSTRUCTOR(S) AND DESTRUCTOR
+//=============================================================================
+//_____________________________________________________________________________
+// Default constructor.
+KneeLigament::KneeLigament()
+{
+    constructProperties();
+}
+
+//_____________________________________________________________________________
+/*
+ * Construct and initialize the properties for the ligament.
+ * 
+ * You should give each property a meaningful name and an informative comment.
+ * The name you give each property is the tag that will be used in the XML
+ * file. The comment will appear before the property in the XML file.
+ * In addition, the comments are used for tool tips in the OpenSim GUI.
+ *
+ * All properties are added to the property set. Once added, they can be
+ * read in and written to file.
+ */
+void KneeLigament::constructProperties()
+{
+    setAuthors("Dimitar Stanev");
+    constructProperty_GeometryPath(GeometryPath());
+    constructProperty_resting_length(0.0);
+	constructProperty_epsilon_length(0.0);
+	constructProperty_ligament_stiffness(0.0);
+}
+
+
+void KneeLigament::extendFinalizeFromProperties()
+{
+    Super::extendFinalizeFromProperties();
+
+    // Resting length must be greater than 0.0.
+    assert(get_resting_length() > 0.0);
+
+    GeometryPath& path = upd_GeometryPath();
+    path.setDefaultColor(DefaultLigamentColor);
+    addComponent(&path);
+    path.setOwner(this);
+}
+
+
+//------------------------------------------------------------------------------
+//                            REALIZE DYNAMICS
+//------------------------------------------------------------------------------
+// See if anyone has an opinion about the path color and change it if so.
+void KneeLigament::extendRealizeDynamics(const SimTK::State& state) const {
+    Super::extendRealizeDynamics(state); // Mandatory first line
+
+    if(!isDisabled(state)){
+        const SimTK::Vec3 color = computePathColor(state);
+        if (!color.isNaN())
+            getGeometryPath().setColor(state, color);
+    }
+}
+
+//------------------------------------------------------------------------------
+//                          COMPUTE PATH COLOR
+//------------------------------------------------------------------------------
+// This is the Ligament base class implementation for choosing the path
+// color. Derived classes can override this with something meaningful.
+// TODO: should the default attempt to use the ligament tension to control
+// colors? Not sure how to scale.
+SimTK::Vec3 KneeLigament::computePathColor(const SimTK::State& state) const {
+    return SimTK::Vec3(SimTK::NaN);
+}
+
+//------------------------------------------------------------------------------
+//                             ADD TO SYSTEM
+//------------------------------------------------------------------------------
+/**
+ * allocate and initialize the SimTK state for this ligament.
+ */
+ void KneeLigament::extendAddToSystem(SimTK::MultibodySystem& system) const
+{
+    Super::extendAddToSystem(system);
+    // Cache the computed tension and strain of the ligament
+    addCacheVariable<double>("tension", 0.0, SimTK::Stage::Velocity);
+    addCacheVariable<double>("strain", 0.0, SimTK::Stage::Velocity);
+}
+
+
+//=============================================================================
+// GET AND SET
+//=============================================================================
+//-----------------------------------------------------------------------------
+// LENGTH
+//-----------------------------------------------------------------------------
+//_____________________________________________________________________________
+/**
+ * Get the length of the ligament. This is a convenience function that passes
+ * the request on to the ligament path.
+ *
+ * @return Current length of the ligament path.
+ */
+double KneeLigament::getLength(const SimTK::State& s) const
+{
+    return getGeometryPath().getLength(s);
+}
+
+//_____________________________________________________________________________
+/**
+ * Set the resting length.
+ *
+ * @param aRestingLength The resting length of the ligament.
+ * @return Whether the resting length was successfully changed.
+ */
+bool KneeLigament::setRestingLength(double aRestingLength)
+{
+    set_resting_length(aRestingLength);
+    return true;
+}
+
+//=============================================================================
+// SCALING
+//=============================================================================
+//_____________________________________________________________________________
+/**
+ * Perform computations that need to happen before the ligament is scaled.
+ * For this object, that entails calculating and storing the
+ * length in the current body position.
+ *
+ * @param aScaleSet XYZ scale factors for the bodies.
+ */
+void KneeLigament::preScale(const SimTK::State& s, const ScaleSet& aScaleSet)
+{
+    updGeometryPath().preScale(s, aScaleSet);
+}
+
+//_____________________________________________________________________________
+/**
+ * Scale the ligament.
+ *
+ * @param aScaleSet XYZ scale factors for the bodies
+ * @return Whether or not the ligament was scaled successfully
+ */
+void KneeLigament::scale(const SimTK::State& s, const ScaleSet& aScaleSet)
+{
+    updGeometryPath().scale(s, aScaleSet);
+}
+
+//_____________________________________________________________________________
+/**
+ * Perform computations that need to happen after the ligament is scaled.
+ * For this object, that entails comparing the length before and after scaling,
+ * and scaling the resting length a proportional amount.
+ *
+ * @param aScaleSet XYZ scale factors for the bodies.
+ */
+void KneeLigament::postScale(const SimTK::State& s, const ScaleSet& aScaleSet)
+{
+    GeometryPath& path          = updGeometryPath();
+    double&       restingLength = upd_resting_length();
+
+    path.postScale(s, aScaleSet);
+
+    if (path.getPreScaleLength(s) > 0.0)
+    {
+        double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);
+
+        // Scale resting length by the same amount as the change in
+        // total ligament length (in the current body position).
+        restingLength *= scaleFactor;
+
+        path.setPreScaleLength(s, 0.0);
+    }
+}
+
+const double& KneeLigament::getTension(const SimTK::State& s) const
+{
+    return getCacheVariableValue<double>(s, "tension"); 
+}
+
+
+//=============================================================================
+// COMPUTATION
+//=============================================================================
+/**
+ * Compute the moment-arm of this muscle about a coordinate.
+ */
+double KneeLigament::computeMomentArm(const SimTK::State& s, Coordinate& aCoord) const
+{
+    return getGeometryPath().computeMomentArm(s, aCoord);
+}
+
+
+
+void KneeLigament::computeForce(const SimTK::State& s, 
+                              SimTK::Vector_<SimTK::SpatialVec>& bodyForces, 
+                              SimTK::Vector& generalizedForces) const
+{
+    const GeometryPath& path = getGeometryPath();
+    const double& restingLength = get_resting_length();
+
+    double force = 0;
+
+    if (path.getLength(s) <= restingLength){
+        setCacheVariableValue<double>(s, "tension", force);
+        return;
+    }
+    
+    // evaluate normalized tendon force length curve
+	force = computeLigamentForceStrain(path.getLength(s));
+    setCacheVariableValue<double>(s, "tension", force);
+
+    OpenSim::Array<PointForceDirection*> PFDs;
+    path.getPointForceDirections(s, &PFDs);
+
+    for (int i=0; i < PFDs.getSize(); i++) {
+        applyForceToPoint(s, PFDs[i]->body(), PFDs[i]->point(), 
+                          force*PFDs[i]->direction(), bodyForces);
+    }
+    for(int i=0; i < PFDs.getSize(); i++)
+        delete PFDs[i];
+}
+
+//_____________________________________________________________________________
+/**
+ * Get the visible object used to represent the Ligament.
+ */
+const VisibleObject* KneeLigament::getDisplayer() const
+{ 
+    return getGeometryPath().getDisplayer(); 
+}
+
+//_____________________________________________________________________________
+/**
+ * Update the visible object used to represent the Ligament.
+ */
+void KneeLigament::updateDisplayer(const SimTK::State& s) const
+{
+    getGeometryPath().updateDisplayer(s);
+}
+
+//_____________________________________________________________________________
+/**
+* Computes the strain force function of the ligament.
+*/
+double KneeLigament::computeLigamentForceStrain(double length) const
+{
+	double e = (length - get_resting_length()) / get_resting_length();
+	double e_l = get_epsilon_length();
+	double k = get_ligament_stiffness();
+
+	if (e < 0)
+	{
+		return 0;
+	}
+	else if (e <= 2 * e_l)
+	{
+		return 0.25 * k * e * e / e_l;
+	}
+	else
+	{
+		return k * (e - e_l);
+	}
+}

--- a/OpenSim/Simulation/Model/KneeLigament.h
+++ b/OpenSim/Simulation/Model/KneeLigament.h
@@ -45,21 +45,43 @@ class GeometryPath;
 //=============================================================================
 //=============================================================================
 /**
-A class implementing a knee ligament. The force strain function is given by:
-	
+A class implementing a knee ligament. The ligament is described by three
+parameters, rest length \f$ l_0 \f$, the stiffness \f$ k \f$ and toe region
+\f$ e_l \f$.
+
+The strain is given by:
+
 \f[
-f(e) =
-\begin{cases}
-0 & \text{if } e \leq 0 \\
-\frac{1}{4} \cdot \frac{e^2}{e_l}      & \text{if } e \leq 2 \cdot e_l\\
-k \cdot (e - e_l) & \text{otherwise}
-\end{cases}
+e = (l -l_0) / l_0
 \f]
 
-where, \f$k\f$ is the stiffness of the ligament, \f$e\f$ is the strain 
-(\f$(l -l0) / l0\f$) and \f$e_l\f$ is the strain related to where it changes from 
-non-linear to linear region.
- */
+where \f$ l_0 \f$ is the resting length of the ligament
+
+The force strain function is given by:
+
+\f[
+f(e) = 0, e \leq 0 
+\f]
+
+\f[
+f(e) = \frac{1}{4} \cdot \frac{e^2}{e_l}, e \leq 2 \cdot e_l
+\f]
+
+\f[
+f(e) = k \cdot (e - e_l), e > 2 \cdot e_l
+\f]
+
+where, \f$ k \f$ is the stiffness of the ligament and \f$ e_l \f$ is the limit 
+at which the ligament moves from the non-linear region to linear region.
+
+Sometime we define the reference length \f$ l_r \f$ and the reference strain
+\f$ e_r \f$, so the rest length is given by:
+
+\f[
+l_0 = l_r / (e_r + 1)
+\f]
+
+*/
 class OSIMSIMULATION_API KneeLigament : public Force {
 OpenSim_DECLARE_CONCRETE_OBJECT(KneeLigament, Force);
 public:

--- a/OpenSim/Simulation/Model/KneeLigament.h
+++ b/OpenSim/Simulation/Model/KneeLigament.h
@@ -1,0 +1,215 @@
+#ifndef OPENSIM_KNEE_LIGAMENT_H_
+#define OPENSIM_KNEE_LIGAMENT_H_
+/* -------------------------------------------------------------------------- *
+ *                            OpenSim:  KneeLigament.h                        *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2013 Stanford University and the Authors                *
+ * Author(s): Peter Loan, Dimitar Stanev                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include <OpenSim/Common/ScaleSet.h>
+#include "Model.h"
+#include "Force.h"
+
+#ifdef SWIG
+    #ifdef OSIMACTUATORS_API
+        #undef OSIMACTUATORS_API
+        #define OSIMACTUATORS_API
+    #endif
+#endif
+
+namespace OpenSim {
+
+class GeometryPath;
+
+//=============================================================================
+//=============================================================================
+/**
+A class implementing a knee ligament. The force strain function is given by:
+	
+\f[
+f(e) =
+\begin{cases}
+0 & \text{if } e \leq 0 \\
+\frac{1}{4} \cdot \frac{e^2}{e_l}      & \text{if } e \leq 2 \cdot e_l\\
+k \cdot (e - e_l) & \text{otherwise}
+\end{cases}
+\f]
+
+where, \f$k\f$ is the stiffness of the ligament, \f$e\f$ is the strain 
+(\f$(l -l0) / l0\f$) and \f$e_l\f$ is the strain related to where it changes from 
+non-linear to linear region.
+ */
+class OSIMSIMULATION_API KneeLigament : public Force {
+OpenSim_DECLARE_CONCRETE_OBJECT(KneeLigament, Force);
+public:
+//=============================================================================
+// PROPERTIES
+//=============================================================================
+    /** @name Property declarations
+    These are the serializable properties associated with this class. **/
+    /**@{**/    
+	OpenSim_DECLARE_UNNAMED_PROPERTY(GeometryPath, 
+        "the set of points defining the path of the ligament");
+    OpenSim_DECLARE_PROPERTY(resting_length, double,
+        "resting length of the ligament");
+	OpenSim_DECLARE_PROPERTY(epsilon_length, double,
+		"length were the curve changes from non-linear to linear region");
+	OpenSim_DECLARE_PROPERTY(ligament_stiffness, double,
+		"stiffness parameter of the ligament");
+    /**@}**/
+
+
+//==============================================================================
+// PUBLIC METHODS
+//==============================================================================
+    KneeLigament();
+
+    // Uses default (compiler-generated) destructor, copy constructor, and copy
+    // assignment operator.
+
+    //--------------------------------------------------------------------------
+    // GET
+    //--------------------------------------------------------------------------
+    // Properties
+    const GeometryPath& getGeometryPath() const 
+    {   return get_GeometryPath(); }
+    GeometryPath& updGeometryPath() 
+    {   return upd_GeometryPath(); }
+    virtual bool hasGeometryPath() const { return true;};
+    virtual double getLength(const SimTK::State& s) const;
+    virtual double getRestingLength() const 
+    {   return get_resting_length(); }
+    virtual bool setRestingLength(double aRestingLength);
+	
+	const double getEpsilonLength() const
+	{
+		return get_epsilon_length();
+	}
+
+	bool setEpsilonLength(double e_l)
+	{
+		set_epsilon_length(e_l);
+		return true;
+	}
+
+	const double getLigamentStiffness() const
+	{
+		return get_ligament_stiffness();
+	}
+
+	bool setLigamentStiffnessg(double k)
+	{
+		set_ligament_stiffness(k);
+		return true;
+	}
+
+    // computed variables
+    const double& getTension(const SimTK::State& s) const;
+
+    //--------------------------------------------------------------------------
+    // COMPUTATIONS
+    //--------------------------------------------------------------------------
+    virtual double computeMomentArm(const SimTK::State& s, Coordinate& aCoord) const;
+    virtual void computeForce(const SimTK::State& s, 
+                              SimTK::Vector_<SimTK::SpatialVec>& bodyForces, 
+                              SimTK::Vector& generalizedForces) const;
+
+    //--------------------------------------------------------------------------
+    // SCALE
+    //--------------------------------------------------------------------------
+    virtual void preScale(const SimTK::State& s, const ScaleSet& aScaleSet);
+    virtual void scale(const SimTK::State& s, const ScaleSet& aScaleSet);
+    virtual void postScale(const SimTK::State& s, const ScaleSet& aScaleSet);
+
+
+    //--------------------------------------------------------------------------
+    // Display
+    //--------------------------------------------------------------------------
+    virtual const VisibleObject* getDisplayer() const;
+    virtual void updateDisplayer(const SimTK::State& s) const;
+
+protected:
+    /** Override this method if you would like to calculate a color for use
+    when the %Ligament's path is displayed in the visualizer. You do not have 
+    to invoke the base class ("Super") method, just replace it completely. This
+    method will be invoked during realizeDynamics() so the supplied \a state has 
+    already been realized through Stage::Velocity and you can access time, 
+    position, and velocity dependent quantities. You must \e not attempt to 
+    realize the passed-in \a state any further since we are already in the 
+    middle of realizing here. Return SimTK::Vec3(SimTK::NaN) if you want to 
+    leave the color unchanged (that's what the base class implementation does).
+
+    @param[in] state    
+        A SimTK::State already realized through Stage::Velocity. Do not 
+        attempt to realize it any further.
+    @returns 
+        The desired color for the path as an RGB vector with each
+        component ranging from 0 to 1, or NaN to indicate that the color
+        should not be changed. **/
+    virtual SimTK::Vec3 computePathColor(const SimTK::State& state) const;
+
+    // Implement ModelComponent interface.
+    /** Extension of parent class method; derived classes may extend further. **/
+    void extendFinalizeFromProperties() override;
+    /** Extension of parent class method; derived classes may extend further. **/
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+    /** Extension of parent class method; derived classes may extend further. **/
+    void extendRealizeDynamics(const SimTK::State& state) const override;
+
+    //Force reporting
+    /** 
+     * Methods to query a Force for the value actually applied during simulation
+     * The names of the quantities (column labels) is returned by this first function
+     * getRecordLabels()
+     */
+    OpenSim::Array<std::string> getRecordLabels() const {
+        OpenSim::Array<std::string> labels("");
+        labels.append(getName());
+        return labels;
+    }
+    /**
+     * Given SimTK::State object extract all the values necessary to report forces, application location
+     * frame, etc. used in conjunction with getRecordLabels and should return same size Array
+     */
+    OpenSim::Array<double> getRecordValues(const SimTK::State& state) const {
+        OpenSim::Array<double> values(1);
+        values.append(getTension(state));
+        return values;
+    }
+
+private:
+    void constructProperties();
+
+	/**
+	* Computes the strain force function of the ligament.
+	*/
+	double computeLigamentForceStrain(double length) const;
+
+//=============================================================================
+};  // END of class Ligament
+//=============================================================================
+//=============================================================================
+} // end of namespace OpenSim
+
+#endif // OPENSIM_LIGAMENT_H_

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -50,6 +50,7 @@
 #include "Model/ElasticFoundationForce.h"
 #include "Model/HuntCrossleyForce.h"
 #include "Model/Ligament.h"
+#include "Model/KneeLigament.h"
 #include "Model/JointSet.h"
 #include "Model/Marker.h"
 #include "Model/Station.h"
@@ -216,6 +217,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( ElasticFoundationForce::ContactParametersSet() );
 
     Object::registerType( Ligament() );
+	Object::registerType( KneeLigament());
     Object::registerType( PrescribedForce() );
     Object::registerType( ExternalForce() );
     Object::registerType( PointToPointSpring() );

--- a/OpenSim/Simulation/Test/testKneeLigament.cpp
+++ b/OpenSim/Simulation/Test/testKneeLigament.cpp
@@ -1,0 +1,178 @@
+/* -------------------------------------------------------------------------- *
+*                         OpenSim:  testKneeLigament.cpp                     *
+* -------------------------------------------------------------------------- *
+* The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+* See http://opensim.stanford.edu and the NOTICE file for more information.  *
+* OpenSim is developed at Stanford University and supported by the US        *
+* National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+* through the Warrior Web program.                                           *
+*                                                                            *
+* Copyright (c) 2005-2012 Stanford University and the Authors                *
+* Author(s): Dimitar Stanev                                                  *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+* not use this file except in compliance with the License. You may obtain a  *
+* copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+* -------------------------------------------------------------------------- */
+
+//============================================================================
+// Tests the KneeLigament by attaching an acl ligament and running FD by 
+// letting the knee to fall from -130deg. Records the acl force and print the 
+// adjusted model.
+//
+//============================================================================
+
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/KneeLigament.h>
+#include <OpenSim/Analyses/ForceReporter.h>
+#include <OpenSim/Simulation/Manager/Manager.h>
+
+using std::cout;
+using std::endl;
+using std::string;
+using namespace OpenSim;
+using namespace SimTK;
+
+KneeLigament* create_ligament(Model& model);
+void setup_configuration(Model& model);
+void simulate(Model& model, State& state);
+void set_all_muscles_on_off(Model& model, State& state, bool isDisabled);
+
+int main()
+{
+	try {
+		Model model("gait2354_simbody.osim");
+
+		model.addForce(create_ligament(model));
+
+		ForceReporter* force_analysis = new ForceReporter(&model);
+		model.addAnalysis(force_analysis);
+
+		setup_configuration(model);
+
+		model.buildSystem();
+
+		model.print("gait2354_simbody_knee_ligament.osim");
+
+		State& s = model.initializeState();
+
+		set_all_muscles_on_off(model, s, true);
+
+		simulate(model, s);
+
+		force_analysis->printResults("knee_ligament");
+
+	}
+	catch (const std::exception& ex)
+	{
+		cout << "Exception: " << ex.what() << endl;
+	}
+	catch (...)
+	{
+		cout << "Unrecognized exception " << endl;
+	}
+	system("pause");
+	return 0;
+}
+
+KneeLigament* create_ligament(Model& model)
+{
+	State dummy = State();
+
+	//create ligament
+	KneeLigament* ligament = new KneeLigament();
+	ligament->setName("acl");
+
+	//create point path
+	PathPointSet* ligament_path = new PathPointSet();
+
+	PathPoint femur_point = PathPoint();
+	femur_point.setName("acl_femur");
+	femur_point.setBody(model.updBodySet().get("femur_r"));
+	femur_point.setLocation(dummy, Vec3(-0.00718, -0.40037, 0.00407));
+	ligament_path->insert(0, femur_point);
+
+	PathPoint tibia_point = PathPoint();
+	tibia_point.setName("acl_tibia");
+	tibia_point.setBody(model.updBodySet().get("tibia_r"));
+	tibia_point.setLocation(dummy, Vec3(0.01657, -0.03009, -0.00074));
+	ligament_path->insert(1, tibia_point);
+
+	//create geometry path
+	GeometryPath* geometry_path = new GeometryPath();
+	geometry_path->setName("acl_geometry_path");
+	geometry_path->updPathPointSet() = *ligament_path;
+	ligament->updGeometryPath() = *geometry_path;
+
+	//parameters
+	ligament->setRestingLength(0.0323 / (1 + 0.02));
+	ligament->setEpsilonLength(0.03);
+	ligament->setLigamentStiffnessg(2000);
+
+	return ligament;
+}
+
+void setup_configuration(Model& model)
+{
+	CoordinateSet& coordinate_set = model.updCoordinateSet();
+
+	//set pelvis tilt
+	coordinate_set.get("pelvis_tilt").setDefaultValue(0);
+
+	//set hip flexion
+	coordinate_set.get("hip_flexion_r").setDefaultValue(0);
+
+	//set knee flexion
+	coordinate_set.get("knee_angle_r").setDefaultValue(convertDegreesToRadians(-130));
+
+
+	Array<string> coordinate_names;
+	coordinate_set.getNames(coordinate_names);
+
+	//lock except knee angle 
+	for (int i = 0; i < coordinate_names.size(); i++)
+	{
+		coordinate_set.get(coordinate_names[i]).setDefaultLocked(true);
+	}
+	coordinate_set.get("knee_angle_r").setDefaultLocked(false);
+}
+
+void simulate(Model& model, State& state)
+{
+	//setup integrator
+	RungeKuttaMersonIntegrator integrator(model.getMultibodySystem());
+	integrator.setAccuracy(1E-7);
+
+	//manager
+	Manager manager(model, integrator);
+	manager.setInitialTime(0);
+	manager.setFinalTime(1);
+
+	//integrate
+	clock_t begin = clock();
+	cout << "Integrating ..." << endl;
+	manager.integrate(state);
+	clock_t end = clock();
+	double elapsed_secs = double(end - begin) / CLOCKS_PER_SEC;
+	cout << "Elapsed time: " << elapsed_secs << endl;
+	cout.flush();
+
+	//state results
+	OpenSim::Storage state_reporter(manager.getStateStorage());
+	model.updSimbodyEngine().convertRadiansToDegrees(state_reporter);
+	state_reporter.print("knee_ligament.sto");
+}
+
+void set_all_muscles_on_off(Model& model, State& state, bool isDisabled)
+{
+	for (int i = 0; i < model.updMuscles().getSize(); i++)
+	{
+		model.updMuscles().get(i).setDisabled(state, isDisabled);
+	}
+}


### PR DESCRIPTION
Implementation of knee ligament force

The primary difference from Ligament class is that it doesn't use splines to define the force strain curve. Additionally, in the literature the curve of the knee ligament is described as a function that has three operating regions (zero for negative, then a non-linear region and linear region). The spline is defined by points so the curve may give negative force (see the curve of the model near zero https://simtk.org/project/xml/downloads.xml?group_id=933). For the knee ligaments there are three parameters that must be specified: 1) the resting length of the ligament, 2) the stiffness, 3) and the toe region (is the limit at which the ligament moves from the non-linear region to linear region).

[bug]
In version OpenSim3.2 when I scaled the model the Ligament class didn't scaled well. I haven't tried this yet with KneeLigament.