### PR TITLE
Export a StatesTrajectory to a TimeSeriesTable

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -127,7 +127,7 @@ protected:
     /** Validate the given row. 
 
     \throws InvalidRow If the timestamp for the row breaks strictly increasing
-                       property of the indpedent column.                      */
+                       property of the indepedent column.                     */
     void validateRow(size_t rowIndex,
                      const double& time, 
                      const RowVector& row) const override {

--- a/OpenSim/Sandbox/futureStatesTrajectoryUsage.cpp
+++ b/OpenSim/Sandbox/futureStatesTrajectoryUsage.cpp
@@ -41,5 +41,9 @@ int main() {
                   << std::endl;
     }
 
+    // Export to data table.
+    // ---------------------
+    auto table = states.exportToTable(model);
+
     return 0;
 }

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -108,6 +108,7 @@ bool StatesTrajectory::isCompatibleWith(const Model& model) const {
     return true;
 }
 
+// Hide this function from other translation units.
 namespace {
     template <typename T>
     std::vector<std::string> createVector(const T& strings) {

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -108,6 +108,55 @@ bool StatesTrajectory::isCompatibleWith(const Model& model) const {
     return true;
 }
 
+namespace {
+    template <typename T>
+    std::vector<std::string> createVector(const T& strings) {
+        std::vector<std::string> vec;
+        for (int i = 0; i < strings.size(); ++i)
+            vec.push_back(strings[i]);
+        return vec;
+    }
+    template <>
+    std::vector<std::string> createVector(
+            const std::vector<std::string>& strings) {
+        return strings;
+    }
+}
+
+TimeSeriesTable StatesTrajectory::exportToTable(const Model& model,
+        const std::vector<std::string>& requestedStateVars) const {
+    // This code is based on DelimFileAdapter::extendRead().
+    TimeSeriesTable table;
+
+    // Set the column labels as metadata.
+    std::vector<std::string> stateVars = requestedStateVars.empty() ?
+            createVector(model.getStateVariableNames()) :
+            createVector(requestedStateVars);
+    ValueArray<std::string> valueArray;
+    for (const auto& labels : stateVars) {
+        valueArray.upd().push_back(SimTK::Value<std::string>(labels));
+    }
+    int numDepColumns = valueArray.size();
+    TimeSeriesTable::DependentsMetaData depMetadata;
+    depMetadata.setValueArrayForKey("labels", valueArray);
+    table.setDependentsMetaData(depMetadata);
+
+    // Fill up the table with the data.
+    for (size_t itime = 0; itime < getSize(); ++itime) {
+        const auto& state = get(itime);
+        TimeSeriesTable::RowVector row(numDepColumns);
+
+        // Get each state variable's value.
+        for (size_t icol = 0; icol < numDepColumns; ++icol) {
+            row[icol] = model.getStateVariableValue(state, stateVars[icol]);
+        }
+
+        table.appendRow(state.getTime(), row);
+    }
+
+    return table;
+}
+
 StatesTrajectory StatesTrajectory::createFromStatesStorage(
         const Model& model,
         const Storage& sto,

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -126,6 +126,10 @@ namespace {
 
 TimeSeriesTable StatesTrajectory::exportToTable(const Model& model,
         const std::vector<std::string>& requestedStateVars) const {
+
+    OPENSIM_THROW_IF(!isCompatibleWith(model),
+                     StatesTrajectory::IncompatibleModel, model);
+
     // This code is based on DelimFileAdapter::extendRead().
     TimeSeriesTable table;
 
@@ -278,4 +282,16 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
         const Model& model,
         const std::string& filepath) {
     return createFromStatesStorage(model, Storage(filepath));
+}
+
+StatesTrajectory::IncompatibleModel::IncompatibleModel(
+        const std::string& file, size_t line,
+        const std::string& func, const Model& model)
+        : OpenSim::Exception(file, line, func) {
+    std::ostringstream msg;
+    auto modelName = model.getName().empty() ? "<empty-name>" :
+                     model.getName();
+    msg << "The provided model '" << modelName << "' is not "
+            "compatible with the StatesTrajectory.";
+    addMessage(msg.str());
 }

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -328,11 +328,13 @@ public:
 
     /** Thrown when trying to use a StatesTrajectory with an incompatible model.
      * See isCompatibleWith(). */
+#ifndef SWIG
     class IncompatibleModel : public OpenSim::Exception {
     public:
         IncompatibleModel(const std::string& file, size_t line,
                           const std::string& func, const Model& model);
     };
+#endif
 
     /** Thrown when trying to create a StatesTrajectory from a states Storage,
      * and the Storage does not contain a column for every continuous state

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -288,10 +288,10 @@ public:
      * You must provide a model that is compatible with this trajectory,
      * since only the model knows the names of the state variables.
      *
-     * By default, all continuous state variables are written to table
+     * By default, all continuous state variables are written to the table
      * (one per column). If you only want some of them to be written to the
-     * table, use the `stateVars` argument to specify the full names
-     * (e.g., `knee/flexion/angle`) of the columns to write.
+     * table, use the `stateVars` argument to specify their full names
+     * (e.g., `knee/flexion/angle`).
      *
      * @code
      * auto allStateVars = states.exportToTable(model);
@@ -300,7 +300,7 @@ public:
      * @endcode
      *
      * @throws IncompatibleModel Thrown if the Model fails the check
-     *      isCompatableWith().
+     *      isCompatibleWith().
      */
     TimeSeriesTable exportToTable(const Model& model,
             const std::vector<std::string>& stateVars = {}) const;

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -27,6 +27,7 @@
 #include <Simbody.h>
 
 #include <OpenSim/Common/Exception.h>
+#include <OpenSim/Common/TimeSeriesTable.h>
 
 #include "osimSimulationDLL.h"
 
@@ -278,6 +279,31 @@ public:
      */
     bool isCompatibleWith(const Model& model) const;
     /// @}
+
+    /** Export the continuous state variables to a data table, perhaps to write
+     * to a file and postprocess in MATLAB/Python/Excel. The names of the
+     * columns in the table will be the full names of the continuous state
+     * variables (e.g., `knee/flexion/angle`).
+     *
+     * You must provide the model corresponding to this trajectory, since only
+     * the model knows the names of the state variables.
+     *
+     * By default, all continuous state variables are written to table
+     * (one per column). If you only want some of them to be written to the
+     * table, use the `stateVarNames` argument to specify the full names
+     * (e.g., `knee/flexion/angle`) of the columns to write.
+     *
+     * @code
+     * auto allStateVars = states.export(model);
+     * auto kneeStates = states.export(model, {"knee/flexion/value",
+     *                                         "knee/flexion/speed"});
+     * @endcode
+     *
+     * TODO exceptions if model is not compatible?
+     */
+    TimeSeriesTable export(const Model& model,
+                           const std::vector<std::string>& stateVarNames={})
+            const;
 
 private:
 

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -299,7 +299,8 @@ public:
      *                                                "knee/flexion/speed"});
      * @endcode
      *
-     * TODO exceptions if model is not compatible?
+     * @throws IncompatibleModel Thrown if the Model fails the check
+     *      isCompatableWith().
      */
     TimeSeriesTable exportToTable(const Model& model,
             const std::vector<std::string>& stateVars = {}) const;
@@ -325,9 +326,17 @@ public:
         }
     };
 
