### PR TITLE
Fix bug due to InverseDynamicsTool caching coordinate values so that …

### DIFF
--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -199,6 +199,7 @@ void InverseDynamicsTool::setCoordinateValues(const OpenSim::Storage& aStorage)
 {
     if (_coordinateValues) delete _coordinateValues;
     _coordinateValues = new Storage(aStorage);
+    _coordinatesFileName = "";
 }
 
 
@@ -265,7 +266,7 @@ bool InverseDynamicsTool::run()
         FunctionSet *coordFunctions = NULL;
         //Storage *coordinateValues = NULL;
 
-        if(hasCoordinateValues()){
+        if (loadCoordinateValues()){
             if(_lowpassCutoffFrequency>=0) {
                 cout<<"\n\nLow-pass filtering coordinates data with a cutoff frequency of "<<_lowpassCutoffFrequency<<"..."<<endl<<endl;
                 _coordinateValues->pad(_coordinateValues->getSize()/2);
@@ -297,7 +298,7 @@ bool InverseDynamicsTool::run()
         }
         else{
             IO::chDir(saveWorkingDirectory);
-            throw Exception("InverseDynamicsTool: no coordinate file found.");
+            throw Exception("InverseDynamicsTool: no coordinate file found, or setCoordinateValues() was not called.");
 
         }
 
@@ -425,7 +426,7 @@ bool InverseDynamicsTool::run()
     return success;
 }
 
-bool InverseDynamicsTool::hasCoordinateValues()
+bool InverseDynamicsTool::loadCoordinateValues()
 {
     if (_coordinateValues!= NULL) // Coordinates has been set from GUI
         return true;

--- a/OpenSim/Tools/InverseDynamicsTool.h
+++ b/OpenSim/Tools/InverseDynamicsTool.h
@@ -29,6 +29,7 @@
 #include <OpenSim/Common/PropertyDbl.h>
 #include <OpenSim/Common/PropertyStr.h>
 #include <OpenSim/Common/PropertyDblArray.h>
+#include <OpenSim/Common/Storage.h>
 #include "DynamicsTool.h"
 
 #ifdef SWIG
@@ -117,6 +118,9 @@ protected:
 private:
     void setNull();
     void setupProperties();
+    /* If CoorindatesFile property is populated, load data into a live _coordinateValues
+    storage object. */
+    bool loadCoordinateValues();
 
     //--------------------------------------------------------------------------
     // OPERATORS
@@ -130,7 +134,6 @@ public:
     // GET AND SET
     //--------------------------------------------------------------------------
     void setCoordinateValues(const OpenSim::Storage& aStorage);
-    bool hasCoordinateValues();
     /**
      * get/set the name of the file to be used as ouput from the tool
      */
@@ -144,6 +147,12 @@ public:
     const std::string& getCoordinatesFileName() const { return _coordinatesFileName;};
     void setCoordinatesFileName(const std::string& aCoordinateFile)  { 
         _coordinatesFileName=aCoordinateFile;
+        if (_coordinateValues != NULL){
+            // there's an old Storage hanging around from potentially different 
+            // CoordinatesFile, wipe it out.
+            delete _coordinateValues;
+            _coordinateValues = NULL;
+        }
     };
     const double getLowpassCutoffFrequency() const {
         return _lowpassCutoffFrequency;

--- a/OpenSim/Tools/InverseDynamicsTool.h
+++ b/OpenSim/Tools/InverseDynamicsTool.h
@@ -145,6 +145,8 @@ public:
      * get/set the name of the file containing coordinates
      */
     const std::string& getCoordinatesFileName() const { return _coordinatesFileName;};
+    /** Set the name of the coordinatesFile to be used. This call resets 
+     _coordinateValues as well. */
     void setCoordinatesFileName(const std::string& aCoordinateFile)  { 
         _coordinatesFileName=aCoordinateFile;
         if (_coordinateValues != NULL){


### PR DESCRIPTION
…setting coordinate file later produces wrong/stale results. Changed method name hasCoordinateValues to loadCoordinateValues and made it private where it belongs.