### PR TITLE
CMake cleanup for Mac, and Mac users don't need to set DYLD_LIBRARY_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,6 @@ cmake_minimum_required(VERSION 2.8.8)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
     cmake_policy(SET CMP0005 NEW)
-    if(NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
-        # MACOSX_RPATH enabled by default; policy introduced with cmake 3.0.
-        cmake_policy(SET CMP0042 NEW)
-    endif()
 endif(COMMAND cmake_policy)
 
 
@@ -261,40 +257,10 @@ set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL
     "Enable this for verbose build output.")
 
 if(WIN32)
-add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-else(WIN32)
-endif(WIN32)
+    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+endif()
 
-##################################################
-## Define Platform to
-##          Win32/VC${version}
-##      or  Mac
-##      or  Linux
-##
-## Also translate ARCH64 to platform specific flags
-##
-##################################################
 include(InstallRequiredSystemLibraries)
-
-if(WIN32)
-else(WIN32)
-    set(NameSpace "")   ## No renamed SimTK libraries except on Windows
-    if(APPLE)
-       if(ARCH64)
-           set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.8" )
-       else(ARCH64)
-           set( CMAKE_CXX_FLAGS
-               "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.8 -m32" )
-       endif(ARCH64)
-    else(APPLE)
-       if(ARCH64)
-           set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64" )
-       else(ARCH64)
-          # I don't believe setting the CXX flags is working in cmake.
-          set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32" )
-       endif(ARCH64)
-    endif(APPLE)
-endif(WIN32)
 
 # C++11: In revision 8629, we started using std::unique_ptr, which requires
 # C++11 features to be enabled when using GCC or Clang.
