### PR TITLE
Printdetailedinfo actuators

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1464,15 +1464,12 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
     const BodySet& bodySet = getBodySet();
     for(int i=0; i < bodySet.getSize(); i++) {
         const OpenSim::Body& body = bodySet.get(i);
-        std::string nameString =
-            "body[" + std::to_string(i) + "] = " + body.getName() + ". ";
-        std::string spaces(nameString.size(), ' ');
-        aOStream << nameString;
-        aOStream << "mass:                " << body.get_mass() << std::endl;
+        aOStream << "body[" + std::to_string(i) + "] = " + body.getName() + ". ";
+        aOStream << "mass: " << body.get_mass() << std::endl;
         const SimTK::Inertia& inertia = body.getInertia();
-        aOStream << spaces << "moments of inertia:  " << inertia.getMoments()
+        aOStream << "              moments of inertia:  " << inertia.getMoments()
             << std::endl;
-        aOStream << spaces << "products of inertia: " << inertia.getProducts()
+        aOStream << "              products of inertia: " << inertia.getProducts()
             << std::endl;
     }
 
@@ -1482,7 +1479,7 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
         const OpenSim::Joint& joint = get_JointSet().get(i);
         aOStream << "joint[" << i << "] = " << joint.getName() << ".";
         aOStream << " parent: " << joint.getParentFrameName() <<
-            " child: " << joint.getChildFrameName() << std::endl;
+            ", child: " << joint.getChildFrameName() << std::endl;
     }
 
     aOStream << "\nACTUATORS (total: " << getActuators().getSize() << ")" << std::endl;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1446,6 +1446,7 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
     //int i;
 
     aOStream << "MODEL: " << getName() << std::endl;
+
     aOStream << std::endl;
     aOStream << "numStates = " << s.getNY() << std::endl;
     aOStream << "numCoordinates = " << getNumCoordinates() << std::endl;
@@ -1463,11 +1464,25 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
     const BodySet& bodySet = getBodySet();
     for(int i=0; i < bodySet.getSize(); i++) {
         const OpenSim::Body& body = bodySet.get(i);
-        aOStream << "body[" << i << "] = " << body.getName();
-        aOStream << " (mass: "<<body.get_mass()<<")";
+        std::string nameString =
+            "body[" + std::to_string(i) + "] = " + body.getName() + ". ";
+        std::string spaces(nameString.size(), ' ');
+        aOStream << nameString;
+        aOStream << "mass:                " << body.get_mass() << std::endl;
         const SimTK::Inertia& inertia = body.getInertia();
-        aOStream << " (inertia: [" << inertia.getMoments() << "  ";
-        aOStream << inertia.getProducts() << "])" << endl;
+        aOStream << spaces << "moments of inertia:  " << inertia.getMoments()
+            << std::endl;
+        aOStream << spaces << "products of inertia: " << inertia.getProducts()
+            << std::endl;
+    }
+
+    aOStream << "\nJOINTS (total: " << getNumJoints() << ")" << std::endl;
+    const JointSet& jointSet = getJointSet();
+    for (int i = 0; i < jointSet.getSize(); i++) {
+        const OpenSim::Joint& joint = get_JointSet().get(i);
+        aOStream << "joint[" << i << "] = " << joint.getName() << ".";
+        aOStream << " parent: " << joint.getParentFrameName() <<
+            " child: " << joint.getChildFrameName() << std::endl;
     }
 
     aOStream << "\nACTUATORS (total: " << getActuators().getSize() << ")" << std::endl;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1446,12 +1446,20 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
     //int i;
 
     aOStream << "MODEL: " << getName() << std::endl;
+    aOStream << std::endl;
+    aOStream << "numStates = " << s.getNY() << std::endl;
+    aOStream << "numCoordinates = " << getNumCoordinates() << std::endl;
+    aOStream << "numSpeeds = " << getNumSpeeds() << std::endl;
+    aOStream << "numActuators = " << getActuators().getSize() << std::endl;
+    aOStream << "numBodies = " << getNumBodies() << std::endl;
+    aOStream << "numConstraints = " << getConstraintSet().getSize() << std::endl;
+    aOStream << "numProbes = " << getProbeSet().getSize() << std::endl;
 
-    aOStream << "\nANALYSES (" << getNumAnalyses() << ")" << std::endl;
+    aOStream << "\nANALYSES (total: " << getNumAnalyses() << ")" << std::endl;
     for (int i = 0; i < _analysisSet.getSize(); i++)
         aOStream << "analysis[" << i << "] = " << _analysisSet.get(i).getName() << std::endl;
 
-    aOStream << "\nBODIES (" << getNumBodies() << ")" << std::endl;
+    aOStream << "\nBODIES (total: " << getNumBodies() << ")" << std::endl;
     const BodySet& bodySet = getBodySet();
     for(int i=0; i < bodySet.getSize(); i++) {
         const OpenSim::Body& body = bodySet.get(i);
@@ -1462,21 +1470,10 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
         aOStream << inertia.getProducts() << "])" << endl;
     }
 
-    int j = 0;
-    aOStream << "\nACTUATORS (" << getActuators().getSize() << ")" << std::endl;
+    aOStream << "\nACTUATORS (total: " << getActuators().getSize() << ")" << std::endl;
     for (int i = 0; i < getActuators().getSize(); i++) {
-         aOStream << "actuator[" << j << "] = " << getActuators().get(i).getName() << std::endl;
-         j++;
+         aOStream << "actuator[" << i << "] = " << getActuators().get(i).getName() << std::endl;
     }
