### PR TITLE
ResetOnCopy<Index>

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1736,8 +1736,9 @@ private:
     // Underlying SimTK custom measure ComponentMeasure, which implements
     // the realizations in the subsystem by calling private concrete methods on
     // the Component. Every model component has one of these, allocated
-    // in its extendAddToSystem() method, and placed in the System's default subsystem.
-    SimTK::MeasureIndex  _simTKcomponentIndex;
+    // in its extendAddToSystem() method, and placed in the System's default
+    // subsystem.
+    SimTK::ResetOnCopy<SimTK::MeasureIndex> _simTKcomponentIndex;
 
     // Structure to hold modeling option information. Modeling options are
     // integers 0..maxOptionValue. At run time we keep them in a Simbody

--- a/OpenSim/Simulation/Model/Force.cpp
+++ b/OpenSim/Simulation/Model/Force.cpp
@@ -42,37 +42,9 @@ Force::Force()
     constructProperties();
 }
 
-//_____________________________________________________________________________
-// Copy constructor.
-Force::Force(const Force& source) : Super(source)
-{
-    copyData(source);
-}
-
-//_____________________________________________________________________________
-// Copy assignment.
-Force& Force::operator=(const Force& source)
-{
-    if (&source != this) {
-        Super::operator=(source);
-        copyData(source);
-    }
-    return *this;
-}
 //=============================================================================
 // CONSTRUCTION METHODS
 //=============================================================================
-//_____________________________________________________________________________
-// Perform copy construction or assignment on local data members; base class
-// (including properties) has already been copied.
-void Force::copyData(const Force& source)
-{
-    copyProperty_isDisabled(source);
-    // A copy is no longer a live Force with an underlying SimTK::Force. The
-    // system must be created, at which time the Force will be assigned an index
-    // corresponding to a valid system SimTK::Force.
-    _index.invalidate();
-}
 
 //_____________________________________________________________________________
 // Set the data members of this Force to their null values.

--- a/OpenSim/Simulation/Model/Force.h
+++ b/OpenSim/Simulation/Model/Force.h
@@ -223,7 +223,7 @@ protected:
 
 protected:
     /** ID for the force in Simbody. */
-    SimTK::ForceIndex   _index;
+    SimTK::ResetOnCopy<SimTK::ForceIndex> _index;
 
 private:
     void setNull();

--- a/OpenSim/Simulation/Model/Force.h
+++ b/OpenSim/Simulation/Model/Force.h
@@ -60,18 +60,6 @@ public:
 // PUBLIC METHODS
 //=============================================================================
 
-    // Constructors are protected; has default destructor.
-
-    /** Implements a copy constructor just so it can invalidate the 
-    SimTK::Force index after copying. **/
-    Force(const Force &aForce);
-
-#ifndef SWIG
-    /** Implements a copy assignment operator just so it can invalidate the 
-    SimTK::Force index after the assignment. **/
-    Force& operator=(const Force &aForce);
-#endif
-
     /**
     * Tell SimBody to parallelize this force. Should be 
     * set to true for any forces that will take time to 
@@ -111,7 +99,9 @@ public:
     /** Return a flag indicating whether the Force is applied along a Path. If
     you override this method to return true for a specific subclass, it must
     also implement the getGeometryPath() method. **/
