### PR TITLE
Make instructions script-able for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,12 +730,13 @@ Your changes will only take effect in new terminal windows.
 ##### Ubuntu 14.04 Trusty Tahr
 In **Terminal** --
 ```shell
-sudo add-apt-repository ppa:george-edison55/cmake-3.x
-sudo apt-add-repository ppa:fenics-packages/fenics-exp
+sudo add-apt-repository --yes ppa:george-edison55/cmake-3.x
+sudo apt-add-repository --yes ppa:fenics-packages/fenics-exp
 sudo apt-get update
-sudo apt-get install git cmake cmake-curses-gui clang-3.6 \
-                     freeglut3-dev libxi-dev libxmu-dev \
-                     liblapack-dev swig3.0 python-dev openjdk-7-jdk
+sudo apt-get --yes install git cmake cmake-curses-gui clang-3.6 \
+                           freeglut3-dev libxi-dev libxmu-dev \
+                           liblapack-dev swig3.0 python-dev \
+                           openjdk-7-jdk
 sudo rm -f /usr/bin/cc /usr/bin/c++
 sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc
 sudo ln -s /usr/bin/clang++-3.6 /usr/bin/c++
@@ -762,11 +763,12 @@ ctest -j8
 ##### Ubuntu 15.10 Wily Werewolf
 In **Terminal** --
 ```shell
-sudo apt-add-repository ppa:fenics-packages/fenics
+sudo apt-add-repository --yes ppa:fenics-packages/fenics
 sudo apt-get update
-sudo apt-get install git cmake cmake-curses-gui \
-                     freeglut3-dev libxi-dev libxmu-dev \
-                     liblapack-dev swig3.0 python-dev openjdk-8-jdk
+sudo apt-get --yes install git cmake cmake-curses-gui \
+                           freeglut3-dev libxi-dev libxmu-dev \
+                           liblapack-dev swig3.0 python-dev \
+                           openjdk-8-jdk
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 git clone https://github.com/opensim-org/opensim-core.git
 mkdir opensim_dependencies_build
@@ -787,4 +789,3 @@ cmake ../opensim-core \
 make -j8
 ctest -j8
 ```
-  


### PR DESCRIPTION
These changes allow users to create a shell script and run it without interaction.
Currently users have to copy-paste and interactively choose 'y or yes' for questions.