### PR TITLE
New Point Component base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ New Classes
 - Joints were refactored so that the base Joint manages the parent and child frame connections, including the definition of local PhysicalOffsetFrames to handle offsets defined as separate location and orientation properties. (PR #589)  
 - The WeldConstraint and BushingForces (BushingForce, CoupledBushingForce, FunctionBasedBushingForce, and ExpressionBasedBushingForce) were similarly unified (like Joints) to handle the two Frames that these classes require to operate. A LinkTwoFrames intermediate class was introduced to house the common operations. Convenience constructors for WeldConstraint and BushingFrames were affected and now require the name of the Component as the first argument. (PR #649)
 - The new StatesTrajectory class allows users to load an exact representation of previously-computed states from a file. (PR #730)
+- Added Point as a new base class for all points, which include: Station, Marker, and PathPoints
 
 
 Python
@@ -66,7 +67,7 @@ Other Changes
 - Made Object::print a const member function (PR #191)
 - Improved the testOptimization/OptimizationExample to reduce the runtime (PR #416)
 - InverseKinematics tool outputs marker error .sto file if report error flag is true.
-- Marker location file output name in IK changed to reflect trial name for batch processing. 
+- Marker location file output name in IK changed to reflect trial name for batch processing.
 
 Documentation
 --------------

--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -577,7 +577,7 @@ record(const SimTK::State& s)
         
         // find the point of application of the joint load on the child
         // in the ground reference frame
-        Vec3 childLocationInGlobal = joint.getChildFrame().getGroundTransform(s_analysis).p();
+        Vec3 childLocationInGlobal = joint.getChildFrame().getTransformInGround(s_analysis).p();
         // set the point of application to the joint location in the child body
         Vec3 pointOfApplication(0,0,0);
         
@@ -587,7 +587,7 @@ record(const SimTK::State& s)
             /*Take reaction load from child and apply on parent*/
             force = -force;
             moment = -moment;
-            Vec3 parentLocationInGlobal = joint.getParentFrame().getGroundTransform(s_analysis).p();
+            Vec3 parentLocationInGlobal = joint.getParentFrame().getTransformInGround(s_analysis).p();
 
             // define vector from the mobilizer location on the child to the location on the parent
             Vec3 translation = parentLocationInGlobal - childLocationInGlobal;

--- a/OpenSim/Sandbox/futureIKListOutputs.cpp
+++ b/OpenSim/Sandbox/futureIKListOutputs.cpp
@@ -217,7 +217,7 @@ public:
         for (int ichan = 0; ichan < input.getNumConnectees(); ++ichan) {
             const auto& markerName = input.getAnnotation(ichan);
             const auto& marker = getModel().getMarkerSet().get(markerName);
-            const auto& mbi = marker.getReferenceFrame().getMobilizedBodyIndex();
+            const auto& mbi = marker.getParentFrame().getMobilizedBodyIndex();
             const_cast<Self*>(this)->_onBodyB.push_back(mbi);
             const_cast<Self*>(this)->_stationPinB.push_back(marker.get_location());
         }
@@ -271,27 +271,27 @@ void createModel(Model& model) {
     hog->getCoordinateSet().get(0).setDefaultValue(0.5 * SimTK::Pi);
     
     auto* asis = new OpenSim::Marker();
-    asis->setName("asis"); asis->setReferenceFrame(*pelvis);
+    asis->setName("asis"); asis->setParentFrame(*pelvis);
     model.addMarker(asis);
     
     auto* psis = new OpenSim::Marker();
-    psis->setName("psis"); psis->setReferenceFrame(*pelvis);
+    psis->setName("psis"); psis->setParentFrame(*pelvis);
     model.addMarker(psis);
     
     auto* med_knee = new OpenSim::Marker();
-    med_knee->setName("med_knee"); med_knee->setReferenceFrame(*femur);
+    med_knee->setName("med_knee"); med_knee->setParentFrame(*femur);
     model.addMarker(med_knee);
     
     auto* lat_knee = new OpenSim::Marker();
-    lat_knee->setName("lat_knee"); lat_knee->setReferenceFrame(*femur);
+    lat_knee->setName("lat_knee"); lat_knee->setParentFrame(*femur);
     model.addMarker(lat_knee);
     
     auto* thigh = new OpenSim::Marker();
-    thigh->setName("thigh"); thigh->setReferenceFrame(*femur);
+    thigh->setName("thigh"); thigh->setParentFrame(*femur);
     model.addMarker(thigh);
     
     auto* hjc = new OpenSim::Marker();
-    hjc->setName("hjc"); hjc->setReferenceFrame(*femur);
+    hjc->setName("hjc"); hjc->setParentFrame(*femur);
     model.addMarker(hjc);
 }
 

--- a/OpenSim/Simulation/InverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/InverseKinematicsSolver.cpp
@@ -233,9 +233,9 @@ void InverseKinematicsSolver::setupGoals(SimTK::State &s)
         if((index >= 0) && (wIndex >=0)){
             Marker &marker = modelMarkerSet[index];
             const SimTK::MobilizedBody& mobod =
-                marker.getReferenceFrame().getMobilizedBody();
+                marker.getParentFrame().getMobilizedBody();
 
-            X_BF = marker.getReferenceFrame().findTransformInBaseFrame();
+            X_BF = marker.getParentFrame().findTransformInBaseFrame();
             _markerAssemblyCondition->
                 addMarker(marker.getName(), mobod, X_BF*marker.get_location(),
 

--- a/OpenSim/Simulation/Model/ExpressionBasedBushingForce.cpp
+++ b/OpenSim/Simulation/Model/ExpressionBasedBushingForce.cpp
@@ -389,7 +389,7 @@ void ExpressionBasedBushingForce::generateDecorations
 
             // location of the bushing on frame2
             //SimTK::Vec3 p_b2M_b2 = frame2.findTransformInBaseFrame().p();
-            SimTK::Vec3 p_GM_G = frame2.getGroundTransform(s).p();
+            SimTK::Vec3 p_GM_G = frame2.getTransformInGround(s).p();
             
             // Add moment on frame2 as line vector starting at bushing location
             SimTK::Vec3 scaled_M_GM(get_moment_visual_scale()*F_GM[0]);

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -95,6 +95,10 @@ public:
         SimTK::Stage::Position);
     OpenSim_DECLARE_OUTPUT(transform, SimTK::Transform, getTransformInGround,
         SimTK::Stage::Position);
+    OpenSim_DECLARE_OUTPUT(velocity, SimTK::SpatialVec, getVelocityInGround,
+        SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(acceleration, SimTK::SpatialVec, getAccelerationInGround,
+        SimTK::Stage::Acceleration);
 
     /** @name Spatial Operations for Frames
     These methods allow access to the frame's transform and some convenient
@@ -235,22 +239,10 @@ public:
         const SimTK::Vec3 scale = SimTK::Vec3(1));
 
 protected:
-    /** @name Component Extension methods.
-        Frame types override these Component methods. */
-    /**@{**/
-    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
-    void extendRealizeTopology(SimTK::State& s) const override;
-
-    /// override default extendAddGeometry to set Frame to this Object
-    void extendAddGeometry(OpenSim::Geometry& geom) override;
-
-    /**@}**/
-
-private:
-    /** @name Extension methods.
+    /** @name Extension of calculations of Frame kinematics.
     Concrete Frame types must override these calculations.
     Results of the calculations are cached by the Frame and made accessible
-    via the corresponding getTransformInGround, getVelocityInGround, 
+    via the corresponding getTransformInGround, getVelocityInGround,
     getAccelerationInGround public methods (above). */
     /**@{**/
 
@@ -262,18 +254,30 @@ private:
     virtual SimTK::Transform
         calcTransformInGround(const SimTK::State& state) const = 0;
 
-    /** The spatial velocity {omega; v} for this Frame in ground. */
+    /** The spatial velocity {omega; v} of this Frame in ground. */
     virtual SimTK::SpatialVec
         calcVelocityInGround(const SimTK::State& state) const = 0;
 
     /** The spatial acceleration {alpha; a} for this Frame in ground */
     virtual SimTK::SpatialVec
         calcAccelerationInGround(const SimTK::State& state) const = 0;
+    /**@}**/
 
+    /** @name Component Extension methods.
+    Frame types override these Component methods. */
+    /**@{**/
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+    void extendRealizeTopology(SimTK::State& s) const override;
+
+    /// override default extendAddGeometry to set Frame to this Object
+    void extendAddGeometry(OpenSim::Geometry& geom) override;
+    /**@}**/
+
+private:
     /** Extend how concrete Frame determines its base Frame. */
     virtual const Frame& extendFindBaseFrame() const = 0;
     virtual SimTK::Transform extendFindTransformInBaseFrame() const = 0;
-    /**@}**/
+
 
     SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _transformIndex;
     SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _velocityIndex;

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -222,7 +222,8 @@ public:
     /** Add a Mesh specified by file name to the list of Geometry owned by the Frame.
     Scale defaults to 1.0 but can be changed on the call line for convenience.
     */
-    void attachMeshGeometry(const std::string &aGeometryFileName, const SimTK::Vec3 scale = SimTK::Vec3(1));
+    void attachMeshGeometry(const std::string &aGeometryFileName,
+        const SimTK::Vec3 scale = SimTK::Vec3(1));
     /** Add a piece of Geometry to the list of Geometry owned by the Frame.
     This function is a convenience for ModelComponent::addGeometry() for the case 
     of adding Geometry directly to a Frame, and thus sets the "frame name" of the 
@@ -230,7 +231,8 @@ public:
     own a copy of the Geometry so any changes you make to geom after calling this 
     method will not have an effect.
     */
-    void attachGeometry(const OpenSim::Geometry& geom, const SimTK::Vec3 scale = SimTK::Vec3(1));
+    void attachGeometry(const OpenSim::Geometry& geom,
+        const SimTK::Vec3 scale = SimTK::Vec3(1));
 
 protected:
     /** @name Component Extension methods.
@@ -246,7 +248,10 @@ protected:
 
 private:
     /** @name Extension methods.
-        Concrete Frame types must override these methods. */
+    Concrete Frame types must override these calculations.
+    Results of the calculations are cached by the Frame and made accessible
+    via the corresponding getTransformInGround, getVelocityInGround, 
+    getAccelerationInGround public methods (above). */
     /**@{**/
 
     /** Calculate the transform related to this Frame with respect to ground.

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -106,7 +106,7 @@ public:
     It transforms quantities expressed in F into quantities expressed
     in G. This is mathematically stated as:
         vec_G = X_GF*vec_F ,
-    where X_GF is the transform returned by getGroundTransform.
+    where X_GF is the transform returned by getTransformInGround.
 
     @param state       The state applied to the model when determining the
                        transform.

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -93,7 +93,7 @@ public:
     //=============================================================================
     OpenSim_DECLARE_OUTPUT(position, SimTK::Vec3, getPositionInGround,
         SimTK::Stage::Position);
-    OpenSim_DECLARE_OUTPUT(transform, SimTK::Transform, getGroundTransform,
+    OpenSim_DECLARE_OUTPUT(transform, SimTK::Transform, getTransformInGround,
         SimTK::Stage::Position);
 
     /** @name Spatial Operations for Frames
@@ -112,7 +112,25 @@ public:
                        transform.
     @return transform  The transform between this frame and the ground frame
     */
-    const SimTK::Transform& getGroundTransform(const SimTK::State& state) const;
+    const SimTK::Transform&
+        getTransformInGround(const SimTK::State& state) const;
+
+    /** The spatial velocity V_GF {omega; v} for this Frame in ground.
+        It can be used to compute the velocity of any stationary point on F,
+        located at r_F (Vec3), in ground, G, as:
+            v_G = V_GF(0)*r_F + V_GF(1);
+        Is only valid at Stage::Velocity or higher. */
+    const SimTK::SpatialVec&
+        getVelocityInGround(const SimTK::State& state) const;
+
+    /** The spatial acceleration A_GF {alpha; a} for this Frame in ground.
+        It can also be used to compute the acceleration of any stationary point
+        on F, located at r_F (Vec3), in ground, G, as:
+            a_G = A_GF(0)*r_F + A_GF(1);
+        Is only valid at Stage::Acceleration or higher. */
+    const SimTK::SpatialVec&
+        getAccelerationInGround(const SimTK::State& state) const;
+
 
     /**
     Find the transform that describes this frame (F) relative to another
@@ -195,7 +213,7 @@ public:
 
     /** Accessor for position of the origin of the Frame in Ground. */
     SimTK::Vec3 getPositionInGround(const SimTK::State& state) const {
-        return getGroundTransform(state).p();
+        return getTransformInGround(state).p();
     };
 
     // End of Base Frame and Transform accessors
@@ -237,14 +255,24 @@ private:
     This is mathematically stated as:
         vec_G = X_GF*vec_F  */
     virtual SimTK::Transform
-        calcGroundTransform(const SimTK::State& state) const = 0;
+        calcTransformInGround(const SimTK::State& state) const = 0;
+
+    /** The spatial velocity {omega; v} for this Frame in ground. */
+    virtual SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const = 0;
+
+    /** The spatial acceleration {alpha; a} for this Frame in ground */
+    virtual SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const = 0;
 
     /** Extend how concrete Frame determines its base Frame. */
     virtual const Frame& extendFindBaseFrame() const = 0;
     virtual SimTK::Transform extendFindTransformInBaseFrame() const = 0;
     /**@}**/
 
-    SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _groundTransformIndex;
+    SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _transformIndex;
+    SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _velocityIndex;
+    SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _accelerationIndex;
 
 //=============================================================================
 };  // END of class Frame

--- a/OpenSim/Simulation/Model/FunctionBasedBushingForce.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedBushingForce.cpp
@@ -277,7 +277,7 @@ void FunctionBasedBushingForce::generateDecorations
 
             // location of the bushing on frame2
             //SimTK::Vec3 p_b2M_b2 = frame2.findTransformInBaseFrame().p();
-            SimTK::Vec3 p_GM_G = frame2.getGroundTransform(s).p();
+            SimTK::Vec3 p_GM_G = frame2.getTransformInGround(s).p();
 
             // Add moment on frame2 as line vector starting at bushing location
             SimTK::Vec3 scaled_M_GM(get_moment_visual_scale()*F_GM[0]);

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -271,10 +271,10 @@ getPointForceDirections(const SimTK::State& s,
 
             // Find the positions of start and end in the inertial frame.
             //engine.getPosition(s, start->getBody(), start->getLocation(), posStart);
-            posStart = start->getBody().getGroundTransform(s)*start->getLocation();
+            posStart = start->getBody().getTransformInGround(s)*start->getLocation();
             
             //engine.getPosition(s, end->getBody(), end->getLocation(), posEnd);
-            posEnd = end->getBody().getGroundTransform(s)*end->getLocation();
+            posEnd = end->getBody().getTransformInGround(s)*end->getLocation();
 
             // Form a vector from start to end, in the inertial frame.
             direction = (posEnd - posStart);
@@ -913,10 +913,10 @@ void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
 
         // Find the positions and velocities in the inertial frame.
         posStartInertial =
-            start->getBody().getGroundTransform(s)*start->getLocation();
+            start->getBody().getTransformInGround(s)*start->getLocation();
 
         posEndInertial =
-            end->getBody().getGroundTransform(s)*end->getLocation();
+            end->getBody().getTransformInGround(s)*end->getLocation();
 
         velStartInertial = start->getBody().getMobilizedBody()
             .findStationVelocityInGround(s, start->getLocation());

--- a/OpenSim/Simulation/Model/Ground.cpp
+++ b/OpenSim/Simulation/Model/Ground.cpp
@@ -48,10 +48,20 @@ Ground::Ground() : PhysicalFrame()
 /*
 * Implementation of Frame interface by Ground.
 */
-SimTK::Transform Ground::
-    calcGroundTransform(const SimTK::State& s) const
+SimTK::Transform Ground::calcTransformInGround(const SimTK::State& s) const
 {
     return SimTK::Transform();
+}
+
+SimTK::SpatialVec Ground::calcVelocityInGround(const SimTK::State& s) const
+{
+    return SimTK::SpatialVec(0);
+}
+
+/** The spatial acceleration {alpha; a} for this Frame in ground */
+SimTK::SpatialVec Ground::calcAccelerationInGround(const SimTK::State& s) const
+{
+    return SimTK::SpatialVec(0);
 }
 
 void Ground::extendAddToSystem(SimTK::MultibodySystem& system) const

--- a/OpenSim/Simulation/Model/Ground.h
+++ b/OpenSim/Simulation/Model/Ground.h
@@ -46,12 +46,21 @@ public:
     virtual ~Ground() {}
 
 protected:
-    /** The transform X_GF is the identity transform since this frame is Ground.*/
-    SimTK::Transform
-        calcGroundTransform(const SimTK::State& state) const override final;
-
     /** Extending the Component interface. */
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+
+private:
+    /** The transform X_GF is the identity transform since this frame is Ground.*/
+    SimTK::Transform
+        calcTransformInGround(const SimTK::State& state) const override final;
+
+    /** The spatial velocity {omega; v} if {0; 0} for ground */
+    SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const override final;
+
+    /** The spatial acceleration {alpha; a} = {0; 0} for ground */
+    SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const override final;
 
 };  // END of class Ground
 

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -77,7 +77,7 @@ void Marker::setFrameName(const string& aName)
     const PhysicalFrame* refFrame = dynamic_cast<const PhysicalFrame*>(&getModel().getFrameSet().get(aName));
     if (refFrame)
     {
-        setReferenceFrame(*refFrame);
+        setParentFrame(*refFrame);
     }
     else
     {
@@ -99,7 +99,7 @@ const string& Marker::getFrameName() const
     //if (_bodyNameProp.getValueIsDefault())
     //  return NULL;
 
-    return getReferenceFrame().getName();
+    return getParentFrame().getName();
 }
 
 //_____________________________________________________________________________
@@ -113,7 +113,7 @@ const string& Marker::getFrameName() const
 void Marker::changeFrame(const OpenSim::PhysicalFrame& aPhysicalFrame)
 {
 
-    if (aPhysicalFrame == getReferenceFrame())
+    if (aPhysicalFrame == getParentFrame())
         return;
 
     setFrameName(aPhysicalFrame.getName());
@@ -133,7 +133,7 @@ void Marker::changeFrame(const OpenSim::PhysicalFrame& aPhysicalFrame)
 void Marker::changeFramePreserveLocation(const SimTK::State& s, OpenSim::PhysicalFrame& aPhysicalFrame)
 {
 
-    if (aPhysicalFrame == getReferenceFrame())
+    if (aPhysicalFrame == getParentFrame())
         return;
 
     // Preserve location means to switch bodies without changing
@@ -198,7 +198,7 @@ void Marker::generateDecorations(bool fixed, const ModelDisplayHints& hints, con
     if (hints.get_show_markers()) { 
         // @TODO default color, size, shape should be obtained from hints
         const Vec3 pink(1, .6, .8);
-        const OpenSim::PhysicalFrame& frame = getReferenceFrame();
+        const OpenSim::PhysicalFrame& frame = getParentFrame();
         //const Frame& bf = frame.findBaseFrame();
         //SimTK::Transform bTrans = frame.findTransformInBaseFrame();
         //const Vec3& p_BM = bTrans*get_location();

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -178,7 +178,7 @@ void Marker::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
             SimTK::Xml::Element connectorsElement("connectors");
             SimTK::Xml::Element frameElement("Connector_PhysicalFrame_");
             connectorsElement.insertNodeAfter(connectorsElement.node_end(), frameElement);
-            frameElement.setAttributeValue("name", "reference_frame");
+            frameElement.setAttributeValue("name", "parent_frame");
             SimTK::Xml::Element connecteeElement("connectee_name");
             connecteeElement.setValue(bName);
             frameElement.insertNodeAfter(frameElement.node_end(), connecteeElement);

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -153,7 +153,13 @@ public:
 protected:
     /** The transform X_GF for this OffsetFrame, F, in ground, G.*/
     SimTK::Transform
-        calcGroundTransform(const SimTK::State& state) const override;
+        calcTransformInGround(const SimTK::State& state) const override;
+    /** The spatial velocity {omega; v} for this OffsetFrame in ground. */
+    SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const override;
+    /** The spatial acceleration {alpha; a} for this OffsetFrame in ground */
+    SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const override;
 
     /** Extend how OffsetFrame determines its base Frame. */
     const Frame& extendFindBaseFrame() const override final;
@@ -247,9 +253,24 @@ void OffsetFrame<C>::constructConnectors()
 // Implementation of Frame interface by OffsetFrame.
 template <class C>
 SimTK::Transform OffsetFrame<C>::
-calcGroundTransform(const SimTK::State& s) const
+calcTransformInGround(const SimTK::State& s) const
 {
-    return getParentFrame().getGroundTransform(s)*getOffsetTransform();
+    return getParentFrame().getTransformInGround(s)*getOffsetTransform();
+}
+
+template <class C>
+SimTK::SpatialVec OffsetFrame<C>::
+calcVelocityInGround(const SimTK::State& state) const
+{
+    const SimTK::Vec3& r = getTransformInGround(state).p();
+    return Super::getVelocityInGround(state);
+}
+
+template <class C>
+SimTK::SpatialVec OffsetFrame<C>::
+calcAccelerationInGround(const SimTK::State& state) const
+{
+    return Super::getAccelerationInGround(state);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -151,16 +151,6 @@ public:
     void scale(const SimTK::Vec3& scaleFactors);
 
 protected:
-    /** The transform X_GF for this OffsetFrame, F, in ground, G.*/
-    SimTK::Transform
-        calcTransformInGround(const SimTK::State& state) const override;
-    /** The spatial velocity {omega; v} for this OffsetFrame in ground. */
-    SimTK::SpatialVec
-        calcVelocityInGround(const SimTK::State& state) const override;
-    /** The spatial acceleration {alpha; a} for this OffsetFrame in ground */
-    SimTK::SpatialVec
-        calcAccelerationInGround(const SimTK::State& state) const override;
-
     /** Extend how OffsetFrame determines its base Frame. */
     const Frame& extendFindBaseFrame() const override final;
     /** Extend how OffsetFrame determines its transform in its base Frame. */
@@ -173,13 +163,22 @@ protected:
     void extendFinalizeFromProperties() override;
     /**@}**/
 
+    // The transform X_GO for this OffsetFrame, O, in Ground, G.
+    SimTK::Transform
+        calcTransformInGround(const SimTK::State& state) const override final;
+    // The spatial velocity, V_GO  {omega; v} of this OffsetFrame in Ground.
+    SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const override final;
+    // The spatial acceleration, A_GO {alpha; a} of this OffsetFrame in Ground.
+    SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const override final;
+
 private:
 
     void setNull();
     void constructProperties() override;
 
-    
-    // the tranform on my parent frame
+    // the Offset transform in its parent frame
     SimTK::Transform _offsetTransform;
 //=============================================================================
 }; // END of class OffsetFrame
@@ -255,21 +254,38 @@ template <class C>
 SimTK::Transform OffsetFrame<C>::
 calcTransformInGround(const SimTK::State& state) const
 {
-    return SimTK::Transform(SimTK::Vec3(SimTK::NaN));
+    return this->getParentFrame().getTransformInGround(state)*getOffsetTransform();
 }
 
 template <class C>
 SimTK::SpatialVec OffsetFrame<C>::
 calcVelocityInGround(const SimTK::State& state) const
 {
-    return SimTK::SpatialVec(SimTK::Vec3(SimTK::NaN));
+    // The rigid offset of the OffsetFrame expressed in ground
+    const SimTK::Vec3& r = this->getParentFrame().getTransformInGround(state).R()*
+        getOffsetTransform().p();
+    // Velocity of the base frame in ground
+    SimTK::SpatialVec V_GF = this->getParentFrame().getVelocityInGround(state);
+    // translational velocity needs additional omega x r term due to offset 
+    V_GF(1) += V_GF(0) % r;
+
+    return V_GF;
 }
 
 template <class C>
 SimTK::SpatialVec OffsetFrame<C>::
 calcAccelerationInGround(const SimTK::State& state) const
 {
-    return SimTK::SpatialVec(SimTK::Vec3(SimTK::NaN));
+    // The rigid offset of the OffsetFrame expressed in ground
+    const SimTK::Vec3& r = this->getParentFrame().getTransformInGround(state).R()*
+        getOffsetTransform().p();
+    // Velocity of the parent frame in ground
+    const SimTK::SpatialVec& V_GF = this->getParentFrame().getVelocityInGround(state);
+    // Velocity of the parent frame in ground
+    SimTK::SpatialVec A_GF = getParentFrame().getAccelerationInGround(state);
+    A_GF[1] += (A_GF[0] % r + V_GF[0] % (V_GF[0] % r));
+
+    return A_GF;
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -248,29 +248,28 @@ void OffsetFrame<C>::constructConnectors()
 }
 
 //=============================================================================
-// FRAME COMPUTATIONS
+// FRAME COMPUTATIONS must be specialized by concrete derived Offsets
 //=============================================================================
 // Implementation of Frame interface by OffsetFrame.
 template <class C>
 SimTK::Transform OffsetFrame<C>::
-calcTransformInGround(const SimTK::State& s) const
+calcTransformInGround(const SimTK::State& state) const
 {
-    return getParentFrame().getTransformInGround(s)*getOffsetTransform();
+    return SimTK::Transform(SimTK::Vec3(SimTK::NaN));
 }
 
 template <class C>
 SimTK::SpatialVec OffsetFrame<C>::
 calcVelocityInGround(const SimTK::State& state) const
 {
-    const SimTK::Vec3& r = getTransformInGround(state).p();
-    return Super::getVelocityInGround(state);
+    return SimTK::SpatialVec(SimTK::Vec3(SimTK::NaN));
 }
 
 template <class C>
 SimTK::SpatialVec OffsetFrame<C>::
 calcAccelerationInGround(const SimTK::State& state) const
 {
-    return Super::getAccelerationInGround(state);
+    return SimTK::SpatialVec(SimTK::Vec3(SimTK::NaN));
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/PhysicalFrame.cpp
+++ b/OpenSim/Simulation/Model/PhysicalFrame.cpp
@@ -80,11 +80,24 @@ SimTK::MobilizedBody& PhysicalFrame::updMobilizedBody()
 * 
 */
 SimTK::Transform PhysicalFrame::
-    calcGroundTransform(const SimTK::State& s) const
+    calcTransformInGround(const SimTK::State& s) const
 {
     // return X_GF = X_GB * X_BF;
     return getMobilizedBody().getBodyTransform(s);
 }
+
+SimTK::SpatialVec PhysicalFrame::
+calcVelocityInGround(const SimTK::State& state) const
+{
+    return getMobilizedBody().getBodyVelocity(state);
+}
+
+SimTK::SpatialVec PhysicalFrame::
+calcAccelerationInGround(const SimTK::State& state) const
+{
+    return getMobilizedBody().getBodyAcceleration(state);
+}
+
 
 SimTK::Transform PhysicalFrame::extendFindTransformInBaseFrame() const
 {

--- a/OpenSim/Simulation/Model/PhysicalFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalFrame.h
@@ -154,10 +154,6 @@ public:
     ///@} 
 
 protected:
-    /** The transform X_GF for this PhysicalFrame, F, in ground, G. */
-    SimTK::Transform
-        calcGroundTransform(const SimTK::State& state) const override;
-
     /** @name Advanced: PhysicalFrame Developer Interface
     These methods are intended for PhysicalFrame builders. */
     ///@{
@@ -193,6 +189,16 @@ protected:
         int versionNumber = -1) override;
 
 private:
+    /** The transform X_GF for this PhysicalFrame, F, in ground, G. */
+    SimTK::Transform
+        calcTransformInGround(const SimTK::State& state) const override;
+
+    /** The spatial velocity {omega; v} for this PhysicalFrame in ground. */
+    SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const override;
+    /** The spatial acceleration {alpha; a} for this PhysicalFrame in ground */
+    SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const override;
 
     /* Component construction interface */
     void constructProperties() override;

--- a/OpenSim/Simulation/Model/PhysicalOffsetFrame.cpp
+++ b/OpenSim/Simulation/Model/PhysicalOffsetFrame.cpp
@@ -33,38 +33,3 @@ void PhysicalOffsetFrame::extendAddToSystem(SimTK::MultibodySystem& system) cons
     Super::extendAddToSystem(system);
     setMobilizedBodyIndex(getParentFrame().getMobilizedBodyIndex());
 }
-
-SimTK::Transform PhysicalOffsetFrame::
-calcTransformInGround(const SimTK::State& state) const
-{
-    return getParentFrame().getTransformInGround(state)*getOffsetTransform();
-}
-
-SimTK::SpatialVec PhysicalOffsetFrame::
-calcVelocityInGround(const SimTK::State& state) const
-{
-    // The rigid offset of the OffsetFrame expressed in ground
-    const SimTK::Vec3& r = getParentFrame().getTransformInGround(state).R()*
-        getOffsetTransform().p();
-    // Velocity of the base frame in ground
-    SimTK::SpatialVec V_G = getParentFrame().getVelocityInGround(state);
-    // translational velocity needs additional omega x r term due to offset 
-    V_G(1) += V_G(0) % r;
-
-    return V_G;
-}
-
-SimTK::SpatialVec PhysicalOffsetFrame::
-calcAccelerationInGround(const SimTK::State& state) const
-{
-    // The rigid offset of the OffsetFrame expressed in ground
-    const SimTK::Vec3& r = getParentFrame().getTransformInGround(state).R()*
-        getOffsetTransform().p();
-    // Velocity of the parent frame in ground
-    const SimTK::SpatialVec& V_G = getParentFrame().getVelocityInGround(state);
-    // Velocity of the parent frame in ground
-    SimTK::SpatialVec A_G = getParentFrame().getAccelerationInGround(state);
-    A_G[1] += (A_G[0] % r + V_G[0] % (V_G[0] % r));
-
-    return A_G;
-}

--- a/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
@@ -66,6 +66,20 @@ protected:
         underlying multibody system */
     void extendAddToSystem(SimTK::MultibodySystem& system) const override final;
 
+private:
+    /** The transform X_GO for this PhysicalOffsetFrame, O, in ground, G. */
+    SimTK::Transform
+        calcTransformInGround(const SimTK::State& state) const override final;
+
+    /** The spatial velocity {omega; v} for this PhysicalOffsetFrame in
+    ground. */
+    SimTK::SpatialVec
+        calcVelocityInGround(const SimTK::State& state) const override final;
+    /** The spatial acceleration {alpha; a} for this PhysicalOffsetFrame
+        in ground */
+    SimTK::SpatialVec
+        calcAccelerationInGround(const SimTK::State& state) const override final;
+
 //=============================================================================
 }; // END of class PhysicalOffsetFrame
 //=============================================================================

--- a/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
@@ -67,18 +67,7 @@ protected:
     void extendAddToSystem(SimTK::MultibodySystem& system) const override final;
 
 private:
-    /** The transform X_GO for this PhysicalOffsetFrame, O, in ground, G. */
-    SimTK::Transform
-        calcTransformInGround(const SimTK::State& state) const override final;
 
-    /** The spatial velocity {omega; v} for this PhysicalOffsetFrame in
-    ground. */
-    SimTK::SpatialVec
-        calcVelocityInGround(const SimTK::State& state) const override final;
-    /** The spatial acceleration {alpha; a} for this PhysicalOffsetFrame
-        in ground */
-    SimTK::SpatialVec
-        calcAccelerationInGround(const SimTK::State& state) const override final;
 
 //=============================================================================
 }; // END of class PhysicalOffsetFrame

--- a/OpenSim/Simulation/Model/Point.cpp
+++ b/OpenSim/Simulation/Model/Point.cpp
@@ -1,0 +1,89 @@
+/* -------------------------------------------------------------------------- *
+ *                             OpenSim:  Point.cpp                            *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2015 Stanford University and the Authors                *
+ * Author(s): Ajay Seth                                                       *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include "Point.h"
+
+//=============================================================================
+// STATICS
+//=============================================================================
+using namespace std;
+using namespace OpenSim;
+using SimTK::Mat33;
+using SimTK::Vec3;
+
+//=============================================================================
+// CONSTRUCTOR(S)
+//=============================================================================
+//_____________________________________________________________________________
+/**
+ * Default constructor.
+ */
+Point::Point() : ModelComponent()
+{
+    setAuthors("Ajay Seth");
+}
+
+
+void Point::extendAddToSystem(SimTK::MultibodySystem& system) const
+{
+    Super::extendAddToSystem(system);
+    SimTK::Vec3 v(SimTK::NaN);
+    // If the properties, topology or coordinate values change, 
+    // Stage::Position will be invalid.
+    addCacheVariable("location", v, SimTK::Stage::Position);
+}
+
+const SimTK::Vec3& Point::getLocationInGround(const SimTK::State& s) const
+{
+    if (!getSystem().getDefaultSubsystem().
+        isCacheValueRealized(s, _groundLocationIndex)){
+        //cache is not valid so calculate the transform
+        SimTK::Value<SimTK::Vec3>::downcast(
+            getSystem().getDefaultSubsystem().
+            updCacheEntry(s, _groundLocationIndex)).upd()
+                = calcLocationInGround(s);
+        // mark cache as up-to-date
+        getSystem().getDefaultSubsystem().
+            markCacheValueRealized(s, _groundLocationIndex);
+    }
+    return SimTK::Value<SimTK::Vec3>::downcast(
+        getSystem().getDefaultSubsystem().
+        getCacheEntry(s, _groundLocationIndex)).get();
+}
+
+//=============================================================================
+// POINT COMPUTATIONS
+//=============================================================================
+
+
+//=============================================================================
+// Component level realizations
+//=============================================================================
+void Point::extendRealizeTopology(SimTK::State& s) const
+{
+    Super::extendRealizeTopology(s);
+    _groundLocationIndex = getCacheVariableIndex("ground_location");
+}

--- a/OpenSim/Simulation/Model/Point.cpp
+++ b/OpenSim/Simulation/Model/Point.cpp
@@ -54,24 +54,62 @@ void Point::extendAddToSystem(SimTK::MultibodySystem& system) const
     // If the properties, topology or coordinate values change, 
     // Stage::Position will be invalid.
     addCacheVariable("location", v, SimTK::Stage::Position);
+    addCacheVariable("velocity", v, SimTK::Stage::Velocity);
+    addCacheVariable("acceleration", v, SimTK::Stage::Acceleration);
 }
 
 const SimTK::Vec3& Point::getLocationInGround(const SimTK::State& s) const
 {
     if (!getSystem().getDefaultSubsystem().
-        isCacheValueRealized(s, _groundLocationIndex)){
+        isCacheValueRealized(s, _locationIndex)){
         //cache is not valid so calculate the transform
         SimTK::Value<SimTK::Vec3>::downcast(
             getSystem().getDefaultSubsystem().
-            updCacheEntry(s, _groundLocationIndex)).upd()
+            updCacheEntry(s, _locationIndex)).upd()
                 = calcLocationInGround(s);
         // mark cache as up-to-date
         getSystem().getDefaultSubsystem().
-            markCacheValueRealized(s, _groundLocationIndex);
+            markCacheValueRealized(s, _locationIndex);
     }
     return SimTK::Value<SimTK::Vec3>::downcast(
         getSystem().getDefaultSubsystem().
-        getCacheEntry(s, _groundLocationIndex)).get();
+        getCacheEntry(s, _locationIndex)).get();
+}
+
+const SimTK::Vec3& Point::getVelocityInGround(const SimTK::State& s) const
+{
+    if (!getSystem().getDefaultSubsystem().
+        isCacheValueRealized(s, _velocityIndex)) {
+        //cache is not valid so calculate the transform
+        SimTK::Value<SimTK::Vec3>::downcast(
+            getSystem().getDefaultSubsystem().
+            updCacheEntry(s, _velocityIndex)).upd()
+            = calcVelocityInGround(s);
+        // mark cache as up-to-date
+        getSystem().getDefaultSubsystem().
+            markCacheValueRealized(s, _velocityIndex);
+    }
+    return SimTK::Value<SimTK::Vec3>::downcast(
+        getSystem().getDefaultSubsystem().
+        getCacheEntry(s, _velocityIndex)).get();
+}
+
+const SimTK::Vec3& Point::getAccelerationInGround(const SimTK::State& s) const
+{
+    if (!getSystem().getDefaultSubsystem().
+        isCacheValueRealized(s, _accelerationIndex)) {
+        //cache is not valid so calculate the transform
+        SimTK::Value<SimTK::Vec3>::downcast(
+            getSystem().getDefaultSubsystem().
+            updCacheEntry(s, _accelerationIndex)).upd()
+            = calcAccelerationInGround(s);
+        // mark cache as up-to-date
+        getSystem().getDefaultSubsystem().
+            markCacheValueRealized(s, _accelerationIndex);
+    }
+    return SimTK::Value<SimTK::Vec3>::downcast(
+        getSystem().getDefaultSubsystem().
+        getCacheEntry(s, _accelerationIndex)).get();
 }
 
 //=============================================================================
@@ -85,5 +123,7 @@ const SimTK::Vec3& Point::getLocationInGround(const SimTK::State& s) const
 void Point::extendRealizeTopology(SimTK::State& s) const
 {
     Super::extendRealizeTopology(s);
-    _groundLocationIndex = getCacheVariableIndex("ground_location");
+    _locationIndex = getCacheVariableIndex("location");
+    _velocityIndex = getCacheVariableIndex("velocity");
+    _accelerationIndex = getCacheVariableIndex("acceleration");
 }

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -62,18 +62,31 @@ public:
     virtual ~Point() {};
 
     /** @name Spatial Operations for Point
-    Convenient spatial operations with Points.*/
+    Convenient access to spatial kinematics of Points.*/
     /**@{**/
 
     /**
     Get the location of this Point relative to the Ground frame.
     @param state       The state applied to the model when determining the
                        location of the Point.
-    @return location   The location of the point expressed in the Ground frame
-    */
+    @return location   The location of the point expressed in the Ground. */
     const SimTK::Vec3& getLocationInGround(const SimTK::State& state) const;
 
-    // End of Point's Spatial Operations
+    /** The velocity v_G of this Point expressed in ground.
+    Is only valid at Stage::Velocity or higher.
+    @param state       The state applied to the model when determining the
+                       velocity of the Point.
+    @return velocity   The velocity of the point expressed in the Ground. */
+    const SimTK::Vec3& getVelocityInGround(const SimTK::State& state) const;
+
+    /** The acceleration a_G, of this Point expressed in ground.
+    Is only valid at Stage::Acceleration or higher. 
+    @param state       The state applied to the model when determining the
+                       acceleration of the Point.
+    @return velocity   The acceleration of the point expressed in Ground */
+    const SimTK::Vec3& getAccelerationInGround(const SimTK::State& state) const;
+
+    // End of Point's Spatial Kinematics
     ///@}
 
 protected:
@@ -105,7 +118,9 @@ protected:
 
 private:
 
-    mutable SimTK::CacheEntryIndex _groundLocationIndex;
+    mutable SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _locationIndex;
+    mutable SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _velocityIndex;
+    mutable SimTK::ResetOnCopy<SimTK::CacheEntryIndex> _accelerationIndex;
 
 //=============================================================================
 };  // END of class Point

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -32,15 +32,17 @@ namespace OpenSim {
 //=============================================================================
 //=============================================================================
 /**
- * A Point is an OpenSim representation for any location in space. Points are 
- * intended to locate physical structures (such as origins of joints
+ * A Point is an OpenSim abstraction for any point location in space. Points
+ * are intended to locate physical structures (such as points of constraints
  * and points of muscle attachments) as well as embody the results of spatial
  * calculations. For example, if your system involves contact, you can define
  * a Point that describes the location of the center-of-pressure as one
  * element rolls over another.
  *
- * A Point provides its location in the Ground frame as a function of the 
- * Model's (SimTK::MultibodySystem's) state.
+ * A Point provides its location, velocity and acceleration in the Ground frame
+ * as a function of the Model's (SimTK::MultibodySystem's) state, which is
+ * accessible when the state has been realized to the corresponding
+ * SimTK::Stage (i.e. Position, Velocity and Acceleration). 
  *
  * @author Ajay Seth
  */
@@ -73,14 +75,14 @@ public:
     const SimTK::Vec3& getLocationInGround(const SimTK::State& state) const;
 
     /** The velocity v_G of this Point expressed in ground.
-    Is only valid at Stage::Velocity or higher.
+        Is only valid at Stage::Velocity or higher.
     @param state       The state applied to the model when determining the
                        velocity of the Point.
     @return velocity   The velocity of the point expressed in the Ground. */
     const SimTK::Vec3& getVelocityInGround(const SimTK::State& state) const;
 
     /** The acceleration a_G, of this Point expressed in ground.
-    Is only valid at Stage::Acceleration or higher. 
+        Is only valid at Stage::Acceleration or higher. 
     @param state       The state applied to the model when determining the
                        acceleration of the Point.
     @return velocity   The acceleration of the point expressed in Ground */
@@ -95,15 +97,18 @@ protected:
     /**@{**/
 
     /** Calculate the location of this Point with respect to and expressed in
-        ground as a function of the state. */
+        ground as a function of the state. Can expect state to be realized to 
+        at least SimTK::Stage::Position */
     virtual SimTK::Vec3
         calcLocationInGround(const SimTK::State& state) const = 0;
     /** Calculate the velocity of this Point with respect to and expressed in
-        ground as a function of the state. */
+        ground as a function of the state. Can expect state to be realized to
+        at least SimTK::Stage::Velocity */
     virtual SimTK::Vec3
         calcVelocityInGround(const SimTK::State& state) const = 0;
     /** Calculate the acceleration of this Point with respect to and expressed
-        in ground as a function of the state. */
+        in ground as a function of the state. Can expect state to be realized 
+        to SimTK::Stage::Acceleration */
     virtual SimTK::Vec3
         calcAccelerationInGround(const SimTK::State& state) const = 0;
 

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -32,7 +32,7 @@ namespace OpenSim {
 //=============================================================================
 //=============================================================================
 /**
- * A Point is an OpenSim abstraction for any point location in space. Points
+ * A Point is an OpenSim abstraction for any location in space. Points
  * are intended to locate physical structures (such as points of constraints
  * and points of muscle attachments) as well as embody the results of spatial
  * calculations. For example, if your system involves contact, you can define
@@ -63,26 +63,27 @@ public:
 
     virtual ~Point() {};
 
-    /** @name Spatial Operations for Point
-    Convenient access to spatial kinematics of Points.*/
+    /** @name The three dimensional kinematics of the Point.
+    Convenient access to the kinematics of a Point expressed in Ground.*/
     /**@{**/
 
     /**
-    Get the location of this Point relative to the Ground frame.
+    Get the location, r_GP, of this Point, P, relative to and expressed in 
+    the Ground. Point position only valid at Stage::Position or higher.
     @param state       The state applied to the model when determining the
                        location of the Point.
     @return location   The location of the point expressed in the Ground. */
     const SimTK::Vec3& getLocationInGround(const SimTK::State& state) const;
 
-    /** The velocity v_G of this Point expressed in ground.
-        Is only valid at Stage::Velocity or higher.
+    /** The velocity v_GP of this Point, P, relative to and expressed in Ground.
+        Point's velocity is only valid at Stage::Velocity or higher.
     @param state       The state applied to the model when determining the
                        velocity of the Point.
     @return velocity   The velocity of the point expressed in the Ground. */
     const SimTK::Vec3& getVelocityInGround(const SimTK::State& state) const;
 
-    /** The acceleration a_G, of this Point expressed in ground.
-        Is only valid at Stage::Acceleration or higher. 
+    /** The acceleration a_GP, of this Point, P, relative to and expressed in
+    Ground. Point's acceleration is only valid at Stage::Acceleration or higher. 
     @param state       The state applied to the model when determining the
                        acceleration of the Point.
     @return velocity   The acceleration of the point expressed in Ground */
@@ -93,21 +94,24 @@ public:
 
 protected:
     /** @name Point Extension methods.
-    Concrete Point types must override these methods. */
+    Concrete Point types must override these calculations.
+    Results of the calculations are cached by the Point and made accessible
+    via the corresponding getLocationInGround, getVelocityInGround, 
+    getAccelerationInGround public methods (above). */
     /**@{**/
 
     /** Calculate the location of this Point with respect to and expressed in
-        ground as a function of the state. Can expect state to be realized to 
+        Ground as a function of the state. Can expect state to be realized to 
         at least SimTK::Stage::Position */
     virtual SimTK::Vec3
         calcLocationInGround(const SimTK::State& state) const = 0;
     /** Calculate the velocity of this Point with respect to and expressed in
-        ground as a function of the state. Can expect state to be realized to
+        Ground as a function of the state. Can expect state to be realized to
         at least SimTK::Stage::Velocity */
     virtual SimTK::Vec3
         calcVelocityInGround(const SimTK::State& state) const = 0;
     /** Calculate the acceleration of this Point with respect to and expressed
-        in ground as a function of the state. Can expect state to be realized 
+        in Ground as a function of the state. Can expect state to be realized 
         to SimTK::Stage::Acceleration */
     virtual SimTK::Vec3
         calcAccelerationInGround(const SimTK::State& state) const = 0;

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -1,0 +1,119 @@
+#ifndef OPENSIM_POINT_H_
+#define OPENSIM_POINT_H_
+/* -------------------------------------------------------------------------- *
+ *                              OpenSim:  Point.h                             *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2016 Stanford University and the Authors                *
+ * Author(s): Ajay Seth                                                       *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+// INCLUDE
+#include <OpenSim/Simulation/osimSimulationDLL.h>
+#include <OpenSim/Simulation/Model/ModelComponent.h>
+
+namespace OpenSim {
+
+//=============================================================================
+//=============================================================================
+/**
+ * A Point is an OpenSim representation for any location in space. Points are 
+ * intended to locate physical structures (such as origins of joints
+ * and points of muscle attachments) as well as embody the results of spatial
+ * calculations. For example, if your system involves contact, you can define
+ * a Point that describes the location of the center-of-pressure as one
+ * element rolls over another.
+ *
+ * A Point provides its location in the Ground frame as a function of the 
+ * Model's (SimTK::MultibodySystem's) state.
+ *
+ * @author Ajay Seth
+ */
+class OSIMSIMULATION_API Point : public ModelComponent {
+OpenSim_DECLARE_ABSTRACT_OBJECT(Point, ModelComponent);
+
+public:
+    OpenSim_DECLARE_OUTPUT(location, SimTK::Vec3, getLocationInGround,
+        SimTK::Stage::Position);
+    OpenSim_DECLARE_OUTPUT(velocity, SimTK::Vec3, calcVelocityInGround,
+        SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(acceleration, SimTK::Vec3, calcAccelerationInGround,
+        SimTK::Stage::Acceleration);
+    //--------------------------------------------------------------------------
+    // CONSTRUCTION
+    //--------------------------------------------------------------------------
+    Point();
+
+    virtual ~Point() {};
+
+    /** @name Spatial Operations for Point
+    Convenient spatial operations with Points.*/
+    /**@{**/
+
+    /**
+    Get the location of this Point relative to the Ground frame.
+    @param state       The state applied to the model when determining the
+                       location of the Point.
+    @return location   The location of the point expressed in the Ground frame
+    */
+    const SimTK::Vec3& getLocationInGround(const SimTK::State& state) const;
+
+    // End of Point's Spatial Operations
+    ///@}
+
+protected:
+    /** @name Point Extension methods.
+    Concrete Point types must override these methods. */
+    /**@{**/
+
+    /** Calculate the location of this Point with respect to and expressed in
+        ground as a function of the state. */
+    virtual SimTK::Vec3
+        calcLocationInGround(const SimTK::State& state) const = 0;
+    /** Calculate the velocity of this Point with respect to and expressed in
+        ground as a function of the state. */
+    virtual SimTK::Vec3
+        calcVelocityInGround(const SimTK::State& state) const = 0;
+    /** Calculate the acceleration of this Point with respect to and expressed
+        in ground as a function of the state. */
+    virtual SimTK::Vec3
+        calcAccelerationInGround(const SimTK::State& state) const = 0;
+
+    /**@}**/
+
+    /** @name Component Extension methods.
+        Point types override these Component methods. */
+    /**@{**/
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+    void extendRealizeTopology(SimTK::State& s) const override;
+    /**@}**/
+
+private:
+
+    mutable SimTK::CacheEntryIndex _groundLocationIndex;
+
+//=============================================================================
+};  // END of class Point
+//=============================================================================
+//=============================================================================
+
+} // end of namespace OpenSim
+
+#endif // OPENSIM_POINT_H_
+
+

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -52,9 +52,9 @@ OpenSim_DECLARE_ABSTRACT_OBJECT(Point, ModelComponent);
 public:
     OpenSim_DECLARE_OUTPUT(location, SimTK::Vec3, getLocationInGround,
         SimTK::Stage::Position);
-    OpenSim_DECLARE_OUTPUT(velocity, SimTK::Vec3, calcVelocityInGround,
+    OpenSim_DECLARE_OUTPUT(velocity, SimTK::Vec3, getVelocityInGround,
         SimTK::Stage::Velocity);
-    OpenSim_DECLARE_OUTPUT(acceleration, SimTK::Vec3, calcAccelerationInGround,
+    OpenSim_DECLARE_OUTPUT(acceleration, SimTK::Vec3, getAccelerationInGround,
         SimTK::Stage::Acceleration);
     //--------------------------------------------------------------------------
     // CONSTRUCTION
@@ -135,5 +135,3 @@ private:
 } // end of namespace OpenSim
 
 #endif // OPENSIM_POINT_H_
-
-

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -40,14 +40,14 @@ using SimTK::Vec3;
 /**
  * Default constructor.
  */
-Station::Station() : Super()
+Station::Station() : Point()
 {
     setNull();
     constructInfrastructure();
 }
 
 Station::Station(const PhysicalFrame& frame, const SimTK::Vec3& location)
-    : Super()
+    : Point()
 {
     setNull();
     constructInfrastructure();
@@ -144,7 +144,7 @@ SimTK::Vec3 Station::calcAccelerationInGround(const SimTK::State& s) const
 
     // The acceleration of the station in ground is a function of its frame's
     // linear (aF = A_GF[1]) and angular (alpha = A_GF[0]) accelerations and
-    // Corriolois acceleration due to the angular velocity (omega = V_GF[0]) of
+    // Coriolis acceleration due to the angular velocity (omega = V_GF[0]) of
     // its frame, such that: a = aF + alphaF x r + omegaF x (omegaF x r)
     return A_GF[1] + A_GF[0]%r +  V_GF[0] % (V_GF[0] % r) ;
 }

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -121,15 +121,30 @@ SimTK::Vec3 Station::calcLocationInGround(const SimTK::State& s) const
 
 SimTK::Vec3 Station::calcVelocityInGround(const SimTK::State& s) const
 {
+    // compute the local position vector of the station in its reference frame
+    // expressed in ground
     Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
     const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
+
+    // The velocity of the station in ground is a function of its frame's
+    // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
+    // velocity of the station: v = vF + omegaF x r
     return V_GF[1] + V_GF[0] % r;
 }
 
 SimTK::Vec3 Station::calcAccelerationInGround(const SimTK::State& s) const
 {
+    // The spatial velocity of the reference frame expressed in ground
     const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
+    // The spatial acceleration of the reference frame expressed in ground
     const SimTK::SpatialVec& A_GF = getReferenceFrame().getAccelerationInGround(s);
+    // compute the local position vector of the point in its reference frame
+    // expressed in ground
     Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
+
+    // The acceleration of the station in ground is a function of its frame's
+    // linear (aF = A_GF[1]) and angular (alpha = A_GF[0]) accelerations and
+    // Corriolois acceleration due to the angular velocity (omega = V_GF[0]) of
+    // its frame, such that: a = aF + alphaF x r + omegaF x (omegaF x r)
     return A_GF[1] + A_GF[0]%r +  V_GF[0] % (V_GF[0] % r) ;
 }

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -51,7 +51,7 @@ Station::Station(const PhysicalFrame& frame, const SimTK::Vec3& location)
 {
     setNull();
     constructInfrastructure();
-    setReferenceFrame(frame);
+    setParentFrame(frame);
     set_location(location);
 }
 
@@ -87,44 +87,44 @@ void Station::constructProperties()
 
 void Station::constructConnectors()
 {
-    constructConnector<PhysicalFrame>("reference_frame");
+    constructConnector<PhysicalFrame>("parent_frame");
 }
 
 /*
- * Return the reference frame with respect to which this station is defined
+ * Return the parent frame with respect to which this station is defined
 */
-const PhysicalFrame& Station::getReferenceFrame() const
+const PhysicalFrame& Station::getParentFrame() const
 {
-    return getConnector<PhysicalFrame>("reference_frame").getConnectee();
+    return getConnector<PhysicalFrame>("parent_frame").getConnectee();
 }
 
 /*
- * setReferenceFrame sets the "reference_frame" connection
+ * setParentFrame sets the "parent_frame" connection
  */
-void Station::setReferenceFrame(const OpenSim::PhysicalFrame& aFrame)
+void Station::setParentFrame(const OpenSim::PhysicalFrame& aFrame)
 {
-    updConnector<PhysicalFrame>("reference_frame").connect(aFrame);
+    updConnector<PhysicalFrame>("parent_frame").connect(aFrame);
 }
 
 SimTK::Vec3 Station::findLocationInFrame(const SimTK::State& s,
         const OpenSim::Frame& aFrame) const
 {
     // transform location from the station's frame to the other frame
-    return getReferenceFrame().findLocationInAnotherFrame(s, 
+    return getParentFrame().findLocationInAnotherFrame(s, 
                                                 get_location(), aFrame);
 }
 
 SimTK::Vec3 Station::calcLocationInGround(const SimTK::State& s) const
 {
-    return getReferenceFrame().getTransformInGround(s)*get_location();
+    return getParentFrame().getTransformInGround(s)*get_location();
 }
 
 SimTK::Vec3 Station::calcVelocityInGround(const SimTK::State& s) const
 {
     // compute the local position vector of the station in its reference frame
     // expressed in ground
-    Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
-    const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
+    Vec3 r = getParentFrame().getTransformInGround(s).R()*get_location();
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
 
     // The velocity of the station in ground is a function of its frame's
     // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
@@ -135,12 +135,12 @@ SimTK::Vec3 Station::calcVelocityInGround(const SimTK::State& s) const
 SimTK::Vec3 Station::calcAccelerationInGround(const SimTK::State& s) const
 {
     // The spatial velocity of the reference frame expressed in ground
-    const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
     // The spatial acceleration of the reference frame expressed in ground
-    const SimTK::SpatialVec& A_GF = getReferenceFrame().getAccelerationInGround(s);
+    const SimTK::SpatialVec& A_GF = getParentFrame().getAccelerationInGround(s);
     // compute the local position vector of the point in its reference frame
     // expressed in ground
-    Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
+    Vec3 r = getParentFrame().getTransformInGround(s).R()*get_location();
 
     // The acceleration of the station in ground is a function of its frame's
     // linear (aF = A_GF[1]) and angular (alpha = A_GF[0]) accelerations and

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -121,14 +121,15 @@ SimTK::Vec3 Station::calcLocationInGround(const SimTK::State& s) const
 
 SimTK::Vec3 Station::calcVelocityInGround(const SimTK::State& s) const
 {
+    Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
     const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
-    return V_GF[1] + V_GF[0] % getLocationInGround(s);
+    return V_GF[1] + V_GF[0] % r;
 }
 
 SimTK::Vec3 Station::calcAccelerationInGround(const SimTK::State& s) const
 {
     const SimTK::SpatialVec& V_GF = getReferenceFrame().getVelocityInGround(s);
     const SimTK::SpatialVec& A_GF = getReferenceFrame().getAccelerationInGround(s);
-    const Vec3& r = getLocationInGround(s);
-    return A_GF[1] + A_GF[0]%r +  V_GF[0] % V_GF[0] % r ;
+    Vec3 r = getReferenceFrame().getTransformInGround(s).R()*get_location();
+    return A_GF[1] + A_GF[0]%r +  V_GF[0] % (V_GF[0] % r) ;
 }

--- a/OpenSim/Simulation/Model/Station.h
+++ b/OpenSim/Simulation/Model/Station.h
@@ -36,10 +36,10 @@ class Body;
 //=============================================================================
 //=============================================================================
 /**
- * A Station is a Point fixed to and located on a PhysicalFrame, which can be a 
- * Body (w.r.t. the Body origin), Ground or any PhysicalOffsetFrame.
- * A Station is an analogous physical Point to a PhyscialFrame where joints,
- * constraints and forces can be attached and/or applied.
+ * A Station is a Point fixed to and located on a PhysicalFrame, which can be
+ * a Body, Ground or any PhysicalOffsetFrame. Stations are analogous to
+ * PhyscialOffsetFrames where joints, constraints and forces can be attached
+ * and/or applied.
  *
  * @author Ayman Habib, Ajay Seth
  */
@@ -49,12 +49,8 @@ public:
     //==============================================================================
     // PROPERTIES
     //==============================================================================
-    /** @name Property declarations
-    These are the serializable properties associated with a Station. **/
-    /**@{**/
     OpenSim_DECLARE_PROPERTY(location, SimTK::Vec3,
-        "The location of the station in its reference frame.");
-    /**@}**/
+        "The fixed location of the station expressed in its parent frame.");
 
 public:
     //--------------------------------------------------------------------------
@@ -69,7 +65,7 @@ public:
     Station(const PhysicalFrame& frame, const SimTK::Vec3& location);
 
     virtual ~Station();
-    /** getter of Reference Frame off which the Station is defined */
+    /** get the parent PhysicalFrame to which the Station is attached */
     const PhysicalFrame& getReferenceFrame() const;
     /** setter of Reference Frame off which the Station is defined */
     void setReferenceFrame(const OpenSim::PhysicalFrame& aFrame);
@@ -77,12 +73,13 @@ public:
     SimTK::Vec3 findLocationInFrame(const SimTK::State& s,
                                     const OpenSim::Frame& frame) const;
 private:
-    /** Calculate this Station's location in Ground */
+    /* Calculate the Station's location with respect to and expressed in Ground
+    */
     SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const override;
-    /** Calculate the velocity of this Station with respect to and expressed in
-        ground as a function of the state. */
+    /* Calculate the velocity of this Station with respect to and expressed in
+       Ground as a function of the state. */
     SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const override;
-    /** Calculate the acceleration of this Station with respect to and 
+    /* Calculate the acceleration of this Station with respect to and 
         expressed in ground as a function of the state. */
     SimTK::Vec3 calcAccelerationInGround(const SimTK::State& state) const override;
 

--- a/OpenSim/Simulation/Model/Station.h
+++ b/OpenSim/Simulation/Model/Station.h
@@ -65,10 +65,12 @@ public:
     Station(const PhysicalFrame& frame, const SimTK::Vec3& location);
 
     virtual ~Station();
+
     /** get the parent PhysicalFrame to which the Station is attached */
-    const PhysicalFrame& getReferenceFrame() const;
+    const PhysicalFrame& getParentFrame() const;
     /** setter of Reference Frame off which the Station is defined */
-    void setReferenceFrame(const OpenSim::PhysicalFrame& aFrame);
+    void setParentFrame(const OpenSim::PhysicalFrame& aFrame);
+
     /** Find this Station's location in any Frame */
     SimTK::Vec3 findLocationInFrame(const SimTK::State& s,
                                     const OpenSim::Frame& frame) const;

--- a/OpenSim/Simulation/Model/Station.h
+++ b/OpenSim/Simulation/Model/Station.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2014 Stanford University and the Authors                *
+ * Copyright (c) 2005-2016 Stanford University and the Authors                *
  * Author(s): Ayman Habib                                                     *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -26,8 +26,7 @@
 
 // INCLUDE
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include "OpenSim/Simulation/Model/ModelComponent.h"
-#include "OpenSim/Simulation/Model/Frame.h"
+#include "OpenSim/Simulation/Model/Point.h"
 #include "OpenSim/Simulation/Model/PhysicalFrame.h"
 
 namespace OpenSim {
@@ -37,38 +36,56 @@ class Body;
 //=============================================================================
 //=============================================================================
 /**
- * A class implementing a Station. A Station is a point fixed to and defined with 
- * respect to a reference frame. The reference frame can be a Body (fixed 
- * to origin of a Body), a FixedFrame (affixed to another PhysicalFrame) or any 
- * other PhysicalFrame. The main functionality provided by Station is to find its 
- * location in any Frame.
+ * A Station is a Point fixed to and located on a PhysicalFrame, which can be a 
+ * Body (w.r.t. the Body origin), Ground or any PhysicalOffsetFrame.
+ * A Station is an analogous physical Point to a PhyscialFrame where joints,
+ * constraints and forces can be attached and/or applied.
  *
- * @author Ayman Habib
- * @version 1.0
+ * @author Ayman Habib, Ajay Seth
  */
-class OSIMSIMULATION_API Station : public ModelComponent {
-OpenSim_DECLARE_CONCRETE_OBJECT(Station, ModelComponent);
+class OSIMSIMULATION_API Station : public Point {
+OpenSim_DECLARE_CONCRETE_OBJECT(Station, Point);
 public:
     //==============================================================================
     // PROPERTIES
     //==============================================================================
+    /** @name Property declarations
+    These are the serializable properties associated with a Station. **/
+    /**@{**/
     OpenSim_DECLARE_PROPERTY(location, SimTK::Vec3,
-        "The location (Vec3) of the station in a reference frame. "
-        "Frame is specified as Connector.");
+        "The location of the station in its reference frame.");
+    /**@}**/
 
 public:
     //--------------------------------------------------------------------------
     // CONSTRUCTION
     //--------------------------------------------------------------------------
+    /** Default constructor */
     Station();
+
+    /** Convenience constructor
+    @param[in] frame     PhysicalFrame in which the Station is located.
+    @param[in] location  Vec3 location of the station in its PhysicalFrame */
+    Station(const PhysicalFrame& frame, const SimTK::Vec3& location);
+
     virtual ~Station();
     /** getter of Reference Frame off which the Station is defined */
-    const OpenSim::PhysicalFrame& getReferenceFrame() const;
+    const PhysicalFrame& getReferenceFrame() const;
     /** setter of Reference Frame off which the Station is defined */
     void setReferenceFrame(const OpenSim::PhysicalFrame& aFrame);
     /** Find this Station's location in any Frame */
-    SimTK::Vec3 findLocationInFrame(const SimTK::State& s, const OpenSim::Frame& aFrame) const;
+    SimTK::Vec3 findLocationInFrame(const SimTK::State& s,
+                                    const OpenSim::Frame& frame) const;
 private:
+    /** Calculate this Station's location in Ground */
+    SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const override;
+    /** Calculate the velocity of this Station with respect to and expressed in
+        ground as a function of the state. */
+    SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const override;
+    /** Calculate the acceleration of this Station with respect to and 
+        expressed in ground as a function of the state. */
+    SimTK::Vec3 calcAccelerationInGround(const SimTK::State& state) const override;
+
     void setNull();
     void constructProperties() override;
     void constructConnectors() override;

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -426,9 +426,9 @@ template <class C, class F>
 SimTK::Transform TwoFrameLinker<C, F>::computeRelativeOffset(const SimTK::State& s) const
 {
     // Define frame1 as the "fixed" frame, F
-    SimTK::Transform X_GF = getFrame1().getGroundTransform(s);
+    SimTK::Transform X_GF = getFrame1().getTransformInGround(s);
     // Define the frame2 as the "moving" frame, M
-    SimTK::Transform X_GM = getFrame2().getGroundTransform(s);
+    SimTK::Transform X_GM = getFrame2().getTransformInGround(s);
     // Express M in F
     return ~X_GF * X_GM;
 }
@@ -458,8 +458,8 @@ SimTK::SpatialVec TwoFrameLinker<C, F>::computeRelativeVelocity(const SimTK::Sta
     const SimTK::Transform& X_GB1 = frame1.getMobilizedBody().getBodyTransform(s);
     const SimTK::Transform& X_GB2 = frame2.getMobilizedBody().getBodyTransform(s);
 
-    SimTK::Transform X_GF = frame1.getGroundTransform(s);
-    SimTK::Transform X_GM = frame2.getGroundTransform(s);
+    SimTK::Transform X_GF = frame1.getTransformInGround(s);
+    SimTK::Transform X_GM = frame2.getTransformInGround(s);
     SimTK::Transform X_FM = ~X_GF * X_GM;
     const SimTK::Rotation& R_GF = X_GF.R();
 
@@ -524,8 +524,8 @@ void TwoFrameLinker<C, F>::convertInternalForceToForcesOnFrames(
     //const SimTK::Transform& X_GB1 = frame1.getMobilizedBody().getBodyTransform(s);
     //const SimTK::Transform& X_GB2 = frame2.getMobilizedBody().getBodyTransform(s);
 
-    SimTK::Transform X_GF = frame1.getGroundTransform(s);
-    SimTK::Transform X_GM = frame2.getGroundTransform(s);
+    SimTK::Transform X_GF = frame1.getTransformInGround(s);
+    SimTK::Transform X_GM = frame2.getTransformInGround(s);
     SimTK::Transform X_FM = ~X_GF * X_GM;
     const SimTK::Mat33 N_FM =
         SimTK::Rotation::calcNForBodyXYZInBodyFrame(dq.getSubVec<3>(0));

--- a/OpenSim/Simulation/SimbodyEngine/ConstantDistanceConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/ConstantDistanceConstraint.cpp
@@ -208,9 +208,9 @@ void ConstantDistanceConstraint::generateDecorations(
     if (fixed) return;
     const Vec3 pink(1, .6, .8);
     const OpenSim::PhysicalFrame& frame1 = getBody1();
-    const Vec3& p_B1 = frame1.getGroundTransform(state)*get_location_body_1();
+    const Vec3& p_B1 = frame1.getTransformInGround(state)*get_location_body_1();
     const OpenSim::PhysicalFrame& frame2 = getBody2();
-    const Vec3& p_B2 = frame2.getGroundTransform(state)*get_location_body_2();
+    const Vec3& p_B2 = frame2.getTransformInGround(state)*get_location_body_2();
     appendToThis.push_back(
         SimTK::DecorativeLine(p_B1, p_B2).setBodyId(0)
         .setColor(pink).setOpacity(1.0).setLineThickness(.05));

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -208,7 +208,7 @@ void EllipsoidJoint::generateDecorations
 
     // Construct the visible Ellipsoid
     SimTK::DecorativeEllipsoid ellipsoid(get_radii_x_y_z());
-    ellipsoid.setTransform(getParentFrame().getGroundTransform(state));
+    ellipsoid.setTransform(getParentFrame().getTransformInGround(state));
     ellipsoid.setColor(Vec3(0.0, 1.0, 1.0));
 
     geometryArray.push_back(ellipsoid);

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2000,7 +2000,7 @@ void testAutomaticJointReversal()
     ASSERT(knee->get_reverse() == true);
     ASSERT(ankle->get_reverse() == true);
 
-    SimTK::Transform pelvisX = pelvis->getGroundTransform(s);
+    SimTK::Transform pelvisX = pelvis->getTransformInGround(s);
     cout << "Pelvis Transform (reverse): " << pelvisX << endl;
 
     model.print("reversedLegWeldJointToGround.osim");
@@ -2056,7 +2056,7 @@ void testAutomaticJointReversal()
     modelConstrained.dumpSubcomponents();
     SimTK::State& sc = modelConstrained.initSystem();
 
-    SimTK::Transform pelvisXc = cpelvis.getGroundTransform(sc);
+    SimTK::Transform pelvisXc = cpelvis.getTransformInGround(sc);
     cout << "Shank Transform (constrained): " << pelvisXc << endl;
 
     modelConstrained.print("forwardLegWeldConstraintToGround.osim");

--- a/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
@@ -147,8 +147,8 @@ void WeldConstraint::
     // We must also get that point position vector wrt ground (i.e., frame1)
     Vec3 spoint = frame2.findLocationInAnotherFrame(s, point, frame1);
 
-    SimTK::Transform in1(frame1.getGroundTransform(s).R(), spoint);
-    SimTK::Transform in2(frame2.getGroundTransform(s).R(), point);
+    SimTK::Transform in1(frame1.getTransformInGround(s).R(), spoint);
+    SimTK::Transform in2(frame2.getTransformInGround(s).R(), point);
 
     // Add new internal PhysicalOffSetFrames that the Constraint can update 
     // without affecting any other components.

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -322,8 +322,8 @@ double calcLigamentLengthError(const SimTK::State &s, const Model &model)
         const PhysicalFrame& b1 = constraint->getBody1();
         const PhysicalFrame& b2 = constraint->getBody2();
 
-        p1inG = b1.getGroundTransform(s)*p1inB1;
-        p2inG = b2.getGroundTransform(s)*p2inB2;
+        p1inG = b1.getTransformInGround(s)*p1inB1;
+        p2inG = b2.getTransformInGround(s)*p2inB2;
 
         double length = (p2inG-p1inG).norm();
         error = length - constraint->get_constant_distance();

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -132,11 +132,11 @@ void testBody()
         const Coordinate& coord = pendulum->getCoordinateSet().get("q1");
         coord.setValue(s, radAngle);
 
-        const SimTK::Transform& xform = rod1.getGroundTransform(s);
+        const SimTK::Transform& xform = rod1.getTransformInGround(s);
 
         now = std::clock();
         for (int i = 0; i < 1000; ++i){
-            /*const SimTK::Transform& xform1 = */rod1.getGroundTransform(s);
+            /*const SimTK::Transform& xform1 = */rod1.getTransformInGround(s);
         }
         after = std::clock();
         lookup_time += (after-now);
@@ -176,8 +176,8 @@ void testPhysicalOffsetFrameOnBody()
     pendulum->addFrame(offsetFrame);
 
     SimTK::State& s = pendulum->initSystem();
-    const SimTK::Transform& X_GR = rod1.getGroundTransform(s);
-    const SimTK::Transform& X_GO = offsetFrame->getGroundTransform(s);
+    const SimTK::Transform& X_GR = rod1.getTransformInGround(s);
+    const SimTK::Transform& X_GO = offsetFrame->getTransformInGround(s);
 
     // Compute the offset transform based on frames expressed in ground
     SimTK::Transform X_RO_2 = ~X_GR*X_GO;
@@ -261,8 +261,8 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrame()
     const Frame& base = secondFrame->findBaseFrame();
     SimTK::Transform XinBase = secondFrame->findTransformInBaseFrame();
 
-    const SimTK::Transform& X_GR = rod1.getGroundTransform(s);
-    const SimTK::Transform& X_GO = secondFrame->getGroundTransform(s);
+    const SimTK::Transform& X_GR = rod1.getTransformInGround(s);
+    const SimTK::Transform& X_GO = secondFrame->getTransformInGround(s);
 
     SimTK::Vec3 angs_known = XinBase.R().convertRotationToBodyFixedXYZ();
 
@@ -310,7 +310,7 @@ void testPhysicalOffsetFrameOnBodySerialize()
     pendulum->addFrame(offsetFrame);
 
     SimTK::State& s1 = pendulum->initSystem();
-    const SimTK::Transform& X_GO_1 = offsetFrame->getGroundTransform(s1);
+    const SimTK::Transform& X_GO_1 = offsetFrame->getTransformInGround(s1);
     pendulum->print("double_pendulum_extraFrame.osim");
     // now read the model from file
     Model* pendulumWFrame = new Model("double_pendulum_extraFrame.osim");
@@ -321,7 +321,7 @@ void testPhysicalOffsetFrameOnBodySerialize()
         dynamic_cast<const PhysicalFrame&>(pendulumWFrame->getComponent("myExtraFrame"));
     ASSERT(*offsetFrame == myExtraFrame);
 
-    const SimTK::Transform& X_GO_2 = myExtraFrame.getGroundTransform(s2);
+    const SimTK::Transform& X_GO_2 = myExtraFrame.getTransformInGround(s2);
     ASSERT_EQUAL(X_GO_2.p(), X_GO_1.p(), tolerance, __FILE__, __LINE__,
         "testPhysicalOffsetFrameOnBodySerialize(): incorrect expression of offset in ground.");
     ASSERT_EQUAL(X_GO_2.R().convertRotationToBodyFixedXYZ(), 

--- a/OpenSim/Simulation/Test/testPoints.cpp
+++ b/OpenSim/Simulation/Test/testPoints.cpp
@@ -142,7 +142,7 @@ void testStationOnOffsetFrame()
 
     auto rod1 = new Body("rod1", 0.54321, SimTK::Vec3(0.1, 0.5, 0.2),
         SimTK::Inertia::cylinderAlongY(0.025, 0.55));
-    rod1->addGeometry(Cylinder(0.025, 0.55));
+    rod1->attachGeometry(Cylinder(0.025, 0.55));
 
     auto rod2 = rod1->clone();
     rod2->setName("rod2");

--- a/OpenSim/Simulation/Test/testPoints.cpp
+++ b/OpenSim/Simulation/Test/testPoints.cpp
@@ -1,0 +1,107 @@
+/* -------------------------------------------------------------------------- *
+ *                          OpenSim:  testPoints.cpp                          *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2016 Stanford University and the Authors                *
+ * Author(s): Ajay Seth                                          *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/*=============================================================================
+
+Tests Include:
+    1. Station
+    2. Marker
+    3. Stations on a Frame computations 
+      
+     Add tests here as Points are added to OpenSim
+
+//=============================================================================*/
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
+#include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+using namespace OpenSim;
+using namespace std;
+using SimTK::Transform;
+
+void testStationOnFrame();
+
+class OrdinaryOffsetFrame : public OffsetFrame < Frame > {
+    OpenSim_DECLARE_CONCRETE_OBJECT(OrdinaryOffsetFrame, OffsetFrame<Frame>);
+public:
+    OrdinaryOffsetFrame() : OffsetFrame() {}
+    virtual ~OrdinaryOffsetFrame() {}
+
+    OrdinaryOffsetFrame(const Frame& parent, const SimTK::Transform& offset) :
+        OffsetFrame(parent, offset) {}
+};
+
+
+int main()
+{
+    try { testStationOnFrame(); }
+    catch (const std::exception& e){
+        cout << e.what() << endl; failures.push_back("testStationOnFrame");
+    }
+
+    if (!failures.empty()) {
+        cout << "Done, with failure(s): " << failures << endl;
+        return 1;
+    }
+
+    cout << "Done. All cases passed." << endl;
+
+    return 0;
+}
+
+//==============================================================================
+// Test Cases
+//==============================================================================
+
+void testStationOnFrame()
+{
+    SimTK::Vec3 tolerance(SimTK::Eps);
+
+    cout << "Running testStationOnFrame" << endl;
+
+    Model* pendulum = new Model("double_pendulum.osim");
+    // Get "rod1" frame
+    const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
+    const SimTK::Vec3& com = rod1.get_mass_center();
+    // Create station aligned with rod1 com in rod1_frame
+    Station* myStation = new Station();
+    myStation->set_location(com);
+    myStation->updConnector<PhysicalFrame>("reference_frame")
+        .setConnecteeName("rod1");
+    pendulum->addModelComponent(myStation);
+    // myStation should coincide with com location of rod1 in ground
+    SimTK::State& s = pendulum->initSystem();
+    for (double ang = 0; ang <= 90.0; ang += 10.){
+        double radAngle = SimTK::convertDegreesToRadians(ang);
+        const Coordinate& coord = pendulum->getCoordinateSet().get("q1");
+        coord.setValue(s, radAngle);
+
+        SimTK::Vec3 comInGround = 
+            myStation->findLocationInFrame(s, pendulum->getGround());
+        SimTK::Vec3 comBySimbody = 
+            rod1.getMobilizedBody().findStationLocationInGround(s, com);
+        ASSERT_EQUAL(comInGround, comBySimbody, tolerance, __FILE__, __LINE__,
+            "testStationOnFrame(): failed to resolve station position in ground.");
+    }
+}
+

--- a/OpenSim/Simulation/Test/testPoints.cpp
+++ b/OpenSim/Simulation/Test/testPoints.cpp
@@ -171,7 +171,7 @@ void testStationOnOffsetFrame()
     Station* myStation = new Station();
     const SimTK::Vec3 point(0.5, 1, -1.5);
     myStation->set_location(point);
-    myStation->setReferenceFrame(*offsetFrame);
+    myStation->setParentFrame(*offsetFrame);
     pendulum.addModelComponent(myStation);
 
     // optionally turn on visualizer to help debug
@@ -187,7 +187,7 @@ void testStationOnOffsetFrame()
     hip->upd_CoordinateSet()[1].setSpeedValue(state, -0.13);
 
     // Get the frame's mobilized body
-    const OpenSim::PhysicalFrame&  frame = myStation->getReferenceFrame();
+    const OpenSim::PhysicalFrame&  frame = myStation->getParentFrame();
     SimTK::MobilizedBody  mb = frame.getMobilizedBody();
 
     // Do a simulation

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -53,6 +53,13 @@ int main()
         availableComponents.push_back(availableFrames[i]);
     }
 
+    // starting with type Frame
+    ArrayPtrs<Point> availablePoints;
+    Object::getRegisteredObjectsOfGivenType(availablePoints);
+    for (int i = 0; i < availablePoints.size(); ++i) {
+        availableComponents.push_back(availablePoints[i]);
+    }
+
     // then type Joint
     ArrayPtrs<Joint> availableJoints;
     Object::getRegisteredObjectsOfGivenType(availableJoints);

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -53,7 +53,7 @@ int main()
         availableComponents.push_back(availableFrames[i]);
     }
 
-    // starting with type Frame
+    // next with type Point
     ArrayPtrs<Point> availablePoints;
     Object::getRegisteredObjectsOfGivenType(availablePoints);
     for (int i = 0; i < availablePoints.size(); ++i) {

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -412,7 +412,7 @@ void MarkerPlacer::moveModelMarkersToPose(SimTK::State& s, Model& aModel, Marker
                     Vec3 globalPt = globalMarker;
                     double conversionFactor = aPose.getUnits().convertTo(aModel.getLengthUnits());
                     pt = conversionFactor*globalPt;
-                    pt2 = modelMarker.getReferenceFrame().findLocationInAnotherFrame(s, pt, aModel.getGround());
+                    pt2 = modelMarker.getParentFrame().findLocationInAnotherFrame(s, pt, aModel.getGround());
                     modelMarker.set_location(pt2);
                 }
                 else

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -392,7 +392,7 @@ double ModelScaler::takeModelMeasurement(const SimTK::State& s, const Model& aMo
     }
     const Marker& marker1 = aModel.getMarkerSet().get(aName1);
     const Marker& marker2 = aModel.getMarkerSet().get(aName2);
-    Vec3 difference = marker1.get_location() - marker2.findLocationInFrame(s, marker1.getReferenceFrame());
+    Vec3 difference = marker1.get_location() - marker2.findLocationInFrame(s, marker1.getParentFrame());
     return difference.norm();
 }
 

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmBody.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmBody.cpp
@@ -114,7 +114,7 @@ void SimbodySimmBody::write(ofstream& aStream)
       for (int i = 0; i < markerSet.getSize(); i++)
       {
          const Marker& marker = markerSet.get(i);
-         const Body* refBody = dynamic_cast<const Body*>(&marker.getReferenceFrame());
+         const Body* refBody = dynamic_cast<const Body*>(&marker.getParentFrame());
          if (refBody && ( refBody == _body))
          {
             // Write out log(_weight) + 1 as marker weight instead of _weight,


### PR DESCRIPTION
Added `Point` as the location/translation only analog of `Frame` and attempted to make their calls consistent. Since we are adding Outputs to Station I thought it would be good time to introduce Point and let it provide the underlying structure. It was also evident that Frame should calculate and provide the velocity and acceleration of the Frame and that points (like Station) should use the Frame calculations to do most of the work.

Also incorporated from #873 into `testPoints.cpp` separate from `testFrames`.

The intention is to use Point to also PathPoints (`ConditionalPathPoint`, `PathWrapPoint`, `MovingPathPoint`) and enable new Points of interest to be computed and easily reported, for example, the center of pressure.