### PR TITLE
Use namestr() for Output::getTypeName()

### DIFF
--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -144,7 +144,7 @@ public:
     
     /** determine the value type for this Output*/
     std::string getTypeName() const override 
-        { return SimTK::NiceTypeName<T>::name(); }
+        { return SimTK::NiceTypeName<T>::namestr(); }
 
     std::string getValueAsString(const SimTK::State& state) const override
     {


### PR DESCRIPTION
This solves an issue when not using MSVC, where type names are all mangled. `namestr()` gives back demangled type names.
