### PR TITLE
Save marker error to a .txt file, and update marker position .sto file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Other Changes
 - Lepton was upgraded to the latest version (PR #349)
 - Made Object::print a const member function (PR #191)
 - Improved the testOptimization/OptimizationExample to reduce the runtime (PR #416)
+- InverseKinematics tool outputs marker error .sto file if report error flag is true.
+- Marker location file output name in IK changed to reflect trial name for batch processing. 
 
 Documentation
 --------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,7 @@ Kate Saul          |              |Original MuscleAnalysis
 Jack Middleton     |              |Initial Simbody integration
 Jeffrey Reinbolt   |              |Static Optimization; Examples; Musculoskeletal modeling
 Shrinidhi Lakshmikanth|@klshrinidhi|Data interface
+Andrew LaPre       |@ankela       |IK error output to file
 
 Contributor License Agreement
 -----------------------------


### PR DESCRIPTION
This update writes time, marker error squared, error rms and max error
to a .txt file with a filename appropriate to the trial data when the
"report_errors" flag is true.   It also modifies the name of the marker
location file to reflect the trial name when the
"report_marker_locations" flag is true.