### PR TITLE
Fix memory leak in testmuscles

### DIFF
--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -301,7 +301,7 @@ void simulateMuscle(
 
     // Create a prescribed controller that simply 
     //applies controls as function of time
-    PrescribedController * muscleController = new PrescribedController();
+    std::unique_ptr<PrescribedController> muscleController{};
     if(control != NULL){
         muscleController->setActuators(model.updActuators());
         // Set the individual muscle control functions 
@@ -309,7 +309,7 @@ void simulateMuscle(
         muscleController->prescribeControlForActuator("muscle",control->clone());
 
         // Add the control set controller to the model
-        model.addController(muscleController);
+        model.addController(muscleController.release());
     }
 
     // Set names for muscles / joints.

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -301,7 +301,8 @@ void simulateMuscle(
 
     // Create a prescribed controller that simply 
     //applies controls as function of time
-    std::unique_ptr<PrescribedController> muscleController{};
+    std::unique_ptr<PrescribedController> 
+        muscleController{new PrescribedController{}};
     if(control != NULL){
         muscleController->setActuators(model.updActuators());
         // Set the individual muscle control functions 

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -136,7 +136,7 @@ public:
     void resetPreviousWrap();
 
 private:
-    void constructProperties();
+    void constructProperties() override;
     void setNull();
 //=============================================================================
 };  // END of class PathWrap


### PR DESCRIPTION
* Fix memory leak in `testMuscles`. <br />
I think it will be good to change the interface of `Model::add<>` methods to accept only `std::unique_ptr`s if the intention is to take over the ownership of the object passed. This will make the caller code clear to read since passing a `std::unique_ptr` means transferring ownership. 

* Fix warning on *missing override*.