### PR TITLE
Include property list of components in component

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -111,17 +111,20 @@ private:
 Component::Component() : Object()
 {
     constructProperty_connectors();
+    constructProperty_components();
 }
 
 Component::Component(const std::string& fileName, bool updFromXMLNode)
 :   Object(fileName, updFromXMLNode)
 {
     constructProperty_connectors();
+    constructProperty_components();
 }
 
 Component::Component(SimTK::Xml::Element& element) : Object(element)
 {
     constructProperty_connectors();
+    constructProperty_components();
 }
 
 void Component::addComponent(Component* comp) {

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -124,10 +124,28 @@ Component::Component(SimTK::Xml::Element& element) : Object(element)
     constructProperty_connectors();
 }
 
+void Component::addComponent(Component* comp) {
+    //get to the root Component
+    const Component* root = this;
+    while (root->hasParent()) {
+        root = &(root->getParent());
+    }
+
+    auto components = root->getComponentList<Component>();
+    for (auto& c : components) {
+        if (comp == &c) {
+            OPENSIM_THROW( ComponentAlreadyPartOfOwnershipTree,
+                comp->getName(), getName());
+        }
+    }
+
+    updProperty_components().adoptAndAppendValue(comp);
+    finalizeFromProperties();
+}
+
 void Component::finalizeFromProperties()
 {
     reset();
-
 
     // TODO use a flag to set whether we are lenient on having nameless
     // Components. For backward compatibility we need to be able to 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -273,6 +273,9 @@ protected:
     OpenSim_DECLARE_LIST_PROPERTY(connectors, AbstractConnector,
         "List of connectors (structural dependencies) that this component has.");
 
+    OpenSim_DECLARE_LIST_PROPERTY(components, Component,
+        "List of components that this component owns and serializes.");
+
 public:
 //==============================================================================
 // METHODS
@@ -395,6 +398,16 @@ public:
     * Returns false if the System has not been created OR if this
     * Component has not added itself to the System.  */
     bool hasSystem() const { return !_system.empty(); }
+
+    /**
+    * Add a Component to this component's property list.
+    * This component takes ownership of the added component.
+    * 
+    * TODO rename to adoptComponent() when Model::add#ModelComponent#()
+    * methods are also renamed. For the time being remain consistent. -aseth 
+    *
+    * @throws ComponentAlreadyPartOfOwnershipTree  */
+    void addComponent(Component* comp);
 
     /**
      * Get an iterator through the underlying subcomponents that this component is 

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -223,9 +223,7 @@ private:
         _filter(filter) {
         advanceToNextValidComponent(); // in case node is not a match.
     }
-
-};
-
+}; // end of ComponentListIterator
 } // end of namespace OpenSim
 
 #endif // OPENSIM_COMPONENT_LIST_H_

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -113,11 +113,6 @@ protected:
     }
 
 private:
-    void constructProperties() override {
-        constructProperty_components();
-    }
-
-private:
     // Keep track of pointers to the underlying computational subsystems. 
     mutable ReferencePtr<SimbodyMatterSubsystem> matter;
     mutable ReferencePtr<GeneralForceSubsystem> forces;

--- a/OpenSim/Sandbox/futureOutputVectorsAndChannels.cpp
+++ b/OpenSim/Sandbox/futureOutputVectorsAndChannels.cpp
@@ -81,45 +81,6 @@ private:
 
 typedef DataSource_<double> DataSource;
 
-template <typename T>
-class ConsoleReporter_ : public ModelComponent {
-    OpenSim_DECLARE_CONCRETE_OBJECT_T(ConsoleReporter_, T, Component);
-public:
-    OpenSim_DECLARE_LIST_INPUT(input, T, SimTK::Stage::Acceleration, "");
-private:
-    void extendRealizeReport(const State& state) const override
-    {
-        const auto& input = getInput<T>("input");
-        
-        if (_printCount % 20 == 0) {
-            std::cout << "[" << getName() << "] "
-                      << std::setw(_width) << "time" << "| ";
-            for (const auto& chan : input.getChannels()) {
-                const auto& name = chan->getPathName();
-                const auto& truncName = name.size() <= _width ?
-                    name : name.substr(name.size() - _width);
-                std::cout << std::setw(_width) << truncName << "|";
-            }
-            std::cout << "\n";
-        }
-        std::cout << "[" << getName() << "] "
-                  << std::setw(_width) << state.getTime() << "| ";
-        for (const auto& chan : input.getChannels()) {
-            const auto& value = chan->getValue(state);
-            const auto& nSigFigs = chan->getOutput().getNumberOfSignificantDigits();
-            std::cout << std::setw(_width)
-                      << std::setprecision(nSigFigs) << value << "|";
-        }
-        std::cout << std::endl;
-        
-        const_cast<ConsoleReporter_<T>*>(this)->_printCount++;
-    }
-    unsigned int _printCount = 0;
-    int _width = 17;
-};
-
-typedef ConsoleReporter_<double> ConsoleReporter;
-
 void integrate(const System& system, Integrator& integrator,
         const State& initialState,
         Real finalTime) {
@@ -166,7 +127,7 @@ void testOutputVectorsAndChannels() {
     // --------
     auto* rep = new ConsoleReporter();
     rep->setName("interped");
-    model.addModelComponent(rep);
+    model.addComponent(rep);
     
     // A component with a non-list output
     // -----------------------------------
@@ -180,10 +141,10 @@ void testOutputVectorsAndChannels() {
     
     // Must connect *after* initSystem(), since it first clears all
     // existing connections.
-    rep->updInput("input").connect(src->getOutput("col").getChannel("col0"));
+    rep->updInput("inputs").connect(src->getOutput("col").getChannel("col0"));
     //rep->updInput("input").connect(src->getOutput("col").getChannel("col1"));
-    rep->updInput("input").connect(src->getOutput("col"));
-    rep->updInput("input").connect(sugar->getOutput("fructose"));
+    rep->updInput("inputs").connect(src->getOutput("col"));
+    rep->updInput("inputs").connect(sugar->getOutput("fructose"));
     
     RungeKuttaMersonIntegrator integrator(model.getSystem());
     integrator.setFixedStepSize(0.1);


### PR DESCRIPTION
This allows API users/model builders to tack on any other component as a subcomponent. 
That means that Matt can add frames to a body, we can add reporters to models, add a device to a model, etc...

Eventually we will need to get the multibody tree building code in Model to traverse ComponentLists for Bodies and Joints that could be nested below in other subcomponents, instead of just those in the Model level sets. 