### PR TITLE
Add output operator for DataTable

### DIFF
--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -33,6 +33,8 @@ in-memory container for data access and manipulation.                         */
 #include "OpenSim/Common/Exception.h"
 #include "OpenSim/Common/ValueArrayDictionary.h"
 
+#include <ostream>
+
 namespace OpenSim {
 
 class InvalidRow : public Exception {
@@ -446,6 +448,33 @@ protected:
     std::vector<ETX>    _indData;
     SimTK::Matrix_<ETY> _depData;
 };  // DataTable_
+
+/** Print DataTable out to a stream. Metadata is not printed to the steam as it
+is currently allowed to contain objects that do not support this operation.   
+Meant to be used for Debugging only.                                          */
+template<typename ETX, typename ETY>
+std::ostream& operator<<(std::ostream& outStream,
+                         const DataTable_<ETX, ETY>& table) {
+    outStream << "----------------------------------------------------------\n";
+    outStream << "NumRows: " << table.getNumRows()    << std::endl;
+    outStream << "NumCols: " << table.getNumColumns() << std::endl;
+    outStream << "Column-Labels: ";
+    const auto& labels = table.getColumnLabels();
+    if(!labels.empty()) {
+        outStream << "['" << labels[0] << "'";
+        if(labels.size() > 1)
+            for(size_t l = 1; l < labels.size(); ++l)
+                outStream << " '" << labels[l] << "'";
+        outStream << "]" << std::endl;
+    }
+    for(size_t r = 0; r < table.getNumRows(); ++r) {
+        outStream << table.getIndependentColumn().at(r) << " ";
+        outStream << table.getRowAtIndex(r) << std::endl;
+    }
+
+    outStream << "----------------------------------------------------------\n";
+    return outStream;
+}
 
 /** See DataTable_ for details on the interface.                              */
 typedef DataTable_<double, double> DataTable;

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -449,7 +449,7 @@ protected:
     SimTK::Matrix_<ETY> _depData;
 };  // DataTable_
 
-/** Print DataTable out to a stream. Metadata is not printed to the steam as it
+/** Print DataTable out to a stream. Metadata is not printed to the stream as it
 is currently allowed to contain objects that do not support this operation.   
 Meant to be used for Debugging only.                                          */
 template<typename ETX, typename ETY>

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -22,6 +22,7 @@
  * -------------------------------------------------------------------------- */
 
 #include <OpenSim/Common/TimeSeriesTable.h>
+#include <iostream>
 
 int main() {
     using namespace SimTK;
@@ -60,6 +61,9 @@ int main() {
                 throw Exception{"Test failed: "
                                 "table.getColumnIndex(labels.at(i)) != i"};
     }
+    // Print out the DataTable to console.
+    std::cout << table << std::endl;
+
     table.setDependentsMetaData(dep_metadata);
     table.setIndependentMetaData(ind_metadata);
 
@@ -81,6 +85,9 @@ int main() {
     table.updTableMetaData().setValueForKey("DataRate", 600);
     table.updTableMetaData().setValueForKey("Filename", 
                                             std::string{"/path/to/file"});
+
+    // Print out the DataTable to console.
+    std::cout << table << std::endl;
 
     // Retrieve added metadata and rows to check.
     if(table.getNumRows() != unsigned{5})

--- a/OpenSim/Examples/DataTable/example1.cpp
+++ b/OpenSim/Examples/DataTable/example1.cpp
@@ -24,7 +24,7 @@
 #include "OpenSim/Common/TimeSeriesTable.h"
 
 #include <vector>
-
+#include <iostream>
 
 int main() {
     using namespace OpenSim;
@@ -58,6 +58,10 @@ int main() {
 
     // Retrieve a column by its label.
     table.getDependentColumn("3");
+
+    // Print the DataTable to console. This is for debugging only. Do not
+    // rely on this output.
+    std::cout << table << std::endl;
 
     return 0;
 }

--- a/OpenSim/Examples/DataTable/example2.cpp
+++ b/OpenSim/Examples/DataTable/example2.cpp
@@ -23,6 +23,7 @@
 
 #include "OpenSim/Common/TimeSeriesTable.h"
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+#include <iostream>
 
 // This example demonstrates creating TimeSeriesTable from a DataTable.
 int main() {
@@ -65,6 +66,9 @@ int main() {
     
     dataTable.appendRow(0.9, row5); // 0.9 is less than previous value (1.00).
 
+    // Print out the DataTable to console. Use this for debugging only.
+    std::cout << dataTable << std::endl;
+
     // Contruction of TimeSeriesTable fails because independent column is not
     // strictly increasing. 
     ASSERT_THROW(OpenSim::Exception,
@@ -75,6 +79,9 @@ int main() {
     dataTable.setIndependentColumnAtIndex(5, 1.25);
     // TimeSeriesTable construction now successful. 
     TimeSeriesTable timeseries_table3{dataTable};
+
+    // Print out the table to console. Use this for debugging only.
+    std::cout << timeseries_table3 << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Addressing #788.

This PR does not:
* Wrap the operator for use in Python/Java.
* Implements `operator<<` for debugging purposes only.