### PR TITLE
[readme] brew python issues with cmake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Building from the source code
 We support a few ways of building OpenSim:
 
 1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio).
-2. [On Mac using Xcode](#on-mac-using-xcode).
+2. [On OSX using Xcode](#on-osx-using-xcode).
 3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles).
 
 
@@ -229,12 +229,12 @@ directory to your `PATH` environment variable.
    the semicolon!
 
 
-On Mac using Xcode
+On OSX using Xcode
 ==================
 
 #### Get the dependencies
 
-* **operating system**: OS X 10.8 or later.
+* **operating system**: OSX 10.8 or later.
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8
 * **compiler / IDE**: [Xcode](https://developer.apple.com/xcode/) >= 5, through
@@ -245,13 +245,18 @@ On Mac using Xcode
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6
 * **version control** (optional): git.
     * Xcode Command Line Tools gives you git on the command line.
-    * [GitHub for Mac](https://mac.github.com), easiest.
+    * [GitHub for Mac](https://mac.github.com), for a simple-to-use GUI.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.5
     * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
     * **python scripting** (optional):
-        * Mac's come with python, but you could also install:
+        * OSX comes with python, but you could also use:
+        * [`brew install python`](http://brew.sh),
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
+
+You can get most of these dependencies using [Homebrew](http://brew.sh):
+
+    $ brew install cmake doxygen swig
 
 #### Download the OpenSim-Core source code
 
@@ -293,7 +298,11 @@ On Mac using Xcode
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above. CMake sets `PYTHON_*` variables to tell you the
-      Python it will use for building the wrappers.
+      Python it will use for building the wrappers. (If you installed python
+      with homebrew, [CMake will not find the homebrew python libraries on its
+      own](https://github.com/Homebrew/homebrew/issues/25118); you must set the
+      CMake variable `PYTHON_LIBRARIES` manually. Use `'$(python-config
+      --prefix)/lib/libpython2.7.dylib'` in bash to get the correct value.)
     * `BUILD_API_ONLY` if you don't want to build the command-line applications.
 8. Click the **Configure** button again. Then, click **Generate** to create
    Xcode project files in the build directory.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Building from the source code
 We support a few ways of building OpenSim:
 
 1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio).
-2. [On OSX using Xcode](#on-osx-using-xcode).
+2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode).
 3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles).
 
 
@@ -229,12 +229,12 @@ directory to your `PATH` environment variable.
    the semicolon!
 
 
-On OSX using Xcode
-==================
+On Mac OSX using Xcode
+======================
 
 #### Get the dependencies
 
-* **operating system**: OSX 10.8 or later.
+* **operating system**: Mac OSX 10.8 or later.
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 2.8.8
 * **compiler / IDE**: [Xcode](https://developer.apple.com/xcode/) >= 5, through
@@ -249,7 +249,7 @@ On OSX using Xcode
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.5
     * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
     * **python scripting** (optional):
-        * OSX comes with python, but you could also use:
+        * Mac OSX comes with python, but you could also use:
         * [`brew install python`](http://brew.sh),
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)


### PR DESCRIPTION
There's a bug with cmake/homebrew when OSX users have installed python via homebrew. I've tried to help people who get stuck in this situation. I also changed "Mac" to "OSX" since I think "OSX" is more accurate ('mac' refers to the hardware and the OS, but I really want to refer to the OS).