### PR TITLE
Add 'tension' output to pathactuator

### DIFF
--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -163,9 +163,6 @@ void PathActuator::addNewPathPoint(
  */
 double PathActuator::computeActuation( const SimTK::State& s ) const
 {
-    if(!_model)
-        return 0.0;
-
     // FORCE
     return( getControl(s) * get_optimal_force() );
 }

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -262,6 +262,26 @@ SimTK::Vec3 PathActuator::computePathColor(const SimTK::State& state) const {
 
 
 //=============================================================================
+// XML
+//=============================================================================
+//-----------------------------------------------------------------------------
+// UPDATE FROM XML NODE
+//-----------------------------------------------------------------------------
+//_____________________________________________________________________________
+/**
+ * Update this object based on its XML node.
+ *
+ * This method simply calls Object::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) and then calls
+ * a few methods in this class to ensure that variable members have been
+ * set in a consistent manner.
+ */
+void PathActuator::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
+{
+    updGeometryPath().setOwner(this);
+    Super::updateFromXMLNode(aNode, versionNumber);
+}   
+
+//=============================================================================
 // SCALING
 //=============================================================================
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -262,26 +262,6 @@ SimTK::Vec3 PathActuator::computePathColor(const SimTK::State& state) const {
 
 
 //=============================================================================
-// XML
-//=============================================================================
-//-----------------------------------------------------------------------------
-// UPDATE FROM XML NODE
-//-----------------------------------------------------------------------------
-//_____________________________________________________________________________
-/**
- * Update this object based on its XML node.
- *
- * This method simply calls Object::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) and then calls
- * a few methods in this class to ensure that variable members have been
- * set in a consistent manner.
- */
-void PathActuator::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
-{
-    updGeometryPath().setOwner(this);
-    Super::updateFromXMLNode(aNode, versionNumber);
-}   
-
-//=============================================================================
 // SCALING
 //=============================================================================
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -265,26 +265,6 @@ SimTK::Vec3 PathActuator::computePathColor(const SimTK::State& state) const {
 
 
 //=============================================================================
-// XML
-//=============================================================================
-//-----------------------------------------------------------------------------
-// UPDATE FROM XML NODE
-//-----------------------------------------------------------------------------
-//_____________________________________________________________________________
-/**
- * Update this object based on its XML node.
- *
- * This method simply calls Object::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) and then calls
- * a few methods in this class to ensure that variable members have been
- * set in a consistent manner.
- */
-void PathActuator::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
-{
-    updGeometryPath().setOwner(this);
-    Super::updateFromXMLNode(aNode, versionNumber);
-}   
-
-//=============================================================================
 // SCALING
 //=============================================================================
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -106,11 +106,6 @@ public:
     virtual double computeMomentArm( const SimTK::State& s, Coordinate& aCoord) const;
 
     //--------------------------------------------------------------------------
-    // XML
-    //--------------------------------------------------------------------------
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
-
-    //--------------------------------------------------------------------------
     // SCALING
     //--------------------------------------------------------------------------
     virtual void preScale(const SimTK::State& s, const ScaleSet& aScaleSet);

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -53,6 +53,9 @@ public:
     OpenSim_DECLARE_PROPERTY(optimal_force, double,
         "The maximum force this actuator can produce.");
 
+    OpenSim_DECLARE_OUTPUT(tension, double, computeActuation,
+                           SimTK::Stage::Acceleration);
+
 //=============================================================================
 // PUBLIC METHODS
 //=============================================================================

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -109,6 +109,11 @@ public:
     virtual double computeMomentArm( const SimTK::State& s, Coordinate& aCoord) const;
 
     //--------------------------------------------------------------------------
+    // XML
+    //--------------------------------------------------------------------------
+    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
+
+    //--------------------------------------------------------------------------
     // SCALING
     //--------------------------------------------------------------------------
     virtual void preScale(const SimTK::State& s, const ScaleSet& aScaleSet);

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -109,11 +109,6 @@ public:
     virtual double computeMomentArm( const SimTK::State& s, Coordinate& aCoord) const;
 
     //--------------------------------------------------------------------------
-    // XML
-    //--------------------------------------------------------------------------
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
-
-    //--------------------------------------------------------------------------
     // SCALING
     //--------------------------------------------------------------------------
     virtual void preScale(const SimTK::State& s, const ScaleSet& aScaleSet);


### PR DESCRIPTION
* Remove the function `updateFromXMLNode` as it is redundant.
* Add output named *tension* that retrieves the scalar(double) actuation from `computeActuation`.

Let me know if you need more changes.