### PR TITLE
ASSERT_EQUAL overload for SimTK::Vec

### DIFF
--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -29,15 +29,20 @@
 #include <OpenSim/Common/PropertyObjArray.h>
 #include "getRSS.h"
 
-using namespace OpenSim;
-using namespace std;
-
 template <typename T>
-void ASSERT_EQUAL(T expected, T found, T tolerance, std::string file="", int line=-1, std::string message="") {
+void ASSERT_EQUAL(T expected, 
+                  T found, 
+                  T tolerance, 
+                  std::string file="", 
+                  int line=-1, 
+                  std::string message="") {
     if (found < expected - tolerance || found > expected + tolerance)
         throw OpenSim::Exception(message, file, line);
 }
-inline void ASSERT(bool cond, std::string file="", int line=-1, std::string message="Exception") {
+inline void ASSERT(bool cond, 
+                   std::string file="", 
+                   int line=-1, 
+                   std::string message="Exception") {
     if (!cond) throw OpenSim::Exception(message, file, line);
 }
 /**
@@ -45,7 +50,12 @@ inline void ASSERT(bool cond, std::string file="", int line=-1, std::string mess
  * specified tolerances. If RMS error for any column is outside the
  * tolerance, throw an Exception.
  */
-void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result, OpenSim::Storage& standard, OpenSim::Array<double> tolerances, std::string testFile, int testFileLine, std::string errorMessage)
+void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result, 
+                                    OpenSim::Storage& standard, 
+                                    OpenSim::Array<double> tolerances, 
+                                    std::string testFile, 
+                                    int testFileLine, 
+                                    std::string errorMessage)
 {
     OpenSim::Array<std::string> columnsUsed;
     OpenSim::Array<double> comparisons;
@@ -53,13 +63,15 @@ void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result, OpenSim::Storage& 
 
     int ncolumns = columnsUsed.getSize();
 
-    ASSERT(ncolumns > 0, testFile, testFileLine, errorMessage + "- no common columns to compare!");
+    ASSERT(ncolumns > 0, testFile, testFileLine, 
+           errorMessage + "- no common columns to compare!");
 
     for (int i = 0; i < ncolumns; ++i) {
         std::cout << "column:    " << columnsUsed[i] << std::endl;
         std::cout << "RMS error: " << comparisons[i] << std::endl;
         std::cout << "tolerance: " << tolerances[i] << std::endl << std::endl;
-        ASSERT(comparisons[i] < tolerances[i], testFile, testFileLine, errorMessage);
+        ASSERT(comparisons[i] < tolerances[i], testFile, testFileLine, 
+               errorMessage);
     }
 }
 
