### PR TITLE
Allow outputs functions to return const T&.

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -917,11 +917,12 @@ setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value)
 
 bool Component::constructOutputForStateVariable(const std::string& name)
 {
-    return constructOutput<double>(name,
-            std::bind(&Component::getStateVariableValue,
-             // (const Component*    , const SimTK::State&  , std::string)
-                std::placeholders::_1, std::placeholders::_2, name),
-            SimTK::Stage::Model);
+    auto func = [name](const Component* comp,
+                       const SimTK::State& s, const std::string&,
+                       double& result) -> void {
+        result = comp->getStateVariableValue(s, name);
+    };
+    return constructOutput<double>(name, func, SimTK::Stage::Model);
 }
 
 // mark components owned as properties as subcomponents

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1854,8 +1854,8 @@ protected:
         // appropriate derived type, then calls the member function of the
         // derived type. Thank you, klshrinidhi!
         auto outputFunc = [memFunc] (const Component* comp,
-                const SimTK::State& s, const std::string&) -> T {
-            return std::mem_fn(memFunc)(dynamic_cast<const CompType*>(comp), s);
+                const SimTK::State& s, const std::string&, T& result) -> void {
+            result = std::mem_fn(memFunc)(dynamic_cast<const CompType*>(comp), s);
         };
         return constructOutput<T>(name, outputFunc, dependsOn);
     }
@@ -1876,8 +1876,8 @@ protected:
         // appropriate derived type, then calls the member function of the
         // derived type. Thank you, klshrinidhi!
         auto outputFunc = [memFunc] (const Component* comp,
-                const SimTK::State& s, const std::string&) -> T {
-            return std::mem_fn(memFunc)(dynamic_cast<const CompType*>(comp), s);
+                const SimTK::State& s, const std::string&, T& result) -> void {
+            result = std::mem_fn(memFunc)(dynamic_cast<const CompType*>(comp), s);
         };
         return constructOutput<T>(name, outputFunc, dependsOn);
     }
@@ -1902,8 +1902,8 @@ protected:
         // appropriate derived type, then calls the member function of the
         // derived type. Thank you, klshrinidhi!
         auto outputFunc = [memFunc] (const Component* comp,
-                const SimTK::State& s, const std::string& channel) -> T {
-            return std::mem_fn(memFunc)(
+                const SimTK::State& s, const std::string& channel, T& result) -> void {
+            result = std::mem_fn(memFunc)(
                     dynamic_cast<const CompType*>(comp), s, channel);
         };
         return constructOutput<T>(name, outputFunc, dependsOn, true);
@@ -2009,9 +2009,9 @@ private:
     */
     template <typename T>
     bool constructOutput(const std::string& name,
-            const std::function<T (const Component*,
-                                   const SimTK::State&,
-                                   const std::string& channel)> outputFunction,
+            const std::function<void (const Component*,
+                                      const SimTK::State&,
+                                      const std::string& channel, T&)> outputFunction,
             const SimTK::Stage& dependsOn = SimTK::Stage::Acceleration,
             bool isList = false) {
         if (_outputsTable.count(name) == 1) {

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1853,6 +1853,8 @@ protected:
         // This lambda takes a pointer to a component, downcasts it to the
         // appropriate derived type, then calls the member function of the
         // derived type. Thank you, klshrinidhi!
+        // TODO right now, the assignment to result within the lambda is
+        // making a copy! We can fix this using a reference pointer.
         auto outputFunc = [memFunc] (const Component* comp,
                 const SimTK::State& s, const std::string&, T& result) -> void {
             result = std::mem_fn(memFunc)(dynamic_cast<const CompType*>(comp), s);

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -345,7 +345,9 @@ private:
  *
  *     -# It is a member function of your component.
  *     -# The member function is const.
- *     -# It takes only one input, which is `const SimTK::State&`
+ *     -# It takes only one argument, which is `const SimTK::State&`.
+ *     -# The function returns the computed quantity *by value* (e.g., 
+ *        `double computeQuantity(const SimTK::State&) const`).
  *
  *  You must also provide the stage on which the output depends.
  *
@@ -357,6 +359,14 @@ private:
  *      ...
  *  };
  *  @endcode
+ *
+ *  @warning The fourth requirement above can be lifted if the function returns
+ *  a quantity that is stored in the provided SimTK::State (as a state
+ *  variable, cache variable, etc.); in this case, your function's return type
+ *  should be `const T&` (e.g, `const double&`). If your function returns a
+ *  `const T&` but the quantity is NOT stored in the provided SimTK::State, the
+ *  output value will be invalid!
+ *
  * @see Component::constructOutput()
  * @relates OpenSim::Output
  */

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -690,6 +690,7 @@ void testMisc() {
     s = ts.getState();
 
     // Check the result of the integration on our state variables.
+    std::cout << "DEBUG " <<  bar.getOutputValue<double>(s, "fiberLength") << std::endl;
     ASSERT_EQUAL(3.5, bar.getOutputValue<double>(s, "fiberLength"), 1e-10);
     ASSERT_EQUAL(1.5, bar.getOutputValue<double>(s, "activation"), 1e-10);
 
@@ -1005,11 +1006,11 @@ int main() {
     Object::registerType(Connector<Foo>());
     Object::registerType(Connector<Bar>());
 
- // TODO   SimTK_START_TEST("testComponentIterface");
+    SimTK_START_TEST("testComponentIterface");
         SimTK_SUBTEST(testMisc);
         SimTK_SUBTEST(testListInputs);
         SimTK_SUBTEST(testListConnectors);
         SimTK_SUBTEST(testComponentPathNames);
-//    SimTK_END_TEST();
+    SimTK_END_TEST();
 }
 

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -156,6 +156,9 @@ public:
 
     OpenSim_DECLARE_OUTPUT(BodyAcc, SpatialVec, calcSpatialAcc,
             SimTK::Stage::Velocity)
+
+    OpenSim_DECLARE_OUTPUT(return_by_ref, double, getReturnByRef,
+            SimTK::Stage::Time);
     
     OpenSim_DECLARE_INPUT(input1, double, SimTK::Stage::Model, "");
     OpenSim_DECLARE_INPUT(AnglesIn, Vector, SimTK::Stage::Model, "");
@@ -193,6 +196,11 @@ public:
 
         return getSystem().getMatterSubsystem().getMobilizedBody(bindex)
             .getBodyAcceleration(state);
+    }
+
+    const double& getReturnByRef(const SimTK::State& s) const {
+        // Must return something that is stored in the state!
+        return s.getTime();
     }
 
 protected:
@@ -560,6 +568,9 @@ void testMisc() {
 
         cout << "foo.input1 = " << foo.getInputValue<double>(s, "input1") << endl;
     }
+
+    // Test the output that returns by const T&.
+    SimTK_TEST(foo.getOutputValue<double>(s, "return_by_ref") == s.getTime());
 
     MultibodySystem system2;
     TheWorld *world2 = new TheWorld(modelFile, true);


### PR DESCRIPTION
This addresses #824 for the Hackathon, and must be revisited afterwards. This change is in accord with what I discussed with @aseth1 and includes warnings in Doxygen to scare people away from using this variant of the Output. 
