### PR TITLE
Remove signed index in Connector classes

### DIFF
--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -12,7 +12,6 @@
 // osimCommon Library
 %include <OpenSim/Common/osimCommonDLL.h>
 %include <OpenSim/Common/Exception.h>
-%template(IndexOutOfRangeSizeT) OpenSim::IndexOutOfRange<size_t>;
 %include <OpenSim/Common/Array.h>
 %include <OpenSim/Common/ArrayPtrs.h>
 %include <OpenSim/Common/AbstractProperty.h>

--- a/OpenSim/Actuators/ContDerivMuscle_Deprecated.cpp
+++ b/OpenSim/Actuators/ContDerivMuscle_Deprecated.cpp
@@ -586,7 +586,7 @@ computeIsometricForce(SimTK::State& s, double aActivation) const
    int i;
    double length, tendon_length, fiber_force, tmp_fiber_length, min_tendon_stiffness;
    double cos_factor, fiber_stiffness;
-   double old_fiber_length, length_change, tendon_stiffness, percent;
+   double old_fiber_length{SimTK::NaN}, length_change, tendon_stiffness, percent;
    double error_force = 0.0, old_error_force, tendon_force, norm_tendon_length;
    
    // If the muscle has no fibers, then treat it as a ligament.

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -307,7 +307,7 @@ void testTorqueActuator()
     }
 
     // determine the initial kinetic energy of the system
-    double iKE = model->getMatterSubsystem().calcKineticEnergy(state);
+    /*double iKE = */model->getMatterSubsystem().calcKineticEnergy(state);
 
     RungeKuttaMersonIntegrator integrator(model->getMultibodySystem());
     integrator.setAccuracy(integ_accuracy);
@@ -322,7 +322,7 @@ void testTorqueActuator()
 
     model->computeStateVariableDerivatives(state);
 
-    double fKE = model->getMatterSubsystem().calcKineticEnergy(state);
+    /*double fKE = */model->getMatterSubsystem().calcKineticEnergy(state);
 
     // Change in system kinetic energy can only be attributable to actuator work
     //double actuatorWork = (powerProbe->getProbeOutputs(state))[0];
@@ -354,9 +354,9 @@ void testClutchedPathSpring()
     double stiffness = 100;
     double dissipation = 0.3;
     double start_h = 0.5;
-    double ball_radius = 0.25;
+    //double ball_radius = 0.25;
 
-    double omega = sqrt(stiffness/mass);
+    //double omega = sqrt(stiffness/mass);
 
     // Setup OpenSim model
     Model* model = new Model;
@@ -376,7 +376,7 @@ void testClutchedPathSpring()
     block->attachMeshGeometry("box.vtp");
     block->scale(Vec3(0.2, 0.1, 0.1), false);
 
-    double dh = mass*gravity_vec(1)/stiffness;
+    //double dh = mass*gravity_vec(1)/stiffness;
     
     WrapCylinder* pulley = new WrapCylinder();
     pulley->setRadius(0.1);
@@ -781,7 +781,7 @@ void testActuatorsCombination()
     Vec3 torqueInG = torqueMag*torqueUnitAxis;
 
     // needed to be called here once to build controller for body actuator
