### PR TITLE
Move to VS2015.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,15 @@ On Windows using Visual Studio
 * **operating system**: Windows 7 or 8.
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8
-* **compiler / IDE**: Visual Studio 2013. We recommended either:
-    * *Visual Studio Express 2013 for Windows Desktop*, which is free, or
-    * *Visual Studio Professional 2013* through
-      [Dreamspark](https://www.dreamspark.com) if you are at an academic
-      institution.
+* **compiler / IDE**: [Visual Studio 2015](https://www.visualstudio.com/).
+    * *Visual Studio Community 2015* is sufficient and is free for everyone.
+        If you want to use *Visual Studio Enterprise 2015*, you may be able 
+        to get it for free at [Dreamspark](https://www.dreamspark.com) if 
+        you are at an academic institution.
+    * Visual Studio 2015 does not install C++ 
+      support by default. During the installation you must select 
+      *Custom*, and check *Programming Languages > Visual C++ > Common Tools for Visual C++ 2015*.
+      You can uncheck all other boxes.
 * **physics engine**:
   [Simbody](https://github.com/simbody/simbody#windows-and-visual-studio) >= 3.4
 * **API documentation** (optional):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ build_script:
   - mkdir build
   - cd build
   # Configure.
-  - cmake .. -G"Visual Studio 12 2013 Win64" -DSIMBODY_HOME=C:\simbody -DCMAKE_INSTALL_PREFIX=%OPENSIM_HOME% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON # TODO -DBUILD_SIMM_TRANSLATOR=ON
+  - cmake .. -G"Visual Studio 14 2015 Win64" -DSIMBODY_HOME=C:\simbody -DCMAKE_INSTALL_PREFIX=%OPENSIM_HOME% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON # TODO -DBUILD_SIMM_TRANSLATOR=ON
   # Build.
   - cmake --build . --target ALL_BUILD --config Release -- /maxcpucount:4 /verbosity:quiet
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,10 @@
 # However, this was causing some weird behavior. Not treating warnings
 # as errors for now.
 #
-### TEMPORARILY DISABLING WRAPPING (see lines with ###)
   
 shallow_clone: true
+
+os: Visual Studio 2015
 
 platform: x64
 
@@ -24,7 +25,7 @@ init:
   # Note: python 2.7 32bit is already on the path. We want v2.7 64bit,
   # so we must add v2.7 64bit earlier on the PATH.
   # http://www.appveyor.com/docs/installed-software
-  - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;C:\Python27-x64\Scripts;%PATH%
+  - SET PATH=C:\Python27-x64\Scripts;%PATH%
   - SET OPENSIM_HOME=C:\OpenSim
   
 nuget:


### PR DESCRIPTION
I've created this PR in preparation for our move to VS2015. I think this PR can be used to mark our official move to VS2015 (so, not just yet).

I've updated the README instructions to say that Windows users need VS2015. When Simbody moves to VS2015, I'll also update the appveyor script so that it builds with VS2015.