### PR TITLE
Update version number to 4.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ endif(COMMAND cmake_policy)
 
 # OpenSim version.
 # ----------------
-SET(OPENSIM_MAJOR_VERSION 3)
-SET(OPENSIM_MINOR_VERSION 2)
+SET(OPENSIM_MAJOR_VERSION 4)
+SET(OPENSIM_MINOR_VERSION 0)
 SET(OPENSIM_PATCH_VERSION 0)
 
 # Don't include the patch version if it is 0.


### PR DESCRIPTION
I think this is important to change before the 3.2.1/3.3 release, considering that the opensim32 repo contains version "3.2.1" or "3.3", while our master branch here still says "3.2". We allow our clients to check the version of OpenSim they are using via CMake, and so this logic will be fuddled up if a user has both master branch and 3.2.1/3.3 on their computer.

I think @sherm1 uses the practice of incrementing the version number on the master branch right after a release.