-    State& state = model->initSystem();
+    /*State& state = */model->initSystem();
     
     // ---------------------------------------------------------------------------
     // Add a set of PointActuator, TorqueActuator and BodyActuator to the model

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1378,7 +1378,7 @@ void Component::dumpConnections() const {
         if (connector.getNumConnectees() == 0) {
             std::cout << "no connectees" << std::endl;
         } else {
-            for (int i = 0; i < connector.getNumConnectees(); ++i) {
+            for (unsigned i = 0; i < connector.getNumConnectees(); ++i) {
                 std::cout << connector.getConnecteeName(i) << " ";
             }
             std::cout << std::endl;
@@ -1396,9 +1396,11 @@ void Component::dumpConnections() const {
         if (input.getNumConnectees() == 0) {
             std::cout << "no connectees" << std::endl;
         } else {
-            for (int i = 0; i < input.getNumConnectees(); ++i) {
+            for (unsigned i = 0; i < input.getNumConnectees(); ++i) {
                 std::cout << input.getConnecteeName(i) << " ";
-                // TODO as is, requires the input connections to be satisfied. std::cout << " (annotation: " << input.getAnnotation(i) << ") ";
+                // TODO as is, requires the input connections to be satisfied. 
+                // std::cout << " (annotation: " << input.getAnnotation(i) 
+                //           << ") ";
             }
             std::cout << std::endl;
         }

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2473,7 +2473,7 @@ void Input<T>::connect(const AbstractChannel& channel,
 template<class T>
 void Input<T>::findAndConnect(const Component& root) {
     std::string outputPath, channelName, annotation;
-    for (int ix = 0; ix < getNumConnectees(); ++ix) {
+    for (unsigned ix = 0; ix < getNumConnectees(); ++ix) {
         parseConnecteeName(getConnecteeName(ix), outputPath, channelName,
                            annotation);
         try {

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -127,8 +127,9 @@ public:
     
     /** The number of connectees connected to this connector. This is either
         0 or 1 for a non-list connector. */
-    int getNumConnectees() const {
-        return getProperty_connectee_name().size();
+    unsigned getNumConnectees() const {
+        auto num = getProperty_connectee_name().size();
+        return static_cast<unsigned>(num);
     }
 
     /** Get the type of object this connector connects to*/

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -61,12 +61,12 @@ public:
     }
 };
 
-class RowIndexOutOfRange : public IndexOutOfRange<size_t> {
+class RowIndexOutOfRange : public IndexOutOfRange {
 public:
     using IndexOutOfRange::IndexOutOfRange;
 };
 
-class ColumnIndexOutOfRange : public IndexOutOfRange<size_t> {
+class ColumnIndexOutOfRange : public IndexOutOfRange {
 public:
     using IndexOutOfRange::IndexOutOfRange;
 };

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -217,15 +217,14 @@ public:
     }
 };
 
-template <typename T>
 class IndexOutOfRange : public Exception {
 public:
     IndexOutOfRange(const std::string& file,
                     size_t line,
                     const std::string& func,
-                    T index,
-                    T min, 
-                    T max) :
+                    size_t index,
+                    size_t min, 
+                    size_t max) :
         Exception(file, line, func) {
         std::string msg = "min = " + std::to_string(min);
         msg += " max = " + std::to_string(max);

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -153,7 +153,7 @@ protected:
         const auto& input = this->template getInput<InputT>("inputs");
         SimTK::RowVector_<ValueT> result(int(input.getNumConnectees()));
 
-        for (auto idx = 0; idx < input.getNumConnectees(); ++idx) {
+        for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
               const auto& chan = input.getChannel(idx);
               const auto& value = chan.getValue(state);
               result[idx] = value;
@@ -168,7 +168,7 @@ protected:
         const auto& input = this->template getInput<InputT>("inputs");
 
         std::vector<std::string> labels;
-        for (auto idx = 0; idx < input.getNumConnectees(); ++idx) {
+        for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
             const auto& chan = input.getChannel(idx);
             std::string label = chan.getName();
             if (label.empty()) {
@@ -214,7 +214,7 @@ private:
         if (_printCount % 40 == 0) {
             std::cout << "[" << this->getName() << "] " << "\n";
             std::cout << std::setw(_width) << "time" << "| ";
-            for (auto idx = 0; idx < input.getNumConnectees(); ++idx) {
+            for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
                 const auto& chan = input.getChannel(idx);
                 const auto& outName = chan.getName();
                 const auto& truncName = 

--- a/OpenSim/Common/ValueArray.h
+++ b/OpenSim/Common/ValueArray.h
@@ -77,7 +77,7 @@ public:
     \throws std::out_of_range If index is out of range.                       */
     Value<T>& operator[](size_t index) override {
         OPENSIM_THROW_IF(isIndexOutOfRange(index), 
-                         IndexOutOfRange<size_t>, index, 0, _values.size());
+                         IndexOutOfRange, index, 0, _values.size());
         return _values.at(index);
     } 
 
@@ -86,7 +86,7 @@ public:
     \throws std::out_of_range If index is out of range.                       */
     const Value<T>& operator[](size_t index) const override {
         OPENSIM_THROW_IF(isIndexOutOfRange(index), 
-                         IndexOutOfRange<size_t>, index, 0, _values.size());
+                         IndexOutOfRange, index, 0, _values.size());
         return _values.at(index);
     }
 

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -137,8 +137,10 @@ Joint::CoordinateIndex Joint::constructCoordinate(Coordinate::MotionType mt)
     upd_CoordinateSet().adoptAndAppend(coord);
     auto cix = CoordinateIndex(get_CoordinateSet().getIndex(coord));
     _motionTypes.push_back(mt);
-    SimTK_ASSERT_ALWAYS(numCoordinates() == _motionTypes.size(), 
-        "Joint::constructCoordinate() MotionTypes do not correspond to coordinates");
+    SimTK_ASSERT_ALWAYS(static_cast<unsigned>(numCoordinates()) == 
+                        _motionTypes.size(), 
+                        "Joint::constructCoordinate() MotionTypes do not "
+                        "correspond to coordinates");
     return cix;
 }
 

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -190,7 +190,8 @@ public:
         try {
             return m_states.at(index);
         } catch (const std::out_of_range&) {
-            OPENSIM_THROW(IndexOutOfRange<size_t>, index, 0, m_states.size() - 1);
+            OPENSIM_THROW(IndexOutOfRange, index, 0, 
+                          static_cast<unsigned>(m_states.size() - 1));
         }
     }
     /** Get a const reference to the first state in the trajectory. */

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -1442,7 +1442,7 @@ void testCoordinateLimitForceRotational()
         double ediss = clf->getDissipatedEnergy(osim_state);
         // system KE + PE including strain energy in CLF
         double eSys = osimModel->getMultibodySystem().calcEnergy(osim_state)+ ediss;
-        double EKsys = osimModel->getMultibodySystem().calcKineticEnergy(osim_state);
+        /*double EKsys = */osimModel->getMultibodySystem().calcKineticEnergy(osim_state);
 
         ASSERT_EQUAL(eSys/eSys0, 1.0, integ_accuracy);
 

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -539,9 +539,9 @@ void testBoundsCheck() {
         states[4];
         states[5];
     #endif
-    SimTK_TEST_MUST_THROW_EXC(states.get(4), IndexOutOfRange<size_t>);
+    SimTK_TEST_MUST_THROW_EXC(states.get(4), IndexOutOfRange);
     SimTK_TEST_MUST_THROW_EXC(states.get(states.getSize() + 100),
-            IndexOutOfRange<size_t>);
+                              IndexOutOfRange);
 }
 
 void testIntegrityChecks() {

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -206,7 +206,7 @@ bool SimbodySimmModel::writeJointFile(const string& aFileName) const
 {
     int i;
    ofstream out;
-    int functionIndex = 1;
+   //int functionIndex = 1;
 
    out.open(aFileName.c_str());
    out.setf(ios::fixed);

--- a/Vendors/lepton/src/CompiledExpression.cpp
+++ b/Vendors/lepton/src/CompiledExpression.cpp
@@ -90,7 +90,7 @@ void CompiledExpression::compileExpression(const ExpressionTreeNode& node, vecto
     // Process the child nodes.
     
     vector<int> args;
-    for (int i = 0; i < node.getChildren().size(); i++) {
+    for (unsigned i = 0; i < node.getChildren().size(); i++) {
         compileExpression(node.getChildren()[i], temps);
         args.push_back(findTempIndex(node.getChildren()[i], temps));
     }
@@ -112,7 +112,7 @@ void CompiledExpression::compileExpression(const ExpressionTreeNode& node, vecto
             // If the arguments are sequential, we can just pass a pointer to the first one.
             
             bool sequential = true;
-            for (int i = 1; i < args.size(); i++)
+            for (unsigned i = 1; i < args.size(); i++)
                 if (args[i] != args[i-1]+1)
                     sequential = false;
             if (sequential)
@@ -149,12 +149,12 @@ double CompiledExpression::evaluate() const {
 #else
     // Loop over the operations and evaluate each one.
     
-    for (int step = 0; step < operation.size(); step++) {
+    for (unsigned step = 0; step < operation.size(); step++) {
         const vector<int>& args = arguments[step];
         if (args.size() == 1)
             workspace[target[step]] = operation[step]->evaluate(&workspace[args[0]], dummyVariables);
         else {
-            for (int i = 0; i < args.size(); i++)
+            for (unsigned i = 0; i < args.size(); i++)
                 argValues[i] = workspace[args[i]];
             workspace[target[step]] = operation[step]->evaluate(&argValues[0], dummyVariables);
         }


### PR DESCRIPTION
* Change Connector classes to use `unsigned` index instead of `signed` index. This provides for a cleaner interface without need for `-1` as default index showing up in the interface of the function. `unsigned` also makes it clear to compiler and user that this number is always non-negative.
* The above change eliminates need to templatize `IndexOutOfRange`. Making it a non-template class required changes to other code.
* Fix some compiler warnings while at it.

I encountered this while working on #889.