### PR TITLE
[travis] Upload binaries to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
 env:
   global:
     # The python tests look for OPENSIM_HOME.
-    - OPENSIM_HOME=~/opensim-install
+    - OPENSIM_HOME=~/opensim-core
     - SWIG_VER=3.0.5
     - USE_CCACHE=1
     - CCACHE_COMPRESS=1
@@ -89,8 +89,8 @@ before_install:
   # The Simbody travis script uploads the latestsimbody binaries to bintray.
   - SIMBODYZIP=simbody-latest_$TRAVIS_OS_NAME.zip
   - wget https://dl.bintray.com/chrisdembia/opensim-testing/$SIMBODYZIP
-  # Put Simbody in ~/simbody.
-  - unzip $SIMBODYZIP -d ~
+  # Put Simbody in ~/simbody (-q: quiet).
+  - unzip -q $SIMBODYZIP -d ~
 
   ## Install SWIG to build Java/python wrapping.
   - if [[ "$WRAP" = "on" ]]; then if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install pcre; fi; fi
@@ -187,3 +187,33 @@ script:
 before_cache:
   # Show cache statistics.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ccache --show-stats; fi
+
+before_deploy:
+
+  # Zip up the installation using a file name that identifies where
+  # the binaries were built.
+  - mkdir ~/binstar-packages
+  - ZIPNAME=opensim-core-latest_$TRAVIS_OS_NAME.zip
+  - # Zip up opensim relative to where it's installed.
+  - cd $OPENSIM_HOME/../
+  - zip --recurse-paths --quiet ~/binstar-packages/$ZIPNAME opensim-core
+
+  # Paths in the .bintray.json file are relative to the current directory.
+  - cd ~
+
+deploy:
+  # Uploads to https://bintray.com/chrisdembia/opensim-testing/opensim-core/view
+  #            https://dl.bintray.com/chrisdembia/opensim-testing/
+  # See http://docs.travis-ci.com/user/deployment/bintray/ for help.
+  provider: bintray
+  file: $TRAVIS_BUILD_DIR/doc/.bintray.json
+  user: chrisdembia
+  skip_cleanup: true
+  # API key is encrypted with travis.
+  key:
+    secure: MOCuM6THnBR82ClEmWFmqVM/GEiNtimz7dMmWUnmgU4gWAU9DBq0OelifQ6XAAhEqZGz0IbVyRo+zDGWRUEC/EIAb9PhTSg6W/XX+zykAQCsIr3BMvOE6v5MXNz/JMFKxZoFmmrL1WR4a4KUOQANr7derYkIZUy/9CnUkJgQGKE=
+  on:
+    branch: bintray
+    # Upload for both linux (once) and OSX. Might need to modify the condition
+    # if we change the build matrix.
+    condition: "$CC = clang && $BTYPE = RelWithDebInfo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,8 +212,7 @@ deploy:
   user: chrisdembia
   skip_cleanup: true
   # API key is encrypted with travis.
-  key:
-    secure: MOCuM6THnBR82ClEmWFmqVM/GEiNtimz7dMmWUnmgU4gWAU9DBq0OelifQ6XAAhEqZGz0IbVyRo+zDGWRUEC/EIAb9PhTSg6W/XX+zykAQCsIr3BMvOE6v5MXNz/JMFKxZoFmmrL1WR4a4KUOQANr7derYkIZUy/9CnUkJgQGKE=
+  key: $BINTRAY_API_KEY
   on:
     branch: bintray
     # Upload for both linux (once) and OSX. Might need to modify the condition

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,21 +86,11 @@ before_install:
   - if [ "$DOXY" = "on" ]; then tar xzf doxygen-1.8.10.linux.bin.tar.gz; fi
 
   ## Install Simbody.
-  # Clone Simbody into the Simbody directory. Don't need its history, and
-  # only need the master branch.
-  - git clone https://github.com/simbody/simbody.git ~/simbody-source --depth 1 --branch master
-  - cd ~/simbody-source
-  # Configure Simbody. No matter how we're compiling OpenSim,
-  # compile Simbody with clang for a faster build (allows us to use 8 procs).
-  - cmake . -DBUILD_VISUALIZER=off -DBUILD_EXAMPLES=off -DCMAKE_INSTALL_PREFIX=~/simbody-install -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=$BTYPE -DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen
-  # Build Simbody.
-  - make -j8
-  # Build Simbody's doxygen, so we can link to it from OpenSim's doxygen.
-  - if [ "$DOXY" = "on" ]; then make doxygen; fi
-  # Test Simbody.
-  - ctest -j8 --output-on-failure
-  # Install Simbody.
-  - make -j8 install > /dev/null
+  # The Simbody travis script uploads the latestsimbody binaries to bintray.
+  - SIMBODYZIP=simbody-latest_$TRAVIS_OS_NAME.zip
+  - wget https://dl.bintray.com/chrisdembia/opensim-testing/$SIMBODYZIP
+  # Put Simbody in ~/simbody.
+  - unzip $SIMBODYZIP -d ~
 
   ## Install SWIG to build Java/python wrapping.
   - if [[ "$WRAP" = "on" ]]; then if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install pcre; fi; fi
