### PR TITLE
Don't build examples and testing for simbody during super-build.

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -119,9 +119,11 @@ AddDependency(NAME       BTK
               CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
 
 
-AddDependency(NAME simbody
-              URL  https://github.com/simbody/simbody.git
-              TAG  ed67885db8983405e0724e63e62bf8e9316b2493)
+AddDependency(NAME       simbody
+              URL        https://github.com/simbody/simbody.git
+              TAG        ed67885db8983405e0724e63e62bf8e9316b2493
+              CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
+              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF)
 
 
 #######################

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -61,8 +61,9 @@ endfunction()
 #   CMAKE_ARGS -- (Optional) A CMake list of arguments to be passed to CMake 
 #                 while building the project.
 function(AddDependency)
-    set(onevalueargs NAME URL TAG CMAKE_ARGS)
-    cmake_parse_arguments(DEP "" "${onevalueargs}" "" ${ARGN})
+    set(onevalueargs NAME URL TAG)
+    set(multiValueArgs CMAKE_ARGS)
+    cmake_parse_arguments(DEP "" "${onevalueargs}" "${multiValueArgs}" ${ARGN})
 
     # Check for presence of required arguments.
     if(NOT DEP_NAME OR NOT DEP_URL OR NOT DEP_TAG)
@@ -122,8 +123,8 @@ AddDependency(NAME       BTK
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
               TAG        ed67885db8983405e0724e63e62bf8e9316b2493
-              CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
-              CMAKE_ARGS -DBUILD_TESTING:BOOL=OFF)
+              CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
+                         -DBUILD_TESTING:BOOL=OFF)
 
 
 #######################


### PR DESCRIPTION
To save time, turn OFF building examples and tests for simbody when built as a dependency during super-build.