### PR TITLE
Convert PathPoint to Component

### DIFF
--- a/Applications/Scale/test/testScale.cpp
+++ b/Applications/Scale/test/testScale.cpp
@@ -193,7 +193,7 @@ void scaleModelWithLigament()
     ScaleTool* scaleTool;
     Model* model;
 
-    // Truncate old model if any
+    // Remove old model if any
     FILE* file2Remove = IO::OpenFile(setupFilePath + "toyLigamentModelScaled.osim", "w");
     fclose(file2Remove);
 
@@ -223,6 +223,16 @@ void scaleModelWithLigament()
     Model comp(scaledModelFile);
     Model std(std_scaledModelFile);
 
+    std.print("std_toyLigamentModelScaled_latest.osim");
+    comp.print("comp_toyLigamentModelScaled_latest.osim");
+
+    // the latest model will not match the standard because the naming convention has
+    // been updated to store path names and connecting a model results in connectors
+    // storing relative paths so that collections of components are more portable.
+    // The models must be equivalent after being connected.
+    comp.setup();
+    std.setup();
+
     ComponentList<Ligament> compLigs = comp.getComponentList<Ligament>();
     ComponentList<Ligament> stdLigs = std.getComponentList<Ligament>();
 
@@ -236,16 +246,6 @@ void scaleModelWithLigament()
         ASSERT(*its == *itc, __FILE__, __LINE__,
             "Scaled ligament " + its->getName() + " did not match standard.");
     }
-
-    std.print("std_toyLigamentModelScaled_latest.osim");
-    comp.print("comp_toyLigamentModelScaled_latest.osim");
-
-    // the latest model will not match the standard because the naming convention has
-    // been updated to store path names and connecting a model results in connectors
-    // storing relative paths so that collections of components are more portable.
-    // The models must be equivalent after being connected.
-    comp.setup();
-    std.setup();
 
     //Finally make sure we didn't incorrectly scale anything else in the model
     ASSERT(std == comp);

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -132,6 +132,8 @@
 
 %include <OpenSim/Simulation/Manager/Manager.h>
 %include <OpenSim/Simulation/Model/AbstractTool.h>
+
+%include <OpenSim/Simulation/Model/Point.h>
 %include <OpenSim/Simulation/Model/Station.h>
 %include <OpenSim/Simulation/Model/Marker.h>
 %template(SetMarkers) OpenSim::Set<OpenSim::Marker>;

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -200,8 +200,7 @@ Object::Object(SimTK::Xml::Element& aNode)
  * @return Reference to this object.
  * @see updateXMLNode()
  */
