### PR TITLE
[cmake] Use correct file dependencies for swig.

### DIFF
--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -6,32 +6,30 @@ find_package(JNI 1.6 REQUIRED)
 
 function(OpenSimGenerateJavaWrapper
         NAME INPUT_INTERFACE_FILE OUTPUT_CXX_FILE OUTPUT_H_FILE)
+
+    set(_swig_common_args -c++ -java
+            -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
+            -I${OpenSim_SOURCE_DIR}
+            -I${OpenSim_SOURCE_DIR}/Bindings
+            -I${Simbody_INCLUDE_DIR}
+            ${SWIG_FLAGS}
+            ${INPUT_INTERFACE_FILE}
+            )
+
+    OpenSimFindSwigFileDependencies(_${NAME}_dependencies ${NAME}
+        "${_swig_common_args}"
+        )
+
     add_custom_command(
         # This target actually creates a lot more (all the produced .java files)
         # but we will just use these two files as a proxy for all of those.
         OUTPUT ${OUTPUT_CXX_FILE} ${OUTPUT_H_FILE}
-        COMMAND ${SWIG_EXECUTABLE} -v -c++ -java
-                -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
-                -I${OpenSim_SOURCE_DIR}
-                -I${OpenSim_SOURCE_DIR}/Bindings
-                -I${Simbody_INCLUDE_DIR}
-                ${SWIG_FLAGS}
-                -o ${OUTPUT_CXX_FILE}
-                -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
-                ${INPUT_INTERFACE_FILE}
-        DEPENDS ${INPUT_INTERFACE_FILE}
-        "${CMAKE_SOURCE_DIR}/Bindings/preliminaries.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/simbody.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/common.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/simulation.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/actuators.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/analyses.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/tools.i"
-        "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders_common.h"
-        "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders_simulation.h"
-        "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders_actuators.h"
-        "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders_analyses.h"
-        "${CMAKE_SOURCE_DIR}/Bindings/OpenSimHeaders_tools.h"
+        COMMAND ${SWIG_EXECUTABLE}
+            -v # verbose
+            -o ${OUTPUT_CXX_FILE}
+            -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
+            ${_swig_common_args}
+        DEPENDS ${_${NAME}_dependencies}
         COMMENT "Generating Java bindings source code with SWIG: ${NAME}")
 endfunction()
 

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -70,36 +70,45 @@ macro(OpenSimAddPythonModule)
     set(_interface_file
         "${CMAKE_CURRENT_SOURCE_DIR}/swig/python_${OSIMSWIGPY_MODULE}.i")
 
-    # Assemble dependencies.
-    set(_dependencies
-        "swig/python_preliminaries.i"
-        "${OpenSim_SOURCE_DIR}/Bindings/preliminaries.i"
-        "${OpenSim_SOURCE_DIR}/Bindings/${OSIMSWIGPY_MODULE}.i"
-        )
-    if(NOT ${OSIMSWIGPY_MODULE} STREQUAL "simbody")
-        list(APPEND _dependencies
-            "${OpenSim_SOURCE_DIR}/Bindings/OpenSimHeaders_${OSIMSWIGPY_MODULE}.h")
+    # We run swig once to get dependencies and then again to actually generate
+    # the wrappers. This variable holds the parts of the swig command that
+    # are shared between both invocations.
+    set(_swig_common_args -c++ -python
+            -I${OpenSim_SOURCE_DIR}
+            -I${OpenSim_SOURCE_DIR}/Bindings/
+            -I${Simbody_INCLUDE_DIR}
+            ${SWIG_FLAGS}
+            )
+
+    # Assemble dependencies. This command is run during CMake's configure step.
+    execute_process(COMMAND ${SWIG_EXECUTABLE} ${_swig_common_args}
+            -MM # List dependencies, but omit files in SWIG library.
+            ${_interface_file}
+        OUTPUT_VARIABLE _dependencies_makefile
+        RESULT_VARIABLE _successfully_got_dependencies
+            )
+    # Clean up the output, since it's in the form of a makefile
+    # (and we just want a list of file paths).
+    if(${_successfully_got_dependencies} EQUAL 0) # return code 0 is success.
+        # '^.*:' matches the first line of the makefile (the output file path).
+        # '\\\\' matches a single \ (escape for CMake, and escape for regex).
+        string(REGEX REPLACE "(^.*:|\\\\\n)" "" _dependencies
+            ${_dependencies_makefile})
+        # Replace spaces with semicolons to create a list of file paths.
+        separate_arguments(_dependencies)
+    else()
+        unset(_dependencies) # In case it has a value for previous modules.
+        # If someone ends up here, it's a bug in this CMakeLists.txt.
+        message(AUTHOR_WARNING
+            "Could not determine dependencies for SWIG module ${OSIMSWIGPY_MODULE}.")
     endif()
