### PR TITLE
[cmake] Remove link_directories() for Simbody.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,6 @@ endif()
 # Directories for Simbody headers and libraries for building.
 # -----------------------------------------------------------
 include_directories("${Simbody_INCLUDE_DIR}")
-link_directories("${Simbody_LIB_DIR}")
 
 
 # Copy files over from the Simbody installation.


### PR DESCRIPTION
No need to call `link_directories()` for Simbody anymore (see https://github.com/simbody/simbody/pull/449) . Thanks @elen4 for pointing out that this call is deprecated.