### PR TITLE
Removed unwarranted hyperlinks to OpenSim::Set

### DIFF
--- a/OpenSim/Actuators/BodyActuator.h
+++ b/OpenSim/Actuators/BodyActuator.h
@@ -88,7 +88,7 @@ public:
     //--------------------------------------------------------------------------
     // Get & Set
     //--------------------------------------------------------------------------
-    /** Set the 'point' property that determines where the force vector should
+    /** %Set the 'point' property that determines where the force vector should
     be applied. The default is the origin of the body Vec3(0). **/
     void setPoint(SimTK::Vec3& point)
     {set_point(point);}
@@ -97,7 +97,7 @@ public:
     {return get_point();}
 
 
-    /** Set the 'point_is_global' property that determines whether the point is  
+    /** %Set the 'point_is_global' property that determines whether the point is  
     specified in inertial coordinates or in the body's local coordinates. **/
     void setPointForceIsGlobal(bool isGlobal)
     {set_point_is_global(isGlobal); }
@@ -106,7 +106,7 @@ public:
     {return get_point_is_global();  }
 
 
-    /** Set the 'spatial_force_is_global' property that determines how to 
+    /** %Set the 'spatial_force_is_global' property that determines how to 
     interpret the 'axis' vector; if not global (Ground frame) it is in body's  
     frame. **/
     void setSpatialForceIsGlobal(bool isGlobal)
@@ -116,12 +116,12 @@ public:
     {return get_spatial_force_is_global();}
 
 
-    /* Set the body to which this actuator applies spatial forces. */
+    /* %Set the body to which this actuator applies spatial forces. */
     void setBody(const Body& body);
     const Body& getBody() const;
 
 
-    /* Set the body name to which this actuator applies spatial forces. */
+    /* %Set the body name to which this actuator applies spatial forces. */
     void setBodyName(const std::string& name);
     const std::string& getBodyName() const;
 

--- a/OpenSim/Actuators/McKibbenActuator.h
+++ b/OpenSim/Actuators/McKibbenActuator.h
@@ -71,21 +71,21 @@ public:
     /** Convenience constructor for API users. **/
     McKibbenActuator(const std::string& name, double num_turns, double thread_length);
 
-    /** Set the 'number of turns' property. **/
+    /** %Set the 'number of turns' property. **/
     void setNumberOfTurns(double val)
     {   set_number_of_turns(val); }
     /** Get the current value of the 'number of turns' property. **/
     double getNumberOfTurns() const 
     {   return get_number_of_turns(); }
     
-    /** Set the 'thread length' property. **/
+    /** %Set the 'thread length' property. **/
     void setThreadLength(double val)
     {   set_thread_length(val); }
     /** Get the current value of the 'thread length' property. **/
     double getThreadLength() const
     {   return get_thread_length(); }
     
-    /** Set the 'cord length' property. **/
+    /** %Set the 'cord length' property. **/
     void setCordLength(double val)
     {   set_cord_length(val); }
     /** Get the current value of the 'cord length' property. **/

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -733,7 +733,7 @@ protected:
 //==============================================================================
 
     /**
-    Set the derivative of an actuator state, specified by name
+    %Set the derivative of an actuator state, specified by name
     @param s the state    
     @param aStateName The name of the state to set.
     @param aValue The value to set the state to.

--- a/OpenSim/Actuators/PointActuator.h
+++ b/OpenSim/Actuators/PointActuator.h
@@ -84,7 +84,7 @@ public:
     // Uses default (compiler-generated) destructor, copy constructor, copy 
     // assignment operator.
 
-    /** Set the 'optimal_force' property. **/
+    /** %Set the 'optimal_force' property. **/
     void setOptimalForce(double aOptimalForce);
     /** Get the current value of the 'optimal_force' property. **/
     double getOptimalForce() const override; // Part of Actuator interface.

--- a/OpenSim/Actuators/PointToPointActuator.h
+++ b/OpenSim/Actuators/PointToPointActuator.h
@@ -79,14 +79,14 @@ public:
     PointToPointActuator(const std::string& bodyNameA, 
                          const std::string& bodyNameB);
     
-    /** Set the 'pointA' property to the supplied value; frame is interpreted
+    /** %Set the 'pointA' property to the supplied value; frame is interpreted
     according to the 'points_are_global' property. **/
     void setPointA(const SimTK::Vec3& pointAPos) 
     {   set_pointA(pointAPos); } ;
     /** Return the current value of the 'pointA' property. **/
     const SimTK::Vec3& getPointA() const 
     {   return get_pointA(); };
-    /** Set the 'pointB' property to the supplied value; frame is interpreted
+    /** %Set the 'pointB' property to the supplied value; frame is interpreted
     according to the 'points_are_global' property. **/
     void setPointB(const SimTK::Vec3& pointBPos) 
     {   set_pointB(pointBPos); } ;
@@ -94,7 +94,7 @@ public:
     const SimTK::Vec3& getPointB() const 
     {   return get_pointB(); };
 
-    /** Set the 'points_are_global' property that determines how to interpret
+    /** %Set the 'points_are_global' property that determines how to interpret
     the 'pointA' and 'pointB' location vectors: if not global (Ground frame) 
     then they are in the local frame of 'bodyA' and 'bodyB' respectively. **/
     void setPointsAreGlobal(bool isGlobal) 
@@ -103,7 +103,7 @@ public:
     bool getPointsAreGlobal() const
     {   return get_points_are_global(); };
 
-    /** Set the 'optimal_force' property. **/
+    /** %Set the 'optimal_force' property. **/
     void setOptimalForce(double optimalForce)
     {   set_optimal_force(optimalForce); }
     /** Get the current value of the 'optimal_force' property. **/

--- a/OpenSim/Actuators/TorqueActuator.h
+++ b/OpenSim/Actuators/TorqueActuator.h
@@ -98,7 +98,7 @@ public:
     // Uses default (compiler-generated) destructor, copy constructor, copy 
     // assignment operator.
     
-    /** Set the 'axis' property to the supplied value; frame is interpreted
+    /** %Set the 'axis' property to the supplied value; frame is interpreted
     according to the 'torque_is_global' property. **/
     void setAxis(const SimTK::Vec3& axis) 
     {   set_axis(axis); }