-    foreach(_depmodule ${OSIMSWIGPY_DEPENDS})
-        list(APPEND _dependencies
-            "swig/python_${_depmodule}.i"
-            "${OpenSim_SOURCE_DIR}/Bindings/${_depmodule}.i")
-        if(NOT ${_depmodule} STREQUAL "simbody")
-            list(APPEND _dependencies
-                "${OpenSim_SOURCE_DIR}/Bindings/OpenSimHeaders_${_depmodule}.h")
-        endif()
-    endforeach()
 
     # Run swig.
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py"
             ${_output_cxx_file} ${_output_header_file}
-        COMMAND ${SWIG_EXECUTABLE} -v -c++  -python
+        COMMAND ${SWIG_EXECUTABLE} ${_swig_common_args}
             #-debug-tmused # Which typemaps were used?
-            -I${OpenSim_SOURCE_DIR}
-            -I${OpenSim_SOURCE_DIR}/Bindings/
-            -I${Simbody_INCLUDE_DIR}
-            ${SWIG_FLAGS}
             -o ${_output_cxx_file}
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
             ${_interface_file}
@@ -185,13 +194,11 @@ endmacro()
 # Build python modules (generate binding source code and compile it).
 # ===================================================================
 OpenSimAddPythonModule(MODULE simbody)
-OpenSimAddPythonModule(MODULE common DEPENDS simbody)
-OpenSimAddPythonModule(MODULE simulation DEPENDS common simbody)
-OpenSimAddPythonModule(MODULE actuators DEPENDS simulation common simbody)
-OpenSimAddPythonModule(MODULE analyses
-                       DEPENDS actuators simulation common simbody)
-OpenSimAddPythonModule(MODULE tools
-                       DEPENDS analyses actuators simulation common simbody)
+OpenSimAddPythonModule(MODULE common)
+OpenSimAddPythonModule(MODULE simulation)
+OpenSimAddPythonModule(MODULE actuators)
+OpenSimAddPythonModule(MODULE analyses)
+OpenSimAddPythonModule(MODULE tools)
 
 
 # Copy files to create complete package in the build tree.

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -78,41 +78,26 @@ macro(OpenSimAddPythonModule)
             -I${OpenSim_SOURCE_DIR}/Bindings/
             -I${Simbody_INCLUDE_DIR}
             ${SWIG_FLAGS}
+            ${_interface_file}
             )
 
-    # Assemble dependencies. This command is run during CMake's configure step.
-    execute_process(COMMAND ${SWIG_EXECUTABLE} ${_swig_common_args}
-            -MM # List dependencies, but omit files in SWIG library.
-            ${_interface_file}
-        OUTPUT_VARIABLE _dependencies_makefile
-        RESULT_VARIABLE _successfully_got_dependencies
-            )
-    # Clean up the output, since it's in the form of a makefile
-    # (and we just want a list of file paths).
-    if(${_successfully_got_dependencies} EQUAL 0) # return code 0 is success.
-        # '^.*:' matches the first line of the makefile (the output file path).
-        # '\\\\' matches a single \ (escape for CMake, and escape for regex).
-        string(REGEX REPLACE "(^.*:|\\\\\n)" "" _dependencies
-            ${_dependencies_makefile})
-        # Replace spaces with semicolons to create a list of file paths.
-        separate_arguments(_dependencies)
-    else()
-        unset(_dependencies) # In case it has a value for previous modules.
-        # If someone ends up here, it's a bug in this CMakeLists.txt.
-        message(AUTHOR_WARNING
-            "Could not determine dependencies for SWIG module ${OSIMSWIGPY_MODULE}.")
-    endif()
+    # Assemble dependencies. This macro runs a command during CMake's
+    # configure step and fills the first argument with a list of the
+    # dependencies.
+    OpenSimFindSwigFileDependencies(_${OSIMSWIGPY_MODULE}_dependencies
+        ${OSIMSWIGPY_MODULE} "${_swig_common_args}")
 
     # Run swig.
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py"
             ${_output_cxx_file} ${_output_header_file}
