### PR TITLE
Suppress VS2015 warnings.

### DIFF
--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -33,7 +33,7 @@
 #include <string>
 
 #ifdef WIN32
-#pragma warning(disable:4251) /*no DLL interface for type of member of exported class.*/
+#pragma warning(disable:4251) /*no DLL interface for type of member of exported class*/
 #pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
 #endif
 

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -33,7 +33,8 @@
 #include <string>
 
 #ifdef WIN32
-#pragma warning( disable : 4251 )   // VC2010 no-dll export of std::string
+#pragma warning(disable:4251) /*no DLL interface for type of member of exported class.*/
+#pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
 #endif
 
 #ifdef SWIG


### PR DESCRIPTION
This is the same fix that I think @sherm1 made for opensim32.