### PR TITLE
Add LoadOpenSimLibraryExact()

### DIFF
--- a/OpenSim/Common/LoadOpenSimLibrary.cpp
+++ b/OpenSim/Common/LoadOpenSimLibrary.cpp
@@ -103,7 +103,7 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
     // mode and a debug library is specified, we'll first try loading the debug library,
     // and then try loading the release library.
     bool tryDebugThenRelease = false;
-#ifndef NDEBUG
+#ifdef _DEBUG
     if(!hasDebugSuffix) {
         if(verbose) cout << "Will try loading debug library first" << endl;
         tryDebugThenRelease = true;

--- a/OpenSim/Common/LoadOpenSimLibrary.h
+++ b/OpenSim/Common/LoadOpenSimLibrary.h
@@ -1,5 +1,5 @@
-#ifndef _LoadOpenSimLibrary_h_
-#define _LoadOpenSimLibrary_h_
+#ifndef OPENSIM_LOAD_OPENSIM_LIBRARY_H_
+#define OPENSIM_LOAD_OPENSIM_LIBRARY_H_
 /* -------------------------------------------------------------------------- *
  *                       OpenSim:  LoadOpenSimLibrary.h                       *
  * -------------------------------------------------------------------------- *
@@ -40,10 +40,26 @@
 namespace OpenSim
 {
 
-OSIMCOMMON_API OPENSIM_PORTABLE_HMODULE WINAPI LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose);
+/** Load an OpenSim (plugin) library, using a path to a library (relative or
+ * absolute) but *without* the file extension (.dll, .so, .dylib). This method
+ * will prefer a debug variant of the library if OpenSim was built in debug. */
+OSIMCOMMON_API OPENSIM_PORTABLE_HMODULE WINAPI LoadOpenSimLibrary(
+        const std::string &lpLibFileName, bool verbose);
+/** Uses LoadOpenSimLibrary(const std::string&, bool) without verbosity. */
 OSIMCOMMON_API void LoadOpenSimLibrary(const std::string &aLibraryName);
-OSIMCOMMON_API void LoadOpenSimLibraries(int argc,char **argv);
+/** Load an OpenSim (plugin) library using the exact path specified. Therefore,
+ * you must supply an exact path to the library (either relative or absolute),
+ * including the file extension (.dll, .so, .dylib). The only change that may
+ * be made to the path is to convert forward slashes to backslashes on Windows
+ * (and vice versa on UNIX).
+ * @returns true if the library was successfully loaded; false otherwise. */
+OSIMCOMMON_API bool LoadOpenSimLibraryExact(const std::string &exactPath,
+                                            bool verbose = true);
+/** Used to process legacy command line arguments that specify plugin libraries
+ * to load. Internally uses LoadOpenSimLibrary(const std::string&, bool) with
+ * verbosity. */
+OSIMCOMMON_API void LoadOpenSimLibraries(int argc, char **argv);
 
 }
 
-#endif // __LoadOpenSimLibrary_h__
+#endif // OPENSIM_LOAD_OPENSIM_LIBRARY_H_


### PR DESCRIPTION
This PR adds a method that loads an OpenSim library using an exact path. The pre-existing LoadOpenSimLibrary methods expect the user *not* to provide a file extension for the library file (except on OSX, which was not handled well and so one still had to provide an extension). The previous methods attempt to detect whether or not you want a debug or release variant of the library, which is neat.

However, I think there is a good reason to use full paths (including the extension) instead of trying to add the extension automatically:

1. It is more natural and less confusing for users to provide a full path to a file. Usually, one specifies the name of a library separately from its path (e.g., LD_LIBRARY_PATH, DYLD_LIBRARY_PATH, PATH), and specifying the name of a library), and so our previous solution of combining the path to the library with the library name is some middle-ground which may be confusing to users. On UNIX, we also automatically insert a "lib" prefix to the library name, which may also be confusing for users.
2. It is actually really hard to add the correct file extension automatically. This is especially true on UNIX, where the SONAME is an additional suffix (e.g., `libFoo.so.1.0.0`; I don't know how we'd figure out to correctly add the `.1.0.0`).

I also considered just having the current methods detect if a full path (with extension) was provided, and to then just load the library at that full path. However, I decided it would be somewhat hard and error-prone to detect if a full path with extension were given (because of (2) above), and so I think it makes more sense to have a separate method that is clear about what it does.

I left in the old methods because I think it is still neat and potentially useful that they try to automatically try to use the correct release/debug variant (and for backwards compatibility).

This PR also fixes the old LoadOpenSimLibrary methods to handle dylib files (OSX).

This PR is in preparation for the upcoming command line tool PR. I have tested the changes in this PR through the command line tool branch.