### PR TITLE
On UNIX-ish platforms use RelWithDebInfo as the default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ SET(BUILD_PLATFORM "${PLATFORM_NAME}:${PLATFORM_ABI}" CACHE STRING
     FORCE)
 
 IF(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)
-    SET(CMAKE_BUILD_TYPE Release CACHE STRING "Debug or Release build" FORCE)
+    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Debug or Release build" FORCE)
 ENDIF()
 
 ## Choose the maximum level of x86 instruction set that the compiler is 

--- a/README.md
+++ b/README.md
@@ -410,12 +410,12 @@ And you could get all the optional dependencies via:
    variable to where you installed Simbody (e.g., `~/simbody`). If you
    installed Simbody using `brew`, then CMake will find Simbody automatically.
 7. Choose your build type by setting `CMAKE_BUILD_TYPE` to one of the following:
-    * *Debug*: debugger symbols; no optimizations (more than 10x slower).
+    * **Debug**: debugger symbols; no optimizations (more than 10x slower).
     Library names end with `_d`.
-    * *Release*: no debugger symbols; optimized.
-    * *RelWithDebInfo*: debugger symbols; optimized. Bigger but not slower
+    * **Release**: no debugger symbols; optimized.
+    * **RelWithDebInfo**: debugger symbols; optimized. Bigger but not slower
     than Release; choose this if unsure.
-    * *MinSizeRel*: minimum size; optimized.
+    * **MinSizeRel**: minimum size; optimized.
 
     You at least want release libraries (the last 3 count as release), but you
     can have debug libraries coexist with them. To do this, go through the


### PR DESCRIPTION
Simbody uses RelWithDebInfo by default as well; see this commit: https://github.com/simbody/simbody/commit/ffb120ba22df96082454f772d0f019e81d1090ab.