### PR TITLE
Update powershell instructions with wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,23 +297,32 @@ directory to your `PATH` environment variable.
  * Choose *Use Git from the Windows Command Prompt*.
 * Get **CMake** from [here](https://cmake.org/download/).
  * Choose *Add CMake to the system PATH for all users*.
+* Get **Chocolatey** from [here](https://chocolatey.org/).
+* In **PowerShell**, *run as Administrator* --
+ ```powershell
+ choco install python
+ choco install jdk8
+ choco install swig
+ ```
 * In **PowerShell** --
 
  ```powershell
 git clone https://github.com/opensim-org/opensim-core.git
 mkdir opensim_dependencies_build
 cd .\opensim_dependencies_build
-cmake ..\opensim-core\dependencies `
-      -G"Visual Studio 14 2015 Win64" `
+cmake ..\opensim-core\dependencies                             `
+      -G"Visual Studio 14 2015 Win64"                          `
       -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
 cd ..
 mkdir opensim_build
 cd .\opensim_build
-cmake ..\opensim-core `
-      -G"Visual Studio 14 2015 Win64" `
-      -DCMAKE_INSTALL_PREFIX="..\opensim_install" `
+cmake ..\opensim-core                                              `
+      -G"Visual Studio 14 2015 Win64"                              `
+      -DCMAKE_INSTALL_PREFIX="..\opensim_install"                  `
       -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install" `
+      -DBUILD_JAVA_WRAPPING=ON                                     `
+      -DBUILD_PYTHON_WRAPPING=ON                                   `
       -DWITH_BTK=ON
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
 ctest -C RelWithDebInfo --parallel 8

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ directory to your `PATH` environment variable.
  * Choose *Add CMake to the system PATH for all users*.
 * Get **Chocolatey** from [here](https://chocolatey.org/).
 * In **PowerShell**, *run as Administrator* --
+
  ```powershell
  choco install python
  choco install jdk8


### PR DESCRIPTION
Windows Powershell instructions currently do not include wrapping but instructions for OS X and Ubuntu do include wrapping. Adding it to Windows too for consistency.