### PR TITLE
[swig] Remove some swig warnings.

### DIFF
--- a/Bindings/Python/swig/python_common.i
+++ b/Bindings/Python/swig/python_common.i
@@ -70,6 +70,11 @@ using namespace SimTK;
 %rename(printToXML) OpenSim::XMLDocument::print();
 %rename(printToFile) OpenSim::Storage::print;
 
+// Ignore
+// ======
+// To suppress a warning.
+%ignore OpenSim::Property<std::string>::appendValue(std::string const *);
+
 
 // Memory management
 // =================

--- a/Bindings/Python/swig/python_preliminaries.i
+++ b/Bindings/Python/swig/python_preliminaries.i
@@ -21,6 +21,7 @@ own project.
 /* If needed %extend will be used, these operators are not supported.*/
 %ignore *::operator[];
 %ignore *::operator=;
+%ignore *::operator++;
 
 // For reference (doesn't work and should not be necessary):
 // %rename(__add__) operator+;

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -46,6 +46,14 @@ using namespace SimTK;
 
 %rename(appendNative) OpenSim::ForceSet::append(Force* aForce);
 
+
+// Ignore
+// ======
+// To suppress a warning.
+%ignore OpenSim::TransformAxis::setFunction(OpenSim::Function const &);
+%ignore OpenSim::CoordinateCouplerConstraint::setFunction(OpenSim::Function *);
+
+
 // Memory management
 // =================
 /*

--- a/OpenSim/Simulation/Model/Appearance.h
+++ b/OpenSim/Simulation/Model/Appearance.h
@@ -33,12 +33,14 @@ namespace OpenSim {
 class Body;
 class Model;
 
+#ifndef SWIG // TODO suppress swig warning 315.
 /**
 VisualRepresentation is the OpenSim name used across the OpenSim API, it is an 
 that describes in what form is Geometry displayed:  
 DrawPoints, DrawWireframe, DrawSurface are supported.
 */
 using VisualRepresentation = SimTK::DecorativeGeometry::Representation;
+#endif
 
 /**
 SurfaceProperties class holds the appearance properties of a piece of Geometry 

--- a/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
@@ -56,8 +56,10 @@ public:
     //--------------------------------------------------------------------------
     // CONSTRUCTION
     //--------------------------------------------------------------------------
+    #ifndef SWIG // TODO suppress swig warning 315.
     /** Constructors are defined by the OffsetFrame base class */
     using OffsetFrame<PhysicalFrame>::OffsetFrame;
+    #endif
 
     ~PhysicalOffsetFrame() final {}
 


### PR DESCRIPTION
This PR removes some swig warnings by ignoring certain functions and using `#ifndef SWIG` macros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/772)
<!-- Reviewable:end -->
