### PR TITLE
Add Joint reaction output and fix doxygen per PR

### DIFF
--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -768,9 +768,11 @@ public:
     SimTK::Vec3 calcMassCenterPosition(const SimTK::State &s) const;
     SimTK::Vec3 calcMassCenterVelocity(const SimTK::State &s) const;
     SimTK::Vec3 calcMassCenterAcceleration(const SimTK::State &s) const;
+    /** return the total Kinetic Energy for the underlying system.*/
     double calcKineticEnergy(const SimTK::State &s) const {
         return getMultibodySystem().calcKineticEnergy(s);
     }    
+    /** return the total Potential Energy for the underlying system.*/
     double calcPotentialEnergy(const SimTK::State &s) const {
         return getMultibodySystem().calcPotentialEnergy(s);
     }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -115,6 +115,10 @@ public:
 // OUTPUTS
 //=============================================================================
     OpenSim_DECLARE_OUTPUT(power, double, calcPower, SimTK::Stage::Acceleration);
+    OpenSim_DECLARE_OUTPUT(reaction_child_origin_in_ground, SimTK::SpatialVec, 
+        calcReactionOnChildAtOriginInGround, SimTK::Stage::Acceleration);
+    OpenSim_DECLARE_OUTPUT(reaction_parent_origin_in_ground, SimTK::SpatialVec, 
+        calcReactionOnParentAtOriginInGround, SimTK::Stage::Acceleration);
 
 //=============================================================================
 // METHODS
@@ -250,8 +254,19 @@ public:
     calcEquivalentSpatialForce(const SimTK::State &s, 
                                const SimTK::Vector &mobilityForces) const;
 
+    // Reaction forces (direct calls into Simbody methods)
+    /** Reaction forces on Child Body at Origin in Ground frame @see SimTK::MobilizedBody method. */
+    SimTK::SpatialVec
+        calcReactionOnChildAtOriginInGround(const SimTK::State &s) const {
+        return getChildFrame().getMobilizedBody().findMobilizerReactionOnBodyAtOriginInGround(s);
+    }
+    /** Reaction forces on Parent Body at Origin in Ground frame @see SimTK::MobilizedBody method. */
+    SimTK::SpatialVec
+        calcReactionOnParentAtOriginInGround(const SimTK::State &s) const {
+        return getChildFrame().getMobilizedBody().findMobilizerReactionOnParentAtOriginInGround(s);
+    }
 
-    /** Joints in general do not contribute power since the reaction space 
+    /** Joints in general do not contribute power since the reaction space
         forces are orthogonal to the mobility space. However, when joint motion 
         is prescribed, the internal forces that move the joint will do work. In 
         that case, the power is non-zero and the supplied SimTK::State

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -115,10 +115,12 @@ public:
 // OUTPUTS
 //=============================================================================
     OpenSim_DECLARE_OUTPUT(power, double, calcPower, SimTK::Stage::Acceleration);
-    OpenSim_DECLARE_OUTPUT(reaction_child_origin_in_ground, SimTK::SpatialVec, 
-        calcReactionOnChildAtOriginInGround, SimTK::Stage::Acceleration);
-    OpenSim_DECLARE_OUTPUT(reaction_parent_origin_in_ground, SimTK::SpatialVec, 
-        calcReactionOnParentAtOriginInGround, SimTK::Stage::Acceleration);
+    // reaction_load_at_parent_frame
+    OpenSim_DECLARE_OUTPUT(reaction_load_at_parent_frame_in_ground_frame, SimTK::SpatialVec,
+        calcReactionAtParentFrameInGround, SimTK::Stage::Acceleration);
+    // reaction_load_at_child_frame
+    OpenSim_DECLARE_OUTPUT(reaction_load_at_child_frame_in_ground_frame, SimTK::SpatialVec,
+        calcReactionAtChildFrameInGround, SimTK::Stage::Acceleration);
 
 //=============================================================================
 // METHODS
@@ -253,17 +255,17 @@ public:
     SimTK::SpatialVec 
     calcEquivalentSpatialForce(const SimTK::State &s, 
                                const SimTK::Vector &mobilityForces) const;
-
+    
     // Reaction forces (direct calls into Simbody methods)
-    /** Reaction forces on Child Body at Origin in Ground frame @see SimTK::MobilizedBody method. */
+    /** Reaction forces on Parent Frame at Mobilizer in Ground @see SimTK::MobilizedBody method. */
     SimTK::SpatialVec
-        calcReactionOnChildAtOriginInGround(const SimTK::State &s) const {
-        return getChildFrame().getMobilizedBody().findMobilizerReactionOnBodyAtOriginInGround(s);
+        calcReactionAtParentFrameInGround(const SimTK::State &s) const {
+        return getChildFrame().getMobilizedBody().findMobilizerReactionOnParentAtFInGround(s);
     }
-    /** Reaction forces on Parent Body at Origin in Ground frame @see SimTK::MobilizedBody method. */
+    /** Reaction forces on Child Frame at Mobilizer Frame in Ground @see SimTK::MobilizedBody method. */
     SimTK::SpatialVec
-        calcReactionOnParentAtOriginInGround(const SimTK::State &s) const {
-        return getChildFrame().getMobilizedBody().findMobilizerReactionOnParentAtOriginInGround(s);
+        calcReactionAtChildFrameInGround(const SimTK::State &s) const {
+        return getChildFrame().getMobilizedBody().findMobilizerReactionOnBodyAtMInGround(s);
     }
 
     /** Joints in general do not contribute power since the reaction space


### PR DESCRIPTION
Remaining outputs for Joint per #851 

Please review the names of the methods used from Simbody since Joint has Child & Parent frames and the SimTK::MobilizedBody refers to Body & Child. I assumed we get MobilizedBody from Child frame.