-
-    aOStream << "numStates = " << s.getNY() << std::endl;
-    aOStream << "numCoordinates = " << getNumCoordinates() << std::endl;
-    aOStream << "numSpeeds = " << getNumSpeeds() << std::endl;
-    aOStream << "numActuators = " << getActuators().getSize() << std::endl;
-    aOStream << "numBodies = " << getNumBodies() << std::endl;
-    aOStream << "numConstraints = " << getConstraintSet().getSize() << std::endl;
-    ;
-    aOStream << "numProbes = " << getProbeSet().getSize() << std::endl;
 
     /*
     int n;
@@ -1503,7 +1500,7 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
 
 */
     Array<string> stateNames = getStateVariableNames();
-    aOStream<<"\nSTATES ("<<stateNames.getSize()<<")"<<std::endl;
+    aOStream<<"\nSTATES (total: "<<stateNames.getSize()<<")"<<std::endl;
     for(int i=0;i<stateNames.getSize();i++) aOStream<<"y["<<i<<"] = "<<stateNames[i]<<std::endl;
 }
 


### PR DESCRIPTION
I fixed a minor bug in the output of `Model::printDetailedInfo()`. Previously, if you had no Actuators, you would have seen output like this:

```
ACTUATORS (0)
numStates = 16
numCoordinates = 2
numSpeeds = 2
numActuators = 8
numBodies = 2
numConstraints = 0
numProbes = 0
```

Even if you didn't have actuators, there wasn't a newline between the ACTUATORS section and the list of numbers of components (but there were newlines separating all other sections).

I then indulged a bit and:
1. Moved the output of numbers of components to the top of the output
2. Cleaned up the output of Body's mass properties by using multiple lines for each body.
3. Added a section for Joints, which lists the parent and child frames of each joint.
4. Converted "BODIES (2)" to "BODIES (total: 2)", etc.

Here's the **old** output for Arm26:
```
55: MODEL: arm26
55: 
55: ANALYSES (0)
55: 
55: BODIES (2)
55: body[0] = r_humerus (mass: 1.86457) (inertia: [~[0.01481,0.004551,0.013193]  ~[0,0,0]])
55: body[1] = r_ulna_radius_hand (mass: 1.53432) (inertia: [~[0.019281,0.001571,0.020062]  ~[0,0,0]])
55: 
55: ACTUATORS (8)
55: actuator[0] = TRIlong
55: actuator[1] = TRIlat
55: actuator[2] = TRImed
55: actuator[3] = BIClong
55: actuator[4] = BICshort
55: actuator[5] = BRA
55: actuator[6] = r_shoulder_elev_reserve
55: actuator[7] = r_elbow_flex_reserve
55: numStates = 16
55: numCoordinates = 2
55: numSpeeds = 2
55: numActuators = 8
55: numBodies = 2
55: numConstraints = 0
55: numProbes = 0
55: 
55: STATES (16)
55: y[0] = r_shoulder/r_shoulder_elev/value
55: y[1] = r_shoulder/r_shoulder_elev/speed
55: y[2] = r_elbow/r_elbow_flex/value
55: y[3] = r_elbow/r_elbow_flex/speed
55: y[4] = TRIlong/activation
55: y[5] = TRIlong/fiber_length
55: y[6] = TRIlat/activation
55: y[7] = TRIlat/fiber_length
55: y[8] = TRImed/activation
55: y[9] = TRImed/fiber_length
55: y[10] = BIClong/activation
55: y[11] = BIClong/fiber_length
55: y[12] = BICshort/activation
55: y[13] = BICshort/fiber_length
55: y[14] = BRA/activation
55: y[15] = BRA/fiber_length
```

Here's the output for Arm26 **with this PR**:

```
55: MODEL: arm26
55: 
55: numStates = 16
55: numCoordinates = 2
55: numSpeeds = 2
55: numActuators = 8
55: numBodies = 2
55: numConstraints = 0
55: numProbes = 0
55: 
55: ANALYSES (total: 0)
55: 
55: BODIES (total: 2)
55: body[0] = r_humerus. mass:                1.86457
55:                      moments of inertia:  ~[0.01481,0.004551,0.013193]
55:                      products of inertia: ~[0,0,0]
55: body[1] = r_ulna_radius_hand. mass:                1.53432
55:                               moments of inertia:  ~[0.019281,0.001571,0.020062]
55:                               products of inertia: ~[0,0,0]
55: 
55: JOINTS (total: 2)
55: joint[0] = r_shoulder. parent: ground child: r_humerus
55: joint[1] = r_elbow. parent: r_humerus child: r_ulna_radius_hand
55: 
55: ACTUATORS (total: 8)
55: actuator[0] = TRIlong
55: actuator[1] = TRIlat
55: actuator[2] = TRImed
55: actuator[3] = BIClong
55: actuator[4] = BICshort
55: actuator[5] = BRA
55: actuator[6] = r_shoulder_elev_reserve
55: actuator[7] = r_elbow_flex_reserve
55: 
55: STATES (total: 16)
55: y[0] = r_shoulder/r_shoulder_elev/value
55: y[1] = r_shoulder/r_shoulder_elev/speed
55: y[2] = r_elbow/r_elbow_flex/value
55: y[3] = r_elbow/r_elbow_flex/speed
55: y[4] = TRIlong/activation
55: y[5] = TRIlong/fiber_length
55: y[6] = TRIlat/activation
55: y[7] = TRIlat/fiber_length
55: y[8] = TRImed/activation
55: y[9] = TRImed/fiber_length
55: y[10] = BIClong/activation
55: y[11] = BIClong/fiber_length
55: y[12] = BICshort/activation
55: y[13] = BICshort/fiber_length
55: y[14] = BRA/activation
55: y[15] = BRA/fiber_length
```