### PR TITLE
Fix Cooordinate's motion type initialization that caused hackathon example bug

### DIFF
--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -397,7 +397,6 @@ void testClutchedPathSpring()
     CoordinateSet &slider_coords = slider->upd_CoordinateSet();
     slider_coords[0].setName("block_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     model->addBody(pulleyBody);
     model->addJoint(weld);

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -39,7 +39,7 @@ static const double GAIN{ 1.0 };
 static const double LOAD{ 2500.0 };
 static const double SPRINGSTIFF{ 5000 };
 static const double SIGNALGEN{ 0.33 };
-static const double REPORTING_INTERVAL{ 0.20 };
+static const double REPORTING_INTERVAL{ 0.2 };
 
 // Configure which hopper model to use and the attachments (by frame name)
 // and any signals (Outputs) for the device that will be created.
@@ -54,7 +54,7 @@ static const std::string HopperHeightOutput{
 
 namespace OpenSim {
 
-/* We begin by creating a class to conatin all the parts for the model of
+/* We begin by creating a class to contain all the parts for the model of
 our device. This is similar to how OpenSim uses Model to hold the parts
 of a musculoskeletal model. In a Model the parts are ModelComponents.
 Since the device will eventually be mounted on a musculoskeletal Model,
@@ -70,51 +70,20 @@ public:
     /** Add outputs so we can report device quantities we care about. */
     /** The length of the device from anchor to anchor point. */
     OpenSim_DECLARE_OUTPUT(length, double, getLength, SimTK::Stage::Position);
-    /** The lengthening speed of the device. */
-    OpenSim_DECLARE_OUTPUT(speed, double, getSpeed, SimTK::Stage::Velocity);
-    /** The force transmitted by the device. */
-    OpenSim_DECLARE_OUTPUT(tension, double, getTension, SimTK::Stage::Dynamics);
-    /** The power produced(+)/dissipated(-) by the device. */
-    OpenSim_DECLARE_OUTPUT(power, double, getPower, SimTK::Stage::Dynamics);
-    /** The height of the model that device is attached to. */
-    OpenSim_DECLARE_OUTPUT(height, double, getHeight, SimTK::Stage::Position);
-    /** The COM height of the model that device is attached to. */
-    OpenSim_DECLARE_OUTPUT(com_height, double, getCenterOfMassHeight,
-        SimTK::Stage::Position);
+
+    // TODO: add other outputs.
 
     /** Member functions to access values of interest from the device. */
     double getLength(const SimTK::State& s) const {
         return getComponent<PathActuator>("cableAtoB").getLength(s);
     }
-    double getSpeed(const SimTK::State& s) const {
-        return getComponent<PathActuator>("cableAtoB").getLengtheningSpeed(s);
-    }
-    double getTension(const SimTK::State& s) const {
-        return getComponent<PathActuator>("cableAtoB").computeActuation(s);
-    }
-    double getPower(const SimTK::State& s) const {
-        return getComponent<PathActuator>("cableAtoB").getPower(s);
-    }
 
-    //device can read model height as measured from the block to ground
-    double getHeight(const SimTK::State& s) const {
-        return getModel().getOutputValue<double>(s, HopperHeightOutput);
-    }
-
-    //device can also "sense" the model center of mass height 
-    double getCenterOfMassHeight(const SimTK::State& s) const {
-        SimTK::Vec3 compos = getModel().calcMassCenterPosition(s);
-        return compos[1];
-    }
-
+    // TODO: add other output functions.
 
 protected:
     /** Optionally change the color of the device's actuator path
         as its tension changes. */
     void extendRealizeDynamics(const SimTK::State& s) const override {
-        const auto& actuator = getComponent<PathActuator>("cableAtoB");
-        double level = fmin(1.0, getTension(s) / actuator.get_optimal_force());
-        actuator.getGeometryPath().setColor(s, SimTK::Vec3(level, 0.9, 0.1));
     }
 }; // end Device
 
@@ -129,12 +98,10 @@ protected:
 class PropMyoController : public OpenSim::Controller {
     OpenSim_DECLARE_CONCRETE_OBJECT(PropMyoController, OpenSim::Controller);
 public:
-    OpenSim_DECLARE_PROPERTY(gain, double,
-        "Gain used in converting muscle activation into a"
-        " control signal (units depend on the device)");
 
-    OpenSim_DECLARE_OUTPUT( myo_control, double, computeControl, 
-                            SimTK::Stage::Time);
+    // TODO: gain property
+
+    // TODO: myo_control output
 
     OpenSim_DECLARE_INPUT(activation, double, SimTK::Stage::Model,
             "The activation signal that this controller's signal is "
@@ -145,30 +112,30 @@ public:
     }
 
     double computeControl(const SimTK::State& s) const {
-        double activation = getInputValue<double>(s, "activation");
-        if (activation < 0.31)
-            return 0;
-        // Compute the control signal.
-        return get_gain() * activation;
+        // Compute the proportional control of GAIN * activation (Input)
+        // TODO
+        return 0;
     }
 
     void computeControls(const SimTK::State& s,
         SimTK::Vector& controls) const override {
         double signal = computeControl(s);
         // Add in this control signal to controls.
-        const auto& actuator = getConnectee<Actuator>("actuator");
+        // TODO
+        // const auto& actuator = getConnectee<Actuator>("actuator");
         SimTK::Vector thisActuatorsControls(1, signal);
-        actuator.addInControls(thisActuatorsControls, controls);
+        // Add in this controller's controls for the actuator
+        // TODO
     }
 
 private:
-    void constructProperties() override {
-        constructProperty_gain(1.0);
-    }
+
+    // TODO constructProperties()
 
     void constructConnectors() override {
         // The ScalarActuator for which we're computing a control signal.
-        constructConnector<Actuator>("actuator");
+        // TODO
+        
     }
 }; // end of PropMyoController
 
@@ -257,19 +224,22 @@ void connectDeviceToModel(const std::string& frameAname,
                           OpenSim::Device* device, OpenSim::Model& model) {
 
     //Get the known anchors (joints) that attach the device to a model
-    auto& anchorA = device->updComponent<OpenSim::Joint>("anchorA");
-    auto& anchorB = device->updComponent<OpenSim::Joint>("anchorB");
+    // TODO
+
     // Attach anchorA to frameA as anchor's (joint's) parent frame.
-    anchorA.setParentFrameName(frameAname);
+    // TODO
+
     // Attach anchorB to frameB as anchor's (joint's) parent frame.
-    anchorB.setParentFrameName(frameBname);
+    // TODO
+
 
     // handle wrapping if there is a wrap surface between the device
     // origin and insertion on the model.
-    handlePathWrapping(device, model);
+    // TODO
 
     // Add the device to the testBed.
-    model.addModelComponent(device);
+    // TODO
+
 }
 
 } // namespace OpenSim
@@ -294,10 +264,11 @@ OpenSim::Device* createDevice() {
     // at the origin of their respective frames, and moment of inertia of 0.5
     // and products of zero.
     auto cuffA = new OpenSim::Body("cuffA", 1, Vec3(0), Inertia(0.5));
-    auto cuffB = new OpenSim::Body("cuffB", 1, Vec3(0), Inertia(0.5));
-    // Add the masses to the device.
-    device->addComponent(cuffA);
-    device->addComponent(cuffB);
+    // TODO: cuffB
+
+    // Add the cuffs to the device.
+    // TODO
+
 
     // Create a sphere geometry to visually represent the cuffs
     OpenSim::Sphere sphere{ 0.01 };
@@ -306,44 +277,33 @@ OpenSim::Device* createDevice() {
     // Add sphere (geometry) attach them to the cuffs
     sphere.setFrameName("cuffA");
     cuffA->addGeometry(sphere);
-    sphere.setFrameName("cuffB");
-    cuffB->addGeometry(sphere);
+    // TODO: cuffB
 
     // Joint from something in the environment to cuffA.
     // It will be used to attach the device at cuffA to a model.
     auto anchorA = new OpenSim::WeldJoint();
-    anchorA->setName("anchorA");
+    // TODO: set name
+
     // Set only the child now. Parent will be in the environment.
-    anchorA->setChildFrameName("cuffA");
-    device->addComponent(anchorA);
+    // TODO
+
 
     // Joint from something in the environment to cuffB.
     // It will be used to attach the device at cuffA to a model.
-    auto anchorB = new OpenSim::WeldJoint();
-    anchorB->setName("anchorB");
-    // Set only the child now. Parent will be in the environment.
-    anchorB->setChildFrameName("cuffB");
-    device->addComponent(anchorB);
+    // TODO
 
-    // Actuator connecting the two cuffs (A and B).
-    auto pathActuator = new OpenSim::PathActuator();
-    pathActuator->setName("cableAtoB");
-    pathActuator->set_optimal_force(OPTIMAL_FORCE);
-    pathActuator->addNewPathPoint("point1", *cuffA, Vec3(0));
-    pathActuator->addNewPathPoint("point2", *cuffB, Vec3(0));
-    device->addComponent(pathActuator);
+    // PathActuator connecting the two cuffs (A and B).
+    // TODO
 
     // A controller that specifies the control to the actuator
-    auto controller = new OpenSim::PropMyoController();
-    controller->setName("controller");
-    controller->set_gain(GAIN);
+    // TODO
+    // TODO: finish implementing the PropMyoController class, above.
 
     // Connect the the controller to the device actuator
-    controller->updConnector<OpenSim::Actuator>("actuator").
-        connect(*pathActuator);
+    // TODO
 
     // Don't forget to add the controller to your device
-    device->addComponent(controller);
+    // TODO
 
     return device;
 }
@@ -368,29 +328,11 @@ void addDeviceReporterToModel(OpenSim::Device& device, OpenSim::Model& model,
 }
 
 void addReporterToHopper(OpenSim::Model& hopper) {
-    auto reporter = new OpenSim::ConsoleReporter();
-    reporter->setName("hopper_results");
-    reporter->set_report_time_interval(REPORTING_INTERVAL);
-    // A reporter has a multi channel Input called inputs that can connect to
-    // any number of Outputs as long as they are of type double.
-    reporter->updInput("inputs")
-        .connect(hopper.getOutput(SignalForKneeDevice));
-    reporter->updInput("inputs")
-        .connect(hopper.getOutput(HopperHeightOutput));
-    // don't forget to add the reporter to the hopper
-    hopper.addComponent(reporter);
+    // TODO
 }
 
 void addSignalGeneratorToDevice(OpenSim::Device* device) {
-    auto generator = new OpenSim::SignalGenerator();
-    generator->setName("generator");
-    // Trying changing the constant value and even changing
-    // the function, e.g. try a LinearFunction
-    generator->set_function(OpenSim::Constant(SIGNALGEN));
-    device->addComponent(generator);
-    // Wire up the Controller to use the generator for fake activations
-    device->updInput("controller/activation").
-        connect(generator->getOutput("signal"));
+    // TODO
 }
 
 
@@ -401,15 +343,9 @@ int main() {
     Model hopper(HopperModelFile);
     hopper.setUseVisualizer(true);
 
-    ForceReporter* fp = new ForceReporter(&hopper);
-    fp->setOn(true);
-    fp->setPrintResultFiles(true);
-
-    hopper.addAnalysis(fp);
-
     /**** EXERCISE 1: Add a Console Reporter ***********************************
-    /* Report the models height and muscle activation during the simulation.   *
-    /***************************************************************************/
+     * Report the models height and muscle activation during the simulation.   *
+     ***************************************************************************/
     addReporterToHopper(hopper);
     /**** EXERCISE 1: end *****************************************************/
     
@@ -418,13 +354,12 @@ int main() {
     // Simulate the hopper from the initial state. The state is updated during
     // the simulation.
     simulate(hopper, sH);
-    fp->printResults("hopperForces");
     //----------------------------- HOPPER CODE end ----------------------------
 
     //--------------------------- DEVICE CODE begin ----------------------------
     /**** EXERCISE 2: Create the Device ****************************************
-    /* Populate a Device instance with parts you need: anchors, actuator,...   *
-    /***************************************************************************/
+     * Populate a Device instance with parts you need: anchors, actuator,...   *
+     ***************************************************************************/
     auto device = createDevice();
     /**** EXERCISE 2: end *****************************************************/
 
@@ -440,8 +375,8 @@ int main() {
     connectDeviceToModel("ground", "load", device, testBed);
 
     /**** EXERCISE 3: Create a Signal Generator ********************************
-    /* Make a SignalGenerator class and use it to input signals to test device *
-    /***************************************************************************/
+     * Make a SignalGenerator class and use it to input signals to test device *
+     ***************************************************************************/
     addSignalGeneratorToDevice(device);
     /**** EXERCISE 3: end *****************************************************/
 
@@ -449,45 +384,43 @@ int main() {
     std::vector<std::string> deviceOutputs{ "length", "tension",
                                 "power", "controller/myo_control" };
     // add a ConsoleReporter to report device values during a simulation
-    addDeviceReporterToModel(*device, testBed, deviceOutputs);
+    // addDeviceReporterToModel(*device, testBed, deviceOutputs);
 
-    auto& sD = testBed.initSystem();
+    // initialize the system and the initial state
+    // auto& sD = testBed.initSystem();
 
     // Simulate the testBed containing the device only.
-    simulate(testBed, sD);
+    // TODO
+
     //----------------------------- DEVICE CODE end ---------------------------
 
     //---------------------------- HOPPER + DEVICE begin ----------------------
     /**** EXERCISE 4: Simulate Hopper with the Device **************************
-    /* Make a SignalGenerator class and use it to input signals to test device *
-    /***************************************************************************/
+     * Combine Hopper and Device models to simulate an assisted jump           *
+     ***************************************************************************/
     // Begin by loading the hopper from file and then we'll connect the device.
-    Model hopperWithDevice(HopperModelFile);
-    hopperWithDevice.setUseVisualizer(true);
+    // TODO
 
     // Make a copy (clone) of the device as a knee specific device to connect
     // to the hopper model
-    Device* kneeDevice = device->clone();
-    kneeDevice->finalizeFromProperties();
+    // TODO
 
     // Connect the kneeDevice to the hopper so it really becomes hopperWithDevice
-    connectDeviceToModel(DeviceAttachmentA, DeviceAttachmentB, 
-                         kneeDevice, hopperWithDevice);
+    // TODO
 
     // Hook-up the device's controller input ("activation") to its signal, which
     // is an Output from the hopper corresponding to the vastus muscle activation
-    kneeDevice->updInput("controller/activation")
-        .connect(hopperWithDevice.getOutput(SignalForKneeDevice));
+    // TODO
 
     // List desired device outputs (values of interest) by name
-    std::vector<std::string> deviceOutputs2{ "controller/myo_control",
-                                             "tension", "height" };
+    // TODO
+
     // add a ConsoleReporter to report device values during a simulation
-    addDeviceReporterToModel(*kneeDevice, hopperWithDevice, deviceOutputs2);
+    // TODO
 
     // Simulate the hopper with the device.
-    SimTK::State& sHD = hopperWithDevice.initSystem();
-    simulate(hopperWithDevice, sHD);
+    // TODO
+
     /**** EXERCISE 4: end *****************************************************/
     //----------------------------- HOPPER + DEVICE end ------------------------
 

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -104,7 +104,7 @@ Coordinate::Coordinate(const std::string &aName, MotionType aMotionType,
     Coordinate()
 {
     setName(aName);
-    setMotionType(aMotionType);
+    //setMotionType(aMotionType);
     setDefaultValue(defaultValue);
     setRangeMin(aRangeMin);
     setRangeMax(aRangeMax);
@@ -117,9 +117,7 @@ Coordinate::Coordinate(const std::string &aName, MotionType aMotionType,
 void Coordinate::constructProperties(void)
 {
     setAuthors("Ajay Seth, Ayman Habib, Michael Sherman");
-    //The motion type of a Coordinate is determined by its parent Joint
-    constructProperty_motion_type("set_by_joint");
-    
+
     constructProperty_default_value(0.0);
     constructProperty_default_speed_value(0.0);
 
@@ -294,6 +292,13 @@ const Joint& Coordinate::getJoint() const
     return(_joint.getRef());
 }
 
+Coordinate::MotionType Coordinate::getMotionType() const
+{
+    int ix = getJoint().get_CoordinateSet().getIndex(this);
+    return getJoint().getMotionType(Joint::CoordinateIndex(ix));
+}
+
+
 //-----------------------------------------------------------------------------
 // VALUE
 //-----------------------------------------------------------------------------
@@ -414,35 +419,6 @@ void Coordinate::setRangeMax(double aMax)
 {
     upd_range(1) = aMax;
 }
-
-//_____________________________________________________________________________
-/**
- * Set coordinate's motion type.
- *
- */
- void Coordinate::setMotionType(MotionType motionType)
- {
-     if (_motionType == motionType) {
-         return;
-     }
-
-     _motionType = motionType;
-
-     //Also update the motionTypeName so that it is serialized with the model
-     switch(motionType){
-        case(Rotational) :  
-            //upd_motion_type() = "rotational";
-            break;
-        case(Translational) :
-            //upd_motion_type() = "translational";
-            break;
-        case(Coupled) :
-            //upd_motion_type() = "coupled";
-            break;
-        default :
-            throw(Exception("Coordinate: Attempting to specify an undefined motion type."));
-     }
- } 
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -109,6 +109,7 @@ public:
         Types include: Rotational, Translational and Coupled (both) */
     enum MotionType
     {
+        Undefined,
         Rotational,
         Translational,
         Coupled
@@ -127,8 +128,7 @@ public:
 
     /** access to the generalized Coordinate's motion type
         This can be Rotational, Translational, or Coupled (both) */
-    MotionType getMotionType() const { return _motionType; }
-    void setMotionType(MotionType aMotionType);
+    MotionType getMotionType() const;
 
     /** get the value of the Coordinate from the state */
     double getValue(const SimTK::State& s) const;
@@ -302,9 +302,6 @@ private:
     /* Keep a reference to the SimTK function owned by the PrescribedMotion
     Constraint, so we can change the value at which to lock the joint. */
     SimTK::ReferencePtr<ModifiableConstant> _lockFunction;
-
-    /* Motion type (translational, rotational or combination). */
-    MotionType _motionType;
 
     /* Label for the related state that is the generalized speed of
        this coordinate. */

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -56,10 +56,6 @@ public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-    OpenSim_DECLARE_PROPERTY(motion_type, std::string, 
-        "Coordinate can describe rotational, translational, or coupled motion. "
-        "Defaults to rotational.");
-
     OpenSim_DECLARE_PROPERTY(default_value, double, 
         "The value of this coordinate before any value has been set. "
         "Rotational coordinate value is in radians and Translational in meters.");

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -212,7 +212,7 @@ void CustomJoint::constructCoordinates()
                 }
             }
         }
-        coord->setMotionType(mt);
+        setMotionType(CoordinateIndex(i), mt);
     }
 }
 

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -174,19 +174,14 @@ void CustomJoint::constructCoordinates()
 
     for (int i = 0; i < ncoords; i++){
         std::string coordName = spatialTransform.getCoordinateNames()[i];
-
+        // Locate the coordinate in the set if it has already been defined (e.g. in XML) 
         int coordIndex = coordinateSet.getIndex(coordName);
-        Coordinate* coord = nullptr;
         if (coordIndex < 0){
-            coord = new Coordinate();
-            coord->setName(coordName);
-            // Let joint take ownership as it should
-            coordinateSet.adoptAndAppend(coord);
+            coordIndex = constructCoordinate(Coordinate::MotionType::Undefined);
         }
-        else {
-            //otherwise already in the set 
-            coord = &coordinateSet.get(coordIndex);
-        }
+        Coordinate& coord = coordinateSet.get(coordIndex);
+        coord.setName(coordName);
+
 
         // Determine if the MotionType of the Coordinate based
         // on which TransformAxis it is relate to 0-2 are Rotational

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -238,7 +238,7 @@ void Joint::setMotionType(CoordinateIndex cix, Coordinate::MotionType mt)
         "Joint::setMotionType() for an invalid CoordinateIndex");
     // Grow the size of _motionTypes (array) if it is less than the number of
     // coordinates. Joint's _motionTypes must correspond to its CoordinateSet.
-    if (_motionTypes.size() < unsigned int(nc))
+    if (_motionTypes.size() < static_cast<unsigned>(nc))
         _motionTypes.resize(nc);
 
     _motionTypes[cix] = mt;

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -230,10 +230,16 @@ Coordinate::MotionType Joint::getMotionType(CoordinateIndex cix) const
 
 void Joint::setMotionType(CoordinateIndex cix, Coordinate::MotionType mt)
 {
-    OPENSIM_THROW_IF(cix >= numCoordinates(), Exception,
+    int nc = numCoordinates();
+
+    // Ensure that coordinate index is less than the number of coordinates
+    // this Joint has in its CoordinateSet.
+    OPENSIM_THROW_IF(cix >= nc, Exception,
         "Joint::setMotionType() for an invalid CoordinateIndex");
-    if (_motionTypes.size() <= cix)
-        _motionTypes.resize(numCoordinates());
+    // Grow the size of _motionTypes (array) if it is less than the number of
+    // coordinates. Joint's _motionTypes must correspond to its CoordinateSet.
+    if (_motionTypes.size() < unsigned int(nc))
+        _motionTypes.resize(nc);
 
     _motionTypes[cix] = mt;
 }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -130,15 +130,15 @@ Joint::Joint(const std::string &name,
 Joint::CoordinateIndex Joint::constructCoordinate(Coordinate::MotionType mt)
 {
     Coordinate* coord = new Coordinate();
-    coord->setMotionType(mt);
-    //Joint has control over what is the motion type during construction
-    //and it should be considered its default value
-    coord->updProperty_motion_type().setValueIsDefault(true);
     coord->setName(getName() + "_coord_"
         + std::to_string(get_CoordinateSet().getSize()));
     // CoordinateSet takes ownership
     upd_CoordinateSet().adoptAndAppend(coord);
-    return CoordinateIndex(get_CoordinateSet().getIndex(coord));
+    auto cix = CoordinateIndex(get_CoordinateSet().getIndex(coord));
+    _motionTypes.push_back(mt);
+    SimTK_ASSERT_ALWAYS(numCoordinates() == _motionTypes.size(), 
+        "Joint::constructCoordinate() MotionTypes do not correspond to coordinates");
+    return cix;
 }
 
 //_____________________________________________________________________________
@@ -194,7 +194,6 @@ void Joint::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-
     CoordinateSet& coords = upd_CoordinateSet();
     // add all coordinates listed under this joint 
     for (int i = 0; i < coords.getSize(); ++i) {
@@ -206,9 +205,8 @@ void Joint::extendFinalizeFromProperties()
 // GET AND SET
 //=============================================================================
 //-----------------------------------------------------------------------------
-// CHILD BODY
+// CHILD Frame
 //-----------------------------------------------------------------------------
-//_____________________________________________________________________________
 const PhysicalFrame& Joint::getChildFrame() const
 {
     return getConnector<PhysicalFrame>("child_frame").getConnectee();
@@ -221,6 +219,24 @@ const OpenSim::PhysicalFrame& Joint::getParentFrame() const
 {
     return getConnector<PhysicalFrame>("parent_frame").getConnectee();
 }
+
+Coordinate::MotionType Joint::getMotionType(CoordinateIndex cix) const
+{
+    OPENSIM_THROW_IF(cix >= _motionTypes.size(), Exception,
+        "Joint::getMotionType() given an invalid CoordinateIndex");
+    return _motionTypes[cix];
+}
+
+void Joint::setMotionType(CoordinateIndex cix, Coordinate::MotionType mt)
+{
+    OPENSIM_THROW_IF(cix >= numCoordinates(), Exception,
+        "Joint::setMotionType() for an invalid CoordinateIndex");
+    if (_motionTypes.size() <= cix)
+        _motionTypes.resize(numCoordinates());
+
+    _motionTypes[cix] = mt;
+}
+
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -133,6 +133,7 @@ Joint::CoordinateIndex Joint::constructCoordinate(Coordinate::MotionType mt)
     coord->setName(getName() + "_coord_"
         + std::to_string(get_CoordinateSet().getSize()));
     // CoordinateSet takes ownership
+    coord->setJoint(*this);
     upd_CoordinateSet().adoptAndAppend(coord);
     auto cix = CoordinateIndex(get_CoordinateSet().getIndex(coord));
     _motionTypes.push_back(mt);

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -293,9 +293,11 @@ public:
     /// @class CoordinateIndex
     /// Unique integer type for local Coordinate indexing
     SimTK_DEFINE_UNIQUE_INDEX_TYPE(CoordinateIndex);
-#endif //SWIG
 
+    /** Get the MotionType for a Coordinate that this Joint has enabled by
+        its CoordinateIndex (in the Joints list of Coordinates). */
     Coordinate::MotionType getMotionType(CoordinateIndex cix) const;
+#endif //SWIG
 protected:
     /** A CoordinateIndex member is created by constructCoordinate(). E.g.:  
     \code{.cpp}
@@ -311,11 +313,12 @@ protected:
     Derived Joints must construct as many Coordinates as reflected by the
     Mobilizer Qs. */
     CoordinateIndex constructCoordinate(Coordinate::MotionType mt); 
-#endif //SWIG
+
 
     // This is only intended to allow the CustomJoint to set the MotionTypes
     // of its Coordinates
     void setMotionType(CoordinateIndex cix, Coordinate::MotionType mt);
+#endif //SWIG
 
     // build Joint transforms from properties
     void extendFinalizeFromProperties() override;

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -289,6 +289,13 @@ public:
     */
     virtual void scale(const ScaleSet& aScaleSet);
 
+#ifndef SWIG
+    /// @class CoordinateIndex
+    /// Unique integer type for local Coordinate indexing
+    SimTK_DEFINE_UNIQUE_INDEX_TYPE(CoordinateIndex);
+#endif //SWIG
+
+    Coordinate::MotionType getMotionType(CoordinateIndex cix) const;
 protected:
     /** A CoordinateIndex member is created by constructCoordinate(). E.g.:  
     \code{.cpp}
@@ -300,15 +307,15 @@ protected:
     \endcode
     */
 #ifndef SWIG
-    /// @class CoordinateIndex
-    /// Unique integer type for local Coordinate indexing
-    SimTK_DEFINE_UNIQUE_INDEX_TYPE(CoordinateIndex);
-
     /** Utility for derived Joints to add Coordinate(s) to reflect its DOFs.
     Derived Joints must construct as many Coordinates as reflected by the
     Mobilizer Qs. */
     CoordinateIndex constructCoordinate(Coordinate::MotionType mt); 
 #endif //SWIG
+
+    // This is only intended to allow the CustomJoint to set the MotionTypes
+    // of its Coordinates
+    void setMotionType(CoordinateIndex cix, Coordinate::MotionType mt);
 
     // build Joint transforms from properties
     void extendFinalizeFromProperties() override;
@@ -493,11 +500,14 @@ private:
         _slaveBodyForChild = slaveForChild;
     }
 
+private:
     //=========================================================================
     // DATA
     //=========================================================================
     SimTK::ReferencePtr<Body> _slaveBodyForParent;
     SimTK::ReferencePtr<Body> _slaveBodyForChild;
+
+    SimTK::Array_<Coordinate::MotionType> _motionTypes;
 
     friend class JointSet;
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1076,7 +1076,6 @@ void testFreeJoint()
         std::stringstream coord_name;
         coord_name << "hip_q" << i;
         hip_coords[i].setName(coord_name.str());
-        hip_coords[i].setMotionType(((i<3) ? Coordinate::Rotational : Coordinate::Translational));
     }
 
     // Add the thigh body which now also contains the hip joint to the model
@@ -1495,9 +1494,7 @@ void testPlanarJoint()
     CoordinateSet& kneeCoords = knee.upd_CoordinateSet();
     kneeCoords[0].setName("knee_rz");
     kneeCoords[0].setName("knee_tx");
-    kneeCoords[0].setMotionType(Coordinate::Translational);
     kneeCoords[0].setName("knee_ty");
-    kneeCoords[0].setMotionType(Coordinate::Translational);
 
     // Add the shank body which now also contains the knee joint to the model
     osimModel.addBody(&osim_shank);

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -189,7 +189,6 @@ void testExpressionBasedCoordinateForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -387,7 +386,6 @@ void testPathSpring()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("block_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&block);
     osimModel->addJoint(&weld);
@@ -493,7 +491,6 @@ void testSpringMass()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -592,7 +589,6 @@ void testBushingForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -708,7 +704,6 @@ void testFunctionBasedBushingForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -1220,7 +1215,6 @@ void testCoordinateLimitForce()
     CoordinateSet &slider_coords = slider.upd_CoordinateSet();
     slider_coords[0].setName("ball_h");
     slider_coords[0].setRange(positionRange);
-    slider_coords[0].setMotionType(Coordinate::Translational);
 
     osimModel->addBody(&ball);
     osimModel->addJoint(&slider);
@@ -1365,7 +1359,6 @@ void testCoordinateLimitForceRotational()
     CoordinateSet &pin_coords = pin.upd_CoordinateSet();
     pin_coords[0].setName("theta");
     pin_coords[0].setRange(positionRange);
-    pin_coords[0].setMotionType(Coordinate::Rotational);
 
     osimModel->addBody(&block);
     osimModel->addJoint(&pin);

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -116,7 +116,6 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
         std::stringstream coord_name;
         coord_name << "free_q" << i;
         free_coords.get(i).setName(coord_name.str());
-        free_coords.get(i).setMotionType(i > 2 ? Coordinate::Translational : Coordinate::Rotational);
     }
 
     osimModel->addBody(&ball);

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -94,7 +94,6 @@ void testControlSetControllerOnBlock()
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
     jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block and joint to the model
@@ -188,8 +187,6 @@ void testPrescribedControllerOnBlock(bool disabled)
     // Create 6 coordinates (degrees-of-freedom) between the ground and block
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
-    jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block body to the model
@@ -284,7 +281,6 @@ void testCorrectionControllerOnBlock()
     CoordinateSet& jointCoordinateSet = blockToGround.upd_CoordinateSet();
     double posRange[2] = {-1, 1};
     jointCoordinateSet[0].setName("xTranslation");
-    jointCoordinateSet[0].setMotionType(Coordinate::Translational);
     jointCoordinateSet[0].setRange(posRange);
 
     // Add the block body to the model


### PR DESCRIPTION
which caused simulation in debug and release and different platforms to be different. In particular, the Joints was correctly setting the MotionType of its coordinates upon construction, BUT when deserializing we use the default (registered) Coordinate (clone) and fill in its property values (effectively wiping out the Joint constructed coordinates), in which case the Coordinate's _motionType was uninitialized, since only a Joint can specify the correct motion type.

**Changes:**
1. Specified `Coordinate::MotionType::Undefined(0)` to be the default constructed value (so it is never uninitialized). This caused both release and debug versions to be consist (but now wrong).
2. For the `Coordinate::MotionType` after deserialization to be correct, it must get its value from its owning `Joint`. Thus, when the `Joint` constructs its coordinates (as member initializers, except for `CustomJoint` which must wait until `finalizeFromProperties`) it also keeps track of the `MotionType` for the same coordinate (by `CoordinateIndex`).
3. `Cooridinate::getMotionType()` remains for convenience but it delegates to its owning `Joint`.
4. Removed the `motion_type` property from `Coordinate`