-    virtual bool hasGeometryPath() const { return getPropertyIndex("GeometryPath").isValid();};
+    virtual bool hasGeometryPath() const {
+        return getPropertyIndex("GeometryPath").isValid();
+    };
 
 protected:
     /** Default constructor sets up Force-level properties; can only be
@@ -228,7 +218,6 @@ protected:
 private:
     void setNull();
     void constructProperties();
-    void copyData(const Force &aForce);
 
     friend class ForceAdapter;
 

--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -58,19 +58,19 @@ void Frame::extendAddToSystem(SimTK::MultibodySystem& system) const
 const SimTK::Transform& Frame::getGroundTransform(const SimTK::State& s) const
 {
     if (!getSystem().getDefaultSubsystem().
-            isCacheValueRealized(s, groundTransformIndex)){
+            isCacheValueRealized(s, _groundTransformIndex)){
         //cache is not valid so calculate the transform
         SimTK::Value<SimTK::Transform>::downcast(
             getSystem().getDefaultSubsystem().
-            updCacheEntry(s, groundTransformIndex)).upd()
+            updCacheEntry(s, _groundTransformIndex)).upd()
                 = calcGroundTransform(s);
         // mark cache as up-to-date
         getSystem().getDefaultSubsystem().
-            markCacheValueRealized(s, groundTransformIndex);
+            markCacheValueRealized(s, _groundTransformIndex);
     }
     return SimTK::Value<SimTK::Transform>::downcast(
         getSystem().getDefaultSubsystem().
-            getCacheEntry(s, groundTransformIndex)).get();
+            getCacheEntry(s, _groundTransformIndex)).get();
 }
 
 void Frame::extendAddGeometry(OpenSim::Geometry& geom) {
@@ -127,5 +127,6 @@ SimTK::Transform Frame::findTransformInBaseFrame() const
 void Frame::extendRealizeTopology(SimTK::State& s) const
 {
     Super::extendRealizeTopology(s);
-    groundTransformIndex = getCacheVariableIndex("ground_transform");
+    const_cast<Self*>(this)->_groundTransformIndex =
+        getCacheVariableIndex("ground_transform");
 }

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -223,7 +223,7 @@ private:
     virtual SimTK::Transform extendFindTransformInBaseFrame() const = 0;
     /**@}**/
 
-    mutable SimTK::CacheEntryIndex groundTransformIndex;
+    mutable SimTK::ResetOnCopy<SimTK::CacheEntryIndex> groundTransformIndex;
 
 //=============================================================================
 };  // END of class Frame

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -223,7 +223,7 @@ private:
     virtual SimTK::Transform extendFindTransformInBaseFrame() const = 0;
     /**@}**/
 
-    mutable SimTK::ResetOnCopy<SimTK::CacheEntryIndex> groundTransformIndex;
+    SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _groundTransformIndex;
 
 //=============================================================================
 };  // END of class Frame

--- a/OpenSim/Simulation/Model/PhysicalFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalFrame.h
@@ -167,7 +167,7 @@ protected:
     set by the end of PhysicalFrame::addToSystem()
         */
     void setMobilizedBodyIndex(const SimTK::MobilizedBodyIndex& mbix) const {
-        _mbIndex = mbix; 
+        const_cast<Self*>(this)->_mbIndex = mbix; 
     }
 
     /** Extend how PhysicalFrame determines its base Frame. */
@@ -193,7 +193,7 @@ private:
     /* ID for the underlying mobilized body in Simbody system.
     Only Joint can set, since it defines the mobilized body type and
     the connection to the parent body in the multibody tree. */
