### PR TITLE
[java] Install jar file.

### DIFF
--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -19,11 +19,11 @@ if( JAVA_COMPILE )
   # message( "WD=" ${CMAKE_BINARY_DIR}"/Bindings/Java/OpenSimJNI/src/" )
 
   add_custom_target( JavaCompile
-     COMMAND ${JAVA_COMPILE} 
-     ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src/org/opensim/modeling/*.java 
-     -source 1.6 -target 1.6
-     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src
-     )
+      COMMAND ${JAVA_COMPILE} 
+      ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src/org/opensim/modeling/*.java 
+      -source 1.6 -target 1.6
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src
+      )
      
   set_target_properties(JavaCompile PROPERTIES FOLDER "Bindings")
 
@@ -32,8 +32,13 @@ if( JAVA_COMPILE )
                    COMMAND ${JAVA_ARCHIVE} -cvf org-opensim-modeling.jar
                    org/opensim/modeling/*.class
                    WORKING_DIRECTORY
-                   ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src/
+                   ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/
    )
+
+   install(FILES
+       "${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/org-opensim-modeling.jar"
+       DESTINATION sdk/Java)
+
 endif( JAVA_COMPILE )
 
 install(DIRECTORY Matlab DESTINATION Scripts 

--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -1,45 +1,70 @@
-#-----------------------------------------------------------------------------
-#set(CMAKE_DEBUG_POSTFIX "_d" CACHE INTERNAL "" FORCE)
+# Generate C++ and Java wrapper code with SWIG.
+# ---------------------------------------------
 
-subdirs(OpenSimJNI)
+set(swig_generated_file_fullname
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/OpenSimJNI_wrap.cxx)
+set(swig_generated_header_fullname
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/OpenSimJNI_wrap.h)
+set(swig_interface_file_fullname
+    ${CMAKE_CURRENT_SOURCE_DIR}/swig/javaWrapOpenSim.i)
+set(OPENSIM_JAVA_WRAPPING_PACKAGE "org.opensim.modeling"
+    CACHE STRING
+    "The wrapping is built as the Java package specified in this variable.")
 
-## Now build jar file from the java files created by SWIG. This depends on finding an installation of Java
-find_package( Java )
-if( JAVA_COMPILE )
-  # message( STATUS " ===========================================" )
-  # message( STATUS "  Java" )
-  # message( STATUS " ===========================================" )
-  ## 
+# Replace periods with slashes (to make a path).
+# Syntax for find-replace:
+# string(REGEX REPLACE <pattern> <replacement string>
+#                      <target variable> <source string>)
+string(REGEX REPLACE "\\." "/"
+       SWIG_JAVA_PACKAGE_PATH ${OPENSIM_JAVA_WRAPPING_PACKAGE})
 
-  get_filename_component(JAVA_BIN_PATH "${JAVA_COMPILE}" PATH)
-  find_program( JAVA_JAVA_H javah PATHS ${JAVA_BIN_PATH} )
+set(SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR
+    ${CMAKE_CURRENT_BINARY_DIR}/src/${SWIG_JAVA_PACKAGE_PATH})
 
-  # message( "JAVA_COMPILE=" ${JAVA_COMPILE} )
-  # message( "JAVA_SRC=" ${CMAKE_BINARY_DIR}"/Bindings/Java/OpenSimJNI/src/org/opensim/modeling/*.java" )
-  # message( "WD=" ${CMAKE_BINARY_DIR}"/Bindings/Java/OpenSimJNI/src/" )
+# We place the .java files in this folder.
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
+    ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR})
 
-  add_custom_target( JavaCompile
-      COMMAND ${JAVA_COMPILE} 
-      ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src/org/opensim/modeling/*.java 
-      -source 1.6 -target 1.6
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/Bindings/Java/OpenSimJNI/src
-      )
-     
-  set_target_properties(JavaCompile PROPERTIES FOLDER "Bindings")
+# The actual SWIG command is in the OpenSimJNI folder, since the custom command
+# must be defined in the same directory that uses it (for the osimJavaJNI
+# target).
 
-  add_custom_command(TARGET JavaCompile
-                   POST_BUILD
-                   COMMAND ${JAVA_ARCHIVE} -cvf org-opensim-modeling.jar
-                   org/opensim/modeling/*.class
-                   WORKING_DIRECTORY
-                   ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/
-   )
+# Compile the C++ wrapper into a library.
+# ---------------------------------------
+add_subdirectory(OpenSimJNI)
 
-   install(FILES
-       "${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/org-opensim-modeling.jar"
-       DESTINATION sdk/Java)
+# Compile java sources.
+# ---------------------
+find_package(Java 1.6 REQUIRED)
 
-endif( JAVA_COMPILE )
+add_custom_command(
+    OUTPUT src/org-opensim-modeling.jar
+    DEPENDS "${swig_generated_file_fullname}"
+    COMMAND ${JAVA_COMPILE} 
+            ${CMAKE_CURRENT_BINARY_DIR}/src/org/opensim/modeling/*.java 
+            -source 1.6 -target 1.6
+    COMMAND ${JAVA_ARCHIVE} -cvf org-opensim-modeling.jar
+            org/opensim/modeling/*.class
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
+    COMMENT "Compiling Java sources and creating jar archive."
+    )
+
+# Umbrella target for assembling the java bindings in the build tree.
+# -------------------------------------------------------------------
+add_custom_target(JavaBindings ALL
+    DEPENDS src/org-opensim-modeling.jar
+    )
+
+add_dependencies(JavaBindings osimJavaJNI)
+
+set_target_properties(JavaBindings PROPERTIES
+    PROJECT_LABEL "Java - umbrella target"
+    FOLDER "Bindings")
+
+# Install.
+# --------
+install(FILES src/org-opensim-modeling.jar
+    DESTINATION sdk/Java)
 
 install(DIRECTORY Matlab DESTINATION Scripts 
     PATTERN "Matlab/Dynamic_Walker_Example" EXCLUDE)

--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(OpenSimJNI)
 find_package(Java 1.6 REQUIRED)
 
 add_custom_command(
-    OUTPUT src/org-opensim-modeling.jar
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/org-opensim-modeling.jar
     DEPENDS "${swig_generated_file_fullname}"
     COMMAND ${JAVA_COMPILE} 
             ${CMAKE_CURRENT_BINARY_DIR}/src/org/opensim/modeling/*.java 
@@ -52,7 +52,7 @@ add_custom_command(
 # Umbrella target for assembling the java bindings in the build tree.
 # -------------------------------------------------------------------
 add_custom_target(JavaBindings ALL
-    DEPENDS src/org-opensim-modeling.jar
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/src/org-opensim-modeling.jar
     )
 
 add_dependencies(JavaBindings osimJavaJNI)
@@ -63,7 +63,7 @@ set_target_properties(JavaBindings PROPERTIES
 
 # Install.
 # --------
-install(FILES src/org-opensim-modeling.jar
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/org-opensim-modeling.jar
     DESTINATION sdk/Java)
 
 install(DIRECTORY Matlab DESTINATION Scripts 

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -1,37 +1,12 @@
 set(KIT JavaJNI)
 set(UKIT JAVAJNI)
 
-include(${CMAKE_ROOT}/Modules/FindJava.cmake)
-include(${CMAKE_ROOT}/Modules/FindJNI.cmake)
-
-if(JAVA_INCLUDE_PATH)
-
-# Run command to generate OpenSimJNI_wrap.cxx
-set(swig_generated_file_fullname
-    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI_wrap.cxx)
-set(swig_generated_header_fullname
-    ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI_wrap.h)
-set(swig_interface_file_fullname
-    ${OpenSim_SOURCE_DIR}/Bindings/Java/swig/javaWrapOpenSim.i)
-set(OPENSIM_JAVA_WRAPPING_PACKAGE "org.opensim.modeling"
-    CACHE STRING
-    "The wrapping is built as the Java package specified in this variable.")
-
-# Replace periods with slashes (to make a path).
-# Syntax for find-replace:
-# string(REGEX REPLACE <pattern> <replacement string>
-#                      <target variable> <source string>)
-string(REGEX REPLACE "\\." "/"
-       SWIG_JAVA_PACKAGE_PATH ${OPENSIM_JAVA_WRAPPING_PACKAGE})
-
-set(SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR
-    ${CMAKE_CURRENT_BINARY_DIR}/src/${SWIG_JAVA_PACKAGE_PATH})
-
-# We place the .java files in this folder.
-execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
-    ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR})
+# For building C++ wrapper.
+find_package(JNI 1.6 REQUIRED)
 
 add_custom_command(
+    # This target actually creates a lot more (all the produced .java files); 
+    # but we will just use these two files as a proxy for all of those.
     OUTPUT "${swig_generated_file_fullname}" "${swig_generated_header_fullname}"
     COMMAND ${SWIG_EXECUTABLE} -v -c++ -java
         -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
@@ -42,20 +17,9 @@ add_custom_command(
         -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
         ${swig_interface_file_fullname}
     DEPENDS "${swig_interface_file_fullname}"
-        "${OpenSim_SOURCE_DIR}/Bindings/opensim.i"
-        "${OpenSim_SOURCE_DIR}/Bindings/OpenSimHeaders.h"
-    )
-    
-# This target actually depends on a lot more (all the produced .java files); 
-# but we will just use these two files as a proxy for all of those. All we need
-# is for this target to depend on outputs of the command above.
-add_custom_target(JavaWrap
-    DEPENDS "${swig_generated_file_fullname}"
-            "${swig_generated_header_fullname}")
-
-set_target_properties(JavaWrap PROPERTIES
-    PROJECT_LABEL "Java - Generate source code"
-    FOLDER "Bindings"
+            "${CMAKE_SOURCE_DIR}/Bindings/opensim.i"
+            "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders.h"
+    COMMENT "Generating java bindings source code with SWIG."
     )
 
 set(SOURCE_FILES "${swig_generated_file_fullname}" OpenSimContext.cpp)
@@ -78,8 +42,6 @@ set_target_properties(osim${KIT} PROPERTIES
    PROJECT_LABEL "Java - osim${KIT}"
    FOLDER "Bindings"
 )
-
-add_dependencies(osim${KIT} JavaWrap)
 
 if(${OPENSIM_USE_INSTALL_RPATH})
     set_target_properties(osim${KIT} PROPERTIES
@@ -108,7 +70,4 @@ install(DIRECTORY ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}/
 
 if(BUILD_TESTING)
     subdirs(Test)
-endif(BUILD_TESTING)
-
-
-endif(JAVA_INCLUDE_PATH)
+endif()

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -58,7 +58,6 @@ set_target_properties(JavaWrap PROPERTIES
     FOLDER "Bindings"
     )
 
-
 set(SOURCE_FILES "${swig_generated_file_fullname}" OpenSimContext.cpp)
 set(INCLUDE_FILES "${swig_generated_header_fullname}" OpenSimContext.h)
 
@@ -81,6 +80,12 @@ set_target_properties(osim${KIT} PROPERTIES
 )
 
 add_dependencies(osim${KIT} JavaWrap)
+
+if(${OPENSIM_USE_INSTALL_RPATH})
+    set_target_properties(osim${KIT} PROPERTIES
+        INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
+        )
+endif()
 
 # Shared libraries are needed at runtime for applications, so we put them
 # at the top level in OpenSim/bin/*.dll (Windows) or OpenSim/lib/*.so (Linux)

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -176,7 +176,7 @@ add_custom_target(PythonBindings ALL
 add_dependencies(PythonBindings _${KIT})
 
 set_target_properties(PythonBindings PROPERTIES
-    PROJECT_LABEL "Python - assemble package"
+    PROJECT_LABEL "Python - umbrella target"
     FOLDER "Bindings")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,13 +349,13 @@ if("${SIMBODY_HOME}" STREQUAL "")
     # we shouldn't let that fail silently and still search for
     # Simbody elsewhere; they may never realize
     # we are not using their requested installation of Simbody.
-    find_package(Simbody ${SIMBODY_VERSION_TO_USE}
+    find_package(Simbody ${SIMBODY_VERSION_TO_USE} QUIET
         NO_MODULE)
 else()
     # Find the package using the user-specified path.
     # NO_DEFAULT_PATH will cause find_package to only
     # look in the provided PATHS.
-    find_package(Simbody ${SIMBODY_VERSION_TO_USE}
+    find_package(Simbody ${SIMBODY_VERSION_TO_USE} QUIET
         PATHS "${SIMBODY_HOME}" NO_MODULE NO_DEFAULT_PATH)
 endif()
 # This variable appears in the CMake GUI and could confuse users,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,13 +349,13 @@ if("${SIMBODY_HOME}" STREQUAL "")
     # we shouldn't let that fail silently and still search for
     # Simbody elsewhere; they may never realize
     # we are not using their requested installation of Simbody.
-    find_package(Simbody ${SIMBODY_VERSION_TO_USE} QUIET
+    find_package(Simbody ${SIMBODY_VERSION_TO_USE}
         NO_MODULE)
 else()
     # Find the package using the user-specified path.
     # NO_DEFAULT_PATH will cause find_package to only
     # look in the provided PATHS.
-    find_package(Simbody ${SIMBODY_VERSION_TO_USE} QUIET
+    find_package(Simbody ${SIMBODY_VERSION_TO_USE}
         PATHS "${SIMBODY_HOME}" NO_MODULE NO_DEFAULT_PATH)
 endif()
 # This variable appears in the CMake GUI and could confuse users,


### PR DESCRIPTION
Also, set RPATH in osimJavaJNI to find other opensim libraries. Now, matlab
users do not need to set DYLD_LIBRARY_PATH.

In the install tree, the sdk folder now has:

```
sdk/Java/org/opensim/modeling/*.java
sdk/Java/org/opensim/modeling/*.class
sdk/Java/org-opensim-modeling.jar
```

Does this cause java classpath issues where the .class files and .jar file may conflict if `sdk/Java` is on the classpath?

@aymanhab could you review?