@@ -85,11 +97,15 @@ do { \
 
 static OpenSim::Object* randomize(OpenSim::Object* obj)
 {
+    using namespace OpenSim;
+    using namespace std;
+
     if (obj==nullptr) return 0; // maybe empty tag
     std::stringstream stream;
     stream << rand();
     obj->setName(obj->getConcreteClassName()+stream.str());
-    // Cycle thru properties and based on type, populate with a random valid value
+    // Cycle thru properties and based on type, populate with a random valid 
+    // value.
      for (int p=0; p < obj->getNumProperties(); ++p) {
         AbstractProperty& ap = obj->updPropertyByIndex(p); 
         //cout << ap.getName() << "=" << ap.toString() << endl;
@@ -102,22 +118,23 @@ static OpenSim::Object* randomize(OpenSim::Object* obj)
         //cout << ts << endl;
         if (ap.isOptionalProperty()) 
             continue;
-        if (ts == "bool"&& !isList) ap.updValue<bool>() = !ap.getValue<bool>();
-        else if (ts == "integer"&& !isList) ap.updValue<int>() = rand();
-        else if (ts == "double" && !isList) ap.updValue<double>() = (double)rand()/RAND_MAX;
-        else if (ts == "Vec3" && !isList){
+        if (ts == "bool"&& !isList) 
+            ap.updValue<bool>() = !ap.getValue<bool>();
+        else if (ts == "integer"&& !isList) 
+            ap.updValue<int>() = rand();
+        else if (ts == "double" && !isList) 
+            ap.updValue<double>() = (double)rand()/RAND_MAX;
+        else if (ts == "Vec3" && !isList) {
             Property<SimTK::Vec3>& prop = Property<SimTK::Vec3>::updAs(ap);
             prop = SimTK::Vec3(abs(rand()), abs(rand()), abs(rand()));
-        }
-        else if (ts == "Vec6" && !isList){
+        } else if (ts == "Vec6" && !isList) {
             // Only property that uses a Vec6 is the inertia property
             // Might as well select valid inertias for the purpose of testing
             Property<SimTK::Vec6>& prop = Property<SimTK::Vec6>::updAs(ap);
             double Ixx = abs(rand());
             double Ixy = 0.01*Ixx;
             prop = SimTK::Vec6(Ixx, Ixx, Ixx, Ixy, Ixy, Ixy);
-        }
-        else if (ts == "string"){
+        } else if (ts == "string") {
             string base("ABCXYZ");
             if (isList){
                 stringstream val;
@@ -127,12 +144,10 @@ static OpenSim::Object* randomize(OpenSim::Object* obj)
             else{
                 ap.updValue<string>() = base;
             }
-        }
-        else if (ts == "double" && isList && ap.getMaxListSize() < 20){
+        } else if (ts == "double" && isList && ap.getMaxListSize() < 20) {
             for (int i=0; i< ap.getMaxListSize(); ++i)
                 ap.updValue<double>(i) = (double) rand();
-        }
-        else if (ts == "Function"){
+        } else if (ts == "Function") {
             //FunctionSet's objects getTypeName() returns "Function"
             //which is wrong! This is a HACK to test that we aren't
             //treating the PropertyObjArray<Function> as a Function.
@@ -144,17 +159,16 @@ static OpenSim::Object* randomize(OpenSim::Object* obj)
                 }
             }
             else{
-                Property<OpenSim::Function>& prop = Property<Function>::updAs(ap);
+                Property<Function>& prop = Property<Function>::updAs(ap);
                 prop = LinearFunction();
             }
             
-        }
-        else if (ap.isObjectProperty() && !isList){
+        } else if (ap.isObjectProperty() && !isList) {
             randomize(&ap.updValueAsObject(0));
             ap.setValueIsDefault(false);
-        }
-        else{
-            //cerr << "Unrecognized Property:"<< ap.getName()<< ":" << ap.toString() << endl;
+        } else {
+            //cerr << "Unrecognized Property:"<< ap.getName()<< ":" 
+            //     << ap.toString() << endl;
         }
      }
      return obj;

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -45,7 +45,11 @@ void ASSERT_EQUAL(const SimTK::Vec<M, ELT, STRIDE>& vecA,
                   const std::string& file = "",
                   int line = -1,
                   const std::string& message = "") {
-    SimTK_TEST_EQ(vecA, vecB);
+    try {
+        SimTK_TEST_EQ(vecA, vecB);
+    } catch(const SimTK::Exception::Assert&) {
+        throw OpenSim::Exception(message, file, line);
+    }
 }
 template<int M, typename ELT, int STRIDE>
 void ASSERT_EQUAL(const SimTK::Vec<M, ELT, STRIDE>& vecA,
@@ -54,7 +58,11 @@ void ASSERT_EQUAL(const SimTK::Vec<M, ELT, STRIDE>& vecA,
                   const std::string& file = "",
                   int line = -1,
                   const std::string& message = "") {
-    SimTK_TEST_EQ_TOL(vecA, vecB, tolerance);
+    try {
+        SimTK_TEST_EQ_TOL(vecA, vecB, tolerance);
+    } catch(const SimTK::Exception::Assert&) {
+        throw OpenSim::Exception(message, file, line);
+    }
 }
 
 

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -33,12 +33,31 @@ template <typename T>
 void ASSERT_EQUAL(T expected, 
                   T found, 
                   T tolerance, 
-                  std::string file="", 
-                  int line=-1, 
-                  std::string message="") {
+                  std::string file = "", 
+                  int line = -1, 
+                  std::string message = "") {
     if (found < expected - tolerance || found > expected + tolerance)
         throw OpenSim::Exception(message, file, line);
 }
+template<int M, typename ELT, int STRIDE>
+void ASSERT_EQUAL(const SimTK::Vec<M, ELT, STRIDE>& vecA,
+                  const SimTK::Vec<M, ELT, STRIDE>& vecB,
+                  const std::string& file = "",
+                  int line = -1,
+                  const std::string& message = "") {
+    SimTK_TEST_EQ(vecA, vecB);
+}
+template<int M, typename ELT, int STRIDE>
+void ASSERT_EQUAL(const SimTK::Vec<M, ELT, STRIDE>& vecA,
+                  const SimTK::Vec<M, ELT, STRIDE>& vecB,
+                  double tolerance,
+                  const std::string& file = "",
+                  int line = -1,
+                  const std::string& message = "") {
+    SimTK_TEST_EQ_TOL(vecA, vecB, tolerance);
+}
+
+
 inline void ASSERT(bool cond, 
                    std::string file="", 
                    int line=-1, 


### PR DESCRIPTION
Addressing #880.

* Added two overloads for `ASSERT_EQUAL` for `SimTK::Vec` --
 * One that accepts tolerance.
 * One that does not accept tolerance and uses the default.

 Delegate to `SimTK_TEST_EQ` and `SimTK_TEST_EQ_TOL` respectively.

* Cleaned up the header file --
 * Moved `using namespace` declarations into function. If `using namespace` declaration is used in the header like it was, any file including this header will be forced to include the namespaces, potentially leading to name collisions.
 * Split lines to fit 80 char width.