### PR TITLE
Avoid Courier for doxygen code block font.

### DIFF
--- a/doc/doxygen_shared.css
+++ b/doc/doxygen_shared.css
@@ -10,7 +10,7 @@ table {
 }
 
 pre, code {
-    font-family: monospace;
+	font-family: Menlo, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
 p {
@@ -197,15 +197,16 @@ pre.fragment {
 div.fragment {
         padding: 4px 6px;
         margin: 4px 8px 4px 2px;
-	background-color: #e3e3e3;
-	border: 1px solid #e3e3e3;
-	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace !important;
+	background-color: #f3f3f3;
+	border: 1px solid #f3f3f3;
 }
 
 div.line {
-	font-family: monospace;
+    /* This is the font used for code blocks (@code). Menlo is on OSX, Consolas
+     * is on Windows. */
+	font-family: Menlo, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
     font-size: 11px;
-    color: #717171;
+    /* color: #000000; */ /* use default font color for code */
 	min-height: 13px; 
 	line-height: 1.0;
 	text-wrap: unrestricted;


### PR DESCRIPTION
Also, use a ligher grey for the background of code blocks, and a darker (black) font color.

Before (in Safari):
<img width="466" alt="screen shot 2015-12-31 at 6 51 05 pm" src="https://cloud.githubusercontent.com/assets/846001/12069610/81cb37b8-afef-11e5-9bb2-9d97e8de8e85.png">

After (in Safari):
<img width="454" alt="screen shot 2015-12-31 at 6 51 51 pm" src="https://cloud.githubusercontent.com/assets/846001/12069615/94248dce-afef-11e5-8af3-8388deea9df1.png">

@jimmyDunne could you look at this?
