### PR TITLE
Add ability to skip Travis build using [skip travis]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ addons:
 before_install:
   ## Ensure that there are no tabs in source code.
   - cd $TRAVIS_BUILD_DIR
+  # Stop build if comment contains [skip travis].
+  - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi
   # GREP returns 0 (true) if there are any matches, and
   # we don't want any matches. If there are matches,
   # print a helpful message, and make the test fail by using "false".

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
   ## Ensure that there are no tabs in source code.
   - cd $TRAVIS_BUILD_DIR
   # Stop build if comment contains [skip travis].
-  - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi
+  - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
   # GREP returns 0 (true) if there are any matches, and
   # we don't want any matches. If there are matches,
   # print a helpful message, and make the test fail by using "false".

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ addons:
       - sshpass
 
 before_install:
+  - cd $TRAVIS_BUILD_DIR
+  # Stop build if comment contains [skip travis].
+  - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
+  
   ###########################################################################################################
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
@@ -69,16 +73,13 @@ before_install:
   ###########################################################################################################
   
   ## Ensure that there are no tabs in source code.
-  - cd $TRAVIS_BUILD_DIR
-  # Stop build if comment contains [skip travis].
-  - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
-  
   # GREP returns 0 (true) if there are any matches, and
   # we don't want any matches. If there are matches,
   # print a helpful message, and make the test fail by using "false".
   # The GREP command here checks for any tab characters in the the files
   # that match the specified pattern. GREP does not pick up explicit tabs
   # (e.g., literally a \t in a source file).
+  - cd $TRAVIS_BUILD_DIR
   - if grep --line-num --recursive --exclude-dir="*dependencies*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
 
   ## Set up environment variables.

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
   # Stop build if comment contains [skip travis].
   - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
+  
   # GREP returns 0 (true) if there are any matches, and
   # we don't want any matches. If there are matches,
   # print a helpful message, and make the test fail by using "false".


### PR DESCRIPTION
Right now, Travis does not have an equivalent of [skip appveyor].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/989)
<!-- Reviewable:end -->
