### PR TITLE
We only support Python2 right now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,9 +301,7 @@ directory to your `PATH` environment variable.
 * In **PowerShell**, *run as Administrator* --
 
  ```powershell
- choco install python
- choco install jdk8
- choco install swig
+ choco install python2 jdk8 swig
  ```
 * In **PowerShell** --
 


### PR DESCRIPTION
Update Powershell instructions to `choco` install Python2. Previously, it would install Python3.