### PR TITLE
[travis] libblas, liblapack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,14 @@ before_install:
   # Only if compiling with gcc, update environment variables
   # to use the new gcc.
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  
+  ## Temporary hack to find libblas and liblapack.
+  # TODO. Currently Simbody is using Travis CI's Ubuntu 14.04 VMs, which link with 
+  # liblapack.so.3 and libblas.so.3. These files don't exist on the 12.04 machines.
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then mkdir ~/lib; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s /usr/lib/liblapack.so ~/lib/liblapack.so.3; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ln -s /usr/lib/libblas.so ~/lib/libblas.so.3; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/lib; fi
 
   ## Set up ccache.
   # Lots of this is borrowed from https://github.com/weitjong/Urho3D/blob/master/.travis.yml.
@@ -76,8 +84,8 @@ before_install:
   # have a symlink in the ccache symlinks directory, so workaround it
   - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
   # Without the following lines, ccache causes clang to not print in color.
-  - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
-  - if [ "$CXX" == "clang++" ]; then export CX="clang++ -fcolor-diagnostics"; fi;
+  - if [[ $CC = clang* ]]; then export CC="$CC -fcolor-diagnostics"; fi;
+  - if [[ $CXX = clang* ]]; then export CXX="$CXX -fcolor-diagnostics"; fi;
   
   ## Doxygen.
   # Need a doxygen that is more recent than that available through apt-get.
@@ -142,7 +150,7 @@ script:
 
   ## Test python wrapping.
   # Add OpenSim libraries to library path.
-  - if [ "$WRAP" = "on" ]; then export LD_LIBRARY_PATH=$OPENSIM_HOME/lib/x86_64-linux-gnu; fi
+  - if [ "$WRAP" = "on" ]; then export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENSIM_HOME/lib/x86_64-linux-gnu; fi
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/share/doc/OpenSim/python; fi
   # Run the python tests, verbosely.


### PR DESCRIPTION
This change is to accomodate Simbody's move to 14.04 with travis. Right now, all travis builds are failing. This change is somewhat temporary, and is just to get the builds to work again.

This change is also somewhat separate from the upgrade in compiler versions.

Another way to fix this problem would be for OpenSim to use 14.04 with travis. However, we can't use caching with 14.04, and caching (ccache) speeds up our travis builds.

Appveyor failed b/c I cancelled it.