-    /** Thrown when trying to create a StatesTrajectory from a states Storage, and
-     * the Storage does not contain a column for every continuous state variable.
-     * */
+    /** Thrown when trying to use a StatesTrajectory with an incompatible model.
+     * See isCompatibleWith(). */
+    class IncompatibleModel : public OpenSim::Exception {
+    public:
+        IncompatibleModel(const std::string& file, size_t line,
+                          const std::string& func, const Model& model);
+    };
+
+    /** Thrown when trying to create a StatesTrajectory from a states Storage,
+     * and the Storage does not contain a column for every continuous state
+     * variable. */
     class MissingColumnsInStatesStorage : public OpenSim::Exception {
     public:
         MissingColumnsInStatesStorage(const std::string& file, size_t line,

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -285,25 +285,24 @@ public:
      * columns in the table will be the full names of the continuous state
      * variables (e.g., `knee/flexion/angle`).
      *
-     * You must provide the model corresponding to this trajectory, since only
-     * the model knows the names of the state variables.
+     * You must provide a model that is compatible with this trajectory,
+     * since only the model knows the names of the state variables.
      *
      * By default, all continuous state variables are written to table
      * (one per column). If you only want some of them to be written to the
-     * table, use the `stateVarNames` argument to specify the full names
+     * table, use the `stateVars` argument to specify the full names
      * (e.g., `knee/flexion/angle`) of the columns to write.
      *
      * @code
      * auto allStateVars = states.export(model);
-     * auto kneeStates = states.export(model, {"knee/flexion/value",
-     *                                         "knee/flexion/speed"});
+     * auto kneeStates = states.exportToTable(model, {"knee/flexion/value",
+     *                                               "knee/flexion/speed"});
      * @endcode
-     *
+     *g
      * TODO exceptions if model is not compatible?
      */
-    TimeSeriesTable export(const Model& model,
-                           const std::vector<std::string>& stateVarNames={})
-            const;
+    TimeSeriesTable exportToTable(const Model& model,
+            const std::vector<std::string>& stateVars = {}) const;
 
 private:
 

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -294,11 +294,11 @@ public:
      * (e.g., `knee/flexion/angle`) of the columns to write.
      *
      * @code
-     * auto allStateVars = states.export(model);
+     * auto allStateVars = states.exportToTable(model);
      * auto kneeStates = states.exportToTable(model, {"knee/flexion/value",
-     *                                               "knee/flexion/speed"});
+     *                                                "knee/flexion/speed"});
      * @endcode
