### PR TITLE
Fix misuse of ReferencePtr in ControllerSet::_controlStore

### DIFF
--- a/OpenSim/Simulation/Model/ControllerSet.cpp
+++ b/OpenSim/Simulation/Model/ControllerSet.cpp
@@ -49,14 +49,6 @@ template class OSIMSIMULATION_API ModelComponentSet<Controller>;
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Destructor.
- */
-ControllerSet::~ControllerSet()
-{
-    delete _controlStore;
-}
-//_____________________________________________________________________________
-/**
  * Default constructor.
  */
 
@@ -83,7 +75,7 @@ ControllerSet::ControllerSet(Model& model, const std::string &aFileName, bool aU
  *
  * @param aControllerSet ControllerSet to be copied.
  */
-ControllerSet::ControllerSet(const ControllerSet &aControllerSet) :
+ControllerSet::ControllerSet(const ControllerSet& aControllerSet) :
     ModelComponentSet<Controller>(aControllerSet)
 {
 
@@ -100,14 +92,14 @@ ControllerSet::ControllerSet(const ControllerSet &aControllerSet) :
  *
  * @param aControllerSet controller set to be copied
  */
-void ControllerSet::copyData(const ControllerSet &aControllerSet)
+void ControllerSet::copyData(const ControllerSet& aControllerSet)
 {
     _actuatorSet =  aControllerSet._actuatorSet;
-    const Storage *source = (Storage *)aControllerSet._controlStore;
-    if(source == NULL){
-        _controlStore =  NULL;
+    const Storage* source = aControllerSet._controlStore.get();
+    if (source) {
+        _controlStore.reset(new Storage(*source, true));
     } else {
-        _controlStore =  new Storage(*source, true);
+        _controlStore.reset();
     }
 }
 
@@ -181,8 +173,7 @@ void ControllerSet::constructStorage()
     Array<string> columnLabels;
 
     // CONTROLS
-    delete _controlStore;
-    _controlStore = new Storage(1023,"controls");
+    _controlStore.reset(new Storage(1023,"controls"));
     columnLabels.append("time");
 
     for(int i=0;i<_actuatorSet->getSize();i++)

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -99,7 +99,7 @@ private:
     std::unique_ptr<Storage> _controlStore;
 
     // Set of actuators controlled by the set of controllers.
-    SimTK::ReferencePtr<Set<Actuator> > _actuatorSet;
+    SimTK::ReferencePtr<Set<Actuator>> _actuatorSet;
 //=============================================================================
 };  // END of class ControllerSet
 //=============================================================================

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -51,41 +51,28 @@ OpenSim_DECLARE_CONCRETE_OBJECT(ControllerSet, ModelComponentSet<Controller>);
 //=============================================================================
 // METHODS
 //=============================================================================
+public:
     //--------------------------------------------------------------------------
     // CONSTRUCTION
     //--------------------------------------------------------------------------
-public:
     ControllerSet() {}
     ControllerSet(Model& model);
     ControllerSet(const ControllerSet &aControllerSet);
     ControllerSet(Model& model, const std::string &aFileName,  bool aUpdateFromXMLNode = true);
-    virtual ~ControllerSet();
+    ~ControllerSet() override = default;
 
     void copyData(const ControllerSet &aAbsControllerSet);
-private:
-
-    /**
-     *   storage object containing the storage object
-     */
-     SimTK::ReferencePtr<Storage> _controlStore;
-
-    /**
-     *   set of actuators controlled by the set of controllers 
-     */
-     SimTK::ReferencePtr<Set<Actuator> > _actuatorSet;
 
 
     //--------------------------------------------------------------------------
     // OPERATORS
     //--------------------------------------------------------------------------
-public:
 #ifndef SWIG
     ControllerSet& operator=(const ControllerSet &aSet);
 #endif
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------
-public:
 
     bool set(int aIndex, Controller *aController);
     bool addController(Controller *aController);
@@ -102,6 +89,13 @@ public:
     virtual void computeControls(const SimTK::State& s, SimTK::Vector &controls) const; 
 
     virtual void printInfo() const;
+
+private:
+
+    std::unique_ptr<Storage> _controlStore;
+
+    // Set of actuators controlled by the set of controllers.
+    SimTK::ReferencePtr<Set<Actuator> > _actuatorSet;
 //=============================================================================
 };  // END of class ControllerSet
 //=============================================================================

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -30,6 +30,8 @@
 #include <OpenSim/Simulation/Model/ModelComponentSet.h>
 #include "SimTKsimbody.h"
 
+#include <memory>
+
 namespace OpenSim {
 
 class Model;

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -99,7 +99,7 @@ private:
     std::unique_ptr<Storage> _controlStore;
 
     // Set of actuators controlled by the set of controllers.
-    SimTK::ReferencePtr<Set<Actuator>> _actuatorSet;
+    SimTK::ReferencePtr<Set<Actuator> > _actuatorSet;
 //=============================================================================
 };  // END of class ControllerSet
 //=============================================================================

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -59,7 +59,9 @@ public:
     ControllerSet(Model& model);
     ControllerSet(const ControllerSet &aControllerSet);
     ControllerSet(Model& model, const std::string &aFileName,  bool aUpdateFromXMLNode = true);
+#ifndef SWIG
     ~ControllerSet() override = default;
+#endif
 
     void copyData(const ControllerSet &aAbsControllerSet);
 


### PR DESCRIPTION
The member variable *was* supposed to own the memory of the `_controlStore`, and so I use a `unique_ptr` instead of a `ReferencePtr`.

Addresses part of #528.