@@ -127,7 +117,7 @@ before_install:
 install:
   - mkdir ~/opensim-core-build && cd ~/opensim-core-build
   # Configure OpenSim.
-  - cmake $TRAVIS_BUILD_DIR -DBUILD_JAVA_WRAPPING=$WRAP -DBUILD_PYTHON_WRAPPING=$WRAP -DSWIG_EXECUTABLE=$HOME/swig/bin/swig -DSIMBODY_HOME=~/simbody-install -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=$OPENSIM_HOME -DCMAKE_BUILD_TYPE=$BTYPE -DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DOPENSIM_DOXYGEN_USE_MATHJAX=off -DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simtk.org/api_docs/simbody/latest/"
+  - cmake $TRAVIS_BUILD_DIR -DBUILD_JAVA_WRAPPING=$WRAP -DBUILD_PYTHON_WRAPPING=$WRAP -DSWIG_EXECUTABLE=$HOME/swig/bin/swig -DSIMBODY_HOME=~/simbody -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_INSTALL_PREFIX=$OPENSIM_HOME -DCMAKE_BUILD_TYPE=$BTYPE -DDOXYGEN_EXECUTABLE=$HOME/doxygen/doxygen-1.8.10/bin/doxygen -DOPENSIM_DOXYGEN_USE_MATHJAX=off -DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simtk.org/api_docs/simbody/latest/"
   # Build OpenSim.
   # Build java and python C++ wrapper separately to avoid going over the memory limit.
   - if [[ "$WRAP" = "on" ]]; then make -j$NPROC osimTools osimJavaJNI PythonBindings; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=1
+      env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=1 DEPLOY=yes
     - os: linux
       compiler: gcc
-      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3
+      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=no
     - os: linux
       compiler: clang
-      env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3
+      env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3 DEPLOY=yes
     - os: osx
       compiler: clang
-      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3
+      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=yes
 
 env:
   global:
@@ -193,7 +193,7 @@ before_deploy:
   # Zip up the installation using a file name that identifies where
   # the binaries were built.
   - mkdir ~/binstar-packages
-  - ZIPNAME=opensim-core-latest_$TRAVIS_OS_NAME_$BTYPE.zip
+  - ZIPNAME=opensim-core-latest_${TRAVIS_OS_NAME}_${BTYPE}.zip
   - # Zip up opensim relative to where it's installed.
   - cd $OPENSIM_HOME/../
   - zip --recurse-paths --quiet ~/binstar-packages/$ZIPNAME opensim-core
@@ -216,4 +216,4 @@ deploy:
     branch: bintray
     # Upload for both linux (once) and OSX. Might need to modify the condition
     # if we change the build matrix.
-    condition: "$CC = clang"
+    condition: "$DEPLOY = yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_install:
 
   ## Install Simbody.
   # The Simbody travis script uploads the latestsimbody binaries to bintray.
-  - SIMBODYZIP=simbody-latest_$TRAVIS_OS_NAME.zip
+  - SIMBODYZIP=simbody-latest_${TRAVIS_OS_NAME}_${BTYPE}.zip
   - wget https://dl.bintray.com/chrisdembia/opensim-testing/$SIMBODYZIP
   # Put Simbody in ~/simbody (-q: quiet).
   - unzip -q $SIMBODYZIP -d ~
@@ -153,7 +153,9 @@ script:
   # The `-e "ssh...` is for providing the password andautomatically
   # accepting the ssh key.
   # https://sourceforge.net/p/forge/documentation/Project%20Web%20Services/