-     *g
+     *
      * TODO exceptions if model is not compatible?
      */
     TimeSeriesTable exportToTable(const Model& model,

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -37,6 +37,7 @@ using namespace SimTK;
 // TODO accessing acceleration-level outputs.
 
 // Big to-do's:
+// TODO createFromStatesStorage -> createFromDataTable, and change its purpose.
 // TODO convert to data table (specify which columns).
 // TODO append two StateTrajectories together.
 // TODO test modeling options (locked coordinates, etc.)
@@ -641,6 +642,39 @@ void testIntegrityChecks() {
     // and Z's both pass the check. 
 }
 
+void testExport() {
+    Model model("gait2354_simbody.osim");
+    model.initSystem();
+
+    const auto stateNames = model.getStateVariableNames();
+    Storage sto(statesStoFname);
+    auto states = StatesTrajectory::createFromStatesStorage(model, sto);
+
+    auto tableAll = states.export(model);
+    SimTK_TEST(tableAll.getNumColumns() == stateNames.getSize());
+    SimTK_TEST(tableAll.getNumRows() == states.getSize());
+
+
+    auto tableKnee = states.export(model, {"knee_l/knee_angle_l/value",
+                                           "knee_r/knee_angle_r/value",
+                                           "knee_r/knee_angle_r/speed"});
+
+    // TODO incompatible model?
+    // TODO try both a smaller and a larger model.
+
+    SimTK_TEST_MUST_THROW_EXC(
+            states.export(model, {"knee_l/knee_angle_l/value",
+                          "not_an_actual_state",
+                          "knee_r/knee_angle_r/speed"}),
+            TODO);
+    SimTK_TEST_MUST_THROW_EXC(
+            states.export(model, {"knee_l/knee_angle_l/value",
+                          "nor/is/this",
+                          "knee_r/knee_angle_r/speed"}),
+            TODO);
+    });
+    // TODO specifying names that are not actual state names.
+}
 
 int main() {
     SimTK_START_TEST("testStatesTrajectory");
@@ -673,6 +707,8 @@ int main() {
         SimTK_SUBTEST1(testFromStatesStorageInconsistentModel, statesStoFname);
         SimTK_SUBTEST(testFromStatesStorageUniqueColumnLabels);
         SimTK_SUBTEST(testFromStatesStorageAllRowsHaveSameLength);
+
+        SimTK_SUBTEST(testExport);
 
     SimTK_END_TEST();
 }

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -707,8 +707,9 @@ void testExport() {
     // Trying to export the trajectory with an incompatible model.
     {
         Model arm26("arm26.osim");
+        states.exportToTable(arm26);
         SimTK_TEST_MUST_THROW_EXC(states.exportToTable(arm26),
-                                  OpenSim::Exception); // TODO diff exception type
+                                  StatesTrajectory::IncompatibleModel);
     }
 
     // Exception if given a non-existant column name.
@@ -716,12 +717,12 @@ void testExport() {
             states.exportToTable(gait, {"knee_l/knee_angle_l/value",
                                         "not_an_actual_state",
                                         "knee_r/knee_angle_r/speed"}),
-            OpenSim::Exception); // TODO diff exception type
+            OpenSim::Exception);
     SimTK_TEST_MUST_THROW_EXC(
             states.exportToTable(gait, {"knee_l/knee_angle_l/value",
                                         "nor/is/this",
                                         "knee_r/knee_angle_r/speed"}),
-            OpenSim::Exception); // TODO diff exception type
+            OpenSim::Exception);
 }
 
 int main() {
@@ -743,7 +744,7 @@ int main() {
         SimTK_SUBTEST(testAppendTimesAreNonDecreasing);
         SimTK_SUBTEST(testCopying);
 
-        // Test creation of trajectory from astates storage.
+        // Test creation of trajectory from a states storage.
         // -------------------------------------------------
         // Using a pre-4.0 states storage file with old column names.
         SimTK_SUBTEST(testFromStatesStoragePre40CorrectStates);
@@ -756,6 +757,7 @@ int main() {
         SimTK_SUBTEST(testFromStatesStorageUniqueColumnLabels);
         SimTK_SUBTEST(testFromStatesStorageAllRowsHaveSameLength);
 
+        // Export to data table.
         SimTK_SUBTEST(testExport);
 
     SimTK_END_TEST();

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -672,8 +672,8 @@ void tableAndTrajectoryMatch(const Model& model,
 
             const auto& valueInStates = model.getStateVariableValue(
                     states[itime], stateName);
-            const auto& valueInTable =
-                    table.getDependentColumnAtIndex(icol)[itime];
+            const auto& column = table.getDependentColumnAtIndex(icol);
+            const auto& valueInTable = column[itime];
 
             SimTK_TEST(valueInStates == valueInTable);
         }
@@ -706,7 +706,6 @@ void testExport() {
     // Trying to export the trajectory with an incompatible model.
     {
         Model arm26("arm26.osim");
-        states.exportToTable(arm26);
         SimTK_TEST_MUST_THROW_EXC(states.exportToTable(arm26),
                                   StatesTrajectory::IncompatibleModel);
     }

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -654,6 +654,22 @@ void testExport() {
     SimTK_TEST(tableAll.getNumColumns() == stateNames.getSize());
     SimTK_TEST(tableAll.getNumRows() == states.getSize());
 
+    // Test that the data table has exactly the same numbers.
+    for (int itime = 0; itime < states.getSize(); ++itime) {
+        // Test time.
+        SimTK_TEST(tableAll.getIndependentColumn()[itime] ==
+                   states[itime].getTime());
+
+        // Test state values.
+        for (const auto& stateName : stateNames) {
+            tableAll.getDependentsMetaData().getValueForKey
+
+        }
+        for (int istate = 0; istate < stateNames.getSize(); ++istate) {
+
+        }
+
+    }
 
     auto tableKnee = states.export(model, {"knee_l/knee_angle_l/value",
                                            "knee_r/knee_angle_r/value",

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -37,7 +37,6 @@ using namespace SimTK;
 // TODO accessing acceleration-level outputs.
 
 // Big to-do's:
-// TODO createFromStatesStorage -> createFromDataTable, and change its purpose.
 // TODO convert to data table (specify which columns).
 // TODO append two StateTrajectories together.
 // TODO test modeling options (locked coordinates, etc.)


### PR DESCRIPTION
This PR introduces the method `StatesTrajectory::exportToTable()`. This allows people to easily save a data file containing state information, which is a more useful file format for using the states trajectory outside of OpenSim.

PR #730 should be merged before this gets merged, though they can be reviewed in any order.

Doxygen for this PR can be viewed at http://myosin.sourceforge.net/795/classOpenSim_1_1StatesTrajectory.html