### PR TITLE
Reduce use of setStateVariableValue

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -925,6 +925,11 @@ void Component::
     setStateVariableValues(SimTK::State& state, const SimTK::Vector& values)
 {
     int nsv = getNumStateVariables();
+
+    SimTK_ASSERT(values.size() == nsv,
+        "Component::setStateVariableValues() number values does not match the "
+        "number of state variables.");
+
     bool valid = //isObjectUpToDateWithProperties() &&                    // 1.
         !_statesAssociatedSystem.empty() &&                      // 2.
         _allStateVariables.size() == nsv &&                       // 3.

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -874,13 +874,9 @@ void Component::
     throw Exception(msg.str(),__FILE__,__LINE__);
 }
 
-// Get all values of the state variables allocated by this Component. Includes
-// state variables allocated by its subcomponents.
-SimTK::Vector Component::
-    getStateVariableValues(const SimTK::State& state) const
+bool Component::isAllStatesVariablesListValid() const
 {
     int nsv = getNumStateVariables();
-
     // Consider the list of all StateVariables to be valid if all of 
     // the following conditions are true:
     // 1. Component is up-to-date with its Properties
@@ -897,12 +893,23 @@ SimTK::Vector Component::
     // check.
     // It has been verified that the adding Components will invalidate the state
     // variables associated with the Model and force the list to be rebuilt.
-    bool valid = //isObjectUpToDateWithProperties() &&                    // 1.
-                !_statesAssociatedSystem.empty()  &&                      // 2.
-                _allStateVariables.size() == nsv &&                       // 3.
-                getSystem().isSameSystem(_statesAssociatedSystem.getRef());//4.
-    // if the StateVariables are invalid (see above) rebuild the list 
-    if (!valid) {
+    bool valid = //isObjectUpToDateWithProperties() &&                  // 1.
+        !_statesAssociatedSystem.empty() &&                             // 2.
+        _allStateVariables.size() == nsv &&                             // 3.
+        getSystem().isSameSystem(_statesAssociatedSystem.getRef());     // 4.
+
+    return valid;
+}
+
+
+// Get all values of the state variables allocated by this Component. Includes
+// state variables allocated by its subcomponents.
+SimTK::Vector Component::
+    getStateVariableValues(const SimTK::State& state) const
+{
+    int nsv = getNumStateVariables();
+    // if the StateVariables are invalid (see above) rebuild the list
+    if (!isAllStatesVariablesListValid()) {
         _statesAssociatedSystem.reset(&getSystem());
         _allStateVariables.clear();
         _allStateVariables.resize(nsv);
@@ -930,12 +937,8 @@ void Component::
         "Component::setStateVariableValues() number values does not match the "
         "number of state variables.");
 
-    bool valid = //isObjectUpToDateWithProperties() &&                    // 1.
-        !_statesAssociatedSystem.empty() &&                      // 2.
-        _allStateVariables.size() == nsv &&                       // 3.
-        getSystem().isSameSystem(_statesAssociatedSystem.getRef());//4.
     // if the StateVariables are invalid (see above) rebuild the list 
-    if (!valid) {
+    if (!isAllStatesVariablesListValid()) {
         _statesAssociatedSystem.reset(&getSystem());
         _allStateVariables.clear();
         _allStateVariables.resize(nsv);

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2288,8 +2288,12 @@ private:
     // cache information.
     mutable std::map<std::string, CacheInfo>            _namedCacheVariableInfo;
 
+    // Check that the list of _allStateVariables is valid
+    bool isAllStatesVariablesListValid() const;
+
     // Array of all state variables for fast access during simulation
-    mutable SimTK::Array_<SimTK::ReferencePtr<const StateVariable> > _allStateVariables;
+    mutable SimTK::Array_<SimTK::ReferencePtr<const StateVariable> > 
+                                                            _allStateVariables;
     // A handle the System associated with the above state variables
     mutable SimTK::ReferencePtr<const SimTK::System> _statesAssociatedSystem;
 

--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -147,8 +147,8 @@ void Frame::attachGeometry(const OpenSim::Geometry& geom, const SimTK::Vec3 scal
 SimTK::Transform Frame::findTransformBetween(const SimTK::State& state,
         const Frame& otherFrame) const
 {
-    SimTK::Transform X_GF = getTransformInGround(state);
-    SimTK::Transform X_GA = otherFrame.getTransformInGround(state);
+    const SimTK::Transform& X_GF = getTransformInGround(state);
+    const SimTK::Transform& X_GA = otherFrame.getTransformInGround(state);
     // return the transform, X_AF that expresses quantities in F into A
     return ~X_GA*X_GF;
 }
@@ -156,15 +156,13 @@ SimTK::Transform Frame::findTransformBetween(const SimTK::State& state,
 SimTK::Vec3 Frame::expressVectorInAnotherFrame(const SimTK::State& state,
                                 const SimTK::Vec3& vec, const Frame& frame) const
 {
-    SimTK::Transform X_AF = findTransformBetween(state, frame);
-    return X_AF.R()*vec;
+    return findTransformBetween(state, frame).R()*vec;
 }
 
 SimTK::Vec3 Frame::findLocationInAnotherFrame(const SimTK::State& state, const
         SimTK::Vec3& point, const Frame& otherFrame) const
 {
-    SimTK::Transform X_AF = findTransformBetween(state, otherFrame);
-    return X_AF*point;
+    return findTransformBetween(state, otherFrame)*point;
 }
 
 const Frame& Frame::findBaseFrame() const

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -919,8 +919,11 @@ void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
         start->getVelocity(s, velStartLocal);
         end->getVelocity(s, velEndLocal);
 
-        velStartMoving = start->getBody().getTransformInGround(s).R()*velStartLocal;
-        velEndMoving = end->getBody().getTransformInGround(s).R()*velEndLocal;
+        velStartMoving = start->getBody()
+            .expressVectorInAnotherFrame(s, velStartLocal, getModel().getGround());
+
+        velEndMoving = end->getBody()
+            .expressVectorInAnotherFrame(s, velEndLocal, getModel().getGround());
 
         // Calculate the relative positions and velocities.
         posRelative = posEndInertial - posStartInertial;


### PR DESCRIPTION
Similar to PR #982, when setting `StateVariable` values en mass, we should use `Component::setStateVariableValues()` with a `Vector` of values instead of looping through each state variable by name. In which case, the values should be mapped directly to StateVariables instead of finding each StateVariable by name. The same "caching" of the list of StateVariables used to speedup calls to `getStateVariableValues()` is used here to set the state variable values.

The `AnalyzeTool` was modified to map the order of read in state values to the order expected by the Model, once, before looping through each row of the states Storage. This was then used to set the vector of state values in the Model order expected by `setStateVariableValues()` (i.e. same order as `getStateVariableNames()`) at every time frame of the analyses.

I also (accidentally) included minor changes to `GeometryPath` to use methods of `Point` and some other cleanup (e.g. using references instead of making copies of Transforms).