-    mutable SimTK::ResetOnCopy<SimTK::MobilizedBodyIndex> _mbIndex;
+    SimTK::ResetOnCopy<SimTK::MobilizedBodyIndex> _mbIndex;
 
     virtual const SimTK::Body& extractInternalRigidBody() const {
         return _internalRigidBody;

--- a/OpenSim/Simulation/Model/PhysicalFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalFrame.h
@@ -193,7 +193,7 @@ private:
     /* ID for the underlying mobilized body in Simbody system.
     Only Joint can set, since it defines the mobilized body type and
     the connection to the parent body in the multibody tree. */
-    mutable SimTK::MobilizedBodyIndex _mbIndex;
+    mutable SimTK::ResetOnCopy<SimTK::MobilizedBodyIndex> _mbIndex;
 
     virtual const SimTK::Body& extractInternalRigidBody() const {
         return _internalRigidBody;

--- a/OpenSim/Simulation/SimbodyEngine/Constraint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Constraint.h
@@ -108,7 +108,7 @@ private:
     void constructProperties();
 
     /** ID for the constraint in Simbody. */
-    mutable SimTK::ConstraintIndex _index;
+    mutable SimTK::ResetOnCopy<SimTK::ConstraintIndex> _index;
 
     friend class SimbodyEngine;
 

--- a/OpenSim/Simulation/SimbodyEngine/Constraint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Constraint.h
@@ -100,7 +100,7 @@ protected:
 
     /** Helper method to assign the underlying SimTK::Constraint index */
     void assignConstraintIndex(SimTK::ConstraintIndex ix) const {
-        _index = ix;
+        const_cast<Self*>(this)->_index = ix;
      }
 
 private:
@@ -108,7 +108,7 @@ private:
     void constructProperties();
 
     /** ID for the constraint in Simbody. */
-    mutable SimTK::ResetOnCopy<SimTK::ConstraintIndex> _index;
+    SimTK::ResetOnCopy<SimTK::ConstraintIndex> _index;
 
     friend class SimbodyEngine;
 

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -201,7 +201,7 @@ public:
     /** @name Advanced Access to underlying Simbody system resources */
     /**@{**/
     int getMobilizerQIndex() const { return _mobilizerQIndex; };
-    SimTK::MobilizedBodyIndex getBodyIndex() const { return _bodyIndex; };
+    const SimTK::MobilizedBodyIndex& getBodyIndex() const { return _bodyIndex; };
     /**@}**/
 
     //--------------------------------------------------------------------------
@@ -281,15 +281,15 @@ private:
     //       during a simulation.
     //       The last constraint to be set takes precedence.
     /** Indices for the constraint in Simbody. */
-    SimTK::ConstraintIndex _prescribedConstraintIndex;
-    SimTK::ConstraintIndex _lockedConstraintIndex;
-    SimTK::ConstraintIndex _clampedConstraintIndex;
+    SimTK::ResetOnCopy<SimTK::ConstraintIndex> _prescribedConstraintIndex;
+    SimTK::ResetOnCopy<SimTK::ConstraintIndex> _lockedConstraintIndex;
+    SimTK::ResetOnCopy<SimTK::ConstraintIndex> _clampedConstraintIndex;
 
     /* MobilizedBodyIndex of the body which this coordinate serves.  */
-    SimTK::MobilizedBodyIndex _bodyIndex;
+    SimTK::ResetOnCopy<SimTK::MobilizedBodyIndex> _bodyIndex;
 
     /* Mobilizer Q (i.e. generalized coordinate) index for this Coordinate. */
-    SimTK::MobilizerQIndex _mobilizerQIndex;
+    SimTK::ResetOnCopy<SimTK::MobilizerQIndex> _mobilizerQIndex;
 
     /* Keep a reference to the SimTK function owned by the PrescribedMotion
     Constraint, so we can change the value at which to lock the joint. */

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -201,7 +201,7 @@ public:
     /** @name Advanced Access to underlying Simbody system resources */
     /**@{**/
     int getMobilizerQIndex() const { return _mobilizerQIndex; };
-    const SimTK::MobilizedBodyIndex& getBodyIndex() const { return _bodyIndex; };
+    SimTK::MobilizedBodyIndex getBodyIndex() const { return _bodyIndex; };
     /**@}**/
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
@@ -87,7 +87,7 @@ protected:
     void extendSetPropertiesFromState(const SimTK::State& state) override;
 
 private:
-    SimTK::MobilizedBodyIndex _masslessBodyIndex;
+    SimTK::ResetOnCopy<SimTK::MobilizedBodyIndex> _masslessBodyIndex;
     void setNull();
 //=============================================================================
 };  // END of class FreeJoint

--- a/OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h
+++ b/OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h
@@ -73,7 +73,7 @@ public:
 private:
 
     /** Get the indices of underlying constraints to access from Simbody */
-    std::vector<SimTK::ConstraintIndex> _indices;
+    SimTK::ResetOnCopy<std::vector<SimTK::ConstraintIndex>> _indices;
 
     /**  This cache acts a temporary hold for the constraint conditions when time has not changed */
     std::vector<bool> _defaultUnilateralConditions;


### PR DESCRIPTION
I employed `SimTK::ResetOnCopy` for a bunch of SimTK indices in OpenSim. I think there are more indices to convert. So I've marked this PR as WIP.