### PR TITLE
Silence verbose `choco install` on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ nuget:
 install:
 
   ## Use Chocolatey to install SWIG.
-  - choco install swig --version 3.0.6 --yes --limitoutput
+  - choco install swig --version 3.0.6 --yes | out-null
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ nuget:
 install:
 
   ## Use Chocolatey to install SWIG.
-  - choco install swig --version 3.0.6 -y
+  - choco install swig --version 3.0.6 --yes --limitoutput
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ nuget:
 install:
 
   ## Use Chocolatey to install SWIG.
-  - choco install swig --version 3.0.6 --yes | out-null
+  - choco install swig --version 3.0.6 --yes > $null
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"


### PR DESCRIPTION
This command is generating a lot of unnecessary output in the log.