### PR TITLE
Comment out findAndConnect message for the hackathon.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2344,7 +2344,7 @@ void Connector<C>::findAndConnect(const Component& root) {
         }
     }
     catch (const ComponentNotFoundOnSpecifiedPath& ex) {
-        std::cout << ex.getMessage() << std::endl;
+        // TODO leave out for hackathon std::cout << ex.getMessage() << std::endl;
         comp =  root.template findComponent<C>(path);
     }
     if (comp)


### PR DESCRIPTION
This message is very good to have but prints too much output. After the hackathon, if we resolve #828, then this message will no longer clutter test output, and we can re-enable the message.