-        COMMAND ${SWIG_EXECUTABLE} ${_swig_common_args}
+        COMMAND ${SWIG_EXECUTABLE}
             #-debug-tmused # Which typemaps were used?
+            -v # verbose
             -o ${_output_cxx_file}
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
-            ${_interface_file}
-        DEPENDS ${_interface_file} ${_dependencies}
+            ${_swig_common_args}
+        DEPENDS ${_${OSIMSWIGPY_MODULE}_dependencies}
             COMMENT "Generating python bindings source code with SWIG: ${OSIMSWIGPY_MODULE} module."
         )
 

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -279,3 +279,52 @@ function(CopyDependencyDLLsForWin DEP_NAME DEP_INSTALL_DIR)
         install(FILES ${DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
 endfunction()
+
+
+# Discover the file dependencies for an invocation of swig, for use with the
+# DEPENDS field of an add_custom_command().
+#
+# OSIMSWIGDEP_RETURNVAL  is filled with a list of the dependencies.
+# OSIMSWIGDEP_MODULE     is the name of the module (just for messages).
+# OSIMSWIGDEP_INVOCATION is the SWIG command to use to check for dependencies.
+#                        We append `-MM` to this, which asks SWIG for the
+#                        dependencies.
+macro(OpenSimFindSwigFileDependencies OSIMSWIGDEP_RETURNVAL
+                                      OSIMSWIGDEP_MODULE
+                                      OSIMSWIGDEP_INVOCATION)
+    # We must use a macro instead of a function in order to return a value.
+
+    # Assemble dependencies. This command is run during CMake's configure step.
+    message(STATUS
+        "Discovering dependencies for SWIG module ${OSIMSWIGDEP_MODULE}.")
+    execute_process(COMMAND ${SWIG_EXECUTABLE}
+            -MM # List dependencies, but omit files in SWIG library.
+            ${OSIMSWIGDEP_INVOCATION}
+        OUTPUT_VARIABLE _dependencies_makefile
+        RESULT_VARIABLE _successfully_got_dependencies
+            )
+    # Clean up the output, since it's in the form of a makefile
+    # (and we just want a list of file paths).
+    if(${_successfully_got_dependencies} EQUAL 0) # return code 0 is success.
+        # '^.*:' matches the first line of the makefile (the output file path).
+        # '\\\\' matches a single \ (escape for CMake, and escape for regex).
+        string(REGEX REPLACE "(^.*:|\\\\\n)" "" ${OSIMSWIGDEP_RETURNVAL}
+            ${_dependencies_makefile})
+        # Replace spaces with semicolons to create a list of file paths.
+        separate_arguments(${OSIMSWIGDEP_RETURNVAL})
+    else()
+        # In case the variable has a value for previous modules.
+        unset(${OSIMSWIGDEP_RETURNVAL})
+        # If someone ends up here, it's a bug in this CMakeLists.txt.
+        message(AUTHOR_WARNING
+            "Could not determine dependencies for SWIG module ${OSIMSWIGDEP_MODULE}.")
+    endif()
+
+    unset(_dependencies_makefile)
+    unset(_successfully_got_dependencies)
+
+endmacro()
+
+
+
+


### PR DESCRIPTION
During cmake's configure step, I run swig on the interface files and ask it to give back a list of the file dependencies for that interface file. Then I pass those files onto CMake as dependencies for generating swig source code. This may substantially improve the process of developing bindings.

The only downside is that the time spent configuring has increased from 1.4 s to 3.4 s (when building only python bindings). However, I think this delay is worthwhile, since much more than 2 seconds are saved when developing the bindings, and this delay is not present if you're not building the bindings.