### PR TITLE
Get rid of deprecated warnings

### DIFF
--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1175,8 +1175,8 @@ ObjectProperty<T>::isEqualTo(const AbstractProperty& other) const {
     assert(this->size() == other.size()); // base class checked
     const ObjectProperty& otherO = ObjectProperty::getAs(other);
     for (int i=0; i<objects.size(); ++i) {
-        const T* const thisp  = objects[i].getPtr();
-        const T* const otherp = otherO.objects[i].getPtr();
+        const T* const thisp  = objects[i].get();
+        const T* const otherp = otherO.objects[i].get();
         if (thisp == otherp)
             continue; // same object or both null
         if (!(thisp && otherp))


### PR DESCRIPTION
Simbody PR simbody/simbody#407 deprecated `ClonePtr::getPtr()` and `updPtr()` because the methods should have been called `get()` and `upd()` which were added in the same PR. That causes OpenSim to get a bunch of "DEPRECATED" warnings because it uses `getPtr()` in a header file. 

This PR switches to the preferred name `get()` and gets rid of the warnings. It does require the most up-to-date version of Simbody from its master branch though or the build will fail.