### PR TITLE
Minor changes to avoid DEPRECATED warnings from Simbody's smart pointers.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1614,7 +1614,7 @@ protected:
     class StateVariable {
         friend void Component::addStateVariable(StateVariable* sv) const;
     public:
-        StateVariable() : name(""), owner(NULL),
+        StateVariable() : name(""), owner(nullptr),
             subsysIndex(SimTK::InvalidIndex), varIndex(SimTK::InvalidIndex),
             sysYIndex(SimTK::InvalidIndex), hidden(true) {}
         explicit StateVariable(const std::string& name, //state var name

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1010,7 +1010,7 @@ private:
     T& updValueVirtual(int index) override final 
     {   return *objects[index]; }
     void setValueVirtual(int index, const T& obj) override final
-    {   objects[index].reset(nullptr);
+    {   objects[index].reset((T*)nullptr);
         objects[index] = obj; }
     int appendValueVirtual(const T& obj) override final
     {   objects.push_back();        // add empty element

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1010,7 +1010,7 @@ private:
     T& updValueVirtual(int index) override final 
     {   return *objects[index]; }
     void setValueVirtual(int index, const T& obj) override final
-    {   objects[index].reset();
+    {   objects[index].reset(nullptr);
         objects[index] = obj; }
     int appendValueVirtual(const T& obj) override final
     {   objects.push_back();        // add empty element

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1010,7 +1010,7 @@ private:
     T& updValueVirtual(int index) override final 
     {   return *objects[index]; }
     void setValueVirtual(int index, const T& obj) override final
-    {   objects[index].clear();
+    {   objects[index].reset();
         objects[index] = obj; }
     int appendValueVirtual(const T& obj) override final
     {   objects.push_back();        // add empty element

--- a/OpenSim/Simulation/MarkersReference.cpp
+++ b/OpenSim/Simulation/MarkersReference.cpp
@@ -40,7 +40,7 @@ MarkersReference::MarkersReference() : Reference_<SimTK::Vec3>(),
         _markerWeightSetProp(PropertyObj("", Set<MarkerWeight>())),
         _markerWeightSet((Set<MarkerWeight>&)_markerWeightSetProp.getValueObj()),
         _defaultWeight(_defaultWeightProp.getValueDbl()),
-        _markerData(NULL)
+        _markerData(nullptr)
 {
     setAuthors("Ajay Seth");
 }
@@ -50,7 +50,7 @@ MarkersReference::MarkersReference(const std::string markerFile, Units modelUnit
         _markerWeightSetProp(PropertyObj("", Set<MarkerWeight>())),
         _markerWeightSet((Set<MarkerWeight>&)_markerWeightSetProp.getValueObj()),
         _defaultWeight(_defaultWeightProp.getValueDbl()),
-        _markerData(NULL)
+        _markerData(nullptr)
 {
     setAuthors("Ajay Seth");
     loadMarkersFile(markerFile, modelUnits);
@@ -66,9 +66,9 @@ MarkersReference::MarkersReference(MarkerData& aMarkerData, const Set<MarkerWeig
         _markerWeightSetProp(PropertyObj("", Set<MarkerWeight>())),
         _markerWeightSet((Set<MarkerWeight>&)_markerWeightSetProp.getValueObj()),
         _defaultWeight(_defaultWeightProp.getValueDbl()),
-        _markerData(NULL)
+        _markerData(nullptr)
 {
-    if (aMarkerWeightSet!=NULL) _markerWeightSet= *aMarkerWeightSet;
+    if (aMarkerWeightSet!=nullptr) _markerWeightSet= *aMarkerWeightSet;
     populateFromMarkerData(aMarkerData);
 }
 

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -320,7 +320,7 @@ void ExternalForce::computeForce(const SimTK::State& state,
     double time = state.getTime();
     const SimbodyEngine& engine = getModel().getSimbodyEngine();
 
-    assert(_appliedToBody!=0);
+    assert(_appliedToBody!=nullptr);
 
     if (_appliesForce) {
         Vec3 force = getForceAtTime(time);

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -58,7 +58,7 @@ static const Vec3 DefaultDefaultColor(.5,.5,.5); // boring gray
 GeometryPath::GeometryPath() :
     ModelComponent(),
     _preScaleLength(0.0),
-    _owner(NULL)
+    _owner(nullptr)
 {
     setNull();
     constructProperties();

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -91,7 +91,7 @@ Model::Model() :
     _coordinateSet(CoordinateSet()),
     _useVisualizer(false),
     _allControllersEnabled(true),
-    _system(NULL),
+    _system(nullptr),
     _workingState()
 {
     constructInfrastructure();    setNull();
@@ -108,7 +108,7 @@ Model::Model(const string &aFileName, const bool finalize) :
     _coordinateSet(CoordinateSet()),
     _useVisualizer(false),
     _allControllersEnabled(true),
-    _system(NULL),
+    _system(nullptr),
     _workingState()
 {   
     constructInfrastructure();

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -260,7 +260,7 @@ public:
     until initSystem() has been successfully invoked. Use this method prior
     to calling getVisualizer() or updVisualizer() to avoid an
     unpleasant exception. **/
-    bool hasVisualizer() const {return _modelViz != 0;}
+    bool hasVisualizer() const {return _modelViz != nullptr;}
 
     /** Obtain read-only access to the ModelVisualizer. This will throw an 
     exception if visualization was not requested or initSystem() not yet

--- a/OpenSim/Simulation/Model/ModelComponent.cpp
+++ b/OpenSim/Simulation/Model/ModelComponent.cpp
@@ -32,19 +32,19 @@ namespace OpenSim {
 //==============================================================================
 //                             MODEL COMPONENT
 //==============================================================================
-ModelComponent::ModelComponent() : _model(NULL) 
+ModelComponent::ModelComponent() : _model(nullptr) 
 {
     constructProperty_geometry();
 }
 
 ModelComponent::ModelComponent(const std::string& fileName, bool updFromXMLNode)
-:   Component(fileName, updFromXMLNode), _model(NULL)
+:   Component(fileName, updFromXMLNode), _model(nullptr)
 {
     constructProperty_geometry();
 }
 
 ModelComponent::ModelComponent(SimTK::Xml::Element& element) 
-:   Component(element), _model(NULL)
+:   Component(element), _model(nullptr)
 {
     constructProperty_geometry();
 }

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -63,7 +63,7 @@ private:
 //=============================================================================
 public:
     /** Default constructor creates an empty Set with no associated Model. **/
-    ModelComponentSet() : _model(NULL)
+    ModelComponentSet() : _model(nullptr)
     {
     }
     /** Create an empty set associated to the specified Model. **/


### PR DESCRIPTION
Mostly this just involves replacing `NULL` and `0` pointers with `nullptr`. Also `clear()` should be `reset()` for smart pointers.

These would generate "deprecated" warnings as soon as PR simbody/simbody#410 is merged to bring the smart pointers into closer compliance with C++11 smart pointers like `std::unique_ptr`.