### PR TITLE
Macros for outputs (OpenSim_DECLARE_OUTPUT())

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -820,7 +820,8 @@ setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value)
     }
 }
 
-int Component::constructOutputForStateVariable(const std::string& name)
+Component::OutputIndex
+Component::constructOutputForStateVariable(const std::string& name)
 {
     return constructOutput<double>(name,
             std::bind(&Component::getStateVariableValue,

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -820,9 +820,9 @@ setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value)
     }
 }
 
-void Component::constructOutputForStateVariable(const std::string& name)
+int Component::constructOutputForStateVariable(const std::string& name)
 {
-    constructOutput<double>(name,
+    return constructOutput<double>(name,
             std::bind(&Component::getStateVariableValue,
                 this, std::placeholders::_1, name),
             SimTK::Stage::Model);

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -820,8 +820,7 @@ setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value)
     }
 }
 
-Component::OutputIndex
-Component::constructOutputForStateVariable(const std::string& name)
+bool Component::constructOutputForStateVariable(const std::string& name)
 {
     return constructOutput<double>(name,
             std::bind(&Component::getStateVariableValue,

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1540,6 +1540,9 @@ template <class T> friend class ComponentMeasure;
      * methods yourself.
      */
     /// @{
+#ifndef SWIG
+    SimTK_DEFINE_UNIQUE_INDEX_TYPE(OutputIndex);
+#endif
     /** Construct an output for a member function of the same component. 
         The following must be true about componentMemberFunction, the function
         that returns the output:
@@ -1555,9 +1558,10 @@ template <class T> friend class ComponentMeasure;
 
        @see constructOutputForStateVariable()
      */
+
 #ifndef SWIG // SWIG can't parse the const at the end of the second argument.
     template <typename T, typename Class>
-    int constructOutput(const std::string& name,
+    OutputIndex constructOutput(const std::string& name,
             T(Class::*const componentMemberFunction)(const SimTK::State&) const,
             const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration) {
         // The `const` in `Class::*const componentMemberFunction` means this
@@ -1590,7 +1594,7 @@ template <class T> friend class ComponentMeasure;
       @see constructOutputForStateVariable()
     */
     template <typename T>
-    int constructOutput(const std::string& name, 
+    OutputIndex constructOutput(const std::string& name, 
         const std::function<T(const SimTK::State&)> outputFunction, 
         const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration) {
         // TODO OPENSIM_THROW_IF(_outputsTable.count(name) == 1,
@@ -1600,7 +1604,7 @@ template <class T> friend class ComponentMeasure;
         // TODO         ") already exists.");
         _outputsTable[name] = SimTK::ClonePtr<AbstractOutput>(
                 new Output<T>(name, outputFunction, dependsOn));
-        return 0;
+        return OutputIndex(0);
     }
 
     /** Construct an Output for a StateVariable. While this method is a
@@ -1612,7 +1616,7 @@ template <class T> friend class ComponentMeasure;
      *
      * @param name Name of the output, which must be the same as the name of
      * the corresponding state variable. */
-    int constructOutputForStateVariable(const std::string& name);
+    OutputIndex constructOutputForStateVariable(const std::string& name);
     
     /// @}
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1540,9 +1540,6 @@ template <class T> friend class ComponentMeasure;
      * methods yourself.
      */
     /// @{
-#ifndef SWIG
-    SimTK_DEFINE_UNIQUE_INDEX_TYPE(OutputIndex);
-#endif
     /** Construct an output for a member function of the same component. 
         The following must be true about componentMemberFunction, the function
         that returns the output:
@@ -1561,7 +1558,7 @@ template <class T> friend class ComponentMeasure;
 
 #ifndef SWIG // SWIG can't parse the const at the end of the second argument.
     template <typename T, typename Class>
-    OutputIndex constructOutput(const std::string& name,
+    bool constructOutput(const std::string& name,
             T(Class::*const componentMemberFunction)(const SimTK::State&) const,
             const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration) {
         // The `const` in `Class::*const componentMemberFunction` means this
@@ -1594,7 +1591,7 @@ template <class T> friend class ComponentMeasure;
       @see constructOutputForStateVariable()
     */
     template <typename T>
-    OutputIndex constructOutput(const std::string& name, 
+    bool constructOutput(const std::string& name, 
         const std::function<T(const SimTK::State&)> outputFunction, 
         const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration) {
         // TODO OPENSIM_THROW_IF(_outputsTable.count(name) == 1,
@@ -1604,7 +1601,7 @@ template <class T> friend class ComponentMeasure;
         // TODO         ") already exists.");
         _outputsTable[name] = SimTK::ClonePtr<AbstractOutput>(
                 new Output<T>(name, outputFunction, dependsOn));
-        return OutputIndex(0);
+        return true;
     }
 
     /** Construct an Output for a StateVariable. While this method is a
@@ -1616,7 +1613,7 @@ template <class T> friend class ComponentMeasure;
      *
      * @param name Name of the output, which must be the same as the name of
      * the corresponding state variable. */
-    OutputIndex constructOutputForStateVariable(const std::string& name);
+    bool constructOutputForStateVariable(const std::string& name);
     
     /// @}
 

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -168,7 +168,7 @@ private:
 /// Use these macros at the top of your component class declaration,
 /// near where you declare @ref Property properties.
 /// @{
-/** Create an output for a member function of the same component. 
+/** Create an output for a member function of this component.
  *  The following must be true about componentMemberFunction, the function
  *  that returns the output:
  *
@@ -200,7 +200,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    int _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) };\
+    OutputIndex _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
     /** @endcond                                                         */
 
 // Note: we could omit the T argument from the above macro by using the
@@ -237,10 +237,10 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    int _output_##oname { constructOutput<T>(#oname, func, ostage) };       \
+    OutputIndex _output_##oname { constructOutput<T>(#oname, func, ostage) }; \
     /** @endcond                                                         */
 
-/** Create an Output for a StateVariable in the same component. The provided
+/** Create an Output for a StateVariable in this component. The provided
  * name is both the name of the output and of the state variable.
  *
  * While this macro is a convenient way to construct an Output for a
@@ -269,7 +269,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    int _output_##oname { constructOutputForStateVariable(#oname) };        \
+    OutputIndex _output_##oname { constructOutputForStateVariable(#oname) }; \
     /** @endcond                                                         */
 /// @}
 //=============================================================================

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -200,7 +200,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    OutputIndex _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
+    bool _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
     /** @endcond                                                         */
 
 // Note: we could omit the T argument from the above macro by using the
@@ -237,7 +237,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    OutputIndex _output_##oname { constructOutput<T>(#oname, func, ostage) }; \
+    bool _output_##oname { constructOutput<T>(#oname, func, ostage) };      \
     /** @endcond                                                         */
 
 /** Create an Output for a StateVariable in this component. The provided
@@ -269,7 +269,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    OutputIndex _output_##oname { constructOutputForStateVariable(#oname) }; \
+    bool _output_##oname { constructOutputForStateVariable(#oname) };       \
     /** @endcond                                                         */
 /// @}
 //=============================================================================

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -200,7 +200,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _unused_output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
+    bool _has_output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
     /** @endcond                                                         */
 
 // Note: we could omit the T argument from the above macro by using the
@@ -237,7 +237,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _unused_output_##oname { constructOutput<T>(#oname, func, ostage) }; \
+    bool _has_output_##oname { constructOutput<T>(#oname, func, ostage) }; \
     /** @endcond                                                         */
 
 /** Create an Output for a StateVariable in this component. The provided
@@ -269,7 +269,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _unused_output_##oname { constructOutputForStateVariable(#oname) }; \
+    bool _has_output_##oname { constructOutputForStateVariable(#oname) }; \
     /** @endcond                                                         */
 /// @}
 //=============================================================================

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -164,6 +164,110 @@ private:
 //=============================================================================
 };  // END class Output
 
+/// @name Creating Outputs for your Component
+/// Use these macros at the top of your component class declaration,
+/// near where you declare @ref Property properties.
+/// @{
+/** Create an output for a member function of the same component. 
+ *  The following must be true about componentMemberFunction, the function
+ *  that returns the output:
+ *
+ *     -# It is a member function of your component.
+ *     -# The member function is const.
+ *     -# It takes only one input, which is `const SimTK::State&`
+ *
+ *  Use #OpenSim_DECLARE_OUTPUT_FLEX if these are not true for you.
+ *
+ *  You must also provide the stage on which the output depends.
+ *
+ *  Here's an example for using this macro:
+ *  @code{.cpp}
+ *  class MyComponent : public Component {
+ *  public:
+ *      OpenSim_DECLARE_OUTPUT(force, double, getForce, SimTK::Stage::Dynamics);
+ *      ...
+ *  };
+ *  @endcode
+ * @see Component::constructOutput()
+ * @relates OpenSim::Output
+ */
+#define OpenSim_DECLARE_OUTPUT(oname, T, func, ostage)                      \
+    /** @name Outputs                                                    */ \
+    /** @{                                                               */ \
+    /** Provides the value of func##() and is available at stage ostage. */ \
+    /** This output was generated with the                               */ \
+    /** #OpenSim_DECLARE_OUTPUT macro.                                   */ \
+    OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
+    /** @}                                                               */ \
+    /** @cond                                                            */ \
+    int _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) };\
+    /** @endcond                                                         */
+
+// TODO std::result_of<decltype(&Self::func)(Self, const SimTK::State&)>::type
+
+/** The most flexible (and difficult) way to create an output.
+   You can specify any function that has the signature `func_name(const
+   SimTK::State&)`.  You must also provide the stage on which the output
+   depends, and a comment describing the output.
+  
+   Here's an example. Say you have a class Markers that manages markers, you
+   have an instance of this class as a member variable in your Component, and
+   Markers has a method <tt> Vec3 Markers::calcMarkerPos(const SimTK::State& s,
+   std::string marker);</tt> to compute motion capture marker positions, given
+   the name of a marker.
+   @code{.cpp}
+   OpenSim_DECLARE_OUTPUT_FLEX(ankle_marker_pos,
+           std::bind(&Markers::calcMarkerPos, _markers,  std::placeholders::_1, "ankle"),
+           SimTK::Stage::Position);
+   @endcode
+   @see Component::constructOutput()
+   @relates OpenSim::Output
+ */
+#define OpenSim_DECLARE_OUTPUT_FLEX(oname, T, func, ostage, comment)        \
+    /** @name Outputs                                                    */ \
+    /** @{                                                               */ \
+    /** comment                                                          */ \
+    /** Available at stage ostage.                                       */ \
+    /** This output was generated with the                               */ \
+    /** #OpenSim_DECLARE_OUTPUT_FLEX macro.                              */ \
+    OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
+    /** @}                                                               */ \
+    /** @cond                                                            */ \
+    int _output_##oname { constructOutput<T>(#oname, func, ostage) };       \
+    /** @endcond                                                         */
+
+/** Create an Output for a StateVariable in the same component. The provided
+ * name is both the name of the output and of the state variable.
+ *
+ * While this macro is a convenient way to construct an Output for a
+ * StateVariable, it is inefficient because it uses a string lookup at runtime.
+ * To create a more efficient Output, create a member variable that returns the
+ * state variable directly (see Coordinate::getValue() or
+ * Muscle::getActivation()) and then use the #OpenSim_DECLARE_OUTPUT macro.
+ *
+ * @code{.cpp}
+ * class MyComponent : public Component {
+ * public:
+ *     OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE(activation);
+ *     ...
+ * };
+ * @endcode
+ * @see Component::constructOutputForStateVariable()
+ * @relates OpenSim::Output
+ */
+#define OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE(oname)                    \
+    /** @name Outputs                                                    */ \
+    /** @{                                                               */ \
+    /** Provides the value of this class's oname state variable.         */ \
+    /** Available at stage SimTK::Stage::Model.                          */ \
+    /** This output was generated with the                               */ \
+    /** #OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE macro.                */ \
+    OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
+    /** @}                                                               */ \
+    /** @cond                                                            */ \
+    int _output_##oname { constructOutputForStateVariable(#oname) };        \
+    /** @endcond                                                         */
+/// @}
 //=============================================================================
 //=============================================================================
 

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -203,7 +203,11 @@ private:
     int _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) };\
     /** @endcond                                                         */
 
-// TODO std::result_of<decltype(&Self::func)(Self, const SimTK::State&)>::type
+// Note: we could omit the T argument from the above macro by using the
+// following code to deduce T from the provided func
+//      std::result_of<decltype(&Self::func)(Self, const SimTK::State&)>::type
+// However, then we wouldn't be able to document the type for the output in
+// doxygen.
 
 /** The most flexible (and difficult) way to create an output.
    You can specify any function that has the signature `func_name(const

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -200,7 +200,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
+    bool _unused_output_##oname { constructOutput<T>(#oname, &Self::func, ostage) }; \
     /** @endcond                                                         */
 
 // Note: we could omit the T argument from the above macro by using the
@@ -237,7 +237,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _output_##oname { constructOutput<T>(#oname, func, ostage) };      \
+    bool _unused_output_##oname { constructOutput<T>(#oname, func, ostage) }; \
     /** @endcond                                                         */
 
 /** Create an Output for a StateVariable in this component. The provided
@@ -269,7 +269,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, oname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    bool _output_##oname { constructOutputForStateVariable(#oname) };       \
+    bool _unused_output_##oname { constructOutputForStateVariable(#oname) }; \
     /** @endcond                                                         */
 /// @}
 //=============================================================================

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1160,6 +1160,7 @@ SimTK_DEFINE_UNIQUE_INDEX_TYPE(PropertyIndex);
 // don't want to prevent our users from potentially using OpenSim in
 // conjunction with Qt.  You can see how this empty macro is used in some of
 // the macros below.
+// We actually also use this macro to document component outputs, etc.
 #define OpenSim_DOXYGEN_Q_PROPERTY(T, name)
 
 /** Declare a required, single-value property of the given \a pname and 
@@ -1188,6 +1189,8 @@ A data member is also created but is intended for internal use only:
             this->template addProperty<T>(#pname,comment,initValue);        \
     }                                                                       \
     /** @endcond **/                                                        \
+    /** @name Properties (single-value)                                  */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1197,6 +1200,7 @@ A data member is also created but is intended for internal use only:
     /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     /** Get the value of the <b> pname </b> property.                    */ \
@@ -1222,6 +1226,8 @@ initialized with an object of type T.
     {   PropertyIndex_##T =                                                 \
             this->template addProperty<T>("", comment, initValue); }        \
     /** @endcond **/                                                        \
+    /** @name Properties (unnamed)                                       */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<%##T##\></b>.                                       */ \
@@ -1231,6 +1237,7 @@ initialized with an object of type T.
     /** @propmethods get_##T##(), upd_##T##(), set_##T##()               */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, T)                                        \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     /** Get the value of the <b> %##T </b> property.                     */ \
@@ -1260,6 +1267,8 @@ value of type T.
             this->template addOptionalProperty<T>(#pname, comment,          \
                                                   initValue); }             \
     /** @endcond **/                                                        \
