### PR TITLE
Installation instructions for impatient

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,22 +717,24 @@ Your changes will only take effect in new terminal windows.
 
 #### For the impatient (Ubuntu)
 
-* In **Terminal** --
- * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
- * `sudo apt-add-repository ppa:fenics-packages/fenics-exp`
- * `sudo apt-get update`
- * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev openjdk-7-jdk`
- * `sudo rm -f /usr/bin/cc /usr/bin/c++`
- * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
- * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`
- * `git clone https://github.com/opensim-org/opensim-core.git`
- * `mkdir opensim_dependencies_build`
- * `cd opensim_dependencies_build`
- * `cmake ../opensim-core/dependencies/ -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- * `make -j8`
- * `cd ..`
- * `mkdir opensim_build`
- * `cd opensim_build`
- * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=ON`
- * `make -j8`
- * `ctest -j8`
+In **Terminal** --
+```shell
+ sudo add-apt-repository ppa:george-edison55/cmake-3.x
+ sudo apt-add-repository ppa:fenics-packages/fenics-exp
+ sudo apt-get update
+ sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev openjdk-7-jdk
+ sudo rm -f /usr/bin/cc /usr/bin/c++
+ sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
+ sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
+ git clone https://github.com/opensim-org/opensim-core.git
+ mkdir opensim_dependencies_build
+ cd opensim_dependencies_build
+ cmake ../opensim-core/dependencies/ -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' -DCMAKE_BUILD_TYPE=RelWithDebInfo
+ make -j8
+ cd ..
+ mkdir opensim_build
+ cd opensim_build
+ cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=ON
+ make -j8
+ ctest -j8
+ ```

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We support a few ways of building OpenSim:
 
 1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient-windows). 
 2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode). In a rush? Use [these instructions](#for-the-impatient-mac-os-x).
-3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles).
+3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles). In a rush? Use [these instructions](#for-the-impatient-ubuntu).
 
 
 On Windows using Visual Studio
@@ -502,7 +502,6 @@ Your changes will only take effect in new terminal windows.
  * `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
  * `brew install cmake`
  * `git clone https://github.com/opensim-org/opensim-core.git`
- * `cd opensim-core`
  * `mkdir opensim_dependencies_build`
  * `cd opensim_dependencies_build`
  * `cmake ../opensim-core/dependencies -DCMAKE_INSTALL_PREFIX="~/opensim_dependencies_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo`
@@ -715,3 +714,24 @@ Your changes will only take effect in new terminal windows.
 [running_gif]: doc/images/opensim_running.gif
 [simple_example_gif]: doc/images/opensim_double_pendulum_muscle.gif
 [java]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html
+
+#### For the impatient (ubuntu)
+
+* In **Terminal** --
+ * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
+ * `sudo apt-get update`
+ * `sudo apt-get install git cmake cmake-curses-gui clang-3.6`
+ * `sudo rm -f /usr/bin/cc /usr/bin/c++`
+ * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
+ * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`
+ * `git clone https://github.com/opensim-org/opensim-core.git`
+ * `mkdir opensim_dependencies_build`
+ * `cd opensim_dependencies_build`
+ * `cmake ../opensim-core/dependencies/ -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' -DCMAKE_BUILD_TYPE=RelWithDebInfo`
+ * `make -j8`
+ * `cd ..`
+ * `mkdir opensim_build`
+ * `cd opensim_build`
+ * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"`
+ * `make -j8`
+ * `ctest -j8`

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ directory to your `PATH` environment variable.
 5. Add **C:/opensim-core/bin;** to the front of of the text field. Don't forget
    the semicolon!
 
-#### For the impatient
+#### For the impatient (Windows)
 
 * Get **Visual Studio Community** from [here](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
  * Choose *Custom' installation*.
@@ -495,6 +495,24 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
 
 Your changes will only take effect in new terminal windows.
 
+#### For the impatient (Mac OS X)
+
+* Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
+* In **Terminal** --
+ * `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
+ * `brew install cmake`
+ * `git clone https://github.com/opensim-org/opensim-core.git`
+ * `cd opensim-core`
+ * `mkdir opensim_dependencies_build`
+ * `cd opensim_dependencies_build`
+ * `cmake ../opensim-core/dependencies -DCMAKE_INSTALL_PREFIX="~/opensim_dependencies_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo`
+ * `make -j8`
+ * `cd ..`
+ * `mkdir opensim_build`
+ * `cd opensim_build`
+ * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"`
+ * `make -j8`
+ * `ctest -j8`
 
 On Ubuntu using Unix Makefiles
 ==============================

--- a/README.md
+++ b/README.md
@@ -733,6 +733,6 @@ Your changes will only take effect in new terminal windows.
  * `cd ..`
  * `mkdir opensim_build`
  * `cd opensim_build`
- * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"`
+ * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON`
  * `make -j8`
  * `ctest -j8`

--- a/README.md
+++ b/README.md
@@ -719,8 +719,9 @@ Your changes will only take effect in new terminal windows.
 
 * In **Terminal** --
  * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
+ * `sudo apt-add-repository ppa:fenics-packages/fenics-exp`
  * `sudo apt-get update`
- * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev`
+ * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0`
  * `sudo rm -f /usr/bin/cc /usr/bin/c++`
  * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
  * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`

--- a/README.md
+++ b/README.md
@@ -496,23 +496,28 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
 Your changes will only take effect in new terminal windows.
 
 #### For the impatient (Mac OS X)
-
-* Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
-* In **Terminal** --
- * `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
- * `brew install cmake`
- * `git clone https://github.com/opensim-org/opensim-core.git`
- * `mkdir opensim_dependencies_build`
- * `cd opensim_dependencies_build`
- * `cmake ../opensim-core/dependencies -DCMAKE_INSTALL_PREFIX="~/opensim_dependencies_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- * `make -j8`
- * `cd ..`
- * `mkdir opensim_build`
- * `cd opensim_build`
- * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"`
- * `make -j8`
- * `ctest -j8`
-
+Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
+In **Terminal** --
+```shell
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install cmake
+git clone https://github.com/opensim-org/opensim-core.git
+mkdir opensim_dependencies_build
+cd opensim_dependencies_build
+cmake ../opensim-core/dependencies \
+      -DCMAKE_INSTALL_PREFIX="~/opensim_dependencies_install" \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make -j8
+cd ..
+mkdir opensim_build
+cd opensim_build
+cmake ../opensim-core \
+      -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"
+make -j8
+ctest -j8
+```
 On Ubuntu using Unix Makefiles
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ Your changes will only take effect in new terminal windows.
 * In **Terminal** --
  * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
  * `sudo apt-get update`
- * `sudo apt-get install git cmake cmake-curses-gui clang-3.6`
+ * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev`
  * `sudo rm -f /usr/bin/cc /usr/bin/c++`
  * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
  * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Your changes will only take effect in new terminal windows.
 [simple_example_gif]: doc/images/opensim_double_pendulum_muscle.gif
 [java]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html
 
-#### For the impatient (ubuntu)
+#### For the impatient (Ubuntu)
 
 * In **Terminal** --
  * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`

--- a/README.md
+++ b/README.md
@@ -496,11 +496,13 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
 Your changes will only take effect in new terminal windows.
 
 #### For the impatient (Mac OS X)
+##### Mac OS X 10.11
 Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
 In **Terminal** --
 ```shell
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-brew install cmake
+brew install cmake swig
+brew cask install java
 git clone https://github.com/opensim-org/opensim-core.git
 mkdir opensim_dependencies_build
 cd opensim_dependencies_build
@@ -514,6 +516,8 @@ cd opensim_build
 cmake ../opensim-core \
       -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DBUILD_PYTHON_WRAPPING=ON \
+      -DBUILD_JAVA_WRAPPING=ON \
       -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install"
 make -j8
 ctest -j8

--- a/README.md
+++ b/README.md
@@ -728,6 +728,7 @@ In **Terminal** --
  sudo rm -f /usr/bin/cc /usr/bin/c++
  sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
  sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
+ export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
  git clone https://github.com/opensim-org/opensim-core.git
  mkdir opensim_dependencies_build
  cd opensim_dependencies_build

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Your changes will only take effect in new terminal windows.
  * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
  * `sudo apt-add-repository ppa:fenics-packages/fenics-exp`
  * `sudo apt-get update`
- * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev`
+ * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev openjdk-7-jdk`
  * `sudo rm -f /usr/bin/cc /usr/bin/c++`
  * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
  * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`
@@ -733,6 +733,6 @@ Your changes will only take effect in new terminal windows.
  * `cd ..`
  * `mkdir opensim_build`
  * `cd opensim_build`
- * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON`
+ * `cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=ON`
  * `make -j8`
  * `ctest -j8`

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Building from the source code
 
 We support a few ways of building OpenSim:
 
-1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio).
+1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient). 
 2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode).
 3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles).
 

--- a/README.md
+++ b/README.md
@@ -716,35 +716,62 @@ Your changes will only take effect in new terminal windows.
 [java]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html
 
 #### For the impatient (Ubuntu)
-
+##### Ubuntu 14.04
 In **Terminal** --
 ```shell
- sudo add-apt-repository ppa:george-edison55/cmake-3.x
- sudo apt-add-repository ppa:fenics-packages/fenics-exp
- sudo apt-get update
- sudo apt-get install git cmake cmake-curses-gui clang-3.6 \
-                      freeglut3-dev libxi-dev libxmu-dev \
-                      liblapack-dev swig3.0 python-dev openjdk-7-jdk
- sudo rm -f /usr/bin/cc /usr/bin/c++
- sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
- sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
- export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
- git clone https://github.com/opensim-org/opensim-core.git
- mkdir opensim_dependencies_build
- cd opensim_dependencies_build
- cmake ../opensim-core/dependencies/ \
-         -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' \
-         -DCMAKE_BUILD_TYPE=RelWithDebInfo
- make -j8
- cd ..
- mkdir opensim_build
- cd opensim_build
- cmake ../opensim-core \
-         -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
-         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-         -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" \
-         -DBUILD_PYTHON_WRAPPING=ON \
-         -DBUILD_JAVA_WRAPPING=ON
- make -j8
- ctest -j8
+sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo apt-add-repository ppa:fenics-packages/fenics-exp
+sudo apt-get update
+sudo apt-get install git cmake cmake-curses-gui clang-3.6 \
+                     freeglut3-dev libxi-dev libxmu-dev \
+                     liblapack-dev swig3.0 python-dev openjdk-7-jdk
+sudo rm -f /usr/bin/cc /usr/bin/c++
+sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
+sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+git clone https://github.com/opensim-org/opensim-core.git
+mkdir opensim_dependencies_build
+cd opensim_dependencies_build
+cmake ../opensim-core/dependencies/ \
+      -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make -j8
+cd ..
+mkdir opensim_build
+cd opensim_build
+cmake ../opensim-core \
+      -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" \
+      -DBUILD_PYTHON_WRAPPING=ON \
+      -DBUILD_JAVA_WRAPPING=ON
+make -j8
+ctest -j8
  ```
+##### Ubuntu 15.10
+In **Terminal** --
+```shell
+sudo apt-get install git cmake cmake-curses-gui \
+                     freeglut3-dev libxi-dev libxmu-dev \
+                     liblapack-dev swig3.0 python-dev openjdk-7-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+git clone https://github.com/opensim-org/opensim-core.git
+mkdir opensim_dependencies_build
+cd opensim_dependencies_build
+cmake ../opensim-core/dependencies/ \
+      -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make -j8
+cd ..
+mkdir opensim_build
+cd opensim_build
+cmake ../opensim-core \
+      -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" \
+      -DBUILD_PYTHON_WRAPPING=ON \
+      -DBUILD_JAVA_WRAPPING=ON
+make -j8
+ctest -j8
+```
+  

--- a/README.md
+++ b/README.md
@@ -496,9 +496,8 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
 Your changes will only take effect in new terminal windows.
 
 #### For the impatient (Mac OS X)
-##### Mac OS X 10.11
+##### Mac OS X 10.10 El Capitan and OS X 10.11 Yosemite
 Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
-
 In **Terminal** --
 ```shell
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -726,7 +725,7 @@ Your changes will only take effect in new terminal windows.
 [java]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html
 
 #### For the impatient (Ubuntu)
-##### Ubuntu 14.04
+##### Ubuntu 14.04 Trusty Tahr
 In **Terminal** --
 ```shell
 sudo add-apt-repository ppa:george-edison55/cmake-3.x
@@ -758,7 +757,7 @@ cmake ../opensim-core \
 make -j8
 ctest -j8
  ```
-##### Ubuntu 15.10
+##### Ubuntu 15.10 Wily Werewolf
 In **Terminal** --
 ```shell
 sudo apt-add-repository ppa:fenics-packages/fenics

--- a/README.md
+++ b/README.md
@@ -722,19 +722,28 @@ In **Terminal** --
  sudo add-apt-repository ppa:george-edison55/cmake-3.x
  sudo apt-add-repository ppa:fenics-packages/fenics-exp
  sudo apt-get update
- sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev openjdk-7-jdk
+ sudo apt-get install git cmake cmake-curses-gui clang-3.6 \
+                      freeglut3-dev libxi-dev libxmu-dev \
+                      liblapack-dev swig3.0 python-dev openjdk-7-jdk
  sudo rm -f /usr/bin/cc /usr/bin/c++
  sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
  sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
  git clone https://github.com/opensim-org/opensim-core.git
  mkdir opensim_dependencies_build
  cd opensim_dependencies_build
- cmake ../opensim-core/dependencies/ -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' -DCMAKE_BUILD_TYPE=RelWithDebInfo
+ cmake ../opensim-core/dependencies/ \
+         -DCMAKE_INSTALL_PREFIX='~/opensim_dependencies_install' \
+         -DCMAKE_BUILD_TYPE=RelWithDebInfo
  make -j8
  cd ..
  mkdir opensim_build
  cd opensim_build
- cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=ON
+ cmake ../opensim-core \
+         -DCMAKE_INSTALL_PREFIX="~/opensim_install" \
+         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+         -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" \
+         -DBUILD_PYTHON_WRAPPING=ON \
+         -DBUILD_JAVA_WRAPPING=ON
  make -j8
  ctest -j8
  ```

--- a/README.md
+++ b/README.md
@@ -301,12 +301,12 @@ directory to your `PATH` environment variable.
  * `git clone https://github.com/opensim-org/opensim-core.git`
  * `mkdir opensim_dependencies_build`
  * `cd .\opensim_dependencies_build`
- * `cmake ..\opensim-core\dependencies -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"`
+ * `cmake ..\opensim-core\dependencies -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"`
  * `cmake --build . --config RelWithDebInfo -- /maxcpucount:8`
  * `cd ..`
  * `mkdir opensim_build`
  * `cd .\opensim_build`
- * `cmake ..\opensim-core -DCMAKE_INSTALL_PREFIX="..\opensim_install" -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install"`
+ * `cmake ..\opensim-core -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="..\opensim_install" -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install"`
  * `cmake --build . --config RelWithDebInfo -- /maxcpucount:8`
  * `ctest -C RelWithDebInfo --parallel 8`
 

--- a/README.md
+++ b/README.md
@@ -751,6 +751,8 @@ ctest -j8
 ##### Ubuntu 15.10
 In **Terminal** --
 ```shell
+sudo apt-add-repository ppa:fenics-packages/fenics
+sudo apt-get update
 sudo apt-get install git cmake cmake-curses-gui \
                      freeglut3-dev libxi-dev libxmu-dev \
                      liblapack-dev swig3.0 python-dev openjdk-7-jdk

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Building from the source code
 
 We support a few ways of building OpenSim:
 
-1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient). 
-2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode).
+1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient-windows). 
+2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode). In a rush? Use [these instructions](#for-the-impatient-mac-os-x).
 3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles).
 
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,28 @@ directory to your `PATH` environment variable.
 5. Add **C:/opensim-core/bin;** to the front of of the text field. Don't forget
    the semicolon!
 
+#### For the impatient
+
+* Get **Visual Studio Community** from [here](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
+ * Choose *Custom' installation*.
+ * Choose *Programming Languages* -> *Visual C++*.
+* Get **git** from [here](https://git-scm.com/downloads).
+ * Choose *Use Git from the Windows Command Prompt*.
+* Get **CMake** from [here](https://cmake.org/download/).
+ * Choose *Add CMake to the system PATH for all users*.
+* In **PowerShell** --
+ * `git clone https://github.com/opensim-org/opensim-core.git`
+ * `mkdir opensim_dependencies_build`
+ * `cd .\opensim_dependencies_build`
+ * `cmake ..\opensim-core\dependencies -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"`
+ * `cmake --build . --config RelWithDebInfo -- /maxcpucount:8`
+ * `cd ..`
+ * `mkdir opensim_build`
+ * `cd .\opensim_build`
+ * `cmake ..\opensim-core -DCMAKE_INSTALL_PREFIX="..\opensim_install" -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install"`
+ * `cmake --build . --config RelWithDebInfo -- /maxcpucount:8`
+ * `ctest -C RelWithDebInfo --parallel 8`
+
 
 On Mac OSX using Xcode
 ======================

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Your changes will only take effect in new terminal windows.
  * `sudo add-apt-repository ppa:george-edison55/cmake-3.x`
  * `sudo apt-add-repository ppa:fenics-packages/fenics-exp`
  * `sudo apt-get update`
- * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0`
+ * `sudo apt-get install git cmake cmake-curses-gui clang-3.6 freeglut3-dev libxi-dev libxmu-dev liblapack-dev swig3.0 python-dev`
  * `sudo rm -f /usr/bin/cc /usr/bin/c++`
  * `sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc`
  * `sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++`

--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ Your changes will only take effect in new terminal windows.
 #### For the impatient (Mac OS X)
 ##### Mac OS X 10.11
 Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement.
+
 In **Terminal** --
 ```shell
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"


### PR DESCRIPTION
Update readme to include build from source instructions for users who are familiar with their development environment and want to get started quickly.

Instructions may need updating for Python/Matlab bindings.