### PR TITLE
[appveyor] TreatWarningsAsErrors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ build_script:
   # Configure.
   - cmake .. -G"Visual Studio 14 2015 Win64" -DSIMBODY_HOME=C:\simbody -DCMAKE_INSTALL_PREFIX=%OPENSIM_HOME% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON # TODO -DBUILD_SIMM_TRANSLATOR=ON
   # Build.
-  - cmake --build . --target ALL_BUILD --config Release -- /maxcpucount:4 /verbosity:quiet
+  - cmake --build . --target ALL_BUILD --config Release -- /maxcpucount:4 /verbosity:quiet /p:TreatWarningsAsErrors="true"
   
 test_script:
   ## Run tests.


### PR DESCRIPTION
This change should cause warnings on appveyor to be treated as errors, so they don't go unnoticed.

The Travis build failed b/c I cancelled it.