### PR TITLE
Move methods to attach Geometry to frames into Frame class and rename methods for clarity.

### DIFF
--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -373,7 +373,7 @@ void testClutchedPathSpring()
     // body the path spring is connected to at both ends
     OpenSim::Body* block =
         new OpenSim::Body("block", mass ,Vec3(0),  mass*Inertia::brick(0.2, 0.1, 0.1));
-    block->addMeshGeometry("box.vtp");
+    block->attachMeshGeometry("box.vtp");
     block->scale(Vec3(0.2, 0.1, 0.1), false);
 
     double dh = mass*gravity_vec(1)/stiffness;
@@ -574,7 +574,7 @@ void testBodyActuator()
                                              blockMassCenter, blockInertia);
 
     // Add display geometry to the block to visualize in the GUI
-    block->addMeshGeometry("block.vtp");
+    block->attachMeshGeometry("block.vtp");
 
     Vec3 locationInParent(0, blockSideLength / 2, 0), orientationInParent(0), 
         locationInBody(0), orientationInBody(0);
@@ -757,7 +757,7 @@ void testActuatorsCombination()
                                     blockMassCenter, blockInertia);
 
     // Add display geometry to the block to visualize in the GUI
-    block->addMeshGeometry("block.vtp");
+    block->attachMeshGeometry("block.vtp");
 
     // Make a FreeJoint from block to ground
     Vec3 locationInParent(0, blockSideLength/2, 0), orientationInParent(0), //locationInParent(0, blockSideLength, 0)

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -233,7 +233,7 @@ void simulateMuscle(
 
     // Get a reference to the model's ground body
     Ground& ground = model.updGround();
-    ground.addMeshGeometry("box.vtp");
+    ground.attachMeshGeometry("box.vtp");
     //ground.updDisplayer()->setScaleFactors(Vec3(anchorWidth, anchorWidth, 2*anchorWidth));
 
     OpenSim::Body * ball = new OpenSim::Body("ball", 
@@ -241,7 +241,7 @@ void simulateMuscle(
                         Vec3(0),  
                         ballMass*SimTK::Inertia::sphere(ballRadius));
     
-    ball->addMeshGeometry("sphere.vtp");
+    ball->attachMeshGeometry("sphere.vtp");
     //ball->updDisplayer()->setScaleFactors(Vec3(2*ballRadius));
     // ball connected  to ground via a slider along X
     double xSinG = optimalFiberLength*cos(pennationAngle)+tendonSlackLength;

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -55,7 +55,7 @@ int main()
             
         // Get the ground body
         Ground& ground = osimModel.updGround();
-        ground.addMeshGeometry("checkered_floor.vtp");
+        ground.attachMeshGeometry("checkered_floor.vtp");
 
         // create linkage body
         double linkageMass = 0.001, linkageLength = 0.5, linkageDiameter = 0.06;
@@ -76,7 +76,7 @@ int main()
         linkage1->addGeometry(cyl);
 
         Sphere sphere(0.1);
-        linkage1->addGeometry(sphere);
+        linkage1->attachGeometry(sphere);
          
         // Create a second linkage body
         OpenSim::Body* linkage2 = new OpenSim::Body(*linkage1);
@@ -91,7 +91,7 @@ int main()
         Inertia blockInertia = blockMass*Inertia::brick(blockSideLength, blockSideLength, blockSideLength);
         OpenSim::Body *block = new OpenSim::Body("block", blockMass, blockMassCenter, blockInertia);
         Brick brick(SimTK::Vec3(0.05, 0.05, 0.05));
-        block->addGeometry(brick);
+        block->attachGeometry(brick);
 
         // Create 1 degree-of-freedom pin joints between the bodies to create a kinematic chain from ground through the block
         Vec3 orientationInGround(0), locationInGround(0), locationInParent(0.0, linkageLength, 0.0), orientationInChild(0), locationInChild(0);

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -75,8 +75,7 @@ int main()
         cyl.setFrameName("Cyl1_frame");
         linkage1->addGeometry(cyl);
 
-        Sphere sphere(0.1);
-        linkage1->attachGeometry(sphere);
+        linkage1->attachGeometry(Sphere(0.1));
          
         // Create a second linkage body
         OpenSim::Body* linkage2 = new OpenSim::Body(*linkage1);
@@ -90,8 +89,7 @@ int main()
         Vec3 blockMassCenter(0);
         Inertia blockInertia = blockMass*Inertia::brick(blockSideLength, blockSideLength, blockSideLength);
         OpenSim::Body *block = new OpenSim::Body("block", blockMass, blockMassCenter, blockInertia);
-        Brick brick(SimTK::Vec3(0.05, 0.05, 0.05));
-        block->attachGeometry(brick);
+        block->attachGeometry(Brick(SimTK::Vec3(0.05, 0.05, 0.05)));
 
         // Create 1 degree-of-freedom pin joints between the bodies to create a kinematic chain from ground through the block
         Vec3 orientationInGround(0), locationInGround(0), locationInParent(0.0, linkageLength, 0.0), orientationInChild(0), locationInChild(0);

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -93,7 +93,7 @@ int main()
 
         // Add display geometry to the ground to visualize in the Visualizer and GUI
         // add a checkered floor
-        ground.addMeshGeometry("checkered_floor.vtp");
+        ground.attachMeshGeometry("checkered_floor.vtp");
         // add anchors for the muscles to be fixed to
         Brick leftAnchorGeometry(SimTK::Vec3(0.05, 0.05, 0.05));
         leftAnchorGeometry.upd_Appearance().set_color(SimTK::Vec3(0.0, 1.0, 0.0));
@@ -131,11 +131,11 @@ int main()
         OpenSim::Body *block = new OpenSim::Body("block", blockMass, blockMassCenter, blockInertia);
 
         // Add display geometry to the block to visualize in the GUI
-        block->addMeshGeometry("block.vtp");
+        block->attachMeshGeometry("block.vtp");
         
         Sphere sphereGeometry(0.1);
-        sphereGeometry.setFrameName(block->getName());
-        block->addGeometry(sphereGeometry);
+        // Use attachGeometry to set frame name & addGeometry
+        block->attachGeometry(sphereGeometry);
         
         // FREE JOINT
 

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -133,9 +133,8 @@ int main()
         // Add display geometry to the block to visualize in the GUI
         block->attachMeshGeometry("block.vtp");
         
-        Sphere sphereGeometry(0.1);
         // Use attachGeometry to set frame name & addGeometry
-        block->attachGeometry(sphereGeometry);
+        block->attachGeometry(Sphere(0.1));
         
         // FREE JOINT
 

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -65,9 +65,9 @@ int main()
         Ground& ground = osimModel.updGround();
 
         // Add display geometry to the ground to visualize in the GUI
-        ground.addMeshGeometry("ground.vtp");
-        ground.addMeshGeometry("anchor1.vtp");
-        ground.addMeshGeometry("anchor2.vtp");
+        ground.attachMeshGeometry("ground.vtp");
+        ground.attachMeshGeometry("anchor1.vtp");
+        ground.attachMeshGeometry("anchor2.vtp");
 
         // BLOCK BODY
 
@@ -82,7 +82,7 @@ int main()
             blockMassCenter, blockInertia);
 
         // Add display geometry to the block to visualize in the GUI
-        block->addMeshGeometry("block.vtp");
+        block->attachMeshGeometry("block.vtp");
 
         // FREE JOINT
 

--- a/OpenSim/Examples/checkEnvironment/test.cpp
+++ b/OpenSim/Examples/checkEnvironment/test.cpp
@@ -69,8 +69,7 @@ int main()
         OpenSim::Body *block = new OpenSim::Body("block", blockMass, blockMassCenter, blockInertia);
 
         // Add display geometry to the block to visualize in the GUI
-        Brick brick(SimTK::Vec3(0.05, 0.05, 0.05));
-        block->attachGeometry(brick);
+        block->attachGeometry(Brick(SimTK::Vec3(0.05, 0.05, 0.05)));
 
         // FREE JOINT
 

--- a/OpenSim/Examples/checkEnvironment/test.cpp
+++ b/OpenSim/Examples/checkEnvironment/test.cpp
@@ -54,9 +54,9 @@ int main()
         Ground& ground = osimModel.updGround();
 
         // Add display geometry to the ground to visualize in the GUI
-        ground.addMeshGeometry("ground.vtp");
-        ground.addMeshGeometry("anchor1.vtp");
-        ground.addMeshGeometry("anchor2.vtp");
+        ground.attachMeshGeometry("ground.vtp");
+        ground.attachMeshGeometry("anchor1.vtp");
+        ground.attachMeshGeometry("anchor2.vtp");
 
         // BLOCK BODY
 
@@ -70,7 +70,7 @@ int main()
 
         // Add display geometry to the block to visualize in the GUI
         Brick brick(SimTK::Vec3(0.05, 0.05, 0.05));
-        block->addGeometry(brick);
+        block->attachGeometry(brick);
 
         // FREE JOINT
 

--- a/OpenSim/Sandbox/CMakeLists.txt
+++ b/OpenSim/Sandbox/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_subdirectory(TaskSpace)
+add_subdirectory(TaskSpace EXCLUDE_FROM_ALL)
 
 file(GLOB TO_COMPILE "future*.cpp")
 

--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -88,11 +88,13 @@ void Frame::attachMeshGeometry(const std::string& aGeometryFileName, const SimTK
 }
 
 
-void Frame::attachGeometry(OpenSim::Geometry& geom, const SimTK::Vec3 scale)
+void Frame::attachGeometry(const OpenSim::Geometry& geom, const SimTK::Vec3 scale)
 {
-    geom.set_scale_factors(scale);
-    geom.setFrameName(getName());
-    addGeometry(geom);
+    SimTK::ClonePtr<Geometry> clone = SimTK::ClonePtr<Geometry>(geom);
+    clone->set_scale_factors(scale);
+    clone->setFrameName(getName());
+    addGeometry(clone.updRef());
+
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -79,9 +79,17 @@ void Frame::extendAddGeometry(OpenSim::Geometry& geom) {
 }
 
 
-void Frame::addMeshGeometry(const std::string& aGeometryFileName, const SimTK::Vec3 scale)
+void Frame::attachMeshGeometry(const std::string& aGeometryFileName, const SimTK::Vec3 scale)
 {
     Mesh geom(aGeometryFileName);
+    geom.set_scale_factors(scale);
+    geom.setFrameName(getName());
+    addGeometry(geom);
+}
+
+
+void Frame::attachGeometry(OpenSim::Geometry& geom, const SimTK::Vec3 scale)
+{
     geom.set_scale_factors(scale);
     geom.setFrameName(getName());
     addGeometry(geom);

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -193,7 +193,11 @@ public:
     */
     void attachMeshGeometry(const std::string &aGeometryFileName, const SimTK::Vec3 scale = SimTK::Vec3(1));
     /** Add a piece of Geometry to the list of Geometry owned by the Frame.
-    Scale defaults to 1.0 but can be changed on the call line, for convenience.
+    This function is a convenience for ModelComponent::addGeometry() for the case 
+    of adding Geometry directly to a Frame, and thus sets the "frame name" of the 
+    Geometry to this frame. The provided geom is copied into the Frame, which will
+    own a copy of the Geometry so any changes you make to geom after calling this 
+    method will not have an effect.
     */
     void attachGeometry(OpenSim::Geometry& geom, const SimTK::Vec3 scale = SimTK::Vec3(1));
 

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -189,9 +189,13 @@ public:
     ///@}
 
     /** Add a Mesh specified by file name to the list of Geometry owned by the Frame.
-    Scale defaults to 1.0 but can be changed on the call line. For convenience 
+    Scale defaults to 1.0 but can be changed on the call line for convenience.
     */
-    void addMeshGeometry(const std::string &aGeometryFileName, const SimTK::Vec3 scale = SimTK::Vec3(1));
+    void attachMeshGeometry(const std::string &aGeometryFileName, const SimTK::Vec3 scale = SimTK::Vec3(1));
+    /** Add a piece of Geometry to the list of Geometry owned by the Frame.
+    Scale defaults to 1.0 but can be changed on the call line, for convenience.
+    */
+    void attachGeometry(OpenSim::Geometry& geom, const SimTK::Vec3 scale = SimTK::Vec3(1));
 
 protected:
     /** @name Component Extension methods.

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -199,7 +199,7 @@ public:
     own a copy of the Geometry so any changes you make to geom after calling this 
     method will not have an effect.
     */
-    void attachGeometry(OpenSim::Geometry& geom, const SimTK::Vec3 scale = SimTK::Vec3(1));
+    void attachGeometry(const OpenSim::Geometry& geom, const SimTK::Vec3 scale = SimTK::Vec3(1));
 
 protected:
     /** @name Component Extension methods.

--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -360,11 +360,7 @@ public:
         }
     /// destructor
     ~Sphere() {}
-    /// Convenience method to set radius
-    void setSphereRadius(double radius)
-    {
-        upd_radius() = radius;
-    }
+
 protected:
     /// Virtual method to map Sphere to Array of SimTK::DecorativeGeometry.
     /// Appearance, Transforms are handled by base Geometry class

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -118,20 +118,6 @@ void Body::extendConnectToModel(Model& aModel)
 //=============================================================================
 // GET AND SET
 //=============================================================================
-//_____________________________________________________________________________
-/**
- * Add display geometry to body.
- *
- * @param aGeometryFileName Geometry filename.
- */
-void Body::addMeshGeometry(const std::string& aGeometryFileName, const SimTK::Vec3 scale)
-{
-    Mesh geom(aGeometryFileName);
-    geom.set_scale_factors(scale);
-    if (geom.getFrameName() == "")
-        geom.setFrameName(getName());
-    addGeometry(geom);
-}
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/SimbodyEngine/Body.h
+++ b/OpenSim/Simulation/SimbodyEngine/Body.h
@@ -95,11 +95,6 @@ public:
     void scale(const SimTK::Vec3& aScaleFactors, bool aScaleMass = false);
     void scaleInertialProperties(const SimTK::Vec3& aScaleFactors, bool aScaleMass = true);
     void scaleMass(double aScaleFactor);
-    /** Add a Mesh specified by file name to the list of Geometry owned by the Body.
-        Transform is assumed to be the same as the Body.
-        Scale defaults to 1.0 but can be changed on the call line.
-    */
-    void addMeshGeometry(const std::string &aGeometryFileName, const SimTK::Vec3 scale = SimTK::Vec3(1));
  protected:
 
     // Model component interface.

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -1007,8 +1007,7 @@ void testRollingOnSurfaceConstraint()
     Ground& ground = osimModel->updGround();;
     Mesh arrowGeom("arrow.vtp");
     arrowGeom.setColor(Vec3(1, 0, 0));
-    arrowGeom.setFrameName("ground");
-    ground.addGeometry(arrowGeom);
+    ground.attachGeometry(arrowGeom);
 
     //OpenSim rod
     auto osim_rod = new OpenSim::Body("rod", mass, comInRod, inertiaAboutCom);

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1664,7 +1664,7 @@ void testCustomVsCompoundJoint()
     //OpenSim thigh
     OpenSim::Body osim_thigh("thigh", femurMass.getMass(),
         femurMass.getMassCenter(), femurMass.getInertia());
-    osim_thigh.addMeshGeometry("femur.vtp");
+    osim_thigh.attachMeshGeometry("femur.vtp");
 
     // Define hip transform in terms of coordinates and axes for custom joint
     SpatialTransform hipTransform;
@@ -1693,7 +1693,7 @@ void testCustomVsCompoundJoint()
     // Add OpenSim shank via a knee joint
     OpenSim::Body osim_shank("shank", tibiaMass.getMass(),
         tibiaMass.getMassCenter(), tibiaMass.getInertia());
-    osim_shank.addMeshGeometry("tibia.vtp");
+    osim_shank.attachMeshGeometry("tibia.vtp");
 
     // Define knee coordinates and axes for custom joint spatial transform
     SpatialTransform kneeTransform;
@@ -1729,7 +1729,7 @@ void testCustomVsCompoundJoint()
     //OpenSim thigh
     OpenSim::Body thigh2("thigh2", femurMass.getMass(),
         femurMass.getMassCenter(), femurMass.getInertia());
-    thigh2.addMeshGeometry("femur.vtp");
+    thigh2.attachMeshGeometry("femur.vtp");
 
     // create compound hip joint
     CompoundJoint hip2("hip2", ground2, hipInPelvis, oInP,
@@ -1742,7 +1742,7 @@ void testCustomVsCompoundJoint()
     // Add OpenSim shank via a knee joint
     OpenSim::Body shank2("shank2", tibiaMass.getMass(),
         tibiaMass.getMassCenter(), tibiaMass.getInertia());
-    shank2.addMeshGeometry("tibia.vtp");
+    shank2.attachMeshGeometry("tibia.vtp");
 
     // create custom knee joint
     CustomJoint knee2("knee2", thigh2, kneeInFemur, Vec3(0),
@@ -1946,11 +1946,10 @@ void testAutomaticJointReversal()
     //thigh.addGeometry(Cylinder(0.035, 0.4));
     thigh->upd_geometry(0).setColor(SimTK::Vec3(0, 0, 1));   // BLUE
     
-    //TODO fix Bug: ModleComponent::addGeometry assumes ownership but does not
-    // take a pointer to heap allocated Geometry
-    shank->addGeometry(*new Cylinder(0.02, 0.243800));
+    //ModelComponent::addGeometry makes a copy of the passed in Geometry
+    shank->addGeometry(Cylinder(0.02, 0.243800));
     shank->upd_geometry(0).setColor(SimTK::Vec3(0, 1, 1));   // CYAN
-    foot->addGeometry(*new Brick(SimTK::Vec3(0.09, 0.025, 0.06)));
+    foot->addGeometry(Brick(SimTK::Vec3(0.09, 0.025, 0.06)));
     foot->upd_geometry(0).setColor(SimTK::Vec3(1, 0, 0));    // RED
 
     // add them to the model

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1948,10 +1948,10 @@ void testAutomaticJointReversal()
     
     //ModelComponent::addGeometry makes a copy of the passed in Geometry
     Cylinder cyl(0.02, 0.243800);
-    shank->addGeometry(cyl);
+    shank->attachGeometry(cyl);
     shank->upd_geometry(0).setColor(SimTK::Vec3(0, 1, 1));   // CYAN
     Brick brick(SimTK::Vec3(0.09, 0.025, 0.06));
-    foot->addGeometry(brick);
+    foot->attachGeometry(brick);
     foot->upd_geometry(0).setColor(SimTK::Vec3(1, 0, 0));    // RED
 
     // add them to the model

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1947,9 +1947,11 @@ void testAutomaticJointReversal()
     thigh->upd_geometry(0).setColor(SimTK::Vec3(0, 0, 1));   // BLUE
     
     //ModelComponent::addGeometry makes a copy of the passed in Geometry
-    shank->addGeometry(Cylinder(0.02, 0.243800));
+    Cylinder cyl(0.02, 0.243800);
+    shank->addGeometry(cyl);
     shank->upd_geometry(0).setColor(SimTK::Vec3(0, 1, 1));   // CYAN
-    foot->addGeometry(Brick(SimTK::Vec3(0.09, 0.025, 0.06)));
+    Brick brick(SimTK::Vec3(0.09, 0.025, 0.06));
+    foot->addGeometry(brick);
     foot->upd_geometry(0).setColor(SimTK::Vec3(1, 0, 0));    // RED
 
     // add them to the model

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1947,11 +1947,9 @@ void testAutomaticJointReversal()
     thigh->upd_geometry(0).setColor(SimTK::Vec3(0, 0, 1));   // BLUE
     
     //ModelComponent::addGeometry makes a copy of the passed in Geometry
-    Cylinder cyl(0.02, 0.243800);
-    shank->attachGeometry(cyl);
+    shank->attachGeometry(Cylinder(0.02, 0.243800));
     shank->upd_geometry(0).setColor(SimTK::Vec3(0, 1, 1));   // CYAN
-    Brick brick(SimTK::Vec3(0.09, 0.025, 0.06));
-    foot->attachGeometry(brick);
+    foot->attachGeometry(Brick(SimTK::Vec3(0.09, 0.025, 0.06)));
     foot->upd_geometry(0).setColor(SimTK::Vec3(1, 0, 0));    // RED
 
     // add them to the model

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -178,7 +178,7 @@ void testExpressionBasedCoordinateForce()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body ball("ball", mass ,Vec3(0),  mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // Add joints
@@ -274,7 +274,7 @@ void testExpressionBasedPointToPointForce()
     //OpenSim bodies
     const Ground& ground = model->getGround();
     OpenSim::Body ball("ball", mass, Vec3(0), mass*SimTK::Inertia::sphere(ball_radius));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // define body's joint
@@ -368,7 +368,7 @@ void testPathSpring()
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body pulleyBody("PulleyBody", mass ,Vec3(0),  mass*SimTK::Inertia::brick(0.1, 0.1, 0.1));
     OpenSim::Body block("block", mass ,Vec3(0),  mass*SimTK::Inertia::brick(0.2, 0.1, 0.1));
-    block.addMeshGeometry("box.vtp");
+    block.attachMeshGeometry("box.vtp");
     block.scale(Vec3(0.2, 0.1, 0.1), false);
     
     WrapCylinder* pulley = new WrapCylinder();
@@ -482,7 +482,7 @@ void testSpringMass()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body ball("ball", mass ,Vec3(0),  mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // Add joints
@@ -581,7 +581,7 @@ void testBushingForce()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body ball("ball", mass, Vec3(0), mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // Add joints
@@ -696,7 +696,7 @@ void testFunctionBasedBushingForce()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body ball("ball", mass, Vec3(0), mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // Add joints
@@ -807,7 +807,7 @@ void testExpressionBasedBushingForceTranslational()
     const Ground& ground = osimModel->getGround();
 
     OpenSim::Body ball("ball", mass, Vec3(0), mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
     
     SliderJoint sliderY("", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
@@ -824,7 +824,7 @@ void testExpressionBasedBushingForceTranslational()
     // Create base body and attach it to ground with a weld
 
     OpenSim::Body base("base_body", mass, Vec3(0), mass*SimTK::Inertia::sphere(0.1));
-    base.addMeshGeometry("sphere.vtp");
+    base.attachMeshGeometry("sphere.vtp");
     base.scale(Vec3(ball_radius), false);
     
     WeldJoint weld("", ground, Vec3(0), Vec3(0), base, Vec3(0), Vec3(0));
@@ -1209,7 +1209,7 @@ void testCoordinateLimitForce()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body ball("ball", mass ,Vec3(0),  mass*SimTK::Inertia::sphere(0.1));
-    ball.addMeshGeometry("sphere.vtp");
+    ball.attachMeshGeometry("sphere.vtp");
     ball.scale(Vec3(ball_radius), false);
 
     // Add joints
@@ -1353,7 +1353,7 @@ void testCoordinateLimitForceRotational()
     //OpenSim bodies
     const Ground& ground = osimModel->getGround();;
     OpenSim::Body block("block", mass ,Vec3(0),  mass*SimTK::Inertia::brick(edge,edge,edge));
-    block.addMeshGeometry("box.vtp");
+    block.attachMeshGeometry("box.vtp");
     block.scale(Vec3(edge), false);
 
     // Add joints
@@ -1479,7 +1479,7 @@ void testExternalForce()
     //OpenSim bodies
     const Ground& ground = model.getGround();
     OpenSim::Body tower("tower", mass, Vec3(0), mass*SimTK::Inertia::brick(0.1, 1.0, 0.2));
-    tower.addMeshGeometry("box.vtp");
+    tower.attachMeshGeometry("box.vtp");
     tower.scale(Vec3(0.1, 1.0, 0.2));
 
     // Add joint connecting the tower to the ground and associate joint to tower body
@@ -1624,7 +1624,7 @@ void testExternalForce()
     // Add joint connecting a "sensor" reference to the ground in which to describe
     // the applied external force
     OpenSim::Body sensor("sensor", 1 ,Vec3(0),  SimTK::Inertia::brick(0.1, 0.1, 0.1));
-    sensor.addMeshGeometry("box.vtp");
+    sensor.attachMeshGeometry("box.vtp");
     sensor.scale(Vec3(0.02, 0.1, 0.01));
 
     // locate joint at 0.3m above tower COM

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -670,7 +670,7 @@ void testProbesUsingMillardMuscleSimulation()
     Inertia blockInertia = blockMass * Inertia::brick(Vec3(blockSideLength/2));
     OpenSim::Body *block = new OpenSim::Body("block", blockMass, Vec3(0),
                                              blockInertia);
-    block->addMeshGeometry("block.vtp");
+    block->attachMeshGeometry("block.vtp");
 
     // Create slider joint between ground and block.
     SliderJoint* prismatic = new SliderJoint("prismatic", ground, Vec3(0), Vec3(0),

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -208,14 +208,14 @@ void simulateMuscle(
 
     // Get a reference to the model's ground body
     Ground& ground = model.updGround();
-    ground.addMeshGeometry("box.vtp");
+    ground.attachMeshGeometry("box.vtp");
 
     OpenSim::Body * ball = new OpenSim::Body("ball",
         ballMass,
         Vec3(0),
                         ballMass*SimTK::Inertia::sphere(ballRadius));
 
-    ball->addMeshGeometry("sphere.vtp");
+    ball->attachMeshGeometry("sphere.vtp");
     // ball connected  to ground via a slider along X
     double xSinG = optimalFiberLength*cos(pennationAngle) + tendonSlackLength;
 


### PR DESCRIPTION
Address issues brought up by @chrisdembia while creating hopper example in particular:
1. Add a convenience method attachGeometry to allow for adding Geometry to any "Frame" object that sets the frame name on the Geometry internally.
2. Renamed the method addMeshGeometry to attachMeshGeometry for consistency with 1. above and to avoid having methods that have same name (addGeometry) and different meaning/function which was quite confusing.
3. Both methods above have been moved to Frame instead of Body for added flexibility.
4. Removed extra methods to access properties of concrete Geometry classes as Property accessor methods should be enough. The meat of the change is in Frame.* and elimination of method in Body.*, the rest is all text substitution due to renaming and simplifying examples as a result.