@@ -313,6 +279,44 @@ if(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
         endif()
     else() # not APPLE
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+endif()
+
+
+## On APPLE, use MACOSX_RPATH.
+set(OPENSIM_USE_INSTALL_RPATH FALSE)
+if(APPLE AND NOT (${CMAKE_VERSION} VERSION_LESS 2.8.12))
+    option(OPENSIM_NO_LIBRARY_PATH_ENV_VAR
+        "If ON, you don't need to set the LD_LIBRARY_PATH (Linux) or
+        DYLD_LIBRARY_PATH (Mac) to make use of OpenSim's executables.
+        Instead, we bake the location of OpenSim's libraries into the
+        executables, so the executables already know where to find the
+        libraries. This uses the RPATH mechanism." ON)
+    if(${OPENSIM_NO_LIBRARY_PATH_ENV_VAR})
+        # CMake 2.8.12 introduced the ability to set RPATH for shared libraries on
+        # OSX. This helps executables find the libraries they depend on without
+        # having to set the DYLD_LIBRARY_PATH environment variable.
+        # The code below is all taken from the link below, and implements the
+        # scenario "Always use full RPATH".
+        # http://www.cmake.org/Wiki/CMake_RPATH_handling
+        # Note: the RPATH won't succeed if the libraries are moved; in this case,
+        # one will still need to set DYLD_LIBRARY_PATH (or alter the RPATH in the
+        # executables/libraries that depend on Simbody's libraries).
+        set(CMAKE_MACOSX_RPATH ON)
+    
+        set(CMAKE_INSTALL_FULL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib")
+    
+        # Add the automatically determined parts of the RPATH
+        # which point to directories outside the build tree to the install RPATH.
+        set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    
+        # The RPATH to be used when installing, but only if it's not a system
+        # directory.
+        list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+            "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
+        if("${isSystemDir}" STREQUAL "-1")
+            set(OPENSIM_USE_INSTALL_RPATH TRUE)
+        endif()
     endif()
 endif()
 

--- a/OpenSim/Wrapping/Python/CMakeLists.txt
+++ b/OpenSim/Wrapping/Python/CMakeLists.txt
@@ -79,6 +79,12 @@ elseif(APPLE)
     set_target_properties(_${KIT} PROPERTIES SUFFIX ".so")
 endif()
 
+if(${OPENSIM_USE_INSTALL_RPATH})
+    set_target_properties(_${KIT} PROPERTIES
+        INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
+        )
+endif()
+
 # Shared libraries are needed at runtime for applications, so we put them
 # at the top level in OpenSim/bin/*.dll (Windows) or OpenSim/lib/*.so (Linux)
 # or OpemSim/lib/*.dylib (Mac). Windows .lib files, and Linux/Mac .a static

--- a/README.md
+++ b/README.md
@@ -327,18 +327,19 @@ On Mac using Xcode
 
 #### Set environment variables
 
-1. Allow executables to find OpenSim-Core libraries by adding the OpenSim-Core
-   `lib/` directory to your linker path. Open a terminal and type:
-
-        $ echo 'export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/opensim-core/lib' >> ~/.bash_profile
-
-2. Add OpenSim-Core's executables to the path so you can access them from any
-   directory on your computer. *Note* some of the names of OpenSim-Core
-   executables conflict with some UNIX commands (e.g., `id`). To give
-   preference to OpenSim-Core's executables, we must *prepend* OpenSim-Core's
-   `bin/` directory to the path. Open a terminal and type:
+1. **Executables**. If you want to run OpenSim-Core's executables from
+   anywhere on your computer, you must update your PATH. *Note* some of the names of OpenSim-Core executables conflict with some UNIX commands (e.g., `id`). To give preference to OpenSim-Core's executables, we must *prepend* OpenSim-Core's `bin/` directory to the path. Open a terminal and type:
 
         $ echo 'export PATH=~/opensim-core/bin:$PATH' >> ~/.bash_profile
+
+2. **Libraries**. Hopefully you can skip this step. This step is required if:
+  1. You are using CMake version 2.8.11 or older.
+  2. You plan on building C++ executables or libraries on top of OpenSim, *and* you plan to "install" them in the CMake sense of the word (that is, you're not going to simply use them from your project's build directory).
+  3. You plan to use the Java or MATLAB wrapping.
+
+  If any of these are true, then you must add OpenSim-Core libraries to your linker path. Open a terminal and type:
+
+          $ echo 'export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/opensim-core/lib' >> ~/.bash_profile
 
 Your changes will only take effect in new terminal windows.
 
@@ -469,18 +470,19 @@ And you could get all the optional dependencies via:
 
 #### Set environment variables
 
-1. Allow executables to find OpenSim-Core libraries by adding the OpenSim-Core
-   `lib/` directory to your linker path.
-
-        $ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/opensim-core/lib' >> ~/.bashrc
-
-2. Add OpenSim-Core's executables to the path so you can access them from any
+1. **Executables**. Add OpenSim-Core's executables to the path so you can access them from any
    directory on your computer. NOTE that some of the names of OpenSim-Core
    executables conflict with some UNIX commands (e.g., `id`). To give
    preference to OpenSim-Core's executables, we must *prepend* OpenSim-Core's
    `bin/` directory to the path.
 
         $ echo 'export PATH=~/opensim-core/bin:$PATH' >> ~/.bashrc
+
+2. **Libraries**. Allow executables to find OpenSim-Core libraries by
+  adding the OpenSim-Core
+   `lib/` directory to your linker path.
+
+        $ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/opensim-core/lib' >> ~/.bashrc
 
 Your changes will only take effect in new terminal windows.
 

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -82,7 +82,6 @@ function(OPENSIM_ADD_LIBRARY)
        PROJECT_LABEL "${OSIMADDLIB_PROJECT_LABEL}"
     )
 
-
     # Install.
     # --------
     # Shared libraries are needed at runtime for applications, so we put them
@@ -221,5 +220,11 @@ function(OpenSimAddApplication APPNAME)
     install(TARGETS ${APPNAME} DESTINATION bin)
     set_target_properties(${APPNAME} PROPERTIES
         PROJECT_LABEL "Applications - ${APPNAME}")
+
+    if(${OPENSIM_USE_INSTALL_RPATH})
+        set_target_properties(${APPNAME} PROPERTIES
+            INSTALL_RPATH "\@executable_path/../lib"
+            )
+    endif()
 
 endfunction()


### PR DESCRIPTION
Mac users no longer need to set DYLD_LIBRARY_PATH to use OpenSim executables or python wrapping, which could save a lot of headache. They still might need to set DYLD_LIBRARY_PATH for java wrapping, MATLAB, or when building their own executables and libraries (though if they make use of RPATH themselves, they don't need to).

Basically, the path to the libraries is saved in the executables: e.g., the analyze tool contains a relative path to the opensim libs, and the opensim libs contain a full path to the simbody libs. The python _opensim.so library contains the full path to the opensim libs.

This all works great if you're building from source on a mac, which is currently the only option. If we ever distribute binaries for mac of OpenSim or Simbody, we'll have to revisit. In such a case, I think we should be using OSX frameworks. If we want to be on OSX for 4.0, then I can look into OSX frameworks (though I am not sure if netbeans works with OSX frameworks). I think they would be very straightforward to set up.

I may eventually get around to using RPATH for Linux as well.

@sherm1 would you like a similar PR for Simbody?

I also did some vacuuming of the root CMakeLists.txt.