### PR TITLE
Hide btk headers from interface.

### DIFF
--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -1,5 +1,10 @@
 #include "C3DFileAdapter.h"
 
+#include "btkAcquisitionFileReader.h"
+#include "btkAcquisition.h"
+#include "btkForcePlatformsExtractor.h"
+#include "btkGroundReactionWrenchFilter.h"
+
 namespace OpenSim {
 
 const std::string C3DFileAdapter::_markers{"markers"};

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -24,11 +24,6 @@
 
 #ifdef WITH_BTK
 
-#include "btkAcquisitionFileReader.h"
-#include "btkAcquisition.h"
-#include "btkForcePlatformsExtractor.h"
-#include "btkGroundReactionWrenchFilter.h"
-
 #include "FileAdapter.h"
 #include "Event.h"
 


### PR DESCRIPTION
Hoping this will fix appveyor build.

@klshrinidhi is there a reason why the btk headers needed to be in the header of the C3D adapter? I think it was causing the Java wrapping c++ files to not compile on Appveyor.