### PR TITLE
Fix Cooordinate's motion type initialization that caused hackathon example bug

### DIFF
--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -397,7 +397,6 @@ void testClutchedPathSpring()
     CoordinateSet &slider_coords = slider->upd_CoordinateSet();
     slider_coords[0].setName("block_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     model->addBody(pulleyBody);
     model->addJoint(weld);

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -104,7 +104,7 @@ Coordinate::Coordinate(const std::string &aName, MotionType aMotionType,
     Coordinate()
 {
     setName(aName);
-    setMotionType(aMotionType);
+    //setMotionType(aMotionType);
     setDefaultValue(defaultValue);
     setRangeMin(aRangeMin);
     setRangeMax(aRangeMax);
@@ -117,9 +117,7 @@ Coordinate::Coordinate(const std::string &aName, MotionType aMotionType,
 void Coordinate::constructProperties(void)
 {
     setAuthors("Ajay Seth, Ayman Habib, Michael Sherman");
-    //The motion type of a Coordinate is determined by its parent Joint
-    constructProperty_motion_type("set_by_joint");
-    
+
     constructProperty_default_value(0.0);
     constructProperty_default_speed_value(0.0);
 
@@ -294,6 +292,13 @@ const Joint& Coordinate::getJoint() const
     return(_joint.getRef());
 }
 
+Coordinate::MotionType Coordinate::getMotionType() const
+{
+    int ix = getJoint().get_CoordinateSet().getIndex(this);
+    return getJoint().getMotionType(Joint::CoordinateIndex(ix));
+}
+
+
 //-----------------------------------------------------------------------------
 // VALUE
 //-----------------------------------------------------------------------------
@@ -414,35 +419,6 @@ void Coordinate::setRangeMax(double aMax)
 {
     upd_range(1) = aMax;
 }
-
-//_____________________________________________________________________________
-/**
- * Set coordinate's motion type.
- *
- */
- void Coordinate::setMotionType(MotionType motionType)
- {
-     if (_motionType == motionType) {
-         return;
-     }
-
-     _motionType = motionType;
-
-     //Also update the motionTypeName so that it is serialized with the model
-     switch(motionType){
-        case(Rotational) :  
-            //upd_motion_type() = "rotational";
-            break;
-        case(Translational) :
-            //upd_motion_type() = "translational";
-            break;
-        case(Coupled) :
-            //upd_motion_type() = "coupled";
-            break;
-        default :
-            throw(Exception("Coordinate: Attempting to specify an undefined motion type."));
-     }
- } 
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -109,6 +109,7 @@ public:
         Types include: Rotational, Translational and Coupled (both) */
     enum MotionType
     {
+        Undefined,
         Rotational,
         Translational,
         Coupled
@@ -127,8 +128,7 @@ public:
 
     /** access to the generalized Coordinate's motion type
         This can be Rotational, Translational, or Coupled (both) */
-    MotionType getMotionType() const { return _motionType; }
-    void setMotionType(MotionType aMotionType);
+    MotionType getMotionType() const;
 
     /** get the value of the Coordinate from the state */
     double getValue(const SimTK::State& s) const;
@@ -302,9 +302,6 @@ private:
     /* Keep a reference to the SimTK function owned by the PrescribedMotion
     Constraint, so we can change the value at which to lock the joint. */
     SimTK::ReferencePtr<ModifiableConstant> _lockFunction;
-
-    /* Motion type (translational, rotational or combination). */
-    MotionType _motionType;
 
     /* Label for the related state that is the generalized speed of
        this coordinate. */

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -56,10 +56,6 @@ public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-    OpenSim_DECLARE_PROPERTY(motion_type, std::string, 
-        "Coordinate can describe rotational, translational, or coupled motion. "
-        "Defaults to rotational.");
-
     OpenSim_DECLARE_PROPERTY(default_value, double, 
         "The value of this coordinate before any value has been set. "
         "Rotational coordinate value is in radians and Translational in meters.");

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -212,7 +212,7 @@ void CustomJoint::constructCoordinates()
                 }
             }
         }
-        coord->setMotionType(mt);
+        setMotionType(CoordinateIndex(i), mt);
     }
 }
 

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -174,19 +174,14 @@ void CustomJoint::constructCoordinates()
 
     for (int i = 0; i < ncoords; i++){
         std::string coordName = spatialTransform.getCoordinateNames()[i];
-
+        // Locate the coordinate in the set if it has already been defined (e.g. in XML) 
         int coordIndex = coordinateSet.getIndex(coordName);
-        Coordinate* coord = nullptr;
         if (coordIndex < 0){
-            coord = new Coordinate();
-            coord->setName(coordName);
-            // Let joint take ownership as it should
-            coordinateSet.adoptAndAppend(coord);
+            coordIndex = constructCoordinate(Coordinate::MotionType::Undefined);
         }
-        else {
-            //otherwise already in the set 
-            coord = &coordinateSet.get(coordIndex);
-        }
+        Coordinate& coord = coordinateSet.get(coordIndex);
+        coord.setName(coordName);
+
 
         // Determine if the MotionType of the Coordinate based
         // on which TransformAxis it is relate to 0-2 are Rotational

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -130,15 +130,15 @@ Joint::Joint(const std::string &name,
 Joint::CoordinateIndex Joint::constructCoordinate(Coordinate::MotionType mt)
 {
     Coordinate* coord = new Coordinate();
-    coord->setMotionType(mt);
-    //Joint has control over what is the motion type during construction
-    //and it should be considered its default value
-    coord->updProperty_motion_type().setValueIsDefault(true);
     coord->setName(getName() + "_coord_"
         + std::to_string(get_CoordinateSet().getSize()));
     // CoordinateSet takes ownership
     upd_CoordinateSet().adoptAndAppend(coord);
-    return CoordinateIndex(get_CoordinateSet().getIndex(coord));
+    auto cix = CoordinateIndex(get_CoordinateSet().getIndex(coord));
+    _motionTypes.push_back(mt);
+    SimTK_ASSERT_ALWAYS(numCoordinates() == _motionTypes.size(), 
+        "Joint::constructCoordinate() MotionTypes do not correspond to coordinates");
+    return cix;
 }
 
 //_____________________________________________________________________________
@@ -194,7 +194,6 @@ void Joint::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-
     CoordinateSet& coords = upd_CoordinateSet();
     // add all coordinates listed under this joint 
     for (int i = 0; i < coords.getSize(); ++i) {
@@ -206,9 +205,8 @@ void Joint::extendFinalizeFromProperties()
 // GET AND SET
 //=============================================================================
 //-----------------------------------------------------------------------------
-// CHILD BODY
+// CHILD Frame
 //-----------------------------------------------------------------------------
-//_____________________________________________________________________________
 const PhysicalFrame& Joint::getChildFrame() const
 {
     return getConnector<PhysicalFrame>("child_frame").getConnectee();
@@ -221,6 +219,24 @@ const OpenSim::PhysicalFrame& Joint::getParentFrame() const
 {
     return getConnector<PhysicalFrame>("parent_frame").getConnectee();
 }
+
+Coordinate::MotionType Joint::getMotionType(CoordinateIndex cix) const
+{
+    OPENSIM_THROW_IF(cix >= _motionTypes.size(), Exception,
+        "Joint::getMotionType() given an invalid CoordinateIndex");
+    return _motionTypes[cix];
+}
+
+void Joint::setMotionType(CoordinateIndex cix, Coordinate::MotionType mt)
+{
+    OPENSIM_THROW_IF(cix >= numCoordinates(), Exception,
+        "Joint::setMotionType() for an invalid CoordinateIndex");
+    if (_motionTypes.size() <= cix)
+        _motionTypes.resize(numCoordinates());
+
+    _motionTypes[cix] = mt;
+}
+
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -133,6 +133,7 @@ Joint::CoordinateIndex Joint::constructCoordinate(Coordinate::MotionType mt)
     coord->setName(getName() + "_coord_"
         + std::to_string(get_CoordinateSet().getSize()));
     // CoordinateSet takes ownership
+    coord->setJoint(*this);
     upd_CoordinateSet().adoptAndAppend(coord);
     auto cix = CoordinateIndex(get_CoordinateSet().getIndex(coord));
     _motionTypes.push_back(mt);

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -289,6 +289,13 @@ public:
     */
     virtual void scale(const ScaleSet& aScaleSet);
 
+#ifndef SWIG
+    /// @class CoordinateIndex
+    /// Unique integer type for local Coordinate indexing
+    SimTK_DEFINE_UNIQUE_INDEX_TYPE(CoordinateIndex);
+#endif //SWIG
+
+    Coordinate::MotionType getMotionType(CoordinateIndex cix) const;
 protected:
     /** A CoordinateIndex member is created by constructCoordinate(). E.g.:  
     \code{.cpp}
@@ -300,15 +307,15 @@ protected:
     \endcode
     */
 #ifndef SWIG
-    /// @class CoordinateIndex
-    /// Unique integer type for local Coordinate indexing
-    SimTK_DEFINE_UNIQUE_INDEX_TYPE(CoordinateIndex);
-
     /** Utility for derived Joints to add Coordinate(s) to reflect its DOFs.
     Derived Joints must construct as many Coordinates as reflected by the
     Mobilizer Qs. */
     CoordinateIndex constructCoordinate(Coordinate::MotionType mt); 
 #endif //SWIG
+
+    // This is only intended to allow the CustomJoint to set the MotionTypes
+    // of its Coordinates
+    void setMotionType(CoordinateIndex cix, Coordinate::MotionType mt);
 
     // build Joint transforms from properties
     void extendFinalizeFromProperties() override;
@@ -493,11 +500,14 @@ private:
         _slaveBodyForChild = slaveForChild;
     }
 
+private:
     //=========================================================================
     // DATA
     //=========================================================================
     SimTK::ReferencePtr<Body> _slaveBodyForParent;
     SimTK::ReferencePtr<Body> _slaveBodyForChild;
+
+    SimTK::Array_<Coordinate::MotionType> _motionTypes;
 
     friend class JointSet;
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1076,7 +1076,6 @@ void testFreeJoint()
         std::stringstream coord_name;
         coord_name << "hip_q" << i;
         hip_coords[i].setName(coord_name.str());
-        hip_coords[i].setMotionType(((i<3) ? Coordinate::Rotational : Coordinate::Translational));
     }
 
     // Add the thigh body which now also contains the hip joint to the model
@@ -1495,9 +1494,7 @@ void testPlanarJoint()
     CoordinateSet& kneeCoords = knee.upd_CoordinateSet();
     kneeCoords[0].setName("knee_rz");
     kneeCoords[0].setName("knee_tx");
-    kneeCoords[0].setMotionType(Coordinate::Translational);
     kneeCoords[0].setName("knee_ty");
-    kneeCoords[0].setMotionType(Coordinate::Translational);
 
     // Add the shank body which now also contains the knee joint to the model
     osimModel.addBody(&osim_shank);

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -189,7 +189,6 @@ void testExpressionBasedCoordinateForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -387,7 +386,6 @@ void testPathSpring()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("block_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&block);
     osimModel->addJoint(&weld);
@@ -493,7 +491,6 @@ void testSpringMass()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -592,7 +589,6 @@ void testBushingForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -708,7 +704,6 @@ void testFunctionBasedBushingForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -1220,7 +1215,6 @@ void testCoordinateLimitForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -1365,7 +1359,6 @@ void testCoordinateLimitForceRotational()
     CoordinateSet &pin_coords = pin.upd_CoordinateSet();
     pin_coords[0].setName("theta");
     pin_coords[0].setRange(positionRange);
-    pin_coords[0].setMotionType(Coordinate::Rotational);
 
     osimModel->addBody(&block);
     osimModel->addJoint(&pin);

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -116,7 +116,6 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
         std::stringstream coord_name;
         coord_name << "free_q" << i;
         free_coords.get(i).setName(coord_name.str());
-        free_coords.get(i).setMotionType(i > 2 ? Coordinate::Translational : Coordinate::Rotational);
     }
 
     osimModel->addBody(&ball);

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -94,7 +94,6 @@ void testControlSetControllerOnBlock()
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
     jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block and joint to the model
@@ -188,8 +187,6 @@ void testPrescribedControllerOnBlock(bool disabled)
     // Create 6 coordinates (degrees-of-freedom) between the ground and block
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
-    jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block body to the model
@@ -284,7 +281,6 @@ void testCorrectionControllerOnBlock()
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
     jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block body to the model


### PR DESCRIPTION
which caused simulation in debug and release and different platforms to be different.  In particular, the Joints was correctly setting the `MotionType` of its coordinates upon construction, BUT when deserializing we use the default (registered) `Coordinate` (clone) and fill in its property values (effectively wiping out the Joint constructed coordinates), in which case the `Coordinate`'s  `_motionType` was uninitialized, since only a Joint can specify the correct motion type.

Changes:
1. Specified `Coordinate::MotionType::Undefined(0)` to be the default constructed value (so it is never uninitialized). This caused both release and debug versions to be consist (but now wrong).
2. For the `Coordinate::MotionType` after deserialization to be correct, it must get its value from its owning Joint. Thus, when the `Joint` constructs its coordinates (as member initializers,  except for `CustomJoint` which must wait until `finalizeFromProperties`) it also keeps track of the `MotionType` for the same coordinate (by `CoordinateIndex`).
3. `Cooridinate::getMotionType()` remains for convenience but it delegates to its owning `Joint`.
4. Removed the `motion_type` property from `Coordinate`.



