### PR TITLE
Remove warnings

### DIFF
--- a/OpenSim/Simulation/Model/ContactMesh.h
+++ b/OpenSim/Simulation/Model/ContactMesh.h
@@ -94,7 +94,7 @@ public:
 private:
     // INITIALIZATION
     void setNull();
-    void constructProperties();
+    void constructProperties() override;
     void extendFinalizeFromProperties() override;
     /**
      * Load the mesh from disk.

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -177,7 +177,11 @@ public:
     *
     * @param scaleSet   Set of XYZ scale factors for PhysicalFrames.
     */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
     virtual void scale(const ScaleSet& scaleSet);
+#pragma clang diagnostic pop
+
 
 protected:
     /** @name Component Interface

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -177,11 +177,7 @@ public:
     *
     * @param scaleSet   Set of XYZ scale factors for PhysicalFrames.
     */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winconsistent-missing-override"
     virtual void scale(const ScaleSet& scaleSet);
-#pragma clang diagnostic pop
-
 
 protected:
     /** @name Component Interface


### PR DESCRIPTION
* Add missing override to `ContactMesh`.
* Suppress missing override warning from clang for `TwoFrameLinker::scale()`. This **does not** address #896, rather just suppresses the warning. The issue still stands.