### PR TITLE
Data adapters wrapping

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -2,6 +2,11 @@ if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
     find_package(SWIG 3.0.5 REQUIRED)
 endif()
 
+# Flags are both Python and Java bindings will use.
+if(WITH_BTK)
+    set(SWIG_FLAGS "-DWITH_BTK")
+endif()
+
 if(BUILD_PYTHON_WRAPPING)
     add_subdirectory(Python)
 endif()

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(
         -I${OpenSim_SOURCE_DIR}
         -I${OpenSim_SOURCE_DIR}/Bindings
         -I${Simbody_INCLUDE_DIR}
+        ${SWIG_FLAGS}
         -o ${swig_generated_file_fullname}
         -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
         ${swig_interface_file_fullname}

--- a/Bindings/OpenSimHeaders_common.h
+++ b/Bindings/OpenSimHeaders_common.h
@@ -44,6 +44,13 @@
 #include <OpenSim/Common/MarkerData.h>
 #include <OpenSim/Common/DataTable.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
+#include <OpenSim/Common/DataAdapter.h>
+#include <OpenSim/Common/FileAdapter.h>
+#include <OpenSim/Common/TRCFileAdapter.h>
+#include <OpenSim/Common/DelimFileAdapter.h>
+#include <OpenSim/Common/MOTFileAdapter.h>
+#include <OpenSim/Common/CSVFileAdapter.h>
+#include <OpenSim/Common/C3DFileAdapter.h>
 
 #endif // OPENSIM_OPENSIM_HEADERS_OPENSIM_H_
 

--- a/Bindings/OpenSimHeaders_common.h
+++ b/Bindings/OpenSimHeaders_common.h
@@ -44,6 +44,7 @@
 #include <OpenSim/Common/MarkerData.h>
 #include <OpenSim/Common/DataTable.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
+#include <OpenSim/Common/Event.h>
 #include <OpenSim/Common/DataAdapter.h>
 #include <OpenSim/Common/FileAdapter.h>
 #include <OpenSim/Common/TRCFileAdapter.h>

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -215,6 +215,12 @@ foreach(test_file
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/storage.sto"
         "${OPENSIM_SHARED_TEST_FILES_DIR}/arm26.osim"
         "${OPENSIM_SHARED_TEST_FILES_DIR}/gait10dof18musc_subject01.osim"
+        "${CMAKE_SOURCE_DIR}/OpenSim/Sandbox/futureOrientationInverseKinematics.trc"
+        "${CMAKE_SOURCE_DIR}/OpenSim/Common/Test/TRCFileWithNANs.trc"
+        "${CMAKE_SOURCE_DIR}/Applications/Analyze/test/subject02_grf_HiFreq.mot"
+        "${CMAKE_SOURCE_DIR}/Applications/IK/test/std_subject01_walk1_ik.mot"
+        "${CMAKE_SOURCE_DIR}/OpenSim/Tests/shared/singleLeglanding_2.c3d"
+        "${CMAKE_SOURCE_DIR}/OpenSim/Tests/shared/jogging.c3d"
         )
 
     OpenSimPutFileInPythonPackage("${test_file}" opensim/tests)

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -94,11 +94,12 @@ macro(OpenSimAddPythonModule)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py"
             ${_output_cxx_file} ${_output_header_file}
-        COMMAND ${SWIG_EXECUTABLE} -v -c++ -python
+        COMMAND ${SWIG_EXECUTABLE} -v -c++  -python
             #-debug-tmused # Which typemaps were used?
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings/
             -I${Simbody_INCLUDE_DIR}
+            ${SWIG_FLAGS}
             -o ${_output_cxx_file}
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
             ${_interface_file}

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -26,7 +26,7 @@ class TestDataAdapter(unittest.TestCase):
         assert table.getNumColumns() == 18
 
         table = adapter.read(os.path.join(test_dir, 
-                                          'std_subject01_walk1_ik.mot')
+                                          'std_subject01_walk1_ik.mot'))
         assert table.getNumRows()    == 73
         assert table.getNumColumns() == 23
 
@@ -36,7 +36,7 @@ class TestDataAdapter(unittest.TestCase):
         except AttributeError:
             # C3D support not available. OpenSim was not compiled with BTK.
             return
