### PR TITLE
Remove annoying Doxygen error.

### DIFF
--- a/OpenSim/doc/CMakeLists.txt
+++ b/OpenSim/doc/CMakeLists.txt
@@ -7,7 +7,6 @@ ELSE(DOXYGEN_EXECUTABLE-NOTFOUND)
     SET(DOXY_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
 
     # Configure linking to Simbody documentation.
-    # Some of these variables are used in Doxyfile.in.
     # This variable must be a STRING; a PATH variable resolves //'s as a single
     # /, but we need to use double slashes for URL's.
     SET(OPENSIM_SIMBODY_DOXYGEN_LOCATION "${Simbody_DOXYGEN_DIR}"
@@ -26,6 +25,15 @@ ELSE(DOXYGEN_EXECUTABLE-NOTFOUND)
         automatically populated again.")
 
     MARK_AS_ADVANCED(OPENSIM_SIMBODY_DOXYGEN_LOCATION)
+
+    # This variable is used in Doxyfile.in.
+    SET(OPENSIM_SIMBODY_TAGFILE_CONFIG "")
+    IF(Simbody_DOXYGEN_TAGFILE)
+        # The variable above is only defined if Simbody's Doxygen documentation
+        # was (built and) installed.
+        SET(OPENSIM_SIMBODY_TAGFILE_CONFIG
+            "${Simbody_DOXYGEN_TAGFILE}=${OPENSIM_SIMBODY_DOXYGEN_LOCATION}")
+    ENDIF()
 
     CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in 
           ${DOXY_CONFIG}

--- a/OpenSim/doc/Doxyfile.in
+++ b/OpenSim/doc/Doxyfile.in
@@ -1572,7 +1572,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = "@Simbody_DOXYGEN_TAGFILE@=@OPENSIM_SIMBODY_DOXYGEN_LOCATION@"
+TAGFILES               = "@OPENSIM_SIMBODY_TAGFILE_CONFIG@"
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.


### PR DESCRIPTION
If you did not install Simbody doxygen, you'd get the following message when
building OpenSim's doxygen:

```
error: Tag file `(null)' does not exist or is not a file. Skipping it...
```

Now, this error is gone.

I tested that the TAGFILE behavior still functions properly after this change.