### PR TITLE
Version number is only mentioned in one place.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,6 +593,25 @@ FILE(APPEND  ${VERSION_FILE_PATH} "\n")
 INSTALL(FILES ${VERSION_FILE_PATH} DESTINATION sdk)
 
 
+# Preprocessor definitions.
+# -------------------------
+# These are used in OpenSim/version.h
+SET(OPENSIM_SYSTEM_INFO ${CMAKE_SYSTEM})
+SET(OPENSIM_OS_NAME ${CMAKE_SYSTEM_NAME})
+
+IF( WIN32 )
+    SET(OPENSIM_COMPILER_INFO ${MSVC_VERSION})
+ELSE ()
+    SET(OPENSIM_COMPILER_INFO ${CMAKE_CXX_COMPILER} )
+ENDIF()
+
+ADD_DEFINITIONS(-DOSIM_SYS_INFO=${OPENSIM_SYSTEM_INFO}
+    -DOSIM_COMPILER_INFO=${OPENSIM_COMPILER_INFO}
+    -DOSIM_OS_NAME=${OPENSIM_OS_NAME}
+    -DOSIM_VERSION=${OPENSIM_VERSION})
+
+
+
 #-----------------------------------------------------------------------------
 SET(BUILD_API_ONLY OFF CACHE BOOL "Build/install only headers, libraries,
     wrapping, tests; not applications (ik, rra, etc.).")

--- a/OpenSim/CMakeLists.txt
+++ b/OpenSim/CMakeLists.txt
@@ -1,18 +1,5 @@
 #-----------------------------------------------------------------------------
 
-SET(OPENSIM_SYSTEM_INFO ${CMAKE_SYSTEM})
-SET(OPENSIM_OS_NAME ${CMAKE_SYSTEM_NAME})
-
-IF( WIN32 )
-    SET(OPENSIM_COMPILER_INFO ${MSVC_VERSION})
-ELSE ()
-    SET(OPENSIM_COMPILER_INFO ${CMAKE_CXX_COMPILER} )
-ENDIF()
-
-ADD_DEFINITIONS(-DOSIM_SYS_INFO=${OPENSIM_SYSTEM_INFO}
--DOSIM_COMPILER_INFO=${OPENSIM_COMPILER_INFO}
--DOSIM_OS_NAME=${OPENSIM_OS_NAME})
-
 SUBDIRS(Common Simulation Actuators Analyses Utilities Tools Wrapping Examples Tests doc)
 
-INSTALL_FILES(/sdk/include/OpenSim .h OpenSim.h)
+INSTALL_FILES(/sdk/include/OpenSim OpenSim.h)

--- a/OpenSim/OpenSimDoxygenMain.h
+++ b/OpenSim/OpenSimDoxygenMain.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2012 Stanford University and the Authors                *                                                *
+ * Copyright (c) 2005-2012 Stanford University and the Authors                *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -28,7 +28,7 @@ Mainpage, the first page that a user sees when entering the Doxygen-
 generated API documentation. This is not actually included as part of the
 OpenSim source and it is not installed with OpenSim. **/
 
-/** @mainpage  OpenSim 3.2 Documentation
+/** @mainpage Overview
 
 \htmlonly
 <!-- ImageReady Slices -->

--- a/OpenSim/OpenSimDoxygenMain.h
+++ b/OpenSim/OpenSimDoxygenMain.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2012 Stanford University and the Authors                *
+ * Copyright (c) 2005-2015 Stanford University and the Authors                *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *

--- a/OpenSim/Wrapping/Python/CMakeLists.txt
+++ b/OpenSim/Wrapping/Python/CMakeLists.txt
@@ -87,8 +87,12 @@ INSTALL(TARGETS _${KIT}
         LIBRARY DESTINATION sdk/python/opensim
         ARCHIVE DESTINATION sdk/python/opensim)
 
+# Configure setup.py
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
+               ${CMAKE_CURRENT_BINARY_DIR}/setup.py @ONLY)
+
 #install .py files
-INSTALL(FILES setup.py DESTINATION sdk/python)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/setup.py DESTINATION sdk/python)
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/opensim.py
     DESTINATION sdk/python/opensim)
 INSTALL(FILES __init__.py DESTINATION sdk/python/opensim)

--- a/OpenSim/Wrapping/Python/setup.py.in
+++ b/OpenSim/Wrapping/Python/setup.py.in
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 setup(name='opensim',
-      version='3.2',
+      version='@OPENSIM_VERSION@',
       description='OpenSim Simulation Framework',
       author='OpenSim Team',
       author_email='ahabib@stanford.edu',

--- a/OpenSim/version.h
+++ b/OpenSim/version.h
@@ -39,10 +39,13 @@
 #define GET_OS_NAME \
     MAKE_STRING(OSIM_OS_NAME)
 
+#define GET_OSIM_VERSION \
+    MAKE_STRING(OSIM_VERSION)
+
 namespace OpenSim {
 #endif
 
-    static const char *OpenSimVersion = "3.2.0";
+    static const char *OpenSimVersion = GET_OSIM_VERSION;
 
 #if defined(__cplusplus) || defined(SWIG)
     std::string GetVersionAndDate() { 


### PR DESCRIPTION
The OpenSim version number was repeated in a few different places. Now it only
appears in the root CMakeLists.txt.

There are some methods in version.h that relied on preprocessor definitions.
However, these definitions were only in place for files within the OpenSim/ directory. That
means if an appplication (e.g., cmc) called one of the functions in version.h, they would get
the version number to be "GET_OSIM_VERSION". So I moved the definitions to the
root CMakeLists.txt.

version.h is not distributed with OpenSim, so clients of OpenSim cannot call
those functions. It would be good if version.h was moved into OpenSim/Common so
that our users could check the version of OpenSim they're using. However, that
is beyond the scope of what I was trying to achieve here.

Fixes #445.

After this gets merged, I'll create a new PR to update master branch to version 4.0.