-        tables = adapter.read(os.path.join(test_dir, 'singleLeglanding_2.c3d')
+        tables = adapter.read(os.path.join(test_dir, 'singleLeglanding_2.c3d'))
         markers = tables['markers']
         forces = tables['forces']
         assert markers.getNumRows()    == 1219
@@ -44,7 +44,7 @@ class TestDataAdapter(unittest.TestCase):
         assert forces.getNumRows()     == 9752
         assert forces.getNumColumns()  == 3
 
-        tables = adapter.read(os.path.join(test_dir, 'jogging.c3d')
+        tables = adapter.read(os.path.join(test_dir, 'jogging.c3d'))
         markers = tables['markers']
         forces = tables['forces']
         assert markers.getNumRows()    == 406

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -4,28 +4,29 @@ Test DataAdapter interface.
 import os, unittest
 import opensim as osim
 
+test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
+                        'tests')
+
 class TestDataAdapter(unittest.TestCase):
     def test_TRCFileAdapter(self):
         adapter = osim.TRCFileAdapter()
-        table = adapter.read('../../../OpenSim/Sandbox/' + 
-                             'futureOrientationInverseKinematics.trc')
+        table = adapter.read(os.path.join(test_dir, 
+                             'futureOrientationInverseKinematics.trc'))
         assert table.getNumRows()    == 1202
         assert table.getNumColumns() == 2
 
-        table = adapter.read('../../../OpenSim/Examples/DataAdapter/' + 
-                             'TRCFileWithNANs.trc')
+        table = adapter.read(os.path.join(test_dir, 'TRCFileWithNANs.trc'))
         assert table.getNumRows()    == 5
         assert table.getNumColumns() == 14
 
     def test_MOTFileAdapter(self):
         adapter = osim.MOTFileAdapter()
-        table = adapter.read('../../../OpenSim/Common/Test/' + 
-                             'subject02_grf_HiFreq.mot')
+        table = adapter.read(os.path.join(test_dir, 'subject02_grf_HiFreq.mot'))
         assert table.getNumRows()    == 439
         assert table.getNumColumns() == 18
 
-        table = adapter.read('../../../OpenSim/Common/Test/' + 
-                             'std_subject01_walk1_ik.mot')
+        table = adapter.read(os.path.join(test_dir, 
+                                          'std_subject01_walk1_ik.mot')
         assert table.getNumRows()    == 73
         assert table.getNumColumns() == 23
 
@@ -35,8 +36,7 @@ class TestDataAdapter(unittest.TestCase):
         except AttributeError:
             # C3D support not available. OpenSim was not compiled with BTK.
             return
-        tables = adapter.read('../../../OpenSim/Common/Test/' + 
-                             'singleLeglanding_2.c3d')
+        tables = adapter.read(os.path.join(test_dir, 'singleLeglanding_2.c3d')
         markers = tables['markers']
         forces = tables['forces']
         assert markers.getNumRows()    == 1219
@@ -44,8 +44,7 @@ class TestDataAdapter(unittest.TestCase):
         assert forces.getNumRows()     == 9752
         assert forces.getNumColumns()  == 3
 
-        tables = adapter.read('../../../OpenSim/Common/Test/' + 
-                             'jogging.c3d')
+        tables = adapter.read(os.path.join(test_dir, 'jogging.c3d')
         markers = tables['markers']
         forces = tables['forces']
         assert markers.getNumRows()    == 406

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -30,7 +30,11 @@ class TestDataAdapter(unittest.TestCase):
         assert table.getNumColumns() == 23
 
     def test_C3DFileAdapter(self):
-        adapter = osim.C3DFileAdapter()
+        try:
+            adapter = osim.C3DFileAdapter()
+        except AttributeError:
+            # C3D support not available. OpenSim was not compiled with BTK.
+            return
         tables = adapter.read('../../../OpenSim/Common/Test/' + 
                              'singleLeglanding_2.c3d')
         markers = tables['markers']

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -1,0 +1,50 @@
+"""
+Test DataAdapter interface.
+"""
+import os, unittest
+import opensim as osim
+
+class TestDataAdapter(unittest.TestCase):
+    def test_TRCFileAdapter(self):
+        adapter = osim.TRCFileAdapter()
+        table = adapter.read('../../../OpenSim/Sandbox/' + 
+                             'futureOrientationInverseKinematics.trc')
+        assert table.getNumRows()    == 1202
+        assert table.getNumColumns() == 2
+
+        table = adapter.read('../../../OpenSim/Examples/DataAdapter/' + 
+                             'TRCFileWithNANs.trc')
+        assert table.getNumRows()    == 5
+        assert table.getNumColumns() == 14
+
+    def test_MOTFileAdapter(self):
+        adapter = osim.MOTFileAdapter()
+        table = adapter.read('../../../OpenSim/Common/Test/' + 
+                             'subject02_grf_HiFreq.mot')
+        assert table.getNumRows()    == 439
+        assert table.getNumColumns() == 18
+
+        table = adapter.read('../../../OpenSim/Common/Test/' + 
+                             'std_subject01_walk1_ik.mot')
+        assert table.getNumRows()    == 73
+        assert table.getNumColumns() == 23
+
+    def test_C3DFileAdapter(self):
+        adapter = osim.C3DFileAdapter()
+        tables = adapter.read('../../../OpenSim/Common/Test/' + 
+                             'singleLeglanding_2.c3d')
+        markers = tables['markers']
+        forces = tables['forces']
+        assert markers.getNumRows()    == 1219
+        assert markers.getNumColumns() == 356
+        assert forces.getNumRows()     == 9752
+        assert forces.getNumColumns()  == 3
+
+        tables = adapter.read('../../../OpenSim/Common/Test/' + 
+                             'jogging.c3d')
+        markers = tables['markers']
+        forces = tables['forces']
+        assert markers.getNumRows()    == 406
+        assert markers.getNumColumns() == 209
+        assert forces.getNumRows()     == 2030
+        assert forces.getNumColumns()  == 12

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -98,7 +98,8 @@
 %include <OpenSim/Common/Event.h>
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
 %template(StdMapStringTimeSeriesTableVec3)
-        std::map<std::string, OpenSim::TimeSeriesTableVec3>;
+        std::map<std::string, 
+                 std::shared_ptr<OpenSim::TimeSeriesTable_<SimTK::Vec3>>>;
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)
 %shared_ptr(OpenSim::DelimFileAdapter)

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -76,6 +76,11 @@
 %include <OpenSim/Common/MarkerData.h>
 
 %include <Bindings/std.i>
+%shared_ptr(OpenSim::AbstractDataTable);
+%shared_ptr(OpenSim::DataTable_<double, double>);
+%shared_ptr(OpenSim::DataTable_<double, SimTK::Vec3>);
+%shared_ptr(OpenSim::TimeSeriesTable_<double>);
+%shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Vec3>);
 %ignore OpenSim::AbstractDataTable::clone;
 %ignore OpenSim::AbstractDataTable::getTableMetaData;
 %ignore OpenSim::AbstractDataTable::updTableMetaData;
@@ -86,6 +91,29 @@
 %include <OpenSim/Common/DataTable.h>
 %include <OpenSim/Common/TimeSeriesTable.h>
 %template(DataTable)           OpenSim::DataTable_<double, double>;
-%template(TimeSeriesTable)     OpenSim::TimeSeriesTable_<double>;
 %template(DataTableVec3)       OpenSim::DataTable_<double, SimTK::Vec3>;
+%template(TimeSeriesTable)     OpenSim::TimeSeriesTable_<double>;
 %template(TimeSeriesTableVec3) OpenSim::TimeSeriesTable_<SimTK::Vec3>;
+
+%include <OpenSim/Common/Event.h>
+%template(StdVectorEvent) std::vector<OpenSim::Event>;
+%template(StdMapStringTimeSeriesTableVec3)
+        std::map<std::string, OpenSim::TimeSeriesTableVec3>;
+%shared_ptr(OpenSim::DataAdapter)
+%shared_ptr(OpenSim::FileAdapter)
+%shared_ptr(OpenSim::DelimFileAdapter)
+%shared_ptr(OpenSim::MOTFileAdapter)
+%shared_ptr(OpenSim::CSVFileAdapter)
+%shared_ptr(OpenSim::TRCFileAdapter)
+%shared_ptr(OpenSim::C3DFileAdapter)
+%template(StdMapStringDataAdapter)
+        std::map<std::string, std::shared_ptr<OpenSim::DataAdapter>>;
+%template(StdMapStringAbstractDataTable)
+        std::map<std::string, std::shared_ptr<OpenSim::AbstractDataTable>>;
+%include <OpenSim/Common/DataAdapter.h>
+%include <OpenSim/Common/FileAdapter.h>
+%include <OpenSim/Common/TRCFileAdapter.h>
+%include <OpenSim/Common/DelimFileAdapter.h>
+%include <OpenSim/Common/MOTFileAdapter.h>
+%include <OpenSim/Common/CSVFileAdapter.h>
+%include <OpenSim/Common/C3DFileAdapter.h>

--- a/Bindings/std.i
+++ b/Bindings/std.i
@@ -1,4 +1,8 @@
 %include "std_string.i"
+
 %include "std_vector.i"
 %template(StdVectorDouble) std::vector<double>;
 %template(StdVectorString) std::vector<std::string>;
+
+%include "std_map.i"
+%include <std_shared_ptr.i>

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -21,11 +21,13 @@ C3DFileAdapter::clone() const {
 C3DFileAdapter::Tables
 C3DFileAdapter::read(const std::string& fileName) const {
     auto abstables = extendRead(fileName);
+    auto marker_table = 
+        std::static_pointer_cast<TimeSeriesTableVec3>(abstables.at(_markers));
+    auto force_table = 
+        std::static_pointer_cast<TimeSeriesTableVec3>(abstables.at(_forces));
     Tables tables{};
-    tables.emplace(_markers, 
-                   static_cast<TimeSeriesTableVec3&>(*abstables.at(_markers)));
-    tables.emplace( _forces, 
-                    static_cast<TimeSeriesTableVec3&>(*abstables.at( _forces)));
+    tables.emplace(_markers, marker_table);
+    tables.emplace( _forces,  force_table);
     return tables;
 }
 

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -20,13 +20,13 @@ C3DFileAdapter::clone() const {
 
 C3DFileAdapter::Tables
 C3DFileAdapter::read(const std::string& fileName) const {
-    auto tables = extendRead(fileName);
-    auto    abs_marker_table = tables.at(_markers).release();
-    auto     abs_force_table = tables.at(_forces ).release();
-    auto    marker_table = static_cast<TimeSeriesTableVec3*>(abs_marker_table);
-    auto     force_table = static_cast<TimeSeriesTableVec3*>(abs_force_table);
-    return std::make_tuple(std::unique_ptr<TimeSeriesTableVec3>{marker_table}, 
-                           std::unique_ptr<TimeSeriesTableVec3>{force_table});
+    auto abstables = extendRead(fileName);
+    Tables tables{};
+    tables.emplace(_markers, 
+                   static_cast<TimeSeriesTableVec3&>(*abstables.at(_markers)));
+    tables.emplace( _forces, 
+                    static_cast<TimeSeriesTableVec3&>(*abstables.at( _forces)));
+    return tables;
 }
 
 void
@@ -46,9 +46,9 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
     auto& marker_table = *(new TimeSeriesTableVec3{});
     auto&  force_table = *(new TimeSeriesTableVec3{});
     tables.emplace(_markers, 
-                   std::unique_ptr<TimeSeriesTableVec3>(&marker_table));
+                   std::shared_ptr<TimeSeriesTableVec3>(&marker_table));
     tables.emplace(_forces, 
-                   std::unique_ptr<TimeSeriesTableVec3>(&force_table));
+                   std::shared_ptr<TimeSeriesTableVec3>(&force_table));
 
     auto marker_pts = btk::PointCollection::New();
 
@@ -235,7 +235,7 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
        marker_table.updTableMetaData().setValueForKey("events", event_table);
         force_table.updTableMetaData().setValueForKey("events", event_table);
 
-    return std::move(tables);
+    return tables;
 }
 
 void

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -36,9 +36,8 @@ namespace OpenSim {
 
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
 public:
-    using EventTable  = std::vector<Event>; 
-    using Tables      = std::tuple<std::unique_ptr<TimeSeriesTableVec3>, 
-                                   std::unique_ptr<TimeSeriesTableVec3>>;
+    typedef std::vector<Event>                         EventTable; 
+    typedef std::map<std::string, TimeSeriesTableVec3> Tables;
 
     C3DFileAdapter()                                 = default;
     C3DFileAdapter(const C3DFileAdapter&)            = default;

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -37,7 +37,7 @@ namespace OpenSim {
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
 public:
     typedef std::vector<Event>                         EventTable; 
-    typedef std::map<std::string, TimeSeriesTableVec3> Tables;
+    typedef std::map<std::string, std::shared_ptr<TimeSeriesTableVec3>> Tables;
 
     C3DFileAdapter()                                 = default;
     C3DFileAdapter(const C3DFileAdapter&)            = default;

--- a/OpenSim/Common/DataAdapter.cpp
+++ b/OpenSim/Common/DataAdapter.cpp
@@ -14,17 +14,17 @@ DataAdapter::registerDataAdapter(const std::string& identifier,
                      identifier);
 
     auto result = _registeredDataAdapters.emplace(identifier, 
-                                 std::unique_ptr<DataAdapter>{adapter.clone()});
+                                 std::shared_ptr<DataAdapter>{adapter.clone()});
 
     return result.second;
 }
 
-std::unique_ptr<DataAdapter> 
+std::shared_ptr<DataAdapter> 
 DataAdapter::createAdapter(const std::string& identifier) {
     try {
         DataAdapter* adapter = 
             _registeredDataAdapters.at(identifier)->clone();
-        return std::unique_ptr<DataAdapter>{adapter};
+        return std::shared_ptr<DataAdapter>{adapter};
     } catch(std::out_of_range&) {
         OPENSIM_THROW(NoRegisteredDataAdapter,
                       identifier);

--- a/OpenSim/Common/DataAdapter.h
+++ b/OpenSim/Common/DataAdapter.h
@@ -77,16 +77,16 @@ file extensions.                                                              */
 class OSIMCOMMON_API DataAdapter {
 public:
     /** Type of the registry containing registered adapters.                  */
-    using RegisteredDataAdapters = 
-        std::unordered_map<std::string, std::unique_ptr<DataAdapter>>;
+    typedef std::map<std::string, std::shared_ptr<DataAdapter>> 
+            RegisteredDataAdapters;
     /** Collection of tables returned by reading methods implemented in derived
     classes.                                                                  */
-    using OutputTables = std::unordered_map<std::string,
-                                            std::unique_ptr<AbstractDataTable>>;
+    typedef std::map<std::string, std::shared_ptr<AbstractDataTable>>
+            OutputTables;
     /** Collection of tables accepted by writing methods implemented in derived
     classes.                                                                  */
-    using InputTables  = std::unordered_map<std::string,
-                                            const AbstractDataTable*>;
+    typedef std::map<std::string, const AbstractDataTable*>
+            InputTables;
 
     virtual DataAdapter* clone() const = 0;
 
@@ -116,7 +116,7 @@ protected:
     component can acquire the necessary adapter instance to read the data
     by the file extension if the extension is used as its identifier.         */
     static
-    std::unique_ptr<DataAdapter> createAdapter(const std::string& identifier);
+    std::shared_ptr<DataAdapter> createAdapter(const std::string& identifier);
 
     /** Immplements reading functionality.                                    */
     virtual OutputTables extendRead(const std::string& sourceName) const = 0;

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -50,7 +50,7 @@ public:
     DelimFileAdapter* clone() const override;
 
     /** Read a given file using the delimiters specified at construction.     */
-    std::unique_ptr<TimeSeriesTable> read(const std::string& filename) const;
+    TimeSeriesTable read(const std::string& filename) const;
 
     /** Write the table to a file using the delimiter specified at 
     construction.                                                             */

--- a/OpenSim/Common/TRCFileAdapter.h
+++ b/OpenSim/Common/TRCFileAdapter.h
@@ -119,8 +119,7 @@ public:
     TRCFileAdapter* clone() const override;
 
     /** Read a given TRC file. The filename provided need not contain ".trc". */
-    std::unique_ptr<TimeSeriesTableVec3> 
-    read(const std::string& filename) const;
+    TimeSeriesTableVec3 read(const std::string& filename) const;
 
     /** Write a table to a TRC file. The filename provided need not contain 
     ".trc".                                                                   */

--- a/OpenSim/Common/Test/testC3DFileAdapter.cpp
+++ b/OpenSim/Common/Test/testC3DFileAdapter.cpp
@@ -48,19 +48,19 @@ int main() {
     C3DFileAdapter c3d_adapter{};
     auto tables = c3d_adapter.read(filename);
 
-    auto&    marker_table = std::get<0>(tables);
-    auto&     force_table = std::get<1>(tables);
+    auto& marker_table = tables.at("markers");
+    auto&  force_table = tables.at("markers");
 
-    if(marker_table->getNumRows() != 0) {
-    marker_table->updTableMetaData().setValueForKey("Units", std::string{"mm"});
+    if(marker_table.getNumRows() != 0) {
+    marker_table.updTableMetaData().setValueForKey("Units", std::string{"mm"});
     TRCFileAdapter trc_adapter{};
-    trc_adapter.write(*marker_table, filename + ".markers.trc");
+    trc_adapter.write(marker_table, filename + ".markers.trc");
     }
 
-    if(force_table->getNumRows() != 0) {
-    force_table->updTableMetaData().setValueForKey("Units", std::string{"mm"});
+    if(force_table.getNumRows() != 0) {
+    force_table.updTableMetaData().setValueForKey("Units", std::string{"mm"});
     TRCFileAdapter trc_adapter{};
-    trc_adapter.write(*force_table, filename + ".forces.trc");
+    trc_adapter.write(force_table, filename + ".forces.trc");
     }
     }
 
@@ -70,8 +70,8 @@ int main() {
         using MT = TimeSeriesTableVec3;
         using FT = TimeSeriesTableVec3;
 
-        auto    marker_table = dynamic_cast<MT*>(tables.at("markers").get());
-        auto     force_table = dynamic_cast<FT*>(tables.at("forces").get());
+        auto marker_table = dynamic_cast<MT*>(tables.at("markers").get());
+        auto  force_table = dynamic_cast<FT*>(tables.at("forces").get());
 
     if(marker_table->getNumRows() != 0) {
     marker_table->updTableMetaData().setValueForKey("Units", std::string{"mm"});

--- a/OpenSim/Common/Test/testC3DFileAdapter.cpp
+++ b/OpenSim/Common/Test/testC3DFileAdapter.cpp
@@ -51,16 +51,16 @@ int main() {
     auto& marker_table = tables.at("markers");
     auto&  force_table = tables.at("markers");
 
-    if(marker_table.getNumRows() != 0) {
-    marker_table.updTableMetaData().setValueForKey("Units", std::string{"mm"});
+    if(marker_table->getNumRows() != 0) {
+    marker_table->updTableMetaData().setValueForKey("Units", std::string{"mm"});
     TRCFileAdapter trc_adapter{};
-    trc_adapter.write(marker_table, filename + ".markers.trc");
+    trc_adapter.write(*marker_table, filename + ".markers.trc");
     }
 
-    if(force_table.getNumRows() != 0) {
-    force_table.updTableMetaData().setValueForKey("Units", std::string{"mm"});
+    if(force_table->getNumRows() != 0) {
+    force_table->updTableMetaData().setValueForKey("Units", std::string{"mm"});
     TRCFileAdapter trc_adapter{};
-    trc_adapter.write(force_table, filename + ".forces.trc");
+    trc_adapter.write(*force_table, filename + ".forces.trc");
     }
     }
 

--- a/OpenSim/Common/Test/testMOTFileAdapter.cpp
+++ b/OpenSim/Common/Test/testMOTFileAdapter.cpp
@@ -100,12 +100,12 @@ int main() {
     for(const auto& filename : filenames) {
         MOTFileAdapter motfileadapter{};
         auto table = motfileadapter.read(filename);
-        motfileadapter.write(*table, tmpfile);
+        motfileadapter.write(table, tmpfile);
         compareFiles(filename, tmpfile);
     }
 
     for(const auto& filename : filenames) {
-        auto table = std::move(FileAdapter::readFile(filename).at("table"));
+        auto table = FileAdapter::readFile(filename).at("table");
         DataAdapter::InputTables tables{};
         tables.emplace(std::string{"table"}, table.get());
         FileAdapter::writeFile(tables, tmpfile);

--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -101,12 +101,12 @@ int main() {
     for(const auto& filename : filenames) {
         TRCFileAdapter trcfileadapter{};
         auto table = trcfileadapter.read(filename);
-        trcfileadapter.write(*table, tmpfile);
+        trcfileadapter.write(table, tmpfile);
         compareFiles(filename, tmpfile);
     }
 
     for(const auto& filename : filenames) {
-        auto table = std::move(FileAdapter::readFile(filename).at("markers"));
+        auto table = FileAdapter::readFile(filename).at("markers");
         DataAdapter::InputTables tables{};
         tables.emplace(std::string{"markers"}, table.get());
         FileAdapter::writeFile(tables, tmpfile);

--- a/OpenSim/Examples/DataAdapter/exampleC3DFileAdapter.cpp
+++ b/OpenSim/Examples/DataAdapter/exampleC3DFileAdapter.cpp
@@ -40,26 +40,26 @@ int main() {
     auto& marker_table = tables.at("markers");
     auto&  force_table = tables.at("forces");
 
-    if(marker_table.getNumRows() != 0) {
+    if(marker_table->getNumRows() != 0) {
         std::cout << "--------------Markers-----------------" << std::endl;
 
     std::cout << "Dim: " 
-              << marker_table.getNumRows() << " "
-              << marker_table.getNumColumns() 
+              << marker_table->getNumRows() << " "
+              << marker_table->getNumColumns() 
               << std::endl;
     std::cout << "DataRate: " 
-              << marker_table.getTableMetaData().
+              << marker_table->getTableMetaData().
                                getValueForKey("DataRate").
                                getValue<std::string>()
               << std::endl;
     std::cout << "Units: " 
-              << marker_table.getTableMetaData().
+              << marker_table->getTableMetaData().
                                getValueForKey("Units").
                                getValue<std::string>()
               << std::endl << std::endl;
-    std::cout << marker_table.getRow(0) << std::endl;
+    std::cout << marker_table->getRow(0) << std::endl;
 
-    auto& events_table = marker_table.getTableMetaData().
+    auto& events_table = marker_table->getTableMetaData().
                                       getValueForKey("events").
                                  getValue<std::vector<OpenSim::Event>>();
     for(const auto& elem : events_table)
@@ -68,55 +68,55 @@ int main() {
                   << "frame: " << elem.frame << " | "
                   << "description: " << elem.description << "\n";
 
-    auto& labels = marker_table.getDependentsMetaData().
+    auto& labels = marker_table->getDependentsMetaData().
                                  getValueArrayForKey("labels");
     for(size_t i = 0; i < labels.size(); ++i)
         std::cout << labels[i].getValue<std::string>() << " ";
     std::cout << "\n";
     }
 
-    if(force_table.getNumRows() != 0) {
+    if(force_table->getNumRows() != 0) {
         std::cout << "--------------Forces-----------------" << std::endl;
 
     std::cout << "Dim: "
-              << force_table.getNumRows() << " "
-              << force_table.getNumColumns()
+              << force_table->getNumRows() << " "
+              << force_table->getNumColumns()
               << std::endl;
     std::cout << "DataRate: "
-              << force_table.getTableMetaData().
+              << force_table->getTableMetaData().
                               getValueForKey("DataRate").
                               getValue<std::string>()
               << std::endl;
     std::cout << "CalibrationMatrices: \n";
-    for(const auto& elem : force_table.getTableMetaData().
+    for(const auto& elem : force_table->getTableMetaData().
             getValueForKey("CalibrationMatrices").
             getValue<std::vector<btk::ForcePlatform::CalMatrix>>())
         std::cout << elem << std::endl;
     std::cout << "Corners: \n";
-    for(const auto& elem : force_table.getTableMetaData().
+    for(const auto& elem : force_table->getTableMetaData().
             getValueForKey("Corners").
             getValue<std::vector<btk::ForcePlatform::Corners>>())
         std::cout << elem << std::endl;
     std::cout << "Origins: \n";
-    for(const auto& elem : force_table.getTableMetaData().
+    for(const auto& elem : force_table->getTableMetaData().
             getValueForKey("Origins").
             getValue<std::vector<btk::ForcePlatform::Origin>>())
         std::cout << elem << std::endl;
     std::cout << "Types: \n";
-    for(const auto& elem : force_table.getTableMetaData().
+    for(const auto& elem : force_table->getTableMetaData().
             getValueForKey("Types").
             getValue<std::vector<unsigned>>())
         std::cout << elem << std::endl;
 
-    const auto& labels = force_table.getDependentsMetaData().
+    const auto& labels = force_table->getDependentsMetaData().
         getValueArrayForKey("labels");
-    const auto& units = force_table.getDependentsMetaData().
+    const auto& units = force_table->getDependentsMetaData().
         getValueArrayForKey("units");
     for(size_t i = 0; i < labels.size(); ++i)
         std::cout << "[ " << labels[i].getValue<std::string>() << " " 
                   << units[i].getValue<std::string>() << " ] ";
     std::cout << std::endl;
-    std::cout << force_table.getRow(0) << std::endl;
+    std::cout << force_table->getRow(0) << std::endl;
     }
 
 

--- a/OpenSim/Examples/DataAdapter/exampleC3DFileAdapter.cpp
+++ b/OpenSim/Examples/DataAdapter/exampleC3DFileAdapter.cpp
@@ -37,29 +37,29 @@ int main() {
     C3DFileAdapter c3d_adapter{};
     auto tables = c3d_adapter.read(filename);
 
-    auto&    marker_table = std::get<0>(tables);
-    auto&     force_table = std::get<1>(tables);
+    auto& marker_table = tables.at("markers");
+    auto&  force_table = tables.at("forces");
 
-    if(marker_table->getNumRows() != 0) {
+    if(marker_table.getNumRows() != 0) {
         std::cout << "--------------Markers-----------------" << std::endl;
 
     std::cout << "Dim: " 
-              << marker_table->getNumRows() << " "
-              << marker_table->getNumColumns() 
+              << marker_table.getNumRows() << " "
+              << marker_table.getNumColumns() 
               << std::endl;
     std::cout << "DataRate: " 
-              << marker_table->getTableMetaData().
+              << marker_table.getTableMetaData().
                                getValueForKey("DataRate").
                                getValue<std::string>()
               << std::endl;
     std::cout << "Units: " 
-              << marker_table->getTableMetaData().
+              << marker_table.getTableMetaData().
                                getValueForKey("Units").
                                getValue<std::string>()
               << std::endl << std::endl;
-    std::cout << marker_table->getRow(0) << std::endl;
+    std::cout << marker_table.getRow(0) << std::endl;
 
-    auto& events_table = marker_table->getTableMetaData().
+    auto& events_table = marker_table.getTableMetaData().
                                       getValueForKey("events").
                                  getValue<std::vector<OpenSim::Event>>();
     for(const auto& elem : events_table)
@@ -68,55 +68,55 @@ int main() {
                   << "frame: " << elem.frame << " | "
                   << "description: " << elem.description << "\n";
 
-    auto& labels = marker_table->getDependentsMetaData().
+    auto& labels = marker_table.getDependentsMetaData().
                                  getValueArrayForKey("labels");
     for(size_t i = 0; i < labels.size(); ++i)
         std::cout << labels[i].getValue<std::string>() << " ";
     std::cout << "\n";
     }
 
-    if(force_table->getNumRows() != 0) {
+    if(force_table.getNumRows() != 0) {
         std::cout << "--------------Forces-----------------" << std::endl;
 
     std::cout << "Dim: "
-              << force_table->getNumRows() << " "
-              << force_table->getNumColumns()
+              << force_table.getNumRows() << " "
+              << force_table.getNumColumns()
               << std::endl;
     std::cout << "DataRate: "
-              << force_table->getTableMetaData().
+              << force_table.getTableMetaData().
                               getValueForKey("DataRate").
                               getValue<std::string>()
               << std::endl;
     std::cout << "CalibrationMatrices: \n";
-    for(const auto& elem : force_table->getTableMetaData().
+    for(const auto& elem : force_table.getTableMetaData().
             getValueForKey("CalibrationMatrices").
             getValue<std::vector<btk::ForcePlatform::CalMatrix>>())
         std::cout << elem << std::endl;
     std::cout << "Corners: \n";
-    for(const auto& elem : force_table->getTableMetaData().
+    for(const auto& elem : force_table.getTableMetaData().
             getValueForKey("Corners").
             getValue<std::vector<btk::ForcePlatform::Corners>>())
         std::cout << elem << std::endl;
     std::cout << "Origins: \n";
-    for(const auto& elem : force_table->getTableMetaData().
+    for(const auto& elem : force_table.getTableMetaData().
             getValueForKey("Origins").
             getValue<std::vector<btk::ForcePlatform::Origin>>())
         std::cout << elem << std::endl;
     std::cout << "Types: \n";
-    for(const auto& elem : force_table->getTableMetaData().
+    for(const auto& elem : force_table.getTableMetaData().
             getValueForKey("Types").
             getValue<std::vector<unsigned>>())
         std::cout << elem << std::endl;
 
-    const auto& labels = force_table->getDependentsMetaData().
+    const auto& labels = force_table.getDependentsMetaData().
         getValueArrayForKey("labels");
-    const auto& units = force_table->getDependentsMetaData().
+    const auto& units = force_table.getDependentsMetaData().
         getValueArrayForKey("units");
     for(size_t i = 0; i < labels.size(); ++i)
         std::cout << "[ " << labels[i].getValue<std::string>() << " " 
                   << units[i].getValue<std::string>() << " ] ";
     std::cout << std::endl;
-    std::cout << force_table->getRow(0) << std::endl;
+    std::cout << force_table.getRow(0) << std::endl;
     }
 
 

--- a/OpenSim/Examples/DataAdapter/exampleMOTFileAdapter.cpp
+++ b/OpenSim/Examples/DataAdapter/exampleMOTFileAdapter.cpp
@@ -52,13 +52,13 @@ int main() {
     // as well.
 
     // Metadata of the table.
-    std::cout << table1->
+    std::cout << table1.
                  getTableMetaData().
                  getValueForKey("header").
                  getValue<std::string>() << std::endl;
 
     // Column labels of the table.
-    auto& labels = table1->
+    auto& labels = table1.
                    getDependentsMetaData().
                    getValueArrayForKey("labels");
     for(size_t i = 0; i < labels.size(); ++i)
@@ -66,12 +66,12 @@ int main() {
     std::cout << std::endl;
 
     // Dimensions of the table.
-    std::cout << table1->getNumRows() << "\t"
-              << table1->getNumColumns() << std::endl;
+    std::cout << table1.getNumRows() << "\t"
+              << table1.getNumColumns() << std::endl;
 
     // Individual rows of the table.
-    for(size_t i = 0; i < std::min(table1->getNumRows(), size_t(3)); ++i)
-        std::cout << table1->getRowAtIndex(i) << std::endl;
+    for(size_t i = 0; i < std::min(table1.getNumRows(), size_t(3)); ++i)
+        std::cout << table1.getRowAtIndex(i) << std::endl;
 
     // See documentation for TimeSeriesTable for full set of operations
     // possible for table1 and table2.

--- a/OpenSim/Examples/DataAdapter/exampleTRCFileAdapter.cpp
+++ b/OpenSim/Examples/DataAdapter/exampleTRCFileAdapter.cpp
@@ -50,18 +50,18 @@ int main() {
     // as well.
 
     // Metadata of the table.
-    std::cout << table1->
+    std::cout << table1.
                  getTableMetaData().
                  getValueForKey("DataRate").
                  getValue<std::string>() << std::endl;
 
-    std::cout << table1->
+    std::cout << table1.
                  getTableMetaData().
                  getValueForKey("Units").
                  getValue<std::string>() << std::endl;
 
     // Column labels of the table.
-    auto& labels = table1->
+    auto& labels = table1.
                    getDependentsMetaData().
                    getValueArrayForKey("labels");
     for(size_t i = 0; i < labels.size(); ++i)
@@ -69,12 +69,12 @@ int main() {
     std::cout << std::endl;
 
     // Dimensions of the table.
-    std::cout << table1->getNumRows() << "\t"
-              << table1->getNumColumns() << std::endl;
+    std::cout << table1.getNumRows() << "\t"
+              << table1.getNumColumns() << std::endl;
 
     // Individual rows of the table.
-    for(size_t i = 0; i < table1->getNumRows(); ++i)
-        std::cout << table1->getRowAtIndex(i) << std::endl;
+    for(size_t i = 0; i < table1.getNumRows(); ++i)
+        std::cout << table1.getRowAtIndex(i) << std::endl;
 
     // See documentation for TimeSeriesTable for full set of operations
     // possible for table1 and table2.


### PR DESCRIPTION
Wrapping DataAdapter and its derived classes to allow access from Python/Java.

See [Bindings/Python/tests/test_DataAdapter.py](https://github.com/opensim-org/opensim-core/blob/data_adapters_wrapping/Bindings/Python/tests/test_DataAdapter.py).