@@ -106,7 +106,7 @@ public:
     const SimTK::Vec3& getAxis() const 
     {   return get_axis(); }
 
-    /** Set the 'torque_is_global' property that determines how to interpret
+    /** %Set the 'torque_is_global' property that determines how to interpret
     the 'axis' vector; if not global (Ground frame) it is in body A's frame. **/
     void setTorqueIsGlobal(bool isGlobal) 
     {   set_torque_is_global(isGlobal); }
@@ -114,18 +114,20 @@ public:
     bool getTorqueIsGlobal() const
     {   return get_torque_is_global(); }
 
-    /** Set the 'optimal_force' property. **/
+    /** %Set the 'optimal_force' property. **/
     void setOptimalForce(double optimalForce)
     {   set_optimal_force(optimalForce); }
     /** Get the current value of the 'optimal_force' property. **/
     double getOptimalForce() const override // Part of Actuator interface.
     {   return get_optimal_force(); }
 
-    /* Set the bodies to which this actuator applies torque. */
+    /** %Set the first body to which this actuator applies torque. */
     void setBodyA(const PhysicalFrame& body);
+    /** %Set the second body to which this actuator applies torque. */
     void setBodyB(const PhysicalFrame& body);
-    /* Get the bodies that this actuator applies torque to. */
+    /** Get the first body to which this actuator applies torque. */
     const PhysicalFrame& getBodyA() const {return *_bodyA;}
+    /** Get the second body to which this actuator applies torque. */
     const PhysicalFrame& getBodyB() const {return *_bodyB;}
 
 //==============================================================================

--- a/OpenSim/Actuators/TorqueActuator.h
+++ b/OpenSim/Actuators/TorqueActuator.h
@@ -45,7 +45,7 @@ class Model;
 //                           TORQUE ACTUATOR
 //==============================================================================
 /**
- * A TorqueActuatorr applies equal and opposite torques on the two bodies 
+ * A TorqueActuator applies equal and opposite torques on the two bodies 
  * (bodyA and B) that it connects. The torque is applied about an axis
  * specified in ground (global) by default, otherwise it is in bodyA's frame. 
  * The magnitude of the torque is equal to the product of the optimal_force of 
@@ -121,13 +121,13 @@ public:
     double getOptimalForce() const override // Part of Actuator interface.
     {   return get_optimal_force(); }
 
-    /** %Set the first body to which this actuator applies torque. */
+    /** %Set the first body (bodyA) to which this actuator applies torque. */
     void setBodyA(const PhysicalFrame& body);
-    /** %Set the second body to which this actuator applies torque. */
+    /** %Set the second body (bodyB) to which this actuator applies torque. */
     void setBodyB(const PhysicalFrame& body);
-    /** Get the first body to which this actuator applies torque. */
+    /** Get the first body (bodyA) to which this actuator applies torque. */
     const PhysicalFrame& getBodyA() const {return *_bodyA;}
-    /** Get the second body to which this actuator applies torque. */
+    /** Get the second body (bodyB) to which this actuator applies torque. */
     const PhysicalFrame& getBodyB() const {return *_bodyB;}
 
 //==============================================================================

--- a/OpenSim/Analyses/InducedAccelerations.h
+++ b/OpenSim/Analyses/InducedAccelerations.h
@@ -160,8 +160,8 @@ private:
     void setNull();
 
     /**
-     * Set up the properties for th analysis.
-     * Each property should have meaningful name and an informative comment.
+     * %Set up the properties for the analysis.
+     * Each property should have a meaningful name and an informative comment.
      * The name you give each property is the tag that will be used in the XML
      * file.  The comment will appear before the property in the XML file.
      * In addition, the comments are used for tool tips in the OpenSim GUI.

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -170,7 +170,7 @@ public:
     @returns writable reference to the value as an Object
     @see getValueAsObject(), updValue\<T>() **/
     virtual Object& updValueAsObject(int index=-1) = 0;
-    /** Set the indicated value element to a new copy of the supplied object.
+    /** %Set the indicated value element to a new copy of the supplied object.
     If you already have a heap-allocated object you're willing to give up and
     want to avoid the extra copy, use adoptValueObject(). **/
     virtual void setValueAsObject(const Object& obj, int index=-1) = 0;

--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -130,7 +130,7 @@ Array(const Array<T> &aArray)
 private:
 //_____________________________________________________________________________
 /**
- * Set all member variables to their null or default values.
+ * %Set all member variables to their null or default values.
  */
 void setNull()
 {
@@ -413,7 +413,7 @@ int getCapacity() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the amount by which the capacity is increased when the capacity of
+ * %Set the amount by which the capacity is increased when the capacity of
  * of the array in exceeded.
  * If the specified increment is negative, the capacity is set to double
  * whenever the capacity is exceeded.
@@ -441,7 +441,7 @@ int getCapacityIncrement() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the size of the array.  This method can be used to either increase
+ * %Set the size of the array.  This method can be used to either increase
  * or decrease the size of the array.  If this size of the array is
  * increased, the new elements are initialized to the default value
  * that was specified at the time of construction.
@@ -661,7 +661,7 @@ int remove(int aIndex)
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the value at a specified index.
+ * %Set the value at a specified index.
  *
  * @param aIndex Index of the array element to be set.  It is permissible
  * for aIndex to be past the current end of the array- the capacity will

--- a/OpenSim/Common/ArrayPtrs.h
+++ b/OpenSim/Common/ArrayPtrs.h
@@ -135,7 +135,7 @@ ArrayPtrs(const ArrayPtrs<T> &aArray)
 private:
 //_____________________________________________________________________________
 /**
- * Set all member variables to their null or default values.
+ * %Set all member variables to their null or default values.
  */
 void setNull()
 {
@@ -301,7 +301,7 @@ friend std::ostream& operator<<(std::ostream &aOut,const ArrayPtrs<T> &aArray)
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Set whether or not this array owns the memory pointed to by the pointers
+ * %Set whether or not this array owns the memory pointed to by the pointers
  * in its array.
  *
  * @param aTrueFalse If true, all the memory associated with each of the
@@ -465,7 +465,7 @@ int getCapacity() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the amount by which the capacity is increased when the capacity of
+ * %Set the amount by which the capacity is increased when the capacity of
  * of the array in exceeded.
  * If the specified increment is negative or this method
  * is called with no argument, the capacity is set to double whenever
@@ -494,7 +494,7 @@ int getCapacityIncrement() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the size of the array.  This method can be used only to decrease
+ * %Set the size of the array.  This method can be used only to decrease
  * the size of the array.  If the size of an array is decreased, all objects
  * in the array that become invalid as a result of the decrease are
  * deleted.
@@ -782,7 +782,7 @@ bool remove(const T* aObject)
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the object at a specified index.  A copy of the object is NOT made.
+ * %Set the object at a specified index.  A copy of the object is NOT made.
  *
  * If the set method is successful and the array is set as the memory
  * owner, the previous object stored at the specified index is deleted.

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -246,7 +246,7 @@ public:
     /** Initialize Component's state variable values from its properties */
     void initStateFromProperties(SimTK::State& state) const;
 
-    /** Set Component's properties given a state. */
+    /** %Set Component's properties given a state. */
     void setPropertiesFromState(const SimTK::State& state);
 
     // End of Component Structural Interface (public non-virtual).
@@ -591,7 +591,7 @@ public:
     int getModelingOption(const SimTK::State& state, const std::string& name) const;
 
     /**
-     * Set the value of a ModelingOption flag for this Component.
+     * %Set the value of a ModelingOption flag for this Component.
      * if the integer value exceeds the number of option names used to
      * define the options, an exception is thrown. The SimTK::State 
      * Stage will be reverted back to Stage::Instance.
@@ -656,7 +656,7 @@ public:
     double getStateVariableValue(const SimTK::State& state, const std::string& name) const;
 
     /**
-     * Set the value of a state variable allocated by this Component by name.
+     * %Set the value of a state variable allocated by this Component by name.
      *
      * @param state  the State for which to set the value
      * @param name   the name of the state variable
@@ -676,7 +676,7 @@ public:
     SimTK::Vector getStateVariableValues(const SimTK::State& state) const;
 
     /**
-     * Set all values of the state variables allocated by this Component.
+     * %Set all values of the state variables allocated by this Component.
      * Includes state variables allocated by its subcomponents.
      *
      * @param state   the State for which to get the value
@@ -704,7 +704,7 @@ public:
     double getDiscreteVariableValue(const SimTK::State& state, const std::string& name) const;
 
     /**
-     * Set the value of a discrete variable allocated by this Component by name.
+     * %Set the value of a discrete variable allocated by this Component by name.
      *
      * @param state  the State for which to set the value
      * @param name   the name of the dsicrete variable
@@ -860,7 +860,7 @@ public:
     }
 
     /**
-     *  Set cache variable value allocated by this Component by name.
+     *  %Set cache variable value allocated by this Component by name.
      *  All cache entries are lazily evaluated (on a need basis) so a set
      *  also marks the cache as valid.
      *
@@ -1170,7 +1170,7 @@ template <class T> friend class ComponentMeasure;
     virtual void computeStateVariableDerivatives(const SimTK::State& s) const;
 
     /**
-     * Set the derivative of a state variable by name when computed inside of  
+     * %Set the derivative of a state variable by name when computed inside of  
      * this Component's computeStateVariableDerivatives() method.
      *
      * @param state  the State for which to set the value

--- a/OpenSim/Common/LinearFunction.h
+++ b/OpenSim/Common/LinearFunction.h
@@ -85,11 +85,11 @@ public:
     // SET AND GET Coefficients
     //--------------------------------------------------------------------------
 public:
-    /** Set Coefficients for slope and intercept */
+    /** %Set Coefficients for slope and intercept */
     void setCoefficients(Array<double> coefficients);
-    /** Set slope */
+    /** %Set slope */
     void setSlope(double slope) {_coefficients[0] = slope; }
-    /** Set intercept */
+    /** %Set intercept */
     void setIntercept(double intercept) {_coefficients[1] = intercept; }
     /** Get Coefficients */
     const Array<double> getCoefficients() const

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -261,23 +261,23 @@ public:
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------
-    /** Set the name of the Object. */
+    /** %Set the name of the Object. */
     void setName(const std::string& name);
     /** Get the name of this Object. */
     const std::string& getName() const;
-    /** Set description, a one-liner summary. */
+    /** %Set description, a one-liner summary. */
     void setDescription(const std::string& description);
     /** Get description, a one-liner summary. */
     const std::string& getDescription() const;
 
     /** Get Authors of this Object */
     const std::string& getAuthors() const { return _authors; };
-    /** Set Authors of this object, call this method in your constructor if needed */
+    /** %Set Authors of this object. Call this method in your constructor if needed. */
     void setAuthors(const std::string& authors) { _authors=authors; };
 
     /** Get references or publications to cite if using this object. */
     const std::string& getReferences() const { return _references; };
-    /** Set references or publications to cite if using this object. */
+    /** %Set references or publications to cite if using this object. */
     void setReferences(const std::string& references) 
     {   _references=references; };
 
@@ -616,7 +616,7 @@ public:
         return this->isKindOf(type); 
     } 
 
-    /** Set the debug level to get verbose output. Zero means no debugging. **/
+    /** %Set the debug level to get verbose output. Zero means no debugging. **/
     static void setDebugLevel(int newLevel) {
         _debugLevel=newLevel; 
     };

--- a/OpenSim/Common/PolynomialFunction.h
+++ b/OpenSim/Common/PolynomialFunction.h
@@ -75,7 +75,7 @@ public:
     //--------------------------------------------------------------------------
     // SET AND GET Coefficients
     //--------------------------------------------------------------------------
-    /** Set coefficients for the polynomial f of variable x:
+    /** %Set coefficients for the polynomial f of variable x:
      * f(x) = a*x^n + b*x^(n-1) + ... + c 
      * The size of the coffecient vector determines the order of the polynomial.
      * n = size-1;

--- a/OpenSim/Common/Set.h
+++ b/OpenSim/Common/Set.h
@@ -131,7 +131,7 @@ private:
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Set all member variables to NULL values.
+ * %Set all member variables to NULL values.
  */
 void
 setNull()
@@ -251,7 +251,7 @@ friend std::ostream& operator<<(std::ostream &aOut,const Set<T> &aSet)
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Set whether or not this set owns the memory pointed to by the pointers
+ * %Set whether or not this Set owns the memory pointed to by the pointers
  * it holds.
  *
  * @param aTrueFalse If true, all the memory associated with each of the
@@ -348,7 +348,7 @@ int getCapacity() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the amount by which the capacity is increased when the capacity of
+ * %Set the amount by which the capacity is increased when the capacity of
  * of the array in exceeded.
  * If the specified increment is negative or this method
  * is called with no argument, the capacity is set to double whenever
@@ -377,7 +377,7 @@ int getCapacityIncrement() const
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the size of the array.  This method can be used only to decrease
+ * %Set the size of the array.  This method can be used only to decrease
  * the size of the array.  If the size of an array is decreased, all objects
  * in the array that become invalid as a result of the decrease are
  * deleted.
@@ -588,7 +588,7 @@ virtual void clearAndDestroy()
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
 /**
- * Set the object at a specified index.  A copy of the object is NOT made.
+ * %Set the object at a specified index.  A copy of the object is NOT made.
  * If getMemoryOwner() is true, this Set takes over ownership of the object and
  * deletes it when the Set itself is deleted.
  *
@@ -617,7 +617,7 @@ virtual bool set(int aIndex, T *aObject, bool preserveGroups = false)
 #ifndef SWIG
 //_____________________________________________________________________________
 /**
- * Set the object at a specified index.  A copy is made of the
+ * %Set the object at a specified index.  A copy is made of the
  * object and added to the Set.  The original object is unaffected.
  *
  * @param aIndex Index of the array element to be set.  aIndex must be

--- a/OpenSim/Common/StepFunction.h
+++ b/OpenSim/Common/StepFunction.h
@@ -94,28 +94,28 @@ public:
     // SET AND GET Coefficients
     //--------------------------------------------------------------------------
 public:
-    /** Set step transition start time */
+    /** %Set step transition start time */
     void setStartTime(double time)
         { _startTime = time; };
     /** Get step transition time */
     double getStartTime() const
         { return _startTime; };
 
-    /** Set step transition end time */
+    /** %Set step transition end time */
     void setEndTime(double time)
         { _endTime = time; };
     /** Get step transition time */
     double getEndTime() const
         { return _endTime; };
 
-    /** Set start value before step */
+    /** %Set start value before step */
     void setStartValue(double start)
         { _startValue = start; };
     /** Get start value before step */
     double getStartValue() const
         { return _startValue; };
 
-    /** Set end value before step */
+    /** %Set end value before step */
     void setEndValue(double end)
         { _endValue = end; };
     /** Get end value before step */

--- a/OpenSim/Simulation/AssemblySolver.h
+++ b/OpenSim/Simulation/AssemblySolver.h
@@ -94,11 +94,11 @@ public:
 
     virtual ~AssemblySolver();
 
-    /** Set the unitless accuracy of the assembly solution, which is dictates to how
+    /** %Set the unitless accuracy of the assembly solution, which is dictates to how
         many significant digits the solution should be resolved to.*/
     void setAccuracy(double accuracy) {_accuracy = accuracy; }
 
-    /** Set the relative weighting for constraints. Use Infinity to identify the 
+    /** %Set the relative weighting for constraints. Use Infinity to identify the 
         strict enforcement of constraints, otherwise any positive weighting will
         append the constraint errors to the assembly cost which the solver will
         minimize.*/

--- a/OpenSim/Simulation/Control/Control.h
+++ b/OpenSim/Simulation/Control/Control.h
@@ -213,7 +213,7 @@ public:
     virtual double getParameterMin(int aI) const = 0;
     // Parameter Max
     /**
-     * Set the maximum value that a control parameter can take on.
+     * %Set the maximum value that a control parameter can take on.
      *
      * @param aI Index of the parameter.
      * @param aMax Maximum value the parameter can have.

--- a/OpenSim/Simulation/Control/ControlLinear.h
+++ b/OpenSim/Simulation/Control/ControlLinear.h
@@ -112,7 +112,7 @@ protected:
     
 private:
     /**
-     * Set the member data to their NULL values.
+     * %Set the member data to their NULL values.
      */
     void setNull();
     /**

--- a/OpenSim/Simulation/Control/TrackingController.h
+++ b/OpenSim/Simulation/Control/TrackingController.h
@@ -75,7 +75,7 @@ public:
     // GET AND SET
     //--------------------------------------------------------------------------
     /**
-     * Set this class's pointer to the storage object containing
+     * %Set this class's pointer to the storage object containing
      * desired model states to point to the storage object passed into
      * this method.  This method is currently implemented only by the
      * CorrectionController class, which is a subclass of Controller.

--- a/OpenSim/Simulation/CoordinateReference.h
+++ b/OpenSim/Simulation/CoordinateReference.h
@@ -107,7 +107,7 @@ public:
     /** set the weighting (importance) of meeting this CoordinateReference */
     void setWeight(double weight);
 
-    /** Set the coordinate value as a function of time. */
+    /** %Set the coordinate value as a function of time. */
     void setValueFunction(const OpenSim::Function& function)
     {
         _coordinateValueFunction = function.clone();

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -142,7 +142,7 @@ public:
 
     // Integrator
     SimTK::Integrator& getIntegrator() const;
-    /** Set the integrator*/
+    /** %Set the integrator */
     void setIntegrator( SimTK::Integrator&);
     // Initial and final times
     void setInitialTime(double aTI);

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -207,7 +207,7 @@ private:
     ControllerSet _controllerCopies;     
 
     /**
-    * Set all member variables to their null or default values.
+    * %Set all member variables to their null or default values.
     */
     void setNull();
     
@@ -244,7 +244,7 @@ public:
     //--------------------------------------------------------------------------
     
     /**
-    * Set the model to be investigated.
+    * %Set the model to be investigated.
     * NOTE: setup() should have been called on the model prior to calling this method
     */
     virtual void setModel(Model& aModel) SWIG_DECLARE_EXCEPTION;

--- a/OpenSim/Simulation/Model/Analysis.h
+++ b/OpenSim/Simulation/Model/Analysis.h
@@ -178,7 +178,7 @@ public:
 
     // DEGREES/RADIANS
     /**
-     * Set whether or not to write the output of angles in degrees.
+     * %Set whether or not to write the output of angles in degrees.
      * This flag must be set before an analysis is performed to ensure that
      * the results are in the proper format.
      * @param aTrueFalse Output will be in degrees if "true" and in radians
@@ -197,7 +197,7 @@ public:
 
     // COLUMN LABLES
     /**
-     * Set the column labels for this analysis.
+     * %Set the column labels for this analysis.
      * @param aLabels an Array of strings (labels).
      */
     void setColumnLabels(const Array<std::string> &aLabels);

--- a/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
@@ -370,10 +370,10 @@ public:
     /** Remove a muscle from the metabolic analysis. */
     void removeMuscle(const std::string& muscleName);
 
-    // Set an existing muscle to use a provided muscle mass. */
+    /** %Set an existing muscle to use a provided muscle mass. */
     void useProvidedMass(const std::string& muscleName, double providedMass);
 
-    /** Set an existing muscle to calculate its own mass. */
+    /** %Set an existing muscle to calculate its own mass. */
     void useCalculatedMass(const std::string& muscleName);
 
     /** Get whether the muscle mass is being explicitly provided.
@@ -391,43 +391,43 @@ public:
     /** Get the ratio of slow twitch fibers for an existing muscle. */
     const double getRatioSlowTwitchFibers(const std::string& muscleName) const;
 
-    /** Set the ratio of slow twitch fibers for an existing muscle. */
+    /** %Set the ratio of slow twitch fibers for an existing muscle. */
     void setRatioSlowTwitchFibers(const std::string& muscleName, const double& ratio);
 
     /** Get the density for an existing muscle (kg/m^3). */
     const double getDensity(const std::string& muscleName) const;
 
-    /** Set the density for an existing muscle (kg/m^3). */
+    /** %Set the density for an existing muscle (kg/m^3). */
     void setDensity(const std::string& muscleName, const double& density);
 
     /** Get the specific tension for an existing muscle (Pascals (N/m^2)). */
     const double getSpecificTension(const std::string& muscleName) const;
 
-    /** Set the specific tension for an existing muscle (Pascals (N/m^2)). */
+    /** %Set the specific tension for an existing muscle (Pascals (N/m^2)). */
     void setSpecificTension(const std::string& muscleName, const double& specificTension);
 
     /** Get the activation constant for slow twitch fibers for an existing muscle. */
     const double getActivationConstantSlowTwitch(const std::string& muscleName) const;
 
-    /** Set the activation constant for slow twitch fibers for an existing muscle. */
+    /** %Set the activation constant for slow twitch fibers for an existing muscle. */
     void setActivationConstantSlowTwitch(const std::string& muscleName, const double& c);
 
     /** Get the activation constant for fast twitch fibers for an existing muscle. */
     const double getActivationConstantFastTwitch(const std::string& muscleName) const;
 
-    /** Set the activation constant for fast twitch fibers for an existing muscle. */
+    /** %Set the activation constant for fast twitch fibers for an existing muscle. */
     void setActivationConstantFastTwitch(const std::string& muscleName, const double& c);
 
     /** Get the maintenance constant for slow twitch fibers for an existing muscle. */
     const double getMaintenanceConstantSlowTwitch(const std::string& muscleName) const;
 
-    /** Set the maintenance constant for slow twitch fibers for an existing muscle. */
+    /** %Set the maintenance constant for slow twitch fibers for an existing muscle. */
     void setMaintenanceConstantSlowTwitch(const std::string& muscleName, const double& c);
 
     /** Get the maintenance constant for fast twitch fibers for an existing muscle. */
     const double getMaintenanceConstantFastTwitch(const std::string& muscleName) const;
 
-    /** Set the maintenance constant for fast twitch fibers for an existing muscle. */
+    /** %Set the maintenance constant for fast twitch fibers for an existing muscle. */
     void setMaintenanceConstantFastTwitch(const std::string& muscleName, const double& c);
 
 

--- a/OpenSim/Simulation/Model/ContactGeometry.h
+++ b/OpenSim/Simulation/Model/ContactGeometry.h
@@ -96,7 +96,7 @@ public:
      */
     const SimTK::Vec3& getLocation() const;
     /**
-     * Set the location of the geometry within the Body it is attached to.
+     * %Set the location of the geometry within the Body it is attached to.
      */
     void setLocation(const SimTK::Vec3& location);
     /**
@@ -104,7 +104,7 @@ public:
      */
     const SimTK::Vec3& getOrientation() const;
     /**
-     * Set the orientation of the geometry within the Body it is attached to.
+     * %Set the orientation of the geometry within the Body it is attached to.
      */
     void setOrientation(const SimTK::Vec3& orientation);
 #ifndef SWIG
@@ -118,7 +118,7 @@ public:
      */
     OpenSim::PhysicalFrame& updBody();
     /**
-     * Set the Body this geometry is attached to.
+     * %Set the Body this geometry is attached to.
      */
     void setBody(PhysicalFrame& body);
     /**
@@ -126,7 +126,7 @@ public:
      */
     const std::string& getBodyName();
     /**
-     * Set the name of the Body this geometry is attached to.  This will cause the
+     * %Set the name of the Body this geometry is attached to.  This will cause the
      * Body to be set to NULL, then resolved when extendConnectToModel() is called.
      */
     void setBodyName(const std::string& name);
@@ -135,7 +135,7 @@ public:
      */
     const int getDisplayPreference();
     /**
-     * Set the display_preference of this geometry.
+     * %Set the display_preference of this geometry.
      */
     void setDisplayPreference(const int dispPref);
     /**

--- a/OpenSim/Simulation/Model/ContactMesh.h
+++ b/OpenSim/Simulation/Model/ContactMesh.h
@@ -94,7 +94,7 @@ public:
      */
     const std::string& getFilename() const;
     /**
-     * Set the name of the file to load the mesh from.
+     * %Set the name of the file to load the mesh from.
      */
     void setFilename(const std::string& filename);
 private:

--- a/OpenSim/Simulation/Model/ContactSphere.h
+++ b/OpenSim/Simulation/Model/ContactSphere.h
@@ -92,7 +92,7 @@ public:
      */
     double getRadius() const;
     /**
-     * Set the radius of the sphere.
+     * %Set the radius of the sphere.
      */
     void setRadius(double radius);
 private:

--- a/OpenSim/Simulation/Model/ElasticFoundationForce.h
+++ b/OpenSim/Simulation/Model/ElasticFoundationForce.h
@@ -75,7 +75,7 @@ public:
      */
     double getTransitionVelocity() const;
     /**
-     * Set the transition velocity for switching between static and dynamic friction.
+     * %Set the transition velocity for switching between static and dynamic friction.
      */
     void setTransitionVelocity(double velocity);
 

--- a/OpenSim/Simulation/Model/ExpressionBasedBushingForce.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedBushingForce.h
@@ -159,43 +159,43 @@ public:
     // Uses default (compiler-generated) destructor, copy constructor, and copy
     // assignment operator.
 
-    /** Set the name of the Body that will serve as body 1 for this bushing. **/
+    /** %Set the name of the Body that will serve as body 1 for this bushing. **/
     void setBody1ByName(const std::string& aBodyName);
-    /** Set the location and orientation (optional) for bushing frame on 
+    /** %Set the location and orientation (optional) for bushing frame on 
       * body 1. **/
     void setBody1BushingLocation(const SimTK::Vec3& location, 
                                  const SimTK::Vec3& orientation=SimTK::Vec3(0));
-    /** Set the name of the Body that will serve as body 2 for this bushing. **/
+    /** %Set the name of the Body that will serve as body 2 for this bushing. **/
     void setBody2ByName(const std::string& aBodyName);
-    /** Set the location and orientation (optional) for bushing frame on 
+    /** %Set the location and orientation (optional) for bushing frame on 
       * body 2. **/
     void setBody2BushingLocation(const SimTK::Vec3& location, 
                                  const SimTK::Vec3& orientation=SimTK::Vec3(0));
-    /** Set the value used to scale the bushing moment on body2 when drawing it to screen.  
+    /** %Set the value used to scale the bushing moment on body2 when drawing it to screen.  
       * A moment of magnitude |M| will be drawn on screen with a length of (|M|*scale).  **/
     void setMomentVisualScale(double scale) {set_moment_visual_scale(scale);};
-    /** Set the value used to scale the bushing force on body2 when drawing it to screen.  
+    /** %Set the value used to scale the bushing force on body2 when drawing it to screen.  
       * A force of magnitude |F| will be drawn on screen with a length of (|F|*scale).  **/
     void setForceVisualScale(double scale) {set_force_visual_scale(scale);}
-    /** Set the aspect ratio used to control the thickness of the bushing force and moment
+    /** %Set the aspect ratio used to control the thickness of the bushing force and moment
       * in drawn in the visualizer.  ratio = length/diameter.**/
     void setVisualAspectRatio(double ratio) {set_visual_aspect_ratio(ratio);}
-    /** Set the expression defining Mx as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining Mx as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setMxExpression(std::string expression);
-    /** Set the expression defining My as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining My as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setMyExpression(std::string expression);
-    /** Set the expression defining Mz as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining Mz as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setMzExpression(std::string expression);
-    /** Set the expression defining Fx as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining Fx as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setFxExpression(std::string expression);
-    /** Set the expression defining Fy as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining Fy as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setFyExpression(std::string expression);
-    /** Set the expression defining Fz as a function of the bushing deflections theta_x, 
+    /** %Set the expression defining Fz as a function of the bushing deflections theta_x, 
       * theta_y, theta_z, delta_x, delta_y, delta_z **/
     void setFzExpression(std::string expression);
     /** Get the expression defining Mx as a function of the bushing deflections theta_x, 

--- a/OpenSim/Simulation/Model/ExpressionBasedCoordinateForce.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedCoordinateForce.h
@@ -63,7 +63,7 @@ public:
     const std::string& getCoordinateName() const {return get_coordinate();}
 
     /**
-    * Set the mathematical expression that defines the force magnitude of this
+    * %Set the mathematical expression that defines the force magnitude of this
     * coordinate force in terms of the coordinate value (q) and its
     * time derivative (qdot). Expressions with C-mathematical operations
     * such as +,-,*,/ and common functions: exp, pow, sqrt, sin, cos, tan, 

--- a/OpenSim/Simulation/Model/ExpressionBasedPointToPointForce.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedPointToPointForce.h
@@ -109,7 +109,7 @@ public:
     const SimTK::Vec3& getPoint2() const { return get_point2(); }
 
     /**
-    * Set the mathematical expression that defines the force magnitude of this
+    * %Set the mathematical expression that defines the force magnitude of this
     * point-to-point force in terms of the point-to-point distance (d) and its
     * time derivative (ddot). Expressions with C-mathematical operations
     * such as +,-,*,/ and common functions: exp, pow, sqrt, sin, cos, tan, 

--- a/OpenSim/Simulation/Model/Force.h
+++ b/OpenSim/Simulation/Model/Force.h
@@ -75,7 +75,7 @@ public:
 
     /** Return if the Force is disabled or not. */
     bool isDisabled(const SimTK::State& s) const;
-    /** Set the Force as disabled (true) or not (false). */
+    /** %Set the Force as disabled (true) or not (false). */
     void setDisabled(SimTK::State& s, bool disabled) const;
 
     /**

--- a/OpenSim/Simulation/Model/FunctionBasedBushingForce.h
+++ b/OpenSim/Simulation/Model/FunctionBasedBushingForce.h
@@ -138,25 +138,25 @@ public:
     // Uses default (compiler-generated) destructor, copy constructor, and copy
     // assignment operator.
 
-    /** Set the name of the Body that will serve as body 1 for this bushing. **/
+    /** %Set the name of the Body that will serve as body 1 for this bushing. **/
     void setBody1ByName(const std::string& aBodyName);
-    /** Set the location and orientation (optional) for bushing frame on 
+    /** %Set the location and orientation (optional) for bushing frame on 
       * body 1. **/
     void setBody1BushingLocation(const SimTK::Vec3& location, 
                                  const SimTK::Vec3& orientation=SimTK::Vec3(0));
-    /** Set the name of the Body that will serve as body 2 for this bushing. **/
+    /** %Set the name of the Body that will serve as body 2 for this bushing. **/
     void setBody2ByName(const std::string& aBodyName);
-    /** Set the location and orientation (optional) for bushing frame on 
+    /** %Set the location and orientation (optional) for bushing frame on 
       * body 2. **/
     void setBody2BushingLocation(const SimTK::Vec3& location, 
                                  const SimTK::Vec3& orientation=SimTK::Vec3(0));
-    /** Set the value used to scale the bushing moment on body2 when drawing it to screen.  
+    /** %Set the value used to scale the bushing moment on body2 when drawing it to screen.  
       * A moment of magnitude |M| will be drawn on screen with a length of (|M|*scale).  **/
     void setMomentVisualScale(double scale) {set_moment_visual_scale(scale);};
-    /** Set the value used to scale the bushing force on body2 when drawing it to screen.  
+    /** %Set the value used to scale the bushing force on body2 when drawing it to screen.  
       * A force of magnitude |F| will be drawn on screen with a length of (|F|*scale).  **/
     void setForceVisualScale(double scale) {set_force_visual_scale(scale);}
-    /** Set the aspect ratio used to control the thickness of the bushing force and moment
+    /** %Set the aspect ratio used to control the thickness of the bushing force and moment
         in drawn in the visualizer.  ratio = length/diameter.*/
     void setVisualAspectRatio(double ratio) {set_visual_aspect_ratio(ratio);}
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -106,9 +106,9 @@ public:
     virtual ~Geometry() {}
     /** Interface methods to handle the Frame which the Geometry is attached to.
     **/
-    /** Set the name of the Frame of attachment **/
+    /** %Set the name of the Frame of attachment **/
     void setFrameName(const std::string& name);
-    /** Set the Frame of attachment **/
+    /** %Set the Frame of attachment **/
     void setFrame(const Frame& frame);
     /** Return a reference to the name of the Frame to which
     this Geometry is attached (using a Connector). **/
@@ -225,7 +225,7 @@ public:
         rPoint1 = get_start_point();
         rPoint2 = get_end_point();
     }
-    /// Set end points from passed in arguments
+    /// %Set end points from passed in arguments
     void setPoints(SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2)
     {
         upd_start_point() = aPoint1;

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -123,7 +123,7 @@ public:
     will be taken from the cache variable, so may have changed. **/
     const SimTK::Vec3& getDefaultColor() const { return get_default_color(); }
 
-    /** Set the value of the color cache variable owned by this %GeometryPath
+    /** %Set the value of the color cache variable owned by this %GeometryPath
     object, in the cache of the given state. The value of this variable is used
     as the color when the path is drawn, which occurs with the state realized 
     to Stage::Dynamics. So you must call this method during realizeDynamics() or 

--- a/OpenSim/Simulation/Model/HuntCrossleyForce.h
+++ b/OpenSim/Simulation/Model/HuntCrossleyForce.h
@@ -71,7 +71,7 @@ public:
      */
     double getTransitionVelocity() const;
     /**
-     * Set the transition velocity for switching between static and dynamic friction.
+     * %Set the transition velocity for switching between static and dynamic friction.
      */
     void setTransitionVelocity(double velocity);
     

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -484,7 +484,7 @@ public:
     const std::string& getInputFileName() const { return _fileName; }
 
     /** 
-     * Set the XML file name used to construct the model.
+     * %Set the XML file name used to construct the model.
      *
      * @param fileName The XML file name.
      */
@@ -502,7 +502,7 @@ public:
     const std::string& getCredits() const { return get_credits(); }
 
     /** 
-     * Set the credits (e.g., model author names) associated with the model.
+     * %Set the credits (e.g., model author names) associated with the model.
      *
      * @param aCredits The string of credits.
      */
@@ -516,7 +516,7 @@ public:
     const std::string& getPublications() const { return get_publications(); }
     
     /** 
-     * Set the publications associated with the model. 
+     * %Set the publications associated with the model. 
      *
      * @param aPublications The string of publications.
      */
@@ -550,7 +550,7 @@ public:
     SimTK::Vec3 getGravity() const;
     
     /**
-     * Set the gravity vector in the gloabl frame.
+     * %Set the gravity vector in the global frame.
      *
      * @param aGrav The XYZ gravity vector
      * @return Whether or not the gravity vector was successfully set.
@@ -953,7 +953,7 @@ public:
     //--------------------------------------------------------------------------
 
 private:
-    // Set the values of all data members to an appropriate "null" value.
+    // %Set the values of all data members to an appropriate "null" value.
     void setNull();
 
     void setDefaultProperties();

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -143,7 +143,7 @@ public:
     // them.
 
     /**
-     * Set the Model this object is part of and allow each contained
+     * %Set the Model this object is part of and allow each contained
      * ModelComponent to connect itself to the Model by invoking its 
      * connectToModel() method.
      * @see ModelComponent::connectToModel()

--- a/OpenSim/Simulation/Model/PrescribedForce.h
+++ b/OpenSim/Simulation/Model/PrescribedForce.h
@@ -122,7 +122,7 @@ public:
     const std::string& getBodyName() const { return get_body(); }
 
     /**
-     * Set the functions which specify the force to apply.  By default the 
+     * %Set the functions which specify the force to apply.  By default the 
      * force is specified in inertial coordinates.
      * This can be changed by calling setForceIsInGlobalFrame().
      *
@@ -147,7 +147,7 @@ public:
         const OpenSim::Storage& kineticsStore);
     void clearForceFunctions() { updForceFunctions().setSize(0); }
     /**
-     * Set the functions which specify the point at which to apply the force.  
+     * %Set the functions which specify the point at which to apply the force.  
      * By default the point is specified in the body's local coordinates.  
      * This can be changed by calling setPointIsInGlobalFrame().
      *
@@ -172,7 +172,7 @@ public:
         const OpenSim::Storage& kineticsStore) ;
     void clearPointFunctions() { updPointFunctions().setSize(0); }
     /**
-     * Set the functions which specify the torque to apply. By default the 
+     * %Set the functions which specify the torque to apply. By default the 
      * torque is specified in inertial coordinates.
      * This can be changed by calling setForceIsInGlobalFrame().
      *
@@ -200,14 +200,14 @@ public:
     /** Get whether the force and torque are specified in inertial coordinates 
     or in the body's local coordinates. **/
     bool getForceIsInGlobalFrame() const {return get_forceIsGlobal();}
-    /** Set whether the force and torque are specified in inertial coordinates 
+    /** %Set whether the force and torque are specified in inertial coordinates 
     or in the body's local coordinates. **/
     void setForceIsInGlobalFrame(bool isGlobal) 
     {   set_forceIsGlobal(isGlobal); }
     /** Get whether the point is specified in inertial coordinates or in the 
     body's local coordinates. **/
     bool getPointIsInGlobalFrame() const {return get_pointIsGlobal();}
-    /** Set whether the point is specified in inertial coordinates or in the 
+    /** %Set whether the point is specified in inertial coordinates or in the 
     body's local coordinates. **/
     void setPointIsInGlobalFrame(bool isGlobal)
     {   set_pointIsGlobal(isGlobal); }

--- a/OpenSim/Simulation/Model/Probe.h
+++ b/OpenSim/Simulation/Model/Probe.h
@@ -156,22 +156,22 @@ public:
 
     /** Returns true if the Probe is disabled or false if the probe is enabled. */
     bool isDisabled() const;
-    /** Set the Probe as disabled (true) or enabled (false). */
+    /** %Set the Probe as disabled (true) or enabled (false). */
     void setDisabled(bool isDisabled);
 
     /** Return the operation being performed on the probe value. */
     std::string getOperation() const;
-    /** Set the operation being performed on the probe value. */
+    /** %Set the operation being performed on the probe value. */
     void setOperation(std::string probe_operation);
 
     /** Return the initial conditions (when the probe_operation is set to 'integrate'). */
     SimTK::Vector getInitialConditions() const;
-    /** Set the initial conditions (when the probe_operation is set to 'integrate'). */
+    /** %Set the initial conditions (when the probe_operation is set to 'integrate'). */
     void setInitialConditions(SimTK::Vector initial_conditions_for_integration);
 
     /** Return the gain to apply to the probe output. */
     double getGain() const;
-    /** Set the gain to apply to the probe output. */
+    /** %Set the gain to apply to the probe output. */
     void setGain(double gain);
     
 

--- a/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
@@ -372,10 +372,10 @@ public:
     /** Remove a muscle from the metabolic analysis. */
     void removeMuscle(const std::string& muscleName);
 
-    /** Set an existing muscle to use a provided muscle mass. */
+    /** %Set an existing muscle to use a provided muscle mass. */
     void useProvidedMass(const std::string& muscleName, double providedMass);
     
-    /** Set an existing muscle to calculate its own mass. */
+    /** %Set an existing muscle to calculate its own mass. */
     void useCalculatedMass(const std::string& muscleName);
 
     /** Get whether the muscle mass is being explicitly provided.
@@ -393,19 +393,19 @@ public:
     /** Get the ratio of slow twitch fibers for an existing muscle. */
     const double getRatioSlowTwitchFibers(const std::string& muscleName) const;
 
-    /** Set the ratio of slow twitch fibers for an existing muscle. */
+    /** %Set the ratio of slow twitch fibers for an existing muscle. */
     void setRatioSlowTwitchFibers(const std::string& muscleName, const double& ratio);
 
     /** Get the density for an existing muscle (kg/m^3). */
     const double getDensity(const std::string& muscleName) const;
 
-    /** Set the density for an existing muscle (kg/m^3). */
+    /** %Set the density for an existing muscle (kg/m^3). */
     void setDensity(const std::string& muscleName, const double& density);
 
     /** Get the specific tension for an existing muscle (Pascals (N/m^2)). */
     const double getSpecificTension(const std::string& muscleName) const;
 
-    /** Set the specific tension for an existing muscle (Pascals (N/m^2)). */
+    /** %Set the specific tension for an existing muscle (Pascals (N/m^2)). */
     void setSpecificTension(const std::string& muscleName, const double& specificTension);
 
 

--- a/OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h
+++ b/OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h
@@ -86,9 +86,9 @@ public:
     RollingOnSurfaceConstraint();
     virtual ~RollingOnSurfaceConstraint();
 
-    /** Set rolling body by its name */
+    /** %Set rolling body by its name */
     void setRollingBodyByName(const std::string& aBodyName);
-    /** Set surface body by its name */
+    /** %Set surface body by its name */
     void setSurfaceBodyByName(const std::string& aBodyName);
 
     /**
@@ -101,7 +101,7 @@ public:
     bool isDisabled(const SimTK::State& state) const override;
 
     /**
-    * Set whether or not the RollingOnSurfaceConstraint is disabled.
+    * %Set whether or not the RollingOnSurfaceConstraint is disabled.
     * Since the constraint is composed of multiple constraints, this method can
     * disable all the constraints, but enabling is not guaranteed. For example, if
     * the unilateral conditions are violated the constraint will be disabled.
@@ -138,7 +138,7 @@ public:
     std::vector<bool> unilateralConditionsSatisfied(const SimTK::State& state) override;
 
 
-    /** Set whether constraint is enabled or disabled but use cached values for 
+    /** %Set whether constraint is enabled or disabled but use cached values for 
         unilateral conditions instead of automatic reevaluation */
     bool setDisabledWithCachedUnilateralConditions(bool isDisabled,
         SimTK::State& state){

--- a/OpenSim/Tools/InverseDynamicsTool.h
+++ b/OpenSim/Tools/InverseDynamicsTool.h
@@ -145,7 +145,7 @@ public:
      * get/set the name of the file containing coordinates
      */
     const std::string& getCoordinatesFileName() const { return _coordinatesFileName;};
-    /** Set the name of the coordinatesFile to be used. This call resets 
+    /** %Set the name of the coordinatesFile to be used. This call resets 
      _coordinateValues as well. */
     void setCoordinatesFileName(const std::string& aCoordinateFile)  { 
         _coordinatesFileName=aCoordinateFile;

--- a/OpenSim/Tools/Tool.h
+++ b/OpenSim/Tools/Tool.h
@@ -116,7 +116,7 @@ public:
 
 private:
     /**
-    * Set all member variables to their null or default values.
+    * %Set all member variables to their null or default values.
     */
     void setNull() {
         setupProperties();


### PR DESCRIPTION
Searched for `" Set "` in header files and prefixed with `%` where appropriate to remove hyperlinks.

Fixes #601
[ci skip]