+    /** @name Properties (optional)                                      */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1269,6 +1278,7 @@ value of type T.
     /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     /** Get the value of the <b> pname </b> property.                    */ \
@@ -1292,6 +1302,8 @@ supports a %size() method and operator[] element selection.
 @see OpenSim_DECLARE_LIST_PROPERTY_RANGE()
 @relates OpenSim::Property **/
 #define OpenSim_DECLARE_LIST_PROPERTY(pname, T, comment)                    \
+    /** @name Properties (list)                                          */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1302,6 +1314,7 @@ supports a %size() method and operator[] element selection.
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     OpenSim_DECLARE_LIST_PROPERTY_HELPER(pname, T, comment,                 \
@@ -1321,6 +1334,8 @@ the right number of elements, using any Container that supports a %size()
 method and operator[] element selection.
 @relates OpenSim::Property **/
 #define OpenSim_DECLARE_LIST_PROPERTY_SIZE(pname, T, listSize, comment)     \
+    /** @name Properties (list)                                          */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1331,6 +1346,7 @@ method and operator[] element selection.
     /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     OpenSim_DECLARE_LIST_PROPERTY_HELPER(pname, T, comment,                 \
@@ -1345,6 +1361,8 @@ using any Container that supports a %size() method and operator[] element
 selection.
 @relates OpenSim::Property **/
 #define OpenSim_DECLARE_LIST_PROPERTY_ATLEAST(pname, T, minSize, comment)   \
+    /** @name Properties (list)                                          */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1356,6 +1374,7 @@ selection.
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     OpenSim_DECLARE_LIST_PROPERTY_HELPER(pname, T, comment,                 \
@@ -1370,6 +1389,8 @@ no more than \a maxSize elements, using any Container that supports a %size()
 method and operator[] element selection.
 @relates OpenSim::Property **/
 #define OpenSim_DECLARE_LIST_PROPERTY_ATMOST(pname, T, maxSize, comment)    \
+    /** @name Properties (list)                                          */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1381,6 +1402,7 @@ method and operator[] element selection.
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     OpenSim_DECLARE_LIST_PROPERTY_HELPER(pname, T, comment, 0, (maxSize))   \
@@ -1400,6 +1422,8 @@ OpenSim_DECLARE_PROPERTY_ATMOST() rather than this macro.
 @relates OpenSim::Property **/
 #define OpenSim_DECLARE_LIST_PROPERTY_RANGE(pname, T, minSize, maxSize,     \
                                             comment)                        \
+    /** @name Properties (list)                                          */ \
+    /** @{                                                               */ \
     /** comment                                                          */ \
     /** This property appears in XML files under                         */ \
     /** the tag <b>\<##pname##\></b>.                                    */ \
@@ -1412,6 +1436,7 @@ OpenSim_DECLARE_PROPERTY_ATMOST() rather than this macro.
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
+    /** @}                                                               */ \
     /** @name Property-related methods                                   */ \
     /** @{                                                               */ \
     OpenSim_DECLARE_LIST_PROPERTY_HELPER(pname, T, comment,                 \

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -193,6 +193,19 @@ private:
     int m_ctr;
     mutable int m_mutableCtr;
 
+    OpenSim_DECLARE_OUTPUT(Output1, double, getSomething, SimTK::Stage::Time)
+    OpenSim_DECLARE_OUTPUT(Output2, SimTK::Vec3, calcSomething,
+            SimTK::Stage::Time)
+
+    OpenSim_DECLARE_OUTPUT_NONMEMBER(Qs, Vector,
+            std::bind([=](const SimTK::State& s)->Vector{return s.getQ(); }, std::placeholders::_1),
+            SimTK::Stage::Position);
+
+    OpenSim_DECLARE_OUTPUT_NONMEMBER(BodyAcc, SpatialVec,
+            std::bind(&Foo::calcSpatialAcc, this, std::placeholders::_1),
+            SimTK::Stage::Velocity)
+
+
     void constructProperties() override {
         constructProperty_mass(1.0);
         Array<double> inertia(0.001, 6);
@@ -209,20 +222,8 @@ private:
     }
 
     void constructOutputs() override {
-        constructOutput<double>("Output1", &Foo::getSomething,
-                SimTK::Stage::Time);
 
-        constructOutput<SimTK::Vec3>("Output2", &Foo::calcSomething,
-                SimTK::Stage::Time);
 
-        double a = 10;
-        constructOutput<Vector>("Qs",
-            std::bind([=](const SimTK::State& s)->Vector{return s.getQ(); }, std::placeholders::_1),
-            SimTK::Stage::Position);
-
-        constructOutput<SpatialVec>("BodyAcc",
-            std::bind(&Foo::calcSpatialAcc, this, std::placeholders::_1),
-            SimTK::Stage::Velocity);
     }
 
     // Keep indices and reference to the world

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2078,17 +2078,3 @@ SimTK::Vec3 Model::calcMassCenterAcceleration(const SimTK::State &s) const
 *
 **/
 
-void Model::constructOutputs()
-{
-    //return the position of the center of mass
-   constructOutput<SimTK::Vec3>("com_position",
-       std::bind(&Model::calcMassCenterPosition,this,std::placeholders::_1), SimTK::Stage::Position);
-   //return the velocity of the center of mass 
-   constructOutput<SimTK::Vec3>("com_velocity",
-       std::bind(&Model::calcMassCenterVelocity,this,std::placeholders::_1), SimTK::Stage::Velocity);
-   //return the acceleration of the center of mass
-   constructOutput<SimTK::Vec3>("com_acceleration",
-       std::bind(&Model::calcMassCenterAcceleration,this,std::placeholders::_1), SimTK::Stage::Acceleration);
-    
-}
-

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -177,6 +177,18 @@ public:
     OpenSim_DECLARE_UNNAMED_PROPERTY(ModelVisualPreferences,
         "Visual preferences for this model.");
 
+//==============================================================================
+// OUTPUTS
+//==============================================================================
+   OpenSim_DECLARE_OUTPUT(com_position, SimTK::Vec3,
+           calcMassCenterPosition, SimTK::Stage::Position);
+
+   OpenSim_DECLARE_OUTPUT(com_velocity, SimTK::Vec3,
+           calcMassCenterVelocity, SimTK::Stage::Velocity);
+
+   OpenSim_DECLARE_OUTPUT(com_acceleration, SimTK::Vec3,
+           calcMassCenterAcceleration, SimTK::Stage::Acceleration);
+
 //=============================================================================
 // METHODS
 //=============================================================================
@@ -959,9 +971,6 @@ private:
     // Construct the properties of a Model.
     void constructProperties();
     void setDefaultProperties();
-
-    // construct outputs
-    void constructOutputs() override;
 
     // Utility to build a connected graph (tree) of the multibody system
     void createMultibodyTree();

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -539,7 +539,7 @@ GENERATE_DEPRECATEDLIST= YES
 # documentation can be controlled using \showinitializer or \hideinitializer 
 # command in the documentation regardless of this setting.
 
-MAX_INITIALIZER_LINES  = 30
+MAX_INITIALIZER_LINES  = 1
 
 # Set the SHOW_USED_FILES tag to NO to disable the list of files generated 
 # at the bottom of the documentation of classes and structs. If set to YES the 
@@ -1563,6 +1563,9 @@ EXPAND_AS_DEFINED      = OpenSim_DECLARE_PROPERTY \
                          OpenSim_DECLARE_LIST_PROPERTY_ATMOST \
                          OpenSim_DECLARE_LIST_PROPERTY_RANGE \
                          OpenSim_DECLARE_PROPERTY_HELPER \
+                         OpenSim_DECLARE_OUTPUT \
+                         OpenSim_DECLARE_OUTPUT_NONMEM \
+                         OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE \
                          SWIG_DECLARE_EXCEPTION
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES (the default) then 

--- a/doc/doxygen-layout-developer.xml
+++ b/doc/doxygen-layout-developer.xml
@@ -66,7 +66,7 @@
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
     <allmemberslink visible="yes"/>
     <memberdecl>
-      <properties title="OpenSim (XML) Properties"/>
+      <properties title="OpenSim Properties, Outputs"/>
       <publicmethods title=""/>
       <publictypes title=""/>
       <publicslots title=""/>
@@ -109,7 +109,7 @@
       <functions title=""/>
       <related title=""/>
       <variables title=""/>
-      <properties title="OpenSim (XML) Property Documentation"/>
+      <properties title="OpenSim Property, Output Documentation"/>
       <events title=""/>
     </memberdef>
     

--- a/doc/doxygen-layout-user.xml
+++ b/doc/doxygen-layout-user.xml
@@ -66,7 +66,7 @@
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
     <allmemberslink visible="yes"/>
     <memberdecl>
-      <properties title="OpenSim (XML) Properties"/>
+      <properties title="OpenSim Properties, Outputs"/>
       <publicmethods title=""/>
     </memberdecl>
    
@@ -75,7 +75,7 @@
       <constructors title=""/>
       <typedefs title=""/>
       <functions title=""/>
-      <properties title="OpenSim (XML) Property Documentation"/>
+      <properties title="OpenSim Property, Output Documentation"/>
       <!-- <enums title=""/>
       
       


### PR DESCRIPTION
I've created three macros for creating outputs:

- OpenSim_DECLARE_OUTPUT
- OpenSim_DECLARE_OUTPUT_FLEX
- OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE

They work just fine, and once this is merged, then other people can start using these macros in prep for the hackathon.  To be consistent, I tried to follow our conventions for properties pretty closely.

I also documented these macros so they appear nicely in doxygen, just like properties. You can view the doxygen here: http://myosin.sourceforge.net/806/classOpenSim_1_1Model.html

I didn't spend too much time on the documentation because it is likely to change when we add multi-outputs and create similar macros for inputs, connectors, etc.

Other than the FLEX macro above, I don't think these macros need to take comments, since member functions and state variables should be documented elsewhere.

Two tasks that might be good to do but that I'd prefer to leave to a subsequent PR:

1. Allow default value for the dependsOn stage through the macros; this requires overloaded/variadic macros and is somewhat complicated but is definitely do-able.
2. The member variable created by `constructOutput()` is an int whose value is always 0. This doesn't make too much sense, but it may also be OK. Luckily, the macro lets us change this in the future, and so I'd rather leave that for a separate PR. Also, we can deal with macro-generated accessor methods in a separate PR (probably after the hackathon).

Once this is merged, I'll move all existing `constructProperty()` calls to the macro.

Also, we can create new macros for list outputs once we figure out how to do those.