### PR TITLE
Remove dependency on SWIGSimTK files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   global:
     # The python tests look for OPENSIM_HOME.
     - OPENSIM_HOME=~/opensim-install
-    - SWIG_VER=3.0.5
+    - SWIG_VER=3.0.6
     - USE_CCACHE=1
     - CCACHE_COMPRESS=1
     # for Clang to work with ccache.

--- a/OpenSim/Wrapping/CMakeLists.txt
+++ b/OpenSim/Wrapping/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 3.0.5 REQUIRED)
+    find_package(SWIG 3.0.6 REQUIRED)
 endif()
 
 subdirs(Java Python)

--- a/OpenSim/Wrapping/Java/OpenSimJNI/CMakeLists.txt
+++ b/OpenSim/Wrapping/Java/OpenSimJNI/CMakeLists.txt
@@ -38,7 +38,6 @@ add_custom_command(
     COMMAND ${SWIG_EXECUTABLE} -v -c++ -java
         -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
         -I${OpenSim_SOURCE_DIR}
-        -I${OpenSim_SOURCE_DIR}/OpenSim/Wrapping
         -I${Simbody_INCLUDE_DIR}
         -o ${swig_generated_file_fullname}
         -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}

--- a/OpenSim/Wrapping/Python/CMakeLists.txt
+++ b/OpenSim/Wrapping/Python/CMakeLists.txt
@@ -30,7 +30,6 @@ add_custom_command(
         ${swig_output_cxx_file_fullname} ${swig_output_header_file_fullname}
     COMMAND ${SWIG_EXECUTABLE} -v -c++ -python
         -I${OpenSim_SOURCE_DIR}
-        -I${OpenSim_SOURCE_DIR}/OpenSim/Wrapping/
         -I${Simbody_INCLUDE_DIR}
         -o ${swig_output_cxx_file_fullname}
         -outdir ${CMAKE_CURRENT_BINARY_DIR}

--- a/OpenSim/Wrapping/Python/swig/pyWrapOpenSim.i
+++ b/OpenSim/Wrapping/Python/swig/pyWrapOpenSim.i
@@ -469,7 +469,7 @@ import_array();
 #undef SimTK_FORCE_INLINE
 #define SimTK_FORCE_INLINE 
 #undef SimTK_DEFINE_UNIQUE_INDEX_TYPE
-#define SimTK_DEFINE_UNIQUE_INDEX_TYPE(x) 
+#define SimTK_DEFINE_UNIQUE_INDEX_TYPE(NAME) typedef int NAME;
 #undef SimTK_PIMPL_DOWNCAST
 #define SimTK_PIMPL_DOWNCAST(x, y)
 

--- a/OpenSim/Wrapping/Python/swig/pyWrapOpenSim.i
+++ b/OpenSim/Wrapping/Python/swig/pyWrapOpenSim.i
@@ -7,6 +7,8 @@
 // you've wrapped your new class properly. However, SWIG generates lots of 401
 // errors that are very difficult to resolve.
 #pragma SWIG nowarn=401
+// 476 is "Initialization using std::initializer_list."
+#pragma SWIG nowarn=476
 
 /*
 For consistency with the rest of the API, we use camel-case for variable names.
@@ -461,29 +463,57 @@ import_array();
 /* rest of header files to be wrapped */
 %include <OpenSim/version.h>
 %include <SimTKcommon.h>
+%include <SimTKcommon/internal/common.h>
+
+// "Remove" problematic SimTK macros defined in common.h
+#undef SimTK_FORCE_INLINE
+#define SimTK_FORCE_INLINE 
+#undef SimTK_DEFINE_UNIQUE_INDEX_TYPE
+#define SimTK_DEFINE_UNIQUE_INDEX_TYPE(x) 
+#undef SimTK_PIMPL_DOWNCAST
+#define SimTK_PIMPL_DOWNCAST(x, y)
 
 %include <SimTKcommon/Constants.h>
-%include <SWIGSimTK/Vec.h>
+namespace SimTK {
+    %ignore Vec::drop1;
+    %ignore Vec::append1;
+    %ignore Vec::insert1;
+    %ignore Vec::scalarMinusEqFromLeft;
+    %ignore Vec::scalarDivideEqFromLeft;
+};
+%include <SimTKcommon/internal/Vec.h>
+%include <SimTKcommon/SmallMatrix.h>
 // Vec3
 namespace SimTK {
-%template(Vec2) Vec<2>;
-%template(Vec3) Vec<3>;
-%template(Vec4) Vec<4>;
-%template(Vec6) Vec<6>;
+    %template(Vec2) Vec<2, double, 1>;
+    %template(Vec3) Vec<3, double, 1>;
+    %template(Vec4) Vec<4, double, 1>;
+    %template(Vec6) Vec<6, double, 1>;
 }
 // Mat33
-%include <SWIGSimTK/Mat.h>
 namespace SimTK {
-%template(Mat33) Mat<3, 3>;
+    %ignore Mat::dropRow;
+    %ignore Mat::dropCol;
+    %ignore Mat::dropRowCol;
+    %ignore Mat::appendRow;
+    %ignore Mat::appendCol;
+    %ignore Mat::appendRowCol;
+    %ignore Mat::insertRow;
+    %ignore Mat::insertCol;
+    %ignore Mat::insertRowCol;
+};
+%include <SimTKcommon/internal/Mat.h>
+namespace SimTK {
+%template(Mat33) Mat<3, 3, double, 3, 1>;
 }
-%include <SWIGSimTK/CoordinateAxis.h>
-%include <SWIGSimTK/UnitVec.h>
+%include <SimTKcommon/internal/CoordinateAxis.h>
+%include <SimTKcommon/internal/UnitVec.h>
 namespace SimTK {
-%template(UnitVec3)  SimTK::UnitVec<double,1>;
+%template(UnitVec3) SimTK::UnitVec<double,1>;
 }
 
 // Vector and Matrix
-%include <SWIGSimTK/BigMatrix.h>
+%include <SimTKcommon/internal/BigMatrix.h>
 namespace SimTK {
 %template(MatrixBaseDouble) SimTK::MatrixBase<double>;
 %template(VectorBaseDouble) SimTK::VectorBase<double>;
@@ -491,7 +521,7 @@ namespace SimTK {
 %template(Matrix) SimTK::Matrix_<double>;
 }
 
-%include <SWIGSimTK/SpatialAlgebra.h>
+%include <SimTKcommon/internal/SpatialAlgebra.h>
 namespace SimTK {
 %template(SpatialVec) Vec<2,   Vec3>;
 %template(VectorBaseOfSpatialVec) VectorBase<SpatialVec>;
@@ -501,25 +531,31 @@ namespace SimTK {
 }
 
 
-%include <SWIGSimTK/Rotation.h>
+%include <SimTKcommon/internal/Rotation.h>
 namespace SimTK {
 %template(Rotation) SimTK::Rotation_<double>;
 %template(InverseRotation) SimTK::InverseRotation_<double>;
 }
 // Transform
-%include <SWIGSimTK/Transform.h>
+%include <SimTKcommon/internal/Transform.h>
 namespace SimTK {
 %template(Transform) SimTK::Transform_<double>;
 }
 
 //
-%include <SWIGSimTK/MassProperties.h>
+%include <SimTKcommon/internal/MassProperties.h>
 namespace SimTK {
 %template(Inertia) SimTK::Inertia_<double>;
 %template(MassProperties) SimTK::MassProperties_<double>;
 }
-%include <SWIGSimTK/common.h>
-%include <SWIGSimTK/Array.h>
+
+namespace SimTK {
+    %ignore Array_::Array_(Array_&&); // warning 509: shadowed.
+    %ignore Array_<OpenSim::CoordinateReference>::push_back(OpenSim::CoordinateReference const&);
+    %ignore Array_<SimTK::DecorativeGeometry>::push_back(SimTK::DecorativeGeometry const&);
+    %ignore Array_<SimTK::Vec3>::push_back(SimTK::Vec<3, SimTK::Real, 1> const&);
+}
+%include <SimTKcommon/internal/Array.h>
 namespace SimTK {
     %template(ArrayView) ArrayView_<double, unsigned int>;
     %template(ArrayViewOfVec3) ArrayView_<Vec3, unsigned int>;
@@ -541,7 +577,7 @@ namespace SimTK {
 %template(ArrayIndexInt) ArrayIndexTraits<int>; 
 }
 
-%include <SWIGSimTK/DecorativeGeometry.h>
+%include <SimTKcommon/internal/DecorativeGeometry.h>
 
 namespace SimTK {
 %template(ArrayDecorativeGeometry) SimTK::Array_<SimTK::DecorativeGeometry>;
@@ -549,8 +585,14 @@ namespace SimTK {
 }
 
 // State & Stage
-%include <SWIGSimTK/Stage.h>
-%include <SWIGSimTK/State.h>
+namespace SimTK {
+    %ignore State::State(State&&); // warning 509: shadowed.
+    %ignore Stage::operator++;
+    %ignore Stage::operator--;
+    %ignore Stage::Stage(int); // warning 509: shadowed.
+}
+%include <SimTKcommon/internal/Stage.h>
+%include <SimTKcommon/internal/State.h>
 
 // osimCommon Library
 %include <OpenSim/Common/osimCommonDLL.h>
@@ -558,6 +600,10 @@ namespace SimTK {
 %include <OpenSim/Common/Array.h>
 %include <OpenSim/Common/ArrayPtrs.h>
 %include <OpenSim/Common/AbstractProperty.h>
+namespace OpenSim {
+    // warning 509: shadowed.
+    %ignore Property<std::string>::appendValue(std::string const *);
+}
 %include <OpenSim/Common/Property.h>
 %include <OpenSim/Common/PropertyGroup.h>
 %template(ArrayPtrsPropertyGroup) OpenSim::ArrayPtrs<OpenSim::PropertyGroup>;

--- a/OpenSim/Wrapping/Python/tests/test_swig_additional_interface.py
+++ b/OpenSim/Wrapping/Python/tests/test_swig_additional_interface.py
@@ -253,3 +253,11 @@ def test_markAdoptedSets():
     constr.setConstantDistance(1)
     a.addConstraint(constr)
 
+def test_SimTK_math_types():
+    # Make sure we can pass SimTK math types to different methods. This checks
+    # a subtle issue created by presence/absence of default template arguments.
+    osim.Inertia(osim.Mat33())
+    osim.Rotation(osim.Mat33())
+    b = osim.Body()
+    b.setMassCenter(osim.UnitVec3(1, 0, 0))
+

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ On Windows using Visual Studio
     * [TortoiseGit](https://code.google.com/p/tortoisegit/wiki/Download),
       intermediate; good for TortoiseSVN users;
     * [GitHub for Windows](https://windows.github.com/), easiest.
-* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.5
+* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.6
     * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
     * **python scripting** (optional):
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
@@ -244,7 +244,7 @@ On Mac using Xcode
 * **version control** (optional): git.
     * Xcode Command Line Tools gives you git on the command line.
     * [GitHub for Mac](https://mac.github.com), easiest.
-* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.5
+* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.6
     * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
     * **python scripting** (optional):
         * Mac's come with python, but you could also install:
@@ -368,7 +368,7 @@ line below, we show the corresponding package.
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6;
   `doxygen`.
 * **version control** (optional): git; `git`.
-* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.5; must get from SWIG website.
+* **Wrapping** (optional): [SWIG](http://www.swig.org/) 3.0.6; must get from SWIG website.
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7;
       `openjdk-6-jdk` or `openjdk-7-jdk`.
     * **python scripting** (optional): `python-dev`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ nuget:
 install:
 
   ## Use Chocolatey to install SWIG.
-  - choco install swig --version 3.0.5 -y
+  - choco install swig --version 3.0.6 -y
   
   ## Install python-nose for python testing.
   - pip install nose


### PR DESCRIPTION
@aymanhab the java and python wrapping _should_ work now, but I think using the SimTK headers may have made the files larger and that is causing the failure on travis. On appveyor, the wrapping works though.

So I suppose this is not ready to merge yet. Perhaps splitting the wrapping into multiple modules must happen first?
