### PR TITLE
Using CMAKE_CXX_STANDARD to specify C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,28 +374,11 @@ endif()
 
 include(InstallRequiredSystemLibraries)
 
-# C++11
-# -----
-# In revision 8629, we started using std::unique_ptr, which requires
-# C++11 features to be enabled when using GCC or Clang.
-if(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
-    # Using C++11 on OSX requires using libc++ instead of libstd++.
-    # libc++ is an implementation of the C++ standard library for OSX.
-    if(APPLE)
-        if(XCODE)
-            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
-            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-        else()
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-            if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-            endif()
-        endif()
-    else() # not APPLE
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif()
-endif()
-
+# Minimum required C++ standard --> C++11
+set(CMAKE_CXX_STANDARD_REQUIRED 11
+    CACHE INTERNAL "Minimum C++ standard support required from compiler.")
+set(CMAKE_CXX_STANDARD 11
+    CACHE INTERNAL "C++ standard for all targets.")
 
 ## On APPLE, use MACOSX_RPATH.
 set(OPENSIM_USE_INSTALL_RPATH FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ endif()
 include(InstallRequiredSystemLibraries)
 
 # Minimum required C++ standard --> C++11.
-set(CMAKE_CXX_STANDARD_REQUIRED 11
+set(CMAKE_CXX_STANDARD_REQUIRED ON
     CACHE INTERNAL "Minimum C++ standard support required from compiler.")
 set(CMAKE_CXX_STANDARD 11
     CACHE INTERNAL "C++ standard for all targets.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ endif()
 
 include(InstallRequiredSystemLibraries)
 
-# Minimum required C++ standard --> C++11
+# Minimum required C++ standard --> C++11.
 set(CMAKE_CXX_STANDARD_REQUIRED 11
     CACHE INTERNAL "Minimum C++ standard support required from compiler.")
 set(CMAKE_CXX_STANDARD 11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,7 @@ project(OpenSim)
 #
 #
 #----------------------------------------------------
-
-if(MSVC)
-    # To properly support Visual Studio 2015.
-    set(OPENSIM_REQUIRED_CMAKE_VERSION 3.1.3)
-else()
-    set(OPENSIM_REQUIRED_CMAKE_VERSION 2.8.8)
-endif()
-cmake_minimum_required(VERSION ${OPENSIM_REQUIRED_CMAKE_VERSION})
+cmake_minimum_required(VERSION 3.1.3)
 
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,9 +8,8 @@ cmake_minimum_required(VERSION 3.1.3)
 include(ExternalProject)
 include(CMakeParseArguments)
 
-# Minimum required C++ standard --> C++11. OpenSim dependencies have to be
-# compiled with same standard requirement as OpenSim to have dependencies ABI 
-# compatible.
+# Minimum required C++ standard --> C++11. This is to make sure dependencies
+# are compiled with same minimum standard as OpenSim.
 set(CMAKE_CXX_STANDARD_REQUIRED 11
     CACHE INTERNAL "Minimum C++ standard support required from compiler.")
 set(CMAKE_CXX_STANDARD 11

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -136,7 +136,8 @@ AddDependency(NAME       BTK
               # URL        https://github.com/Biomechanical-ToolKit/BTKCore.git
               URL        https://github.com/klshrinidhi/BTKCore.git
               TAG        ae0d2a43de0fe6c9ef2acce34a87c944dd113829
-              CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
+              CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON 
+                         -DCMAKE_CXX_FLAGS:STRING="/EHsc")
 
 
 AddDependency(NAME       simbody

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -15,6 +15,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED 11
 set(CMAKE_CXX_STANDARD 11
     CACHE INTERNAL "C++ standard for all targets.")
 
+# Suppress warnings when compiling dependencies.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "-w")
+    set(CMAKE_C_FLAGS   "-w")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(CMAKE_CXX_FLAGS "/w")
+    set(CMAKE_C_FLAGS   "/w")
+endif()
+
 # Set the default for CMAKE_INSTALL_PREFIX.
 function(SetDefaultCMakeInstallPrefix)
     get_filename_component(BASE_DIR ${CMAKE_BINARY_DIR} DIRECTORY)
@@ -92,6 +102,7 @@ function(AddDependency)
         RemoveDefaultInstallDirIfEmpty(${DEFAULT_INSTALL_DIR})
 
         set(CMAKE_ARGS -DCMAKE_CXX_STANDARD:INTERNAL=${CMAKE_CXX_STANDARD}
+                       -DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}
                        -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR})
         if(NOT CMAKE_CONFIGURATION_TYPES)
             list(APPEND CMAKE_ARGS

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -16,13 +16,14 @@ set(CMAKE_CXX_STANDARD 11
     CACHE INTERNAL "C++ standard for all targets.")
 
 # Suppress warnings when compiling dependencies.
+# Set the exception handling model for MSVC.
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "-w")
     set(CMAKE_C_FLAGS   "-w")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(CMAKE_CXX_FLAGS "/w")
-    set(CMAKE_C_FLAGS   "/w")
+    set(CMAKE_CXX_FLAGS "/W0 /EHsc")
+    set(CMAKE_C_FLAGS   "/W0 /EHsc")
 endif()
 
 # Set the default for CMAKE_INSTALL_PREFIX.
@@ -136,8 +137,7 @@ AddDependency(NAME       BTK
               # URL        https://github.com/Biomechanical-ToolKit/BTKCore.git
               URL        https://github.com/klshrinidhi/BTKCore.git
               TAG        ae0d2a43de0fe6c9ef2acce34a87c944dd113829
-              CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON 
-                         -DCMAKE_CXX_FLAGS:STRING="/EHsc")
+              CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
 
 
 AddDependency(NAME       simbody

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -3,10 +3,18 @@
 # OpenSim does not use this file directly.
 
 project(OpenSimDependencies)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.3)
 
 include(ExternalProject)
 include(CMakeParseArguments)
+
+# Minimum required C++ standard --> C++11. OpenSim dependencies have to be
+# compiled with same standard requirement as OpenSim to have dependencies ABI 
+# compatible.
+set(CMAKE_CXX_STANDARD_REQUIRED 11
+    CACHE INTERNAL "Minimum C++ standard support required from compiler.")
+set(CMAKE_CXX_STANDARD 11
+    CACHE INTERNAL "C++ standard for all targets.")
 
 # Set the default for CMAKE_INSTALL_PREFIX.
 function(SetDefaultCMakeInstallPrefix)
@@ -84,7 +92,8 @@ function(AddDependency)
         set(DEFAULT_INSTALL_DIR ${DEFAULT_CMAKE_INSTALL_PREFIX}/${DEP_NAME})
         RemoveDefaultInstallDirIfEmpty(${DEFAULT_INSTALL_DIR})
 
-        set(CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR})
+        set(CMAKE_ARGS -DCMAKE_CXX_STANDARD:INTERNAL=${CMAKE_CXX_STANDARD}
+                       -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR})
         if(NOT CMAKE_CONFIGURATION_TYPES)
             list(APPEND CMAKE_ARGS
                 -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
This PR intends :

* To eliminate some code from top level CMakeLists.txt by replacing manual specification of compiler flags to set the C++ standard with the CMake variable [CMAKE_CXX_STANDARD](https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD).

* Make minimum CMake version required the same across platforms.