### PR TITLE
Fix MACOSX_RPATH cmake warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,12 @@ PROJECT (OpenSim)
 
 cmake_minimum_required(VERSION 2.8.8)
 if(COMMAND cmake_policy)
-        cmake_policy(SET CMP0003 NEW)
-        cmake_policy(SET CMP0005 NEW)
+    cmake_policy(SET CMP0003 NEW)
+    cmake_policy(SET CMP0005 NEW)
+    if(NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
+        # MACOSX_RPATH enabled by default; policy introduced with cmake 3.0.
+        cmake_policy(SET CMP0042 NEW)
+    endif()
 endif(COMMAND cmake_policy)
 
 
@@ -311,8 +315,8 @@ IF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
         ELSE()
             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
             IF(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-        ENDIF()
+                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+            ENDIF()
         ENDIF()
     ELSE() # not APPLE
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/OpenSim/Tests/CMakeLists.txt
+++ b/OpenSim/Tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
             ${OpenSim_SOURCE_DIR}/Vendors)
 

--- a/OpenSim/Tests/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Tests/ControllerExample/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation

--- a/OpenSim/Tests/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Tests/CoupledBushingForceExample/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 
 # Variable definitions
 SET(EXAMPLE_TARGET exampleCoupledBushingForcePlugin)

--- a/OpenSim/Tests/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Tests/CustomActuatorExample/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation

--- a/OpenSim/Tests/Environment/CMakeLists.txt
+++ b/OpenSim/Tests/Environment/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
 
 SET(TEST_ENVIRONMENT checkEnvironment)       
          

--- a/OpenSim/Tests/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Tests/ExampleMain/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation

--- a/OpenSim/Tests/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Tests/MuscleExample/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation

--- a/OpenSim/Tests/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Tests/OptimizationExample_Arm26/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation

--- a/OpenSim/Tests/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Tests/SimpleOptimizationExample/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
-INCLUDE_DIRECTORIES(${OpenSim_SOURCE_DIR} 
-            ${OpenSim_SOURCE_DIR}/Vendors)
 
 LINK_LIBRARIES( debug osimCommon${CMAKE_DEBUG_POSTFIX} optimized osimCommon
         debug osimSimulation${CMAKE_DEBUG_POSTFIX} optimized osimSimulation


### PR DESCRIPTION
On OSX with cmake 3.0 or greater, one gets a warning about MACOSX_RPATH. This PR gets rid of that warning.

Also, some minor cleanup of cmake (removing unnecessary lines).