### PR TITLE
Upgrade Travis CMake version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ before_install:
   - if grep --line-num --recursive --exclude-dir="*dependencies*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
 
   - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew unlink cmake; fi
   - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install cmake; fi
   - cmake --version
   ## Set up environment variables.

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,6 @@ addons:
       - sshpass
 
 before_install:
-  - cmake --version
   ## Ensure that there are no tabs in source code.
   - cd $TRAVIS_BUILD_DIR
   # GREP returns 0 (true) if there are any matches, and
@@ -74,6 +73,9 @@ before_install:
   # (e.g., literally a \t in a source file).
   - if grep --line-num --recursive --exclude-dir="*dependencies*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
 
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install cmake; fi
+  - cmake --version
   ## Set up environment variables.
   # Only if compiling with gcc, update environment variables
   # to use the new gcc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ script:
 
   ## Test python wrapping.
   # Add OpenSim libraries to library path.
-  - if [ "$WRAP" = "on" ]; then export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENSIM_HOME/lib/x86_64-linux-gnu:$OPENSIM_DEPENDENCIES_INSTALL_DIR/BTK/lib/btk-0.4dev; fi
+  - if [ "$WRAP" = "on" ]; then export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$OPENSIM_HOME/lib:$OPENSIM_HOME/lib/x86_64-linux-gnu:$OPENSIM_DEPENDENCIES_INSTALL_DIR/BTK/lib/btk-0.4dev; fi
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/share/doc/OpenSim/python; fi
   # Run the python tests, verbosely.

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew unlink cmake; fi
   - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install cmake; fi
   - cmake --version
+  
   ## Set up environment variables.
   # Only if compiling with gcc, update environment variables
   # to use the new gcc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ addons:
       - llvm-toolchain-precise-3.5
       # For cmake >= 2.8.8 (for CMakePackageConfigHelpers)
       - kubuntu-backports
+      - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
     packages:
       - cmake
       # For Simbody.

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ addons:
       - sshpass
 
 before_install:
-
+  - cmake --version
   ## Ensure that there are no tabs in source code.
   - cd $TRAVIS_BUILD_DIR
   # GREP returns 0 (true) if there are any matches, and


### PR DESCRIPTION
This is related to PR #925 which bumps up the CMake version required on Linux and OSX to be the same as that for Windows.