### PR TITLE
Remove ObjectProperty::isEqualTo() dependence on non-standard ClonePtr behavior

### DIFF
--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1174,9 +1174,16 @@ ObjectProperty<T>::isEqualTo(const AbstractProperty& other) const {
         return false;
     assert(this->size() == other.size()); // base class checked
     const ObjectProperty& otherO = ObjectProperty::getAs(other);
-    for (int i=0; i<objects.size(); ++i)
-        if (!(objects[i] == otherO.objects[i]))
+    for (int i=0; i<objects.size(); ++i) {
+        const T* const thisp  = objects[i].getPtr();
+        const T* const otherp = otherO.objects[i].getPtr();
+        if (thisp == otherp)
+            continue; // same object or both null
+        if (!(thisp && otherp))
+            return false; // only one is null; they are different
+        if (!(*thisp == *otherp)) // delegate to object's operator==()
             return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
`ObjectProperty<T>::isEqualTo()` was depending on non-standard behavior of `ClonePtr<T>::operator==()`, where the smart pointer delegated to `T::operator==()`. That doesn't match the C++11 smart pointer behavior (only the contained pointers should be compared) and will change shortly in Simbody 3.6. `CloneOnWritePtr<T>` already behaves correctly (see PR simbody/simbody#405) -- my intention is to modify `ClonePtr<T>` to match.

This change extracts the pointer and does its own delegation so will continue working when `ClonePtr` is fixed. This was the only instance I could find in OpenSim 4.0 that depended on the non-standard operator behavior. Ajay and Chris, please review (very short) and let me know if you think there is anywhere else.

I verified that `testSerialization` does test `isEqualTo()` and that it still works.

/cc @aseth1, @chrisdembia, @klshrinidhi