-  - if [ "$DOXY" = "on" ]; then if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then rsync -az -e "sshpass -p rectusfemoris ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $OPENSIM_HOME/sdk/doc/html_developer/ opensim-bot@web.sourceforge.net:/home/project-web/myosin/htdocs/$TRAVIS_PULL_REQUEST; fi; fi
+  # MYOSIN_SOURCEFORGE_PASSWORD is a hidden environment variable that we set
+  # at https://travis-ci.org/opensim-org/opensim-core/settings.
+  - if [ "$DOXY" = "on" ]; then if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then rsync -az -e "sshpass -p $MYOSIN_SOURCEFORGE_PASSWORD ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $OPENSIM_HOME/sdk/doc/html_developer/ opensim-bot@web.sourceforge.net:/home/project-web/myosin/htdocs/$TRAVIS_PULL_REQUEST; fi; fi
   # If we're uploading doxygen, we also want to delete old
   # doxygen files from the server so they don't build up indefinitely.
   # However, ssh'ing into the server takes a while, so we only do this
@@ -161,14 +163,14 @@ script:
   - if [[ "$DOXY" = "on" && "$TRAVIS_PULL_REQUEST" != "false" && $(python -c "import random; print(random.random() < 0.01)") = "True" ]]; then CLEAN_UP_MYOSIN=0; else CLEAN_UP_MYOSIN=1; fi
   - if [ $CLEAN_UP_MYOSIN = "0" ]; then echo "This build is randomly selected to delete old folders from myosin.sourceforge.net."; fi
   # Creates an environment at sourceforge that we can ssh into.
-  - if [ $CLEAN_UP_MYOSIN = "0" ]; then sshpass -p rectusfemoris ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null opensim-bot,myosin@shell.sourceforge.net create; fi
+  - if [ $CLEAN_UP_MYOSIN = "0" ]; then sshpass -p $MYOSIN_SOURCEFORGE_PASSWORD ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null opensim-bot,myosin@shell.sourceforge.net create; fi
   # Now that the environment is created, we can run a command on the server.
   # mindepth and maxdepth makes sure that we only look to delete folders
   # in the htdocs folder, and we don't look at subdirectories.
   # We only look for folders (`-type d`).
   # We delete folders older than 30 days (`-mtime +30`).
   # The "shutdown" command shuts down the ssh environment.
-  - if [ $CLEAN_UP_MYOSIN = "0" ]; then sshpass -p rectusfemoris ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null opensim-bot,myosin@shell.sourceforge.net 'cd /home/project-web/myosin/htdocs && find . -mindepth 1 -maxdepth 1 -type d -mtime +30 | xargs rm -rf && shutdown'; fi
+  - if [ $CLEAN_UP_MYOSIN = "0" ]; then sshpass -p $MYOSIN_SOURCEFORGE_PASSWORD ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null opensim-bot,myosin@shell.sourceforge.net 'cd /home/project-web/myosin/htdocs && find . -mindepth 1 -maxdepth 1 -type d -mtime +30 | xargs rm -rf && shutdown'; fi
   
   ## Ensure that there are no tabs in source code.
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,7 +193,7 @@ before_deploy:
   # Zip up the installation using a file name that identifies where
   # the binaries were built.
   - mkdir ~/binstar-packages
-  - ZIPNAME=opensim-core-latest_$TRAVIS_OS_NAME.zip
+  - ZIPNAME=opensim-core-latest_$TRAVIS_OS_NAME_$BTYPE.zip
   - # Zip up opensim relative to where it's installed.
   - cd $OPENSIM_HOME/../
   - zip --recurse-paths --quiet ~/binstar-packages/$ZIPNAME opensim-core
@@ -216,4 +216,4 @@ deploy:
     branch: bintray
     # Upload for both linux (once) and OSX. Might need to modify the condition
     # if we change the build matrix.
-    condition: "$CC = clang && $BTYPE = RelWithDebInfo"
+    condition: "$CC = clang"

--- a/doc/.bintray.json
+++ b/doc/.bintray.json
@@ -1,0 +1,24 @@
+{
+    "package": {
+        "name": "opensim-core",
+        "repo": "opensim-testing",
+        "subject": "chrisdembia"
+    },
+
+    "version": {
+        "name": "latest"
+    },
+
+    "files": 
+        [
+            {
+                "includePattern": "binstar-packages/(.*)",
+                "uploadPattern": "$1", /* replaced with the match to (.*) . */
+                "matrixParams": {"override": 1} /* overwrite existing files. */
+            }
+        ],
+
+    "publish": true
+}
+
+


### PR DESCRIPTION
This allows using opensim's latest binaries in other automated tests (e.g., for opensim-models).