### PR TITLE
Provide python package version in __version__.

### DIFF
--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -200,12 +200,15 @@ OpenSimAddPythonModule(MODULE tools
 # Note: some of the commands to do this copying (for the swig-generated py
 # files) appear above.
 
-# Configure setup.py
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
-    "${CMAKE_CURRENT_BINARY_DIR}/setup.py" @ONLY)
+# Configure version.py.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.py.in
+    "${CMAKE_CURRENT_BINARY_DIR}/version.py" @ONLY)
 
-# Copy the configured setup.py for each build configuration.
-OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_BINARY_DIR}/setup.py" ".")
+# Copy the configured version.py for each build configuration.
+OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_BINARY_DIR}/version.py" opensim)
+
+# Copy setup.py for each build configuration.
+OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/setup.py" ".")
 
 # __init__.py.
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" opensim)

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -4,3 +4,5 @@ from simulation import *
 from actuators import *
 from analyses import *
 from tools import *
+
+from .version import __version__

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -4,8 +4,11 @@ import os
 
 from setuptools import setup
 
+# This provides the variable `__version__`.
+execfile('opensim/version.py')
+
 setup(name='opensim',
-      version='@OPENSIM_VERSION@',
+      version=__version__,
       description='OpenSim Simulation Framework',
       author='OpenSim Team',
       author_email='ahabib@stanford.edu',

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -12,6 +12,9 @@ test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
 class TestBasics(unittest.TestCase):
+    def test_version(self):
+        print(osim.__version__)
+
     def test_Thelen2003Muscle_helper_classes(self):
         # This test exists because some classes that Thelen2003Muscle used were
         # not accessibly in the bindings.

--- a/Bindings/Python/version.py.in
+++ b/Bindings/Python/version.py.in
@@ -1,0 +1,1 @@
+__version__ = @OPENSIM_VERSION@


### PR DESCRIPTION
This PR allows python users to get the version of OpenSim in a way that is somewhat standard in the python community:

```
import opensim
print(opensim.__version__)
```

Addresses part of #945.