-Object& Object::
-operator=(const Object& source)
+Object& Object::operator=(const Object& source)
 {
     if (&source != this) {
         _name           = source._name;
@@ -224,50 +223,19 @@ operator=(const Object& source)
 /**
  * Set all non-static member variables to their null or default values.
  */
-void Object::
-setNull()
+void Object::setNull()
 {
     _propertySet.clear();
     _propertyTable.clear();
     _objectIsUpToDate = false;
 
-    _name           = "";
-    _description    = "";
-    _authors        = "";
-    _references     = "";
+    _name = "";
+    _description = "";
+    _authors = "";
+    _references = "";
 
-    _document       = NULL;
-    _inlined        = true;
-
-    // In case there are properties allocated at the Object base class level,
-    // they need to be reallocated now. Derived objects will get a chance to
-    // do this later.
-    setupProperties();
-}
-//_____________________________________________________________________________
-/**
- * Set up the serialized member variables.  This involves both generating
- * the properties and connecting them to the local pointers used to access
- * the serialized member variables.
- */
-void Object::
-setupProperties()
-{
-
-    // CURRENTLY THERE ARE NO SERIALIZED MEMBERS IN Object
-
-}
-
-//_____________________________________________________________________________
-/**
- * Perform any initializations that should occur upon instantiation.
- */
-void Object::
-init()
-{
-
-    // CURRENTLY THERE ARE NO INITIALIZATIONS NEEDED.
-
+    _document = NULL;
+    _inlined = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -276,8 +244,7 @@ init()
 // Compare the base class mundane data members, and the properties. Concrete
 // Objects should override this but they must make sure to invoke the base
 // operator.
-bool Object::
-operator==(const Object& other) const
+bool Object::operator==(const Object& other) const
 {
     if (getConcreteClassName()  != other.getConcreteClassName()) return false;
     if (getName()               != other.getName())         return false;

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -771,8 +771,6 @@ protected:
 //--------------------------------------------------------------------------
 private:
     void setNull();
-    void setupProperties();
-    void init();
 
     // Functions to support deserialization. 
     void generateXMLDocument();

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -243,7 +243,7 @@ bool ConditionalPathPoint::isActive(const SimTK::State& s) const
  *
  * @param aModel model containing this ConditionalPathPoint.
  */
-void ConditionalPathPoint::connectToModelAndPath(const Model& aModel, GeometryPath& aPath)
+void ConditionalPathPoint::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
 {
     // base class
     Super::connectToModelAndPath(aModel, aPath);

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.h
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.h
@@ -100,7 +100,7 @@ public:
 
     // Override PathPoint methods.
     bool isActive(const SimTK::State& s) const override;
-    void connectToModelAndPath(const Model& aModel, GeometryPath& aPath) 
+    void connectToModelAndPath(Model& aModel, GeometryPath& aPath) 
                                                                 override;
 #endif
 private:

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -510,7 +510,7 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
     newPoint->setBody(aBody);
     Vec3& location = newPoint->getLocation();
     placeNewPathPoint(s, location, aIndex, aBody);
-    newPoint->connectToModelAndPath(getModel(), *this);
+    newPoint->connectToModelAndPath(updModel(), *this);
     upd_PathPointSet().insert(aIndex, newPoint);
 
     // Rename the path points starting at this new one.
@@ -540,7 +540,7 @@ appendNewPathPoint(const std::string& proposedName,
     PathPoint* newPoint = new PathPoint();
     newPoint->setBody(aBody);
     newPoint->setName(proposedName);
-    for (int i=0; i<3; i++) newPoint->setLocationCoord(i, aPositionOnBody[i]);
+    newPoint->set_location(aPositionOnBody);
     upd_PathPointSet().adoptAndAppend(newPoint);
 
     return newPoint;
@@ -729,7 +729,7 @@ void GeometryPath::addPathWrap(WrapObject& aWrapObject)
     PathWrap* newWrap = new PathWrap();
     newWrap->setWrapObject(aWrapObject);
     newWrap->setMethod(PathWrap::hybrid);
-    newWrap->connectToModelAndPath(getModel(), *this);
+    newWrap->connectToModelAndPath(updModel(), *this);
     upd_PathWrapSet().adoptAndAppend(newWrap);
 }
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -73,10 +73,6 @@ void GeometryPath::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
 
-    // aModel will be NULL when objects are being registered.
-    if (&aModel == NULL)
-        return;
-
     // Name the path points based on the current path
     // (i.e., the set of currently active points is numbered
     // 1, 2, 3, ...).
@@ -992,7 +988,7 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
 
             // First remove this object's wrapping points from the current path.
             for (int j = 0; j <path.getSize(); j++) {
-                if( path.get(j) == &ws.getWrapPoint(0)) {
+                if( path.get(j) == &ws.getWrapPoint1()) {
                     path.remove(j); // remove the first wrap point
                     path.remove(j); // remove the second wrap point
                     break;
@@ -1115,16 +1111,16 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                 }
 
                 // Deallocate previous wrapping points if necessary.
-                ws.getWrapPoint(1).getWrapPath().setSize(0);
+                ws.updWrapPoint2().getWrapPath().setSize(0);
 
                 if (best_wrap.wrap_pts.getSize() == 0) {
                     ws.resetPreviousWrap();
-                    ws.getWrapPoint(1).getWrapPath().setSize(0);
+                    ws.updWrapPoint2().getWrapPath().setSize(0);
                 } else {
                     // If wrapping did occur, copy wrap info into the PathStruct.
-                    ws.getWrapPoint(0).getWrapPath().setSize(0);
+                    ws.updWrapPoint1().getWrapPath().setSize(0);
 
-                    Array<SimTK::Vec3>& wrapPath = ws.getWrapPoint(1).getWrapPath();
+                    Array<SimTK::Vec3>& wrapPath = ws.updWrapPoint2().getWrapPath();
                     wrapPath = best_wrap.wrap_pts;
 
                     // In OpenSim, all conversion to/from the wrap object's 
@@ -1137,17 +1133,17 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                     //            ms->ground_segment);
                     // }
 
-                    ws.getWrapPoint(0).setWrapLength(0.0);
-                    ws.getWrapPoint(1).setWrapLength(best_wrap.wrap_path_length);
-                    ws.getWrapPoint(0).setBody(wo->getBody());
-                    ws.getWrapPoint(1).setBody(wo->getBody());
+                    ws.updWrapPoint1().setWrapLength(0.0);
+                    ws.updWrapPoint2().setWrapLength(best_wrap.wrap_path_length);
+                    ws.updWrapPoint1().setBody(wo->getBody());
+                    ws.updWrapPoint2().setBody(wo->getBody());
 
-                    ws.getWrapPoint(0).setLocation(s,best_wrap.r1);
-                    ws.getWrapPoint(1).setLocation(s,best_wrap.r2);
+                    ws.updWrapPoint1().setLocation(s,best_wrap.r1);
+                    ws.updWrapPoint2().setLocation(s,best_wrap.r2);
 
                     // Now insert the two new wrapping points into mp[] array.
-                    path.insert(best_wrap.endPoint, &ws.getWrapPoint(0));
-                    path.insert(best_wrap.endPoint + 1, &ws.getWrapPoint(1));
+                    path.insert(best_wrap.endPoint, &ws.updWrapPoint1());
+                    path.insert(best_wrap.endPoint + 1, &ws.updWrapPoint2());
                 }
             }
         }
@@ -1172,7 +1168,7 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                 // remove wrap object 0 from the list of path points
                 PathWrap& ws = get_PathWrapSet().get(0);
                 for (int j = 0; j < path.getSize(); j++) {
-                    if (path.get(j) == &ws.getWrapPoint(0)) {
+                    if (path.get(j) == &ws.updWrapPoint1()) {
                         path.remove(j); // remove the first wrap point
                         path.remove(j); // remove the second wrap point
                         break;
@@ -1308,4 +1304,16 @@ void GeometryPath::updateDisplayPath(const SimTK::State& s) const
     }
 
     markCacheVariableValid(s, "current_display_path");
+}
+
+void GeometryPath::extendFinalizeFromProperties()
+{
+    Super::extendFinalizeFromProperties();
+    for (int i = 0; i < get_PathWrapSet().getSize(); ++i) {
+        if (upd_PathWrapSet()[i].getName().empty()) {
+            std::stringstream label;
+            label << "pathwrap_" << i;
+            upd_PathWrapSet()[i].setName(label.str());
+        }
+    }
 }

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -206,6 +206,8 @@ protected:
             SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
             override;
 
+    void extendFinalizeFromProperties() override;
+
 private:
 
     void computePath(const SimTK::State& s ) const;

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -312,8 +312,7 @@ void MovingPathPoint::setZFunction( const SimTK::State& s, OpenSim::Function& aF
  *
  * @param aModel model containing this MovingPathPoint.
  */
-void MovingPathPoint::
-connectToModelAndPath(const Model& aModel, GeometryPath& aPath)
+void MovingPathPoint::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
 {
     // base class
     Super::connectToModelAndPath(aModel, aPath);
@@ -375,25 +374,25 @@ void MovingPathPoint::update(const SimTK::State& s)
         const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
                                          _xCoordinate->getValue(s),
                                          _xCoordinate->getRangeMax());
-        _location[0] = _xLocation->calcValue(SimTK::Vector(1, xval));
+        upd_location()[0] = _xLocation->calcValue(SimTK::Vector(1, xval));
     } else // type == Constant
-        _location[0] = _xLocation->calcValue(SimTK::Vector(1, 0.0));
+        upd_location()[0] = _xLocation->calcValue(SimTK::Vector(1, 0.0));
 
     if (_yCoordinate) {
         const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
                                          _yCoordinate->getValue(s),
                                          _yCoordinate->getRangeMax());
-        _location[1] = _yLocation->calcValue(SimTK::Vector(1, yval));
+        upd_location()[1] = _yLocation->calcValue(SimTK::Vector(1, yval));
     } else // type == Constant
-        _location[1] = _yLocation->calcValue(SimTK::Vector(1, 0.0));
+        upd_location()[1] = _yLocation->calcValue(SimTK::Vector(1, 0.0));
 
     if (_zCoordinate) {
         const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
                                          _zCoordinate->getValue(s),
                                          _zCoordinate->getRangeMax());
-        _location[2] = _zLocation->calcValue(SimTK::Vector(1, zval));
+        upd_location()[2] = _zLocation->calcValue(SimTK::Vector(1, zval));
     } else // type == Constant
-        _location[2] = _zLocation->calcValue(SimTK::Vector(1, 0.0));
+        upd_location()[2] = _zLocation->calcValue(SimTK::Vector(1, 0.0));
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -50,7 +50,7 @@ using SimTK::Vec3;
 /**
  * Default constructor.
  */
-MovingPathPoint::MovingPathPoint() :
+MovingPathPoint::MovingPathPoint() : PathPoint(),
    _xLocation(_xLocationProp.getValueObjPtrRef()),
     _xCoordinateName(_xCoordinateNameProp.getValueStr()),
    _yLocation(_yLocationProp.getValueObjPtrRef()),
@@ -224,7 +224,7 @@ void MovingPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionN
         }
     
     // Call base class now assuming _node has been corrected for current version
-    Object::updateFromXMLNode(aNode, versionNumber);
+    Super::updateFromXMLNode(aNode, versionNumber);
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -121,7 +121,7 @@ public:
 
     // Override methods from PathPoint.
     bool isActive(const SimTK::State& s) const override { return true; }
-    void connectToModelAndPath(const Model& aModel, GeometryPath& aPath) 
+    void connectToModelAndPath(Model& aModel, GeometryPath& aPath) 
                                                                 override;
     void update(const SimTK::State& s) override;
     void getVelocity(const SimTK::State& s, SimTK::Vec3& aVelocity) override;

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -144,13 +144,9 @@ void PathActuator::addNewPathPoint(
          const std::string& proposedName, 
          PhysicalFrame& aBody, 
          const SimTK::Vec3& aPositionOnBody) {
-    // Create new PathPoint
+    // Create new PathPoint already appended to the PathPointSet for the path
     PathPoint* newPathPoint = updGeometryPath()
         .appendNewPathPoint(proposedName, aBody, aPositionOnBody);
-    // Set offset/position on owner body
-    newPathPoint->setName(proposedName);
-    for (int i=0; i<3; i++) // Use interface that does not depend on state
-        newPathPoint->setLocationCoord(i, aPositionOnBody[i]);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -67,9 +67,6 @@ void PathPoint::connectToModelAndPath(Model& model, GeometryPath& path)
 {
     Super::connectToModel(model);
     _path = &path;
-
-    cout << getConcreteClassName() << " connected to model " << model.getName();
-    cout << "and path " << path.getFullPathName();
 }
 
 

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -93,7 +93,6 @@ PathPoint* PathPoint::makePathPointOfType(PathPoint* aPoint, const string& aNewT
 
 void PathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
 {
-    using SimTK::Vec3;
     int documentVersion = versionNumber;
     if (documentVersion < XMLDocument::getLatestVersion()) {
         if (documentVersion < 30505) {
@@ -104,11 +103,10 @@ void PathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                 bodyElement->getValueAs<std::string>(bodyName);
                 XMLDocument::addConnector(aNode, "Connector_PhysicalFrame_",
                     "parent_frame", bodyName);
-
-                cout << getConcreteClassName() << " converted body property " << bodyName;
-                cout << " to Connector_PhysicalFrame_" << endl;
             }
         }
     }
+
+    Super::updateFromXMLNode(aNode, versionNumber);
 }
 

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -44,226 +44,20 @@ using SimTK::Transform;
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
 //_____________________________________________________________________________
-/**
- * Default constructor.
- */
-PathPoint::PathPoint() :
-   _location(_locationProp.getValueDblVec()),
-    _bodyName(_bodyNameProp.getValueStr())
-{
-    setNull();
-    setupProperties();
-}
-
-//_____________________________________________________________________________
-/**
- * Destructor.
- */
-PathPoint::~PathPoint()
-{
-}
-
-//_____________________________________________________________________________
-/**
- * Copy constructor.
- *
- * @param aPoint PathPoint to be copied.
- */
-PathPoint::PathPoint(const PathPoint &aPoint) :
-   Object(aPoint),
-   _location(_locationProp.getValueDblVec()),
-    _bodyName(_bodyNameProp.getValueStr())
-{
-    setNull();
-    setupProperties();
-    copyData(aPoint);
-}
 
 
 //=============================================================================
 // CONSTRUCTION METHODS
 //=============================================================================
 //_____________________________________________________________________________
-/**
- * Copy data members from one PathPoint to another.
+/* Copy data members from one PathPoint to another.
  *
  * @param aPoint PathPoint to be copied.
  */
 void PathPoint::copyData(const PathPoint &aPoint)
 {
     _location = aPoint._location;
-    _bodyName = aPoint._bodyName;
-    _body = aPoint._body;
     _path = aPoint._path;
-}
-
-//_____________________________________________________________________________
-/**
- * Initialize a PathPoint with data from another PathPoint.
- *
- * @param aPoint PathPoint to be copied.
- */
-void PathPoint::init(const PathPoint& aPoint)
-{
-    copyData(aPoint);
-}
-
-//_____________________________________________________________________________
-/**
- * Set the data members of this PathPoint to their null values.
- */
-void PathPoint::setNull()
-{
-    _body = NULL;
-    _path = NULL;
-}
-
-//_____________________________________________________________________________
-/**
- * Connect properties to local pointers.
- */
-void PathPoint::setupProperties()
-{
-    const SimTK::Vec3 defaultLocation(0.0);
-    _locationProp.setName("location");
-    _locationProp.setValue(defaultLocation);
-    //_locationProp.setAllowableListSize(3);
-    _propertySet.append(&_locationProp);
-
-    _bodyNameProp.setName("body");
-    _propertySet.append(&_bodyNameProp);
-}
-
-//_____________________________________________________________________________
-/**
- * TODO: All Points should be Components that use Connectors
- * and extendConnect(). This must go away! -aseth
- */
-void PathPoint::connectToModelAndPath(const Model& aModel, GeometryPath& aPath)
-{
-    _path = &aPath;
-    _model  = &aModel;
-
-    if (_bodyName == aModel.getGround().getName()){
-        _body = &const_cast<Model*>(&aModel)->updGround();
-        return;
-    }
-
-    // Look up the body by name in the Model.
-    // will throw ComponentNotFound Exception if the body (PhysicalFrame)
-    // with this name cannot be found.
-    _body = aModel.findComponent<PhysicalFrame>(_bodyName);
-}
-
-//_____________________________________________________________________________
-/**
- * Update geometry of the muscle point.
- *
- */
-void PathPoint::updateGeometry()
-{
-    Transform position;
-    position.setP(_location);
-    //updDisplayer()->setTransform(position);
-}
-//=============================================================================
-// OPERATORS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Assignment operator.
- *
- * @return Reference to this object.
- */
-PathPoint& PathPoint::operator=(const PathPoint &aPoint)
-{
-    // BASE CLASS
-    Object::operator=(aPoint);
-
-    copyData(aPoint);
-
-    return(*this);
-}
-
-//_____________________________________________________________________________
-/**
- * Set the body that this point is fixed to.
- *
- * @param aBody Reference to the body.
- */
-void PathPoint::setBody(const PhysicalFrame& aBody)
-{
-    if (&aBody == _body)
-        return;
-
-    _body = &aBody;
-    _bodyName = aBody.getName();
-}
-
-//_____________________________________________________________________________
-/**
- * Change the body that this point is attached to. It assumes that the body is
- * already set, so that connectToModelAndPath() needs to be called to update 
- * dependent information.
- *
- * @param s State.
- * @param aBody Reference to the body.
- */
-void PathPoint::changeBodyPreserveLocation(const SimTK::State& s, PhysicalFrame& aBody)
-{
-    if (!_body){
-        throw Exception("PathPoint::changeBodyPreserveLocation attempted to "
-            " change the body on PathPoint which was not assigned to a body.");
-    }
-    // if it is already assigned to aBody, do nothing
-    if (_body == &aBody )
-        return;
-
-    // Preserve location means to switch bodies without changing
-    // the location of the point in the inertial reference frame.
-    _location = _body->findLocationInAnotherFrame(s, _location, aBody);
-    _bodyName = aBody.getName();
-
-    // now assign this point's body to point to aBody
-    _body = &aBody;
-
-    connectToModelAndPath(aBody.getModel(), *getPath());
-}
-
-//_____________________________________________________________________________
-/**
- * Set the XYZ location of the point.
- *
- * @param aLocation The XYZ coordinates.
- */
-void PathPoint::setLocation( const SimTK::State& s, const SimTK::Vec3& aLocation)
-{
-    _location = aLocation;
-}
-
-//_____________________________________________________________________________
-/**
- * Set the X, Y, or Z location of the point.
- *
- * @param aCoordIndex The coordinate to change (0=X, 1=Y, 2=Z).
- * @param aLocation The X, Y, or Z coordinate.
- */
-void PathPoint::setLocation( const SimTK::State& s, int aCoordIndex, double aLocation)
-{
-    if (aCoordIndex >= 0 && aCoordIndex <= 2)
-        _location[aCoordIndex] = aLocation;
-}
-
-//_____________________________________________________________________________
-/**
- * Get the velocity of the point in the body's local reference frame.
- *
- * @param aVelocity The velocity.
- */
-
-void PathPoint::getVelocity(const SimTK::State& s, SimTK::Vec3& aVelocity)
-{
-    aVelocity[0] = aVelocity[1] = aVelocity[2] = 0.0;
 }
 
 PathPoint* PathPoint::makePathPointOfType(PathPoint* aPoint, const string& aNewTypeName)
@@ -284,19 +78,3 @@ PathPoint* PathPoint::makePathPointOfType(PathPoint* aPoint, const string& aNewT
     return newPoint;
 }
 
-//=============================================================================
-// SCALING
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Scale the muscle point.
- *
- * @param aScaleFactors the XYZ scale factors to scale the point by.
- */
-void PathPoint::scale(const SimTK::State& s, const SimTK::Vec3& aScaleFactors)
-{
-    for (int i = 0; i < 3; i++)
-        _location[i] *= aScaleFactors[i];
-
-    updateGeometry();
-}

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -56,7 +56,6 @@ using SimTK::Transform;
  */
 void PathPoint::copyData(const PathPoint &aPoint)
 {
-    cout << getConcreteClassName() << "::copyData()" << endl;
     _path = aPoint._path;
 }
 

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -158,7 +158,7 @@ public:
 
     static void deletePathPoint(PathPoint* aPoint) { if (aPoint) delete aPoint; }
 
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber);
+    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
 //=============================================================================
 };  // END of class PathPoint_
 //=============================================================================

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -143,7 +143,7 @@ public:
     // get the relative velocity of the path point with respect to the body
     // it is connected to.
     virtual void getVelocity(const SimTK::State& s, SimTK::Vec3& velocity) {
-        velocity[0] = velocity[1] = velocity[2] = 0.0;
+        velocity.setToZero();
     }
     // get the partial of the point location w.r.t. to the coordinates (Q)
     // it is dependent on.

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -114,7 +114,7 @@ void PathWrap::setupProperties()
 }
 
 
-void PathWrap::connectToModelAndPath(const Model& aModel, GeometryPath& aPath)
+void PathWrap::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
 {
     _path = &aPath;
 

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -44,7 +44,7 @@ using namespace OpenSim;
  * Default constructor.
  */
 PathWrap::PathWrap() :
-    Object(),
+    Component(),
     _wrapObjectName(_wrapObjectNameProp.getValueStr()),
     _methodName(_methodNameProp.getValueStr()),
    _range(_rangeProp.getValueIntArray())
@@ -68,7 +68,7 @@ PathWrap::~PathWrap()
  * @param aPathWrap PathWrap to be copied.
  */
 PathWrap::PathWrap(const PathWrap& aPathWrap) :
-    Object(aPathWrap),
+    Component(aPathWrap),
     _wrapObjectName(_wrapObjectNameProp.getValueStr()),
     _methodName(_methodNameProp.getValueStr()),
    _range(_rangeProp.getValueIntArray())
@@ -124,18 +124,18 @@ void PathWrap::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
         const WrapObject* wo = it->getWrapObject(getWrapObjectName());
         if (wo) {
             _wrapObject = wo;
-            _wrapPoints[0].setBody(wo->getBody());
-            _wrapPoints[0].setWrapObject(wo);
-            _wrapPoints[1].setBody(wo->getBody());
-            _wrapPoints[1].setWrapObject(wo);
+            updWrapPoint1().setBody(wo->getBody());
+            updWrapPoint1().setWrapObject(wo);
+            updWrapPoint2().setBody(wo->getBody());
+            updWrapPoint2().setWrapObject(wo);
             break;
         }
     }
 
     // connectToModelAndPath() must be called after setBody() because it requires
     // that _bodyName already be assigned.
-    _wrapPoints[0].connectToModelAndPath(aModel, aPath);
-    _wrapPoints[1].connectToModelAndPath(aModel, aPath);
+    updWrapPoint1().connectToModelAndPath(aModel, aPath);
+    updWrapPoint2().connectToModelAndPath(aModel, aPath);
 
     if (_methodName == "hybrid" || _methodName == "Hybrid" || _methodName == "HYBRID")
         _method = hybrid;
@@ -167,8 +167,8 @@ void PathWrap::copyData(const PathWrap& aPathWrap)
     _wrapObject = aPathWrap._wrapObject;
     _previousWrap = aPathWrap._previousWrap;
 
-    _wrapPoints[0] = aPathWrap._wrapPoints[0];
-    _wrapPoints[1] = aPathWrap._wrapPoints[1];
+    updWrapPoint1() = aPathWrap.getWrapPoint1();
+    updWrapPoint2() = aPathWrap.getWrapPoint2();
 }
 
 //=============================================================================
@@ -190,16 +190,6 @@ PathWrap& PathWrap::operator=(const PathWrap& aPathWrap)
     return(*this);
 }
 
-PathWrapPoint& PathWrap::getWrapPoint(int aIndex)
-{
-    if (aIndex < 0 || aIndex > 1)
-    {
-        // TODO string errorMessage = "PathWrap::getWrapPoint(): invalid index (" + aIndex + ")";
-        // throw Exception(errorMessage);
-    }
-
-    return _wrapPoints[aIndex];
-}
 
 void PathWrap::setStartPoint( const SimTK::State& s, int aIndex)
 {

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -57,8 +57,8 @@ class GeometryPath;
  * @author Peter Loan
  * @version 1.0
  */
-class OSIMSIMULATION_API PathWrap : public Object {
-OpenSim_DECLARE_CONCRETE_OBJECT(PathWrap, Object);
+class OSIMSIMULATION_API PathWrap : public Component {
+OpenSim_DECLARE_CONCRETE_OBJECT(PathWrap, Component);
 
 //=============================================================================
 // DATA
@@ -88,7 +88,12 @@ protected:
 
     WrapResult _previousWrap;  // results from previous wrapping
 
-    PathWrapPoint _wrapPoints[2]; // the two muscle points created when the muscle wraps
+    //PathWrapPoint _wrapPoints[2]; // the two muscle points created when the muscle wraps
+
+    MemberSubcomponentIndex _wrapPoint1Ix {
+        constructSubcomponent<PathWrapPoint>("pwpt1") };
+    MemberSubcomponentIndex _wrapPoint2Ix {
+        constructSubcomponent<PathWrapPoint>("pwpt2") };
 
 //=============================================================================
 // METHODS
@@ -113,7 +118,21 @@ public:
     const std::string& getWrapObjectName() const { return _wrapObjectName; }
     const WrapObject* getWrapObject() const { return _wrapObject; }
     void setWrapObject(WrapObject& aWrapObject);
-    PathWrapPoint& getWrapPoint(int aIndex);
+
+    const PathWrapPoint& getWrapPoint1() const {
+        return getMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
+    }
+    const PathWrapPoint& getWrapPoint2() const {
+        return getMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
+    }
+    PathWrapPoint& updWrapPoint1() { 
+        return updMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
+    }
+    PathWrapPoint& updWrapPoint2() {
+        return updMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
+    }
+
+
     WrapMethod getMethod() const { return _method; }
     void setMethod(WrapMethod aMethod);
     const std::string& getMethodName() const { return _methodName; }

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -29,8 +29,6 @@
 #include <string>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <OpenSim/Common/Object.h>
-#include <OpenSim/Common/PropertyStr.h>
-#include <OpenSim/Common/PropertyIntArray.h>
 #include "PathWrapPoint.h"
 #include "WrapResult.h"
 
@@ -59,36 +57,34 @@ class GeometryPath;
  */
 class OSIMSIMULATION_API PathWrap : public Component {
 OpenSim_DECLARE_CONCRETE_OBJECT(PathWrap, Component);
-
-//=============================================================================
-// DATA
-//=============================================================================
 public:
+    //==============================================================================
+    // PROPERTIES
+    //==============================================================================
+    OpenSim_DECLARE_PROPERTY(wrap_object, std::string,
+        "A WrapObject that this PathWrap interacts with.");
+    OpenSim_DECLARE_PROPERTY(method, std::string,
+        "The wrapping method used to solve the path around the wrap object.");
 
-    enum WrapMethod
-    {
+    // Range should not be exposed as far as one can tell, since al instances are
+    // -1, -1 which is the default value, which means the PathWrap is overwriting
+    // anyways.
+    OpenSim_DECLARE_LIST_PROPERTY_SIZE(range, int, 2,
+        "The range of indices to use to compute the path over the wrap object.")
+
+    enum WrapMethod {
         hybrid,
         midpoint,
         axial
     };
 
 protected:
-    PropertyStr _wrapObjectNameProp;
-    std::string &_wrapObjectName;
-
-    PropertyStr _methodNameProp;   // currently used only for ellipsoid wrapping
-    std::string& _methodName;
     WrapMethod _method;
-
-    PropertyIntArray _rangeProp;
-    Array<int> &_range;
 
     const WrapObject* _wrapObject;
     GeometryPath* _path;
 
     WrapResult _previousWrap;  // results from previous wrapping
-
-    //PathWrapPoint _wrapPoints[2]; // the two muscle points created when the muscle wraps
 
     MemberSubcomponentIndex _wrapPoint1Ix {
         constructSubcomponent<PathWrapPoint>("pwpt1") };
@@ -103,19 +99,16 @@ protected:
     //--------------------------------------------------------------------------
 public:
     PathWrap();
-    PathWrap(const PathWrap& aPathWrap);
     ~PathWrap();
 
 #ifndef SWIG
-    PathWrap& operator=(const PathWrap& aPathWrap);
     void connectToModelAndPath(Model& aModel, GeometryPath& aPath);
     void setStartPoint( const SimTK::State& s, int aIndex);
     void setEndPoint( const SimTK::State& s, int aIndex);
 #endif
-    void copyData(const PathWrap& aPathWrap);
-    int getStartPoint() const { return _range[0]; }
-    int getEndPoint() const { return _range[1]; }
-    const std::string& getWrapObjectName() const { return _wrapObjectName; }
+    int getStartPoint() const { return get_range(0); }
+    int getEndPoint() const { return get_range(1); }
+    const std::string& getWrapObjectName() const { return get_wrap_object(); }
     const WrapObject* getWrapObject() const { return _wrapObject; }
     void setWrapObject(WrapObject& aWrapObject);
 
@@ -135,17 +128,15 @@ public:
 
     WrapMethod getMethod() const { return _method; }
     void setMethod(WrapMethod aMethod);
-    const std::string& getMethodName() const { return _methodName; }
+    const std::string& getMethodName() const { return get_method(); }
     GeometryPath* getPath() const { return _path; }
 
     const WrapResult& getPreviousWrap() const { return _previousWrap; }
     void setPreviousWrap(const WrapResult& aWrapResult);
     void resetPreviousWrap();
 
-protected:
-    void setupProperties();
-
 private:
+    void constructProperties();
     void setNull();
 //=============================================================================
 };  // END of class PathWrap

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -103,7 +103,7 @@ public:
 
 #ifndef SWIG
     PathWrap& operator=(const PathWrap& aPathWrap);
-    void connectToModelAndPath(const Model& aModel, GeometryPath& aPath);
+    void connectToModelAndPath(Model& aModel, GeometryPath& aPath);
     void setStartPoint( const SimTK::State& s, int aIndex);
     void setEndPoint( const SimTK::State& s, int aIndex);
 #endif

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -138,20 +138,20 @@ int main()
             numModelComponentsWithStateVariables++;
         }
         //Now test a std::iterator method
-        ComponentList<ModelComponent> allModelComps = model.getComponentList<ModelComponent>();
-        ComponentList<ModelComponent>::const_iterator skipIter = allModelComps.begin();
-        int countSkipComponent = 0;
-        while (skipIter != allModelComps.end()){
+        ComponentList<Frame> allFrames = model.getComponentList<Frame>();
+        ComponentList<Frame>::const_iterator skipIter = allFrames.begin();
+        int countSkipFrames = 0;
+        while (skipIter != allFrames.end()){
             cout << skipIter->getConcreteClassName() << ":" << skipIter->getFullPathName() << endl;
             std::advance(skipIter, 2);
-            countSkipComponent++;
+            countSkipFrames++;
         }
 
         // TODO: Hard-coding these numbers is not ideal. As we introduce more components
         // to recompose existing components, this will need continual updating. For example,
         // Joint's often add PhysicalOffsetFrames to handle what used to be baked in location
         // and orientation offsets.
-        ASSERT(numComponents == 77); 
+        ASSERT(numComponents == 130); 
         ASSERT(numBodies == model.getNumBodies());
         ASSERT(numBodiesPost == numBodies);
         ASSERT(numMuscles == model.getMuscles().getSize());
@@ -159,10 +159,9 @@ int main()
         ASSERT(numModelComponentsWithStateVariables == 10);
         // Below updated from 1 to 3 to account for offset frame and its geometry added to the Joint
         ASSERT(numJntComponents == 3);
-        // Unclear what the following tests. But given that 4 more components were added
-        // and skipIter seems to be skipping by 2 (counting every other ModelComponent),
-        // then 77 components - 35 mesh geometry - 5 frame geom = 37 now /2 = 18 
-        ASSERT(countSkipComponent == 18);
+        // Test using the iterator to skip over every other Component (Frame in this case)
+        // nf = 1 ground + 2 bodies + 2 joint offsets = 5, skipping - 2 = 3
+        ASSERT(countSkipFrames == 3);
     }
     catch (Exception &ex) {
         ex.print(std::cout);


### PR DESCRIPTION
Minimal changes to `PathPoint` and derived classes so that they are based on `Point` (`Station` for the time being). 

Subsequent PRs will whittle-down the methods in `PathPoint` until there is nothing left. The longer-term goal is to eliminate PathPoints altogether and to compose GeometryPaths from Points. The designation of whether a Point is a path point or not should simply be whether it belongs to a GeometryPath and nothing else.

@aymanhab can you confirm that you can still build the GUI and use the MuscleEditor to edit muscle paths? I will need to work closely with you to make sure that we have equivalent (or better) methods for editing in the GUI.

