### PR TITLE
[cmake] Rename OpenSim.config to OpenSimConfigToInstall.cmake in the build tree

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -6,12 +6,12 @@ include(CMakePackageConfigHelpers)
 
 set(OPENSIM_INSTALL_CMAKE_DIR cmake)
 
-configure_file(OpenSimConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfig.cmake" @ONLY)
-
+# The generated file must not be named OpenSimConfig.cmake, otherwise CMake
+# will pick it up and think that the build tree contains an OpenSim
+# installation.
 configure_package_config_file(
     OpenSimConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfigToInstall.cmake"
     INSTALL_DESTINATION "${OPENSIM_INSTALL_CMAKE_DIR}"
     PATH_VARS # Variables to edit in OpenSimConfig.cmake.in.
         CMAKE_INSTALL_PREFIX
@@ -24,10 +24,14 @@ write_basic_config_version_file(
     VERSION "${OPENSIM_VERSION}"
     COMPATIBILITY SameMajorVersion)
 
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfigToInstall.cmake"
+    DESTINATION "${OPENSIM_INSTALL_CMAKE_DIR}"
+    RENAME OpenSimConfig.cmake
+    )
+
 install(
     FILES
         "SampleCMakeLists.txt"
-        "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/OpenSimConfigVersion.cmake"
     DESTINATION
         "${OPENSIM_INSTALL_CMAKE_DIR}"


### PR DESCRIPTION

This is the same change that @elen4 made for Simbody.

I'll merge this myself soon.