### PR TITLE
Fix some warnings and uses of SimTK::Xml

### DIFF
--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -258,7 +258,7 @@ public:
     RowVectorView getRowAtIndex(size_t index) const {
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, index, 0, _indData.size())
-        return _depData.row(index);
+        return _depData.row((int)index);
     }
 
     /** Get row corresponding to the given entry in the independent column.   
@@ -271,7 +271,7 @@ public:
         OPENSIM_THROW_IF(iter == _indData.cend(),
                          KeyNotFound, std::to_string(ind));
 
-        return _depData.row(std::distance(_indData.cbegin(), iter));
+        return _depData.row((int)std::distance(_indData.cbegin(), iter));
     }
 
     /** Update row at index.                                                  
@@ -280,7 +280,7 @@ public:
     RowVectorView updRowAtIndex(size_t index) {
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, index, 0, _indData.size());
-        return _depData.updRow(index);
+        return _depData.updRow((int)index);
     }
 
     /** Update row corresponding to the given entry in the independent column.
@@ -293,7 +293,7 @@ public:
         OPENSIM_THROW_IF(iter == _indData.cend(),
                          KeyNotFound, std::to_string(ind));
 
-        return _depData.updRow(std::distance(_indData.cbegin(), iter));
+        return _depData.updRow((int)std::distance(_indData.cbegin(), iter));
     }
 
     /** Get independent column.                                               */
@@ -308,7 +308,7 @@ public:
         OPENSIM_THROW_IF(isColumnIndexOutOfRange(index),
                          ColumnIndexOutOfRange, index, 0,
                          static_cast<size_t>(_depData.ncol()));
-        return _depData.col(index);
+        return _depData.col((int)index);
     }
 
     /** Set independent column at index.                                      
@@ -319,7 +319,7 @@ public:
     void setIndependentColumnAtIndex(size_t index, const ETX& value) {
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, index, 0, _indData.size());
-        validateRow(index, value, _depData.row(index));
+        validateRow(index, value, _depData.row((int)index));
         _indData[index] = value;
     }
 
@@ -365,7 +365,8 @@ protected:
     void validateDependentsMetaData() const override {
         unsigned numCols{};
         try {
-            numCols = _dependentsMetaData.getValueArrayForKey("labels").size();
+            numCols = (unsigned)_dependentsMetaData
+                                        .getValueArrayForKey("labels").size();
         } catch (KeyNotFound&) {
             OPENSIM_THROW(MissingMetaData, "labels");
         }

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -48,7 +48,6 @@
 
 using namespace OpenSim;
 using namespace std;
-using SimTK::Xml;
 using SimTK::Vec3;
 using SimTK::Transform;
 

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -100,7 +100,7 @@ XMLDocument::XMLDocument()
  * @param aFileName File name of the XML document.
  */
 XMLDocument::XMLDocument(const string &aFileName) :
-Xml::Document(aFileName)
+SimTK::Xml::Document(aFileName)
 {
 
 
@@ -278,7 +278,7 @@ void XMLDocument::copyDefaultObjects(const XMLDocument &aDocument){
 /*static*/ 
 void  XMLDocument::renameChildNode(SimTK::Xml::Element& aNode, std::string oldElementName, std::string newElementName)
 {
-    Xml::element_iterator elmtIter(aNode.element_begin(oldElementName));
+    SimTK::Xml::element_iterator elmtIter(aNode.element_begin(oldElementName));
     if (elmtIter!=aNode.element_end()){
         elmtIter->setElementTag(newElementName);
     }
@@ -292,8 +292,8 @@ bool XMLDocument::isEqualTo(XMLDocument& aOtherDocument, double toleranceForDoub
         equal = (_documentVersion == aOtherDocument._documentVersion);
     if (!equal) return false;
     // Get Roots 
-    Xml::Element root1=  getRootElement();
-    Xml::Element root2=  aOtherDocument.getRootElement();
+    SimTK::Xml::Element root1=  getRootElement();
+    SimTK::Xml::Element root2=  aOtherDocument.getRootElement();
 
     //if (!equal) return false;
     // Cycle through children and compare. Order is assumed to be the same for now

--- a/OpenSim/Common/XMLDocument.h
+++ b/OpenSim/Common/XMLDocument.h
@@ -90,7 +90,7 @@ public:
     static void renameChildNode(SimTK::Xml::Element& aNode, std::string oldElementName, std::string newElementName);
     const int& getDocumentVersion() const { return _documentVersion; };
     static void getVersionAsString(const int aVersion, std::string& aString); 
-    Xml::Element getRootDataElement();
+    SimTK::Xml::Element getRootDataElement();
     bool isEqualTo(XMLDocument& aOtherDocument, double toleranceForDoubles=1e-6, 
         bool compareDefaults=false, bool compareVersionNumbers=false);
     static void addConnector(SimTK::Xml::Element& element,

--- a/OpenSim/Simulation/SimbodyEngine/TransformAxis.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/TransformAxis.cpp
@@ -40,7 +40,7 @@
 //=============================================================================
 using namespace std;
 using namespace OpenSim;
-using SimTK::Vec3; using SimTK::State; using SimTK::Vector; using SimTK::Xml;
+using SimTK::Vec3; using SimTK::State; using SimTK::Vector;
 
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
@@ -62,7 +62,7 @@ TransformAxis::TransformAxis(const Array<string>& coordNames,
     setAxis(axis);
 }
 // Constructor from XML node.
-TransformAxis::TransformAxis(Xml::Element& aNode) {
+TransformAxis::TransformAxis(SimTK::Xml::Element& aNode) {
     setNull();
     constructProperties();
     updateFromXMLNode(aNode);
@@ -182,7 +182,7 @@ void TransformAxis::setFunction(const OpenSim::Function& func)
 
 
 void TransformAxis::updateFromXMLNode
-   (Xml::Element& node, int versionNumber)
+   (SimTK::Xml::Element& node, int versionNumber)
 {
     // Version before refactoring spatialTransform.
     // TODO: this is handled in CustomJoint's updateFromXMLNode() method

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -467,7 +467,7 @@ void InverseKinematicsTool::updateFromXMLNode(SimTK::Xml::Element& aNode, int ve
         }
         if (versionNumber <= 20201){
             // get filename and use SimTK::Xml to parse it
-            SimTK::Xml doc = SimTK::Xml(newFileName);
+            SimTK::Xml::Document doc = SimTK::Xml::Document(newFileName);
             Xml::Element root = doc.getRootElement();
             if (root.getElementTag()=="OpenSimDocument"){
                 int curVersion = root.getRequiredAttributeValueAs<int>("Version");


### PR DESCRIPTION
As part of the State serialization project, the SimTK::Xml *class* will be the SimTK::Xml *namespace*. In most cases this is backwards compatible because other classes like Element were local to Xml and hence referenced `Xml::Element`, which will still work. There were a few `using` statements and the like that will have to change; I believe the changes here will work now and after Xml gets promoted to namespace.

Also fixed miscellaneous new warnings caught by VC++.