### PR TITLE
Attempt to fix appveyor error creating Release directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ build_script:
   - mkdir %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cd %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cmake %OPENSIM_DEPENDENCIES_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DSUPERBUILD_simbody=OFF 
-  - cmake --build . --config Release -- /maxcpucount:4 # /verbosity:quiet
+  - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet
   - mkdir %OPENSIM_BUILD_DIR%
   ## Configure and build OpenSim.
   # Must create separate build dir, otherwise can't read test files
@@ -72,14 +72,14 @@ build_script:
   # Hack to avoid error MSB3191: Unable to create directory "C:\projects\opensim_build\Release\"
   # which may result from parallel jobs trying to create this directory.
   - cmake --build . --target SimbodyFiles --config Release
-  - cmake --build . --config Release -- /maxcpucount:4 # /verbosity:quiet #/p:TreatWarningsAsErrors="true"
+  - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet #/p:TreatWarningsAsErrors="true"
   
 test_script:
   ## Run tests.
   - ctest --parallel 4 --build-config Release --output-on-failure
 
   ## Ensure we have no trouble installing.
-  - cmake --build . --target install --config Release -- /maxcpucount:4 # /verbosity:quiet
+  - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   
   ## Test python wrapping.
   - set PATH=%OPENSIM_INSTALL_DIR%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ build_script:
   - mkdir %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cd %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cmake %OPENSIM_DEPENDENCIES_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DSUPERBUILD_simbody=OFF 
-  - cmake --build . --config Release -- /maxcpucount:4
+  - cmake --build . --config Release -- /maxcpucount:4 # /verbosity:quiet
   - mkdir %OPENSIM_BUILD_DIR%
   ## Configure and build OpenSim.
   # Must create separate build dir, otherwise can't read test files
@@ -69,14 +69,14 @@ build_script:
   - cmake %OPENSIM_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DSIMBODY_HOME=C:\simbody -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON 
 
   # Build.
-  - cmake --build . --config Release -- /maxcpucount:4 #/p:TreatWarningsAsErrors="true"
+  - cmake --build . --config Release -- /maxcpucount:4 # /verbosity:quiet #/p:TreatWarningsAsErrors="true"
   
 test_script:
   ## Run tests.
   - ctest --parallel 4 --build-config Release --output-on-failure
 
   ## Ensure we have no trouble installing.
-  - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
+  - cmake --build . --target install --config Release -- /maxcpucount:4 # /verbosity:quiet
   
   ## Test python wrapping.
   - set PATH=%OPENSIM_INSTALL_DIR%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ init:
   # The Scripts directory is for putting nosetests on the path.
   # http://www.appveyor.com/docs/installed-software
   - SET PATH=C:\Python27-x64\;%PATH%
-  - SET OPENSIM_HOME=C:\OpenSim
   - SET OPENSIM_SOURCE_DIR=C:\projects\opensim-core
   - SET OPENSIM_BUILD_DIR=C:\projects\opensim_build
   - SET OPENSIM_INSTALL_DIR=C:\projects\opensim_install
@@ -60,7 +59,7 @@ build_script:
   - mkdir %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cd %OPENSIM_DEPENDENCIES_BUILD_DIR%
   - cmake %OPENSIM_DEPENDENCIES_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DSUPERBUILD_simbody=OFF 
-  - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet
+  - cmake --build . --config Release -- /maxcpucount:4
   - mkdir %OPENSIM_BUILD_DIR%
   ## Configure and build OpenSim.
   # Must create separate build dir, otherwise can't read test files
@@ -70,7 +69,7 @@ build_script:
   - cmake %OPENSIM_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DSIMBODY_HOME=C:\simbody -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON 
 
   # Build.
-  - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet #/p:TreatWarningsAsErrors="true"
+  - cmake --build . --config Release -- /maxcpucount:4 #/p:TreatWarningsAsErrors="true"
   
 test_script:
   ## Run tests.
@@ -92,7 +91,7 @@ after_test:
   - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   - # Create and upload NuGet package.
   - IF DEFINED DISTR cd %APPVEYOR_BUILD_FOLDER%
-  - IF DEFINED DISTR nuget pack .opensim-core.nuspec -BasePath %OPENSIM_HOME%
+  - IF DEFINED DISTR nuget pack .opensim-core.nuspec -BasePath %OPENSIM_INSTALL_DIR%
   - IF DEFINED DISTR appveyor PushArtifact opensim-core.0.0.0.nupkg
 
 # The following, if uncommented, should allow you to remote-desktop into

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,6 +69,9 @@ build_script:
   - cmake %OPENSIM_SOURCE_DIR% -G"Visual Studio 14 2015 Win64" -DSIMBODY_HOME=C:\simbody -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON 
 
   # Build.
+  # Hack to avoid error MSB3191: Unable to create directory "C:\projects\opensim_build\Release\"
+  # which may result from parallel jobs trying to create this directory.
+  - cmake --build . --target SimbodyFiles --config Release
   - cmake --build . --config Release -- /maxcpucount:4 # /verbosity:quiet #/p:TreatWarningsAsErrors="true"
   
 test_script:


### PR DESCRIPTION
This PR attempts to fix the issue with Appveyor where MSBuild has trouble creating the Release directory.

This PR also fixes #870 