### PR TITLE
[cmake] Different required cmake version for MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,14 @@ project(OpenSim)
 #
 #----------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8.8)
+if(MSVC)
+    # To properly support Visual Studio 2015.
+    set(OPENSIM_REQUIRED_CMAKE_VERSION 3.1.3)
+else()
+    set(OPENSIM_REQUIRED_CMAKE_VERSION 2.8.8)
+endif()
+cmake_minimum_required(VERSION ${OPENSIM_REQUIRED_CMAKE_VERSION})
+
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
     cmake_policy(SET CMP0005 NEW)


### PR DESCRIPTION
We don't want to change the required version for *all* platforms since we expect people to get cmake through package managers on linux, and so linux users will likely have an older version of cmake.