### PR TITLE
Update GeometryPath computations to use Point methods

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -137,50 +137,44 @@ void OpenSimContext::copyMuscle(Muscle& from, Muscle& to) {
 
 // Muscle Points
 void OpenSimContext::setXFunction(MovingPathPoint& mmp, Function& newFunction) {
-    mmp.setXFunction(*_configState, newFunction );
+    mmp.set_x_location(newFunction );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
    return;
 }
 
 void OpenSimContext::setYFunction(MovingPathPoint& mmp, Function& newFunction) {
-    mmp.setYFunction(*_configState, newFunction );
+    mmp.set_y_location(newFunction );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
     return;
 }
 
 void OpenSimContext::setZFunction(MovingPathPoint& mmp, Function& newFunction) {
-    mmp.setZFunction(*_configState, newFunction );
+    mmp.set_z_location(newFunction );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
     return;
 }
 
 void OpenSimContext::setXCoordinate(MovingPathPoint& mmp, Coordinate&  newCoord) {
-    mmp.setXCoordinate(*_configState, newCoord );
+    mmp.setXCoordinate(newCoord);
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
   return;
 }
 
 void OpenSimContext::setYCoordinate(MovingPathPoint& mmp, Coordinate&  newCoord) {
-    mmp.setYCoordinate(*_configState, newCoord );
+    mmp.setYCoordinate( newCoord );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
     return;
 }
 
 void OpenSimContext::setZCoordinate(MovingPathPoint& mmp, Coordinate&  newCoord) {
-    mmp.setZCoordinate(*_configState, newCoord );
+    mmp.setZCoordinate( newCoord );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mmp.getPath()->updateGeometry(*_configState);
     return;
 }
 
@@ -210,26 +204,23 @@ void OpenSimContext::recreateSystemAfterSystemExists( )
 
 
 void OpenSimContext::setCoordinate(ConditionalPathPoint&  via, Coordinate&  newCoord) {
-    via.setCoordinate(*_configState, newCoord );
+    via.setCoordinate( newCoord );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  via.getPath()->updateGeometry(*_configState);
     return;
 }
 
 void OpenSimContext::setRangeMin(ConditionalPathPoint&  via, double d) {
-     via.setRangeMin(*_configState, d );
+     via.setRangeMin( d );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  via.getPath()->updateGeometry(*_configState);
      return;
 }
 
 void OpenSimContext::setRangeMax(ConditionalPathPoint&  via, double d) {
-    via.setRangeMax(*_configState, d );
+    via.setRangeMax( d );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  via.getPath()->updateGeometry(*_configState);
     return;
 }
 
@@ -245,7 +236,6 @@ void OpenSimContext::setLocation(PathPoint& mp, int i, double d) {
     mp.setLocation(*_configState, i, d);
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mp.getPath()->updateGeometry(*_configState);
     return;
 }
 
@@ -253,7 +243,6 @@ void OpenSimContext::setEndPoint(PathWrap& mw, int newEndPt) {
     mw.setEndPoint(*_configState, newEndPt );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  mw.getPath()->updateGeometry(*_configState);
     return;
 }
 
@@ -269,7 +258,6 @@ bool OpenSimContext::deletePathPoint(GeometryPath& p, int menuChoice) {
     bool ret = p.deletePathPoint(*_configState, menuChoice );
   _configState->invalidateAll(SimTK::Stage::Position);
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-  p.updateGeometry(*_configState);
   return ret;
 }
 

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -173,7 +173,7 @@ static OpenSim::Object* randomize(OpenSim::Object* obj)
             }
         } else if (ts == "double" && isList && ap.getMaxListSize() < 20) {
             for (int i=0; i< ap.getMaxListSize(); ++i)
-                ap.updValue<double>(i) = (double) rand();
+                ap.updValue<double>(i) = (double) rand() / RAND_MAX;
         } else if (ts == "Function") {
             //FunctionSet's objects getTypeName() returns "Function"
             //which is wrong! This is a HACK to test that we aren't

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -110,6 +110,17 @@ void ConditionalPathPoint::setCoordinate(const Coordinate& coordinate)
     updConnector<Coordinate>("coordinate").connect(coordinate);
 }
 
+bool ConditionalPathPoint::hasCoordinate() const
+{
+    return getConnector<Coordinate>("coordinate").isConnected();
+}
+
+const Coordinate& ConditionalPathPoint::getCoordinate() const
+{
+    return getConnectee<Coordinate>("coordinate");
+}
+
+
 //_____________________________________________________________________________
 /**
  * Set the range min.

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -100,10 +100,8 @@ void ConditionalPathPoint::constructConnectors()
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Set the coordinate that this point is linked to.
- *
- * @return Whether or not this point is active.
  */
 void ConditionalPathPoint::setCoordinate(const Coordinate& coordinate)
 {

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -26,11 +26,6 @@
 //=============================================================================
 #include "ConditionalPathPoint.h"
 #include <OpenSim/Common/XMLDocument.h>
-#include <OpenSim/Simulation/Model/Model.h>
-#include <OpenSim/Simulation/Model/GeometryPath.h>
-#include <OpenSim/Simulation/Model/CoordinateSet.h>
-#include <OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h>
-#include <OpenSim/Simulation/SimbodyEngine/Body.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 
 //=============================================================================
@@ -59,7 +54,7 @@ ConditionalPathPoint::~ConditionalPathPoint()
 {}
 
 //_____________________________________________________________________________
-/**
+/*
  * Override default implementation by object to intercept and fix the XML node
  * underneath the model to match current version
  */
@@ -84,7 +79,7 @@ void ConditionalPathPoint::updateFromXMLNode(SimTK::Xml::Element& node,
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Connect properties to local pointers.
  */
 void ConditionalPathPoint::constructProperties()
@@ -120,10 +115,8 @@ const Coordinate& ConditionalPathPoint::getCoordinate() const
 
 
 //_____________________________________________________________________________
-/**
+/*
  * Set the range min.
- *
- * @param aRange range min to change to.
  */
 void ConditionalPathPoint::setRangeMin(double minVal)
 {
@@ -131,10 +124,8 @@ void ConditionalPathPoint::setRangeMin(double minVal)
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Set the range max.
- *
- * @param aRange range max to change to.
  */
 void ConditionalPathPoint::setRangeMax(double maxVal)
 {
@@ -142,11 +133,9 @@ void ConditionalPathPoint::setRangeMax(double maxVal)
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Determine if this point is active by checking the value of the
  * coordinate that it is linked to.
- *
- * @return Whether or not this point is active.
  */
 bool ConditionalPathPoint::isActive(const SimTK::State& s) const
 {

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -46,13 +46,9 @@ using namespace OpenSim;
 /**
  * Default constructor.
  */
-ConditionalPathPoint::ConditionalPathPoint() :
-   _range(_rangeProp.getValueDblArray()),
-    _coordinateName(_coordinateNameProp.getValueStr()),
-    _coordinate(NULL)
+ConditionalPathPoint::ConditionalPathPoint() : PathPoint()
 {
-    setNull();
-    setupProperties();
+    constructInfrastructure();
 }
 
 //_____________________________________________________________________________
@@ -60,117 +56,47 @@ ConditionalPathPoint::ConditionalPathPoint() :
  * Destructor.
  */
 ConditionalPathPoint::~ConditionalPathPoint()
-{
-}
-
-//_____________________________________________________________________________
-/**
- * Copy constructor.
- *
- * @param aPoint ConditionalPathPoint to be copied.
- */
-ConditionalPathPoint::ConditionalPathPoint(const ConditionalPathPoint &aPoint) :
-   PathPoint(aPoint),
-   _range(_rangeProp.getValueDblArray()),
-    _coordinateName(_coordinateNameProp.getValueStr()),
-    _coordinate(NULL)
-{
-    setNull();
-    setupProperties();
-    copyData(aPoint);
-}
-
-//=============================================================================
-// CONSTRUCTION METHODS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Copy data members from one ConditionalPathPoint to another.
- *
- * @param aPoint ConditionalPathPoint to be copied.
- */
-void ConditionalPathPoint::copyData(const ConditionalPathPoint &aPoint)
-{
-    _range = aPoint._range;
-    _coordinateName = aPoint._coordinateName;
-    _coordinate = aPoint._coordinate;
-}
-
-//_____________________________________________________________________________
-/**
- * Initialize a ConditionalPathPoint with data from a PathPoint.
- * This function should not do anything to invalidate the path,
- * because the via point may not be added to it.
- *
- * @param aPoint PathPoint to be copied.
- */
-void ConditionalPathPoint::init(const PathPoint& aPoint)
-{
-    PathPoint::copyData(aPoint);
-
-    // If aPoint is a ConditionalPathPoint, then you can copy all of its members over.
-    // Otherwise, set the range and coordinate name to default values (using the first
-    // coordinate in the model, if there is one).
-   const ConditionalPathPoint* mmp = dynamic_cast<const ConditionalPathPoint*>(&aPoint);
-    if (mmp) {
-        copyData(*mmp);
-    } else {
-        _range[0] = 0.0;
-        _range[1] = 0.0;
-        GeometryPath* path = aPoint.getPath();
-        if (path) {
-            ModelComponent* comp = dynamic_cast<ModelComponent*>(path->getOwner());
-            if (comp) {
-                const CoordinateSet& coords = comp->getModel().getCoordinateSet();
-                if (coords.getSize() > 0) {
-                    int index = 0;
-                    _coordinateName = coords.get(index).getName();
-                    _range[0] = coords.get(index).getRangeMin();
-                    _range[1] = coords.get(index).getRangeMax();
-                }
-            }
-        }
-    }
-}
-
-//_____________________________________________________________________________
-/**
- * Set the data members of this ConditionalPathPoint to their null values.
- */
-void ConditionalPathPoint::setNull()
-{
-}
+{}
 
 //_____________________________________________________________________________
 /**
  * Override default implementation by object to intercept and fix the XML node
  * underneath the model to match current version
  */
-void ConditionalPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
+void ConditionalPathPoint::updateFromXMLNode(SimTK::Xml::Element& node, 
+                                             int versionNumber)
 {
-    if ( versionNumber < XMLDocument::getLatestVersion()){
-        if (versionNumber<=20001)
+    if (versionNumber <= 20001) {
         // Version has to be 1.6 or later, otherwise assert
-        XMLDocument::renameChildNode(aNode, "coordinates", "coordinate");
-        }
+        XMLDocument::renameChildNode(node, "coordinates", "coordinate");
+    }
+    if (versionNumber < 30505) {
+        // replace old properties with latest use of Connectors
+        SimTK::Xml::element_iterator coord = node.element_begin("coordinate");
+        std::string coord_name("");
+        if (coord != node.element_end())
+            coord->getValueAs<std::string>(coord_name);
+        XMLDocument::addConnector(node, "Connector_Coordinate_", "coordinate", coord_name);
+    }
+
     // Call base class now assuming _node has been corrected for current version
-    PathPoint::updateFromXMLNode(aNode, versionNumber);
+    PathPoint::updateFromXMLNode(node, versionNumber);
 }
 
 //_____________________________________________________________________________
 /**
  * Connect properties to local pointers.
  */
-void ConditionalPathPoint::setupProperties()
+void ConditionalPathPoint::constructProperties()
 {
-    const double defaultRange[] = {0.0, 0.0};
-    _rangeProp.setName("range");
-    _rangeProp.setValue(2, defaultRange);
-    _rangeProp.setAllowableListSize(2);
-    _propertySet.append(&_rangeProp);
+    Array<double> defaultRange(0.0, 2); //two values of the range
+    constructProperty_range(defaultRange);
+}
 
-    _coordinateNameProp.setName("coordinate");
-    _propertySet.append(&_coordinateNameProp);
+
+void ConditionalPathPoint::constructConnectors()
+{
+    constructConnector<Coordinate>("coordinate");
 }
 
 //_____________________________________________________________________________
@@ -179,13 +105,9 @@ void ConditionalPathPoint::setupProperties()
  *
  * @return Whether or not this point is active.
  */
-void ConditionalPathPoint::setCoordinate(const SimTK::State& s, Coordinate& aCoordinate)
+void ConditionalPathPoint::setCoordinate(const Coordinate& coordinate)
 {
-    if (&aCoordinate != _coordinate)
-    {
-       _coordinate = &aCoordinate;
-       _coordinateName = _coordinate->getName();
-    }
+    updConnector<Coordinate>("coordinate").connect(coordinate);
 }
 
 //_____________________________________________________________________________
@@ -194,12 +116,9 @@ void ConditionalPathPoint::setCoordinate(const SimTK::State& s, Coordinate& aCoo
  *
  * @param aRange range min to change to.
  */
-void ConditionalPathPoint::setRangeMin(const SimTK::State& s, double aMin)
+void ConditionalPathPoint::setRangeMin(double minVal)
 {
-    if (aMin <= _range[1])
-    {
-        _range[0] = aMin;
-    }
+    set_range(0, minVal);
 }
 
 //_____________________________________________________________________________
@@ -208,12 +127,9 @@ void ConditionalPathPoint::setRangeMin(const SimTK::State& s, double aMin)
  *
  * @param aRange range max to change to.
  */
-void ConditionalPathPoint::setRangeMax( const SimTK::State& s, double aMax)
+void ConditionalPathPoint::setRangeMax(double maxVal)
 {
-    if (aMax >= _range[0])
-    {
-        _range[1] = aMax;
-    }
+    set_range(1, maxVal);
 }
 
 //_____________________________________________________________________________
@@ -225,58 +141,11 @@ void ConditionalPathPoint::setRangeMax( const SimTK::State& s, double aMax)
  */
 bool ConditionalPathPoint::isActive(const SimTK::State& s) const
 {
-    if (_coordinate)
-    {
-        double value = _coordinate->getValue(s);
-        if (value >= _range[0] - 1e-5 &&
-             value <= _range[1] + 1e-5)
+    if (getConnector<Coordinate>("coordinate").isConnected()) {
+        double value = getConnectee<Coordinate>("coordinate").getValue(s);
+        if (value >= get_range(0) - 1e-5 &&
+             value <= get_range(1) + 1e-5)
             return true;
     }
-
     return false;
-}
-
-//_____________________________________________________________________________
-/**
- * Perform some set up functions that happen after the
- * object has been deserialized or copied.
- *
- * @param aModel model containing this ConditionalPathPoint.
- */
-void ConditionalPathPoint::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
-{
-    // base class
-    Super::connectToModelAndPath(aModel, aPath);
-
-    // Setup() can be called before the model's coordinate set has been constructed, in which
-    // case you don't want to throw an exception if the coordinate is not found.
-    if (aModel.getCoordinateSet().getSize() > 0) {
-        // Look up the coordinate by name and store a pointer to it.
-        if (aModel.getCoordinateSet().contains(_coordinateName)) {
-            _coordinate = &aModel.getCoordinateSet().get(_coordinateName);
-        } else {
-            string errorMessage = "Error: Coordinate " + _coordinateName + " referenced in muscle " + aPath.getOwner()->getName() +
-                " does not exist in model " +   aModel.getName();
-            throw Exception(errorMessage);
-        }
-    }
-}
-
-//=============================================================================
-// OPERATORS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Assignment operator.
- *
- * @return Reference to this object.
- */
-ConditionalPathPoint& ConditionalPathPoint::operator=(const ConditionalPathPoint &aPoint)
-{
-    // BASE CLASS
-    PathPoint::operator=(aPoint);
-
-    copyData(aPoint);
-
-    return(*this);
 }

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.h
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.h
@@ -25,29 +25,12 @@
 
 
 // INCLUDE
-#include <iostream>
-#include <string>
-#include <math.h>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include <OpenSim/Common/PropertyDblArray.h>
-#include <OpenSim/Common/PropertyStr.h>
-#include <OpenSim/Common/Storage.h>
 #include <OpenSim/Simulation/Model/PathPoint.h>
-
-#ifdef SWIG
-    #ifdef OSIMSIMULATION_API
-        #undef OSIMSIMULATION_API
-        #define OSIMSIMULATION_API
-    #endif
-#endif
 
 namespace OpenSim {
 
 class Coordinate;
-class Model;
-class GeometryPath;
-class SimbodyEngine;
-
 //=============================================================================
 //=============================================================================
 /**
@@ -59,18 +42,14 @@ class SimbodyEngine;
  */
 class OSIMSIMULATION_API ConditionalPathPoint : public PathPoint {
 OpenSim_DECLARE_CONCRETE_OBJECT(ConditionalPathPoint, PathPoint);
-
-//=============================================================================
-// DATA
-//=============================================================================
+public:
+//==============================================================================
+// PROPERTIES
+//==============================================================================
 protected:
-    PropertyDblArray _rangeProp;
-    Array<double> &_range;
-
-    PropertyStr _coordinateNameProp;
-    std::string &_coordinateName;
-
-    const Coordinate* _coordinate;
+    OpenSim_DECLARE_LIST_PROPERTY_SIZE(range, double, 2,
+        "The minimum and maximum values that the coordinate can range between, "
+        "for which the PathPoint is active. Angular coordinates in radians.");
 
 //=============================================================================
 // METHODS
@@ -80,32 +59,20 @@ protected:
     //--------------------------------------------------------------------------
 public:
     ConditionalPathPoint();
-    ConditionalPathPoint(const ConditionalPathPoint &aPoint);
     virtual ~ConditionalPathPoint();
 
-#ifndef SWIG
-    ConditionalPathPoint& operator=(const ConditionalPathPoint &aPoint);
-#endif
-    void copyData(const ConditionalPathPoint &aPoint);
-    void init(const PathPoint& aPoint) override;
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
 
-    Array<double>& getRange() const { return _range; }
-    const Coordinate* getCoordinate() const { return _coordinate; }
-    const std::string& getCoordinateName() const { return _coordinateName; }
-#ifndef SWIG
-    void setCoordinate(const SimTK::State& s, Coordinate& aCoordinate);
-    void setRangeMin( const SimTK::State& s, double aMin);
-    void setRangeMax( const SimTK::State& s, double aMax);
+    void setRangeMin(double minVal);
+    void setRangeMax(double maxVal);
+    void setCoordinate(const Coordinate& coordinate);
 
     // Override PathPoint methods.
     bool isActive(const SimTK::State& s) const override;
-    void connectToModelAndPath(Model& aModel, GeometryPath& aPath) 
-                                                                override;
-#endif
+
 private:
-    void setNull();
-    void setupProperties();
+    void constructProperties() override;
+    void constructConnectors() override;
 //=============================================================================
 };  // END of class ConditionalPathPoint
 //=============================================================================

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.h
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.h
@@ -46,7 +46,6 @@ public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-protected:
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(range, double, 2,
         "The minimum and maximum values that the coordinate can range between, "
         "for which the PathPoint is active. Angular coordinates in radians.");
@@ -60,12 +59,12 @@ protected:
 public:
     ConditionalPathPoint();
     virtual ~ConditionalPathPoint();
-
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
-
     void setRangeMin(double minVal);
     void setRangeMax(double maxVal);
     void setCoordinate(const Coordinate& coordinate);
+
+    bool hasCoordinate() const;
+    const Coordinate& getCoordinate() const;
 
     // Override PathPoint methods.
     bool isActive(const SimTK::State& s) const override;
@@ -73,6 +72,9 @@ public:
 private:
     void constructProperties() override;
     void constructConnectors() override;
+    void updateFromXMLNode(SimTK::Xml::Element& aNode,
+                           int versionNumber = -1) override;
+
 //=============================================================================
 };  // END of class ConditionalPathPoint
 //=============================================================================

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.h
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.h
@@ -72,9 +72,7 @@ public:
 private:
     void constructProperties() override;
     void constructConnectors() override;
-    void updateFromXMLNode(SimTK::Xml::Element& aNode,
-                           int versionNumber = -1) override;
-
+    void updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber) override;
 //=============================================================================
 };  // END of class ConditionalPathPoint
 //=============================================================================

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -25,9 +25,6 @@
 // INCLUDES
 //=============================================================================
 #include "GeometryPath.h"
-#include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
-#include <OpenSim/Simulation/SimbodyEngine/Body.h>
-#include <OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h>
 #include "ConditionalPathPoint.h"
 #include "MovingPathPoint.h"
 #include "PointForceDirection.h"
@@ -36,7 +33,6 @@
 #include <OpenSim/Simulation/Wrap/PathWrap.h>
 #include "CoordinateSet.h"
 #include "Model.h"
-
 #include "ModelVisualizer.h"
 //=============================================================================
 // STATICS
@@ -77,15 +73,6 @@ void GeometryPath::extendConnectToModel(Model& aModel)
     // (i.e., the set of currently active points is numbered
     // 1, 2, 3, ...).
     namePathPoints(0);
-
-    /**
-    for (int i = 0; i < get_PathWrapSet().getSize(); i++)
-        upd_PathWrapSet().get(i).connectToModelAndPath(aModel, *this);
-
-    for (int i = 0; i < get_PathPointSet().getSize(); i++){
-        upd_PathPointSet().get(i).connectToModelAndPath(aModel, *this);
-    }
-    */
 }
 
 //_____________________________________________________________________________
@@ -243,9 +230,6 @@ getPointForceDirections(const SimTK::State& s,
     const Array<PathPoint*>& currentPath = getCurrentPath(s);
 
     int np = currentPath.getSize();
-
-    //const SimbodyEngine& engine = _model->getSimbodyEngine();
- 
     rPFDs->ensureCapacity(np);
     
     for (i = 0; i < np; i++) {
@@ -522,7 +506,6 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
     newPoint->setBody(aBody);
     Vec3& location = newPoint->getLocation();
     placeNewPathPoint(s, location, aIndex, aBody);
-    newPoint->connectToModelAndPath(updModel(), *this);
     upd_PathPointSet().insert(aIndex, newPoint);
 
     // Rename the path points starting at this new one.
@@ -540,7 +523,6 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
         if (endPoint != -1 && aIndex <= endPoint)
             get_PathWrapSet().get(i).setEndPoint(s,endPoint + 1);
     }
-
 
     return newPoint;
 }
@@ -908,8 +890,6 @@ void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
 
     double speed = 0.0;
     double speed2 = 0.0;
-
-    //const SimbodyEngine& engine = _model->getSimbodyEngine()
     
     for (int i = 0; i < currentPath.getSize() - 1; i++) {
         start = currentPath[i];

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -1179,17 +1179,11 @@ calcPathLengthChange(const SimTK::State& s, const WrapObject& wo,
     const PathPoint* pt1 = path.get(wr.startPoint);
     const PathPoint* pt2 = path.get(wr.endPoint);
 
-    double straight_length = getModel().getSimbodyEngine()
-        .calcDistance(s, pt1->getBody(), pt1->getLocation(),
-                         pt2->getBody(), pt2->getLocation());
+    double straight_length = pt1->calcDistanceBetween(s, *pt2);
 
-    const Vec3& p1 = pt1->getLocation();
-    const Vec3& p2 = pt2->getLocation();
-    double wrap_length = getModel().getSimbodyEngine()
-        .calcDistance(s, pt1->getBody(), p1, wo.getFrame(), wr.r1);
+    double wrap_length = pt1->calcDistanceBetween(s, wo.getFrame(), wr.r1);
     wrap_length += wr.wrap_path_length;
-    wrap_length += getModel().getSimbodyEngine()
-        .calcDistance(s, wo.getFrame(), wr.r2, pt2->getBody(), p2);
+    wrap_length += pt2->calcDistanceBetween(s, wo.getFrame(), wr.r2);
 
     return wrap_length - straight_length; // return absolute diff, not relative
 }
@@ -1220,7 +1214,7 @@ calcLengthAfterPathComputation(const SimTK::State& s,
             if (smwp)
                 length += smwp->getWrapLength();
         } else {
-            length += (p1->getLocationInGround(s) - p2->getLocationInGround(s)).norm();;
+            length += p1->calcDistanceBetween(s, *p2);
         }
     }
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -1205,8 +1205,6 @@ calcLengthAfterPathComputation(const SimTK::State& s,
 {
     double length = 0.0;
 
-    const SimbodyEngine& engine = _model->getSimbodyEngine();
-
     for (int i = 0; i < currentPath.getSize() - 1; i++) {
         const PathPoint* p1 = currentPath[i];
         const PathPoint* p2 = currentPath[i+1];
@@ -1222,8 +1220,7 @@ calcLengthAfterPathComputation(const SimTK::State& s,
             if (smwp)
                 length += smwp->getWrapLength();
         } else {
-            length += engine.calcDistance(s, p1->getBody(), p1->getLocation(), 
-                                             p2->getBody(), p2->getLocation());
+            length += (p1->getLocationInGround(s) - p2->getLocationInGround(s)).norm();;
         }
     }
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -78,12 +78,14 @@ void GeometryPath::extendConnectToModel(Model& aModel)
     // 1, 2, 3, ...).
     namePathPoints(0);
 
+    /**
     for (int i = 0; i < get_PathWrapSet().getSize(); i++)
         upd_PathWrapSet().get(i).connectToModelAndPath(aModel, *this);
 
     for (int i = 0; i < get_PathPointSet().getSize(); i++){
         upd_PathPointSet().get(i).connectToModelAndPath(aModel, *this);
     }
+    */
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -27,14 +27,12 @@
 #include <OpenSim/Common/XMLDocument.h>
 #include "MovingPathPoint.h"
 #include <OpenSim/Common/Function.h>
+#include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/MultiplierFunction.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
-#include <OpenSim/Simulation/Model/CoordinateSet.h>
-#include <OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
-#include <OpenSim/Common/SimmSpline.h>
-#include <OpenSim/Simulation/SimbodyEngine/Body.h>
+
 
 //=============================================================================
 // STATICS
@@ -50,16 +48,9 @@ using SimTK::Vec3;
 /**
  * Default constructor.
  */
-MovingPathPoint::MovingPathPoint() : PathPoint(),
-   _xLocation(_xLocationProp.getValueObjPtrRef()),
-    _xCoordinateName(_xCoordinateNameProp.getValueStr()),
-   _yLocation(_yLocationProp.getValueObjPtrRef()),
-    _yCoordinateName(_yCoordinateNameProp.getValueStr()),
-   _zLocation(_zLocationProp.getValueObjPtrRef()),
-    _zCoordinateName(_zCoordinateNameProp.getValueStr())
+MovingPathPoint::MovingPathPoint() : PathPoint()
 {
-    setNull();
-    setupProperties();
+    constructInfrastructure();
 }
 
 //_____________________________________________________________________________
@@ -72,139 +63,64 @@ MovingPathPoint::~MovingPathPoint()
 
 //_____________________________________________________________________________
 /**
- * Copy constructor.
- *
- * @param aPoint MovingPathPoint to be copied.
- */
-MovingPathPoint::MovingPathPoint(const MovingPathPoint &aPoint) :
-   PathPoint(aPoint),
-   _xLocation(_xLocationProp.getValueObjPtrRef()),
-    _xCoordinateName(_xCoordinateNameProp.getValueStr()),
-   _yLocation(_yLocationProp.getValueObjPtrRef()),
-    _yCoordinateName(_yCoordinateNameProp.getValueStr()),
-   _zLocation(_zLocationProp.getValueObjPtrRef()),
-    _zCoordinateName(_zCoordinateNameProp.getValueStr())
+* Connect properties to local pointers.
+*/
+void MovingPathPoint::constructProperties()
 {
-    setNull();
-    setupProperties();
-    copyData(aPoint);
+    constructProperty_x_location(Constant(0.0));
+    constructProperty_y_location(Constant(0.0));
+    constructProperty_z_location(Constant(0.0));
 }
 
-//=============================================================================
-// CONSTRUCTION METHODS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Copy data members from one MovingPathPoint to another.
- *
- * @param aPoint MovingPathPoint to be copied.
- */
-void MovingPathPoint::copyData(const MovingPathPoint &aPoint)
+void MovingPathPoint::constructConnectors()
 {
-    _xLocation = (Function*)Object::SafeCopy(aPoint._xLocation);
-    _xCoordinateName = aPoint._xCoordinateName;
-    _yLocation = (Function*)Object::SafeCopy(aPoint._yLocation);
-    _yCoordinateName = aPoint._yCoordinateName;
-    _zLocation = (Function*)Object::SafeCopy(aPoint._zLocation);
-    _zCoordinateName = aPoint._zCoordinateName;
+    constructConnector<Coordinate>("x_coordinate");
+    constructConnector<Coordinate>("y_coordinate");
+    constructConnector<Coordinate>("z_coordinate");
 }
 
-//_____________________________________________________________________________
-/**
- * Initialize a MovingPathPoint with data from a PathPoint.
- *
- * @param aPoint PathPoint to be copied.
- */
-void MovingPathPoint::init(const PathPoint& aPoint)
+const Coordinate& MovingPathPoint::getXCoordinate() const
 {
-    PathPoint::copyData(aPoint);
+    return _xCoordinate.getRef();
+}
 
-    // If aPoint is a MovingPathPoint, then you can copy all of its members over.
-    // Otherwise, create new functions for X, Y, and Z so that the point starts
-    // out in a reasonable state.
-   const MovingPathPoint* mmp = dynamic_cast<const MovingPathPoint*>(&aPoint);
-    if (mmp) {
-        copyData(*mmp);
-    } else {
-        double x[2], y[2];
+const Coordinate& MovingPathPoint::getYCoordinate() const
+{
+    return _yCoordinate.getRef();
+}
 
-        // See if you can find a coordinate to use as the default for this point.
-        const Coordinate* coord = NULL;
-        GeometryPath* path = aPoint.getPath();
-        if (path) {
-            ModelComponent* comp = dynamic_cast<ModelComponent*>(path->getOwner());
-            if (comp) {
-                const CoordinateSet& coordSet = comp->getModel().getCoordinateSet();
-                if (coordSet.getSize() > 0) {
-                    int index = 0;
-                    coord = &coordSet.get(index);
-                }
-            }
-        }
+const Coordinate& MovingPathPoint::getZCoordinate() const
+{
+    return _zCoordinate.getRef();
+}
 
-        // If there is a coordinate, use its range as the range for each function.
-        if (coord) {
-            x[0] = coord->getRangeMin();
-            x[1] = coord->getRangeMax();
-        } else {
-            x[0] = 0.0;
-            x[1] = 1.0;
-        }
+void MovingPathPoint::setXCoordinate(const Coordinate& coordinate)
+{
+    updConnector<Coordinate>("x_coordinate").connect(coordinate);
+}
+void MovingPathPoint::setYCoordinate(const Coordinate& coordinate)
+{
+    updConnector<Coordinate>("y_coordinate").connect(coordinate);
+}
+void MovingPathPoint::setZCoordinate(const Coordinate& coordinate)
+{
+    updConnector<Coordinate>("z_coordinate").connect(coordinate);
+}
 
-        // Create the default X component.
-        if (coord)
-            _xCoordinateName = coord->getName();
-        y[0] = y[1] = aPoint.getLocation()[0];
-        _xLocation = new SimmSpline(2, x, y);
 
-        // Create the default Y component.
-        if (coord)
-            _yCoordinateName = coord->getName();
-        y[0] = y[1] = aPoint.getLocation()[1];
-        _yLocation = new SimmSpline(2, x, y);
-
-        // Create the default Z component.
-        if (coord)
-            _zCoordinateName = coord->getName();
-        y[0] = y[1] = aPoint.getLocation()[2];
-        _zLocation = new SimmSpline(2, x, y);
+void MovingPathPoint::extendFinalizeFromProperties()
+{
+    // Hang on to references to the Coordinates instead of
+    // finding the connector each time we need a Coordinate value
+    if (getConnector<Coordinate>("x_coordinate").isConnected()) {
+        _xCoordinate.reset(&getXCoordinate());
     }
-}
-
-//_____________________________________________________________________________
-/**
- * Set the data members of this MovingPathPoint to their null values.
- */
-void MovingPathPoint::setNull()
-{
-    _xCoordinate = NULL;
-    _yCoordinate = NULL;
-    _zCoordinate = NULL;
-}
-
-//_____________________________________________________________________________
-/**
- * Connect properties to local pointers.
- */
-void MovingPathPoint::setupProperties()
-{
-    _xLocationProp.setName("x_location");
-    _propertySet.append(&_xLocationProp);
-
-    _xCoordinateNameProp.setName("x_coordinate");
-    _propertySet.append(&_xCoordinateNameProp);
-
-    _yLocationProp.setName("y_location");
-    _propertySet.append(&_yLocationProp);
-
-    _yCoordinateNameProp.setName("y_coordinate");
-    _propertySet.append(&_yCoordinateNameProp);
-
-    _zLocationProp.setName("z_location");
-    _propertySet.append(&_zLocationProp);
-
-    _zCoordinateNameProp.setName("z_coordinate");
-    _propertySet.append(&_zCoordinateNameProp);
+    if (getConnector<Coordinate>("y_coordinate").isConnected()) {
+        _yCoordinate.reset(&getYCoordinate());
+    }
+    if (getConnector<Coordinate>("z_coordinate").isConnected()) {
+        _zCoordinate.reset(&getZCoordinate());
+    }
 }
 
 //_____________________________________________________________________________
@@ -215,184 +131,35 @@ void MovingPathPoint::setupProperties()
 void MovingPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
 {
     int documentVersion = versionNumber;
-    if (documentVersion < XMLDocument::getLatestVersion()) {
+    if (documentVersion < 30000) {
         if (Object::getDebugLevel()>=1)
             cout << "Updating MovingPathPoint object to latest format..." << endl;
         XMLDocument::renameChildNode(aNode, "XAttachment", "x_location");
         XMLDocument::renameChildNode(aNode,"YAttachment", "y_location");
         XMLDocument::renameChildNode(aNode,"ZAttachment", "z_location");
-        }
-    
+    }
+    if (documentVersion < 30505) {
+        // replace old properties with latest use of Connectors
+        SimTK::Xml::element_iterator xCoord = aNode.element_begin("x_coordinate");
+        SimTK::Xml::element_iterator yCoord = aNode.element_begin("y_coordinate");
+        SimTK::Xml::element_iterator zCoord = aNode.element_begin("z_coordinate");
+
+        std::string xCoord_name(""), yCoord_name(""), zCoord_name("");
+        // If default constructed then elements not serialized since they are default
+        // values. Check that we have associated elements, then extract their values.
+        if (xCoord != aNode.element_end())
+            xCoord->getValueAs<std::string>(xCoord_name);
+        if (yCoord != aNode.element_end())
+            yCoord->getValueAs<std::string>(yCoord_name);
+        if (zCoord != aNode.element_end())
+            zCoord->getValueAs<std::string>(zCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "x_coordinate", xCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "y_coordinate", yCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "z_coordinate", zCoord_name);
+    }
+
     // Call base class now assuming _node has been corrected for current version
     Super::updateFromXMLNode(aNode, versionNumber);
-}
-
-//_____________________________________________________________________________
-/**
- * Set the coordinate used for the X location function.
- *
- * @param aCoordinate the coordinate to set to.
- */
-void MovingPathPoint::setXCoordinate( const SimTK::State& s, Coordinate& aCoordinate)
-{
-    if (&aCoordinate != _xCoordinate) {
-       _xCoordinate = &aCoordinate;
-       _xCoordinateName = _xCoordinate->getName();
-    }
-}
-
-//_____________________________________________________________________________
-/**
- * Set the coordinate used for the Y location function.
- *
- * @param aCoordinate the coordinate to set to.
- */
-void MovingPathPoint::setYCoordinate( const SimTK::State& s, Coordinate& aCoordinate)
-{
-    if (&aCoordinate != _yCoordinate) {
-       _yCoordinate = &aCoordinate;
-       _yCoordinateName = _yCoordinate->getName();
-    }
-}
-
-//_____________________________________________________________________________
-/**
- * Set the coordinate used for the Z location function.
- *
- * @param aCoordinate the coordinate to set to.
- */
-void MovingPathPoint::setZCoordinate( const SimTK::State& s, Coordinate& aCoordinate)
-{
-    if (&aCoordinate != _zCoordinate) {
-       _zCoordinate = &aCoordinate;
-       _zCoordinateName = _zCoordinate->getName();
-    }
-}
-
-//_____________________________________________________________________________
-/**
- * Set the function used for the X location.
- *
- * @param aFunction the function to set to.
- */
-void MovingPathPoint::setXFunction( const SimTK::State& s, OpenSim::Function& aFunction)
-{
-    _xLocation = &aFunction;
-
-}
-
-//_____________________________________________________________________________
-/**
- * Set the function used for the Y location.
- *
- * @param aFunction the function to set to.
- */
-void MovingPathPoint::setYFunction( const SimTK::State& s, OpenSim::Function& aFunction)
-{
-    _yLocation = &aFunction;
-
-}
-
-//_____________________________________________________________________________
-/**
- * Set the function used for the Z location.
- *
- * @param aFunction the function to set to.
- */
-void MovingPathPoint::setZFunction( const SimTK::State& s, OpenSim::Function& aFunction)
-{
-    _zLocation = &aFunction;
-
-}
-
-//_____________________________________________________________________________
-/**
- * Perform some set up functions that happen after the
- * object has been deserialized or copied.
- *
- * @param aModel model containing this MovingPathPoint.
- */
-void MovingPathPoint::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
-{
-    // base class
-    Super::connectToModelAndPath(aModel, aPath);
-
-    // Look up the coordinates by name in the dynamics engine and
-    // store pointers to them.
-    if (aModel.getCoordinateSet().contains(_xCoordinateName))
-        _xCoordinate = &aModel.getCoordinateSet().get(_xCoordinateName);
-    if (aModel.getCoordinateSet().contains(_yCoordinateName))
-        _yCoordinate = &aModel.getCoordinateSet().get(_yCoordinateName);
-    if (aModel.getCoordinateSet().contains(_zCoordinateName))
-        _zCoordinate = &aModel.getCoordinateSet().get(_zCoordinateName);
-    // Update the XYZ location of the point (stored in _location).
-    
-    // As OpenSim 3.2 with corrections to the work and corresponding torque
-    // generate by the "gearing" that moves the point under tension,
-    // we no longer support independent components.
-    if(!((_xCoordinate == _yCoordinate) && (_xCoordinate == _zCoordinate))){
-        string msg = "MovingPathPoint:: Components of the same path point ";
-        msg += "must depend on same the coordinate. Condition: ";
-        msg += "x_coordinate == y_coordinate == z_coordinate  FAILED.";
-        throw Exception(msg, __FILE__, __LINE__);       
-    }
-
-    if(_xCoordinate == NULL){
-        string msg = "MovingPathPoint:: Coordinate '";
-        msg += _xCoordinateName + "' governing the moving point was not found.";
-        throw Exception(msg, __FILE__, __LINE__);   
-    }
-}
-
-//=============================================================================
-// OPERATORS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Assignment operator.
- *
- * @return Reference to this object.
- */
-MovingPathPoint& MovingPathPoint::operator=(const MovingPathPoint &aPoint)
-{
-    // BASE CLASS
-    PathPoint::operator=(aPoint);
-
-    copyData(aPoint);
-
-    return(*this);
-}
-
-//_____________________________________________________________________________
-/**
- * Update the point's location.
- *
- */
-void MovingPathPoint::update(const SimTK::State& s)
-{
-    if (_xCoordinate) {
-        const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
-                                         _xCoordinate->getValue(s),
-                                         _xCoordinate->getRangeMax());
-        upd_location()[0] = _xLocation->calcValue(SimTK::Vector(1, xval));
-    } else // type == Constant
-        upd_location()[0] = _xLocation->calcValue(SimTK::Vector(1, 0.0));
-
-    if (_yCoordinate) {
-        const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
-                                         _yCoordinate->getValue(s),
-                                         _yCoordinate->getRangeMax());
-        upd_location()[1] = _yLocation->calcValue(SimTK::Vector(1, yval));
-    } else // type == Constant
-        upd_location()[1] = _yLocation->calcValue(SimTK::Vector(1, 0.0));
-
-    if (_zCoordinate) {
-        const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
-                                         _zCoordinate->getValue(s),
-                                         _zCoordinate->getRangeMax());
-        upd_location()[2] = _zLocation->calcValue(SimTK::Vector(1, zval));
-    } else // type == Constant
-        upd_location()[2] = _zLocation->calcValue(SimTK::Vector(1, 0.0));
 }
 
 //_____________________________________________________________________________
@@ -402,34 +169,40 @@ void MovingPathPoint::update(const SimTK::State& s)
  * @param aVelocity The velocity.
  */
 
-void MovingPathPoint::getVelocity(const SimTK::State& s, SimTK::Vec3& aVelocity)
+SimTK::Vec3 MovingPathPoint::getVelocity(const SimTK::State& s) const
 {
     std::vector<int> derivComponents;
     derivComponents.push_back(0);
 
-    if (_xCoordinate){
+    SimTK::Vec3 vInF(0);
+
+    if (!_xCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        aVelocity[0] = _xLocation->calcDerivative(derivComponents, SimTK::Vector(1, _xCoordinate->getValue(s)))*
-            _xCoordinate->getSpeedValue(s);
+        vInF[0] = get_x_location().calcDerivative(
+            derivComponents, SimTK::Vector(1, _xCoordinate->getValue(s)))*
+                _xCoordinate->getSpeedValue(s);
     }
     else
-        aVelocity[0] = 0.0;
+        vInF[0] = 0.0;
 
-    if (_yCoordinate){
+    if (!_yCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        aVelocity[1] = _yLocation->calcDerivative(derivComponents, SimTK::Vector(1, _yCoordinate->getValue(s)))*
-            _yCoordinate->getSpeedValue(s);
+        vInF[1] = get_y_location().calcDerivative(
+            derivComponents, SimTK::Vector(1, _yCoordinate->getValue(s)))*
+                _yCoordinate->getSpeedValue(s);
     }
     else
-        aVelocity[1] = 0.0;
+        vInF[1] = 0.0;
 
-    if (_zCoordinate){
+    if (!_zCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        aVelocity[2] = _zLocation->calcDerivative(derivComponents, SimTK::Vector(1, _zCoordinate->getValue(s)))*
+        vInF[2] = get_z_location().calcDerivative(derivComponents, SimTK::Vector(1, _zCoordinate->getValue(s)))*
             _zCoordinate->getSpeedValue(s);
     }
     else
-        aVelocity[2] = 0.0;
+        vInF[2] = 0.0;
+
+    return vInF;
 }
 
 //_____________________________________________________________________________
@@ -448,17 +221,17 @@ SimTK::Vec3 MovingPathPoint::getdPointdQ(const SimTK::State& s) const
 
     if (_xCoordinate){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        dPdq_B[0] = _xLocation->calcDerivative(derivComponents, 
+        dPdq_B[0] = get_x_location().calcDerivative(derivComponents, 
             SimTK::Vector(1, _xCoordinate->getValue(s)));
     }
     if (_yCoordinate){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        dPdq_B[1] = _yLocation->calcDerivative(derivComponents, 
+        dPdq_B[1] = get_y_location().calcDerivative(derivComponents,
             SimTK::Vector(1, _yCoordinate->getValue(s)));
     }
     if (_zCoordinate){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        dPdq_B[2] = _zLocation->calcDerivative(derivComponents, 
+        dPdq_B[2] = get_z_location().calcDerivative(derivComponents,
             SimTK::Vector(1, _zCoordinate->getValue(s)));
     }
 
@@ -466,21 +239,19 @@ SimTK::Vec3 MovingPathPoint::getdPointdQ(const SimTK::State& s) const
 }
 
 
-void MovingPathPoint::scale(const SimTK::State& s, const SimTK::Vec3& aScaleFactors)
+void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
 {
     if (_xCoordinate) {
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
-        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(_xLocation);
+        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(&upd_x_location());
         if (mf) {
             mf->setScale(mf->getScale() * aScaleFactors[0]);
         } else {
             // Make a copy of the original function and delete the original
             // (so its node will be removed from the XML document).
-            mf = new MultiplierFunction(_xLocation->clone(), aScaleFactors[0]);
-            delete _xLocation;
-            setXFunction(s, *mf);
+            set_x_location(MultiplierFunction(get_x_location().clone(), aScaleFactors[0]));
         }
     }
 
@@ -488,15 +259,13 @@ void MovingPathPoint::scale(const SimTK::State& s, const SimTK::Vec3& aScaleFact
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
-        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(_yLocation);
+        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(&upd_y_location());
         if (mf) {
             mf->setScale(mf->getScale() * aScaleFactors[1]);
         } else {
             // Make a copy of the original function and delete the original
             // (so its node will be removed from the XML document).
-            mf = new MultiplierFunction(_yLocation->clone(), aScaleFactors[1]);
-            delete _yLocation;
-            setYFunction(s, *mf);
+            set_y_location(MultiplierFunction(get_y_location().clone(), aScaleFactors[1]));
         }
     }
 
@@ -504,15 +273,74 @@ void MovingPathPoint::scale(const SimTK::State& s, const SimTK::Vec3& aScaleFact
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
-        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(_zLocation);
+        MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(&upd_z_location());
         if (mf) {
             mf->setScale(mf->getScale() * aScaleFactors[2]);
         } else {
-            mf = new MultiplierFunction(_zLocation->clone(), aScaleFactors[2]);
-            delete _zLocation;
-            setZFunction(s, *mf);
+            set_z_location(MultiplierFunction(get_z_location().clone(), aScaleFactors[2]));
         }
     }
 
     updateGeometry();
+}
+
+SimTK::Vec3 MovingPathPoint::getLocation(const SimTK::State& s) const
+{
+    SimTK::Vec3 pInF(0);
+    if (!_xCoordinate.empty()) {
+        const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
+            _xCoordinate->getValue(s),
+            _xCoordinate->getRangeMax());
+        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, xval));
+    }
+    else // assume a Constant
+        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, 0.0));
+
+    if (!_yCoordinate.empty()) {
+        const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
+            _yCoordinate->getValue(s),
+            _yCoordinate->getRangeMax());
+        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, yval));
+    }
+    else // type == Constant
+        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, 0.0));
+
+    if (_zCoordinate) {
+        const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
+            _zCoordinate->getValue(s),
+            _zCoordinate->getRangeMax());
+        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, zval));
+    }
+    else // type == Constant
+        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, 0.0));
+
+    return pInF;
+}
+
+
+SimTK::Vec3 MovingPathPoint::calcLocationInGround(const SimTK::State& s) const
+{
+    return getParentFrame().getTransformInGround(s)*getLocation(s);
+}
+
+SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
+{
+    // compute the local position vector of the station in its reference frame
+    // expressed in ground
+    const auto& R_GF = getParentFrame().getTransformInGround(s).R();
+    Vec3 r = R_GF*getLocation(s);
+
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
+    Vec3 v = R_GF*getVelocity(s);
+
+
+    // The velocity of the station in ground is a function of its frame's
+    // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
+    // velocity of the station: v = vF + omegaF x r
+    return V_GF[1] + V_GF[0] % r + v;
+}
+SimTK::Vec3 MovingPathPoint::calcAccelerationInGround(const SimTK::State& state) const
+{
+    OPENSIM_THROW(Exception, "MovingPathPoint::calcAccelerationInGround not implemented.");
+    return Vec3(SimTK::NaN);
 }

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -29,8 +29,6 @@
 #include <OpenSim/Common/Function.h>
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/MultiplierFunction.h>
-#include <OpenSim/Simulation/Model/Model.h>
-#include <OpenSim/Simulation/Model/GeometryPath.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 
 
@@ -45,7 +43,7 @@ using SimTK::Vec3;
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
 //_____________________________________________________________________________
-/**
+/*
  * Default constructor.
  */
 MovingPathPoint::MovingPathPoint() : PathPoint()
@@ -54,7 +52,7 @@ MovingPathPoint::MovingPathPoint() : PathPoint()
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Destructor.
  */
 MovingPathPoint::~MovingPathPoint()
@@ -62,7 +60,7 @@ MovingPathPoint::~MovingPathPoint()
 }
 
 //_____________________________________________________________________________
-/**
+/*
 * Connect properties to local pointers.
 */
 void MovingPathPoint::constructProperties()
@@ -158,7 +156,7 @@ void MovingPathPoint::extendConnectToModel(Model& model)
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Override default implementation by Object to intercept and fix the XML node
  * underneath the MovingPathPoint to match the current version.
  */
@@ -220,7 +218,7 @@ SimTK::Vec3 MovingPathPoint::getLocation(const SimTK::State& s) const
     else // type == Constant
         pInF[1] = get_y_location().calcValue(SimTK::Vector(1, 0.0));
 
-    if (_zCoordinate) {
+    if (!_zCoordinate.empty()) {
         const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
             _zCoordinate->getValue(s),
             _zCoordinate->getRangeMax());
@@ -271,12 +269,9 @@ SimTK::Vec3 MovingPathPoint::getVelocity(const SimTK::State& s) const
 }
 
 //_____________________________________________________________________________
-/**
+/*
  * Get the velocity of the point in the body's local reference frame.
- *
- * @param aVelocity The velocity.
  */
-
 SimTK::Vec3 MovingPathPoint::getdPointdQ(const SimTK::State& s) const
 {
     SimTK::Vec3 dPdq_B(0);
@@ -284,17 +279,17 @@ SimTK::Vec3 MovingPathPoint::getdPointdQ(const SimTK::State& s) const
     std::vector<int> derivComponents;
     derivComponents.push_back(0);
 
-    if (_xCoordinate){
+    if (!_xCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
         dPdq_B[0] = get_x_location().calcDerivative(derivComponents, 
             SimTK::Vector(1, _xCoordinate->getValue(s)));
     }
-    if (_yCoordinate){
+    if (!_yCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
         dPdq_B[1] = get_y_location().calcDerivative(derivComponents,
             SimTK::Vector(1, _yCoordinate->getValue(s)));
     }
-    if (_zCoordinate){
+    if (!_zCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
         dPdq_B[2] = get_z_location().calcDerivative(derivComponents,
             SimTK::Vector(1, _zCoordinate->getValue(s)));
@@ -306,7 +301,7 @@ SimTK::Vec3 MovingPathPoint::getdPointdQ(const SimTK::State& s) const
 
 void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
 {
-    if (_xCoordinate) {
+    if (!_xCoordinate.empty()) {
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
@@ -320,7 +315,7 @@ void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
         }
     }
 
-    if (_yCoordinate) {
+    if (!_yCoordinate.empty()) {
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
@@ -334,7 +329,7 @@ void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
         }
     }
 
-    if (_zCoordinate) {
+    if (!_zCoordinate.empty()) {
         // If the function is already a MultiplierFunction, just update its scale factor.
         // Otherwise, make a MultiplierFunction from it and make the muscle point use
         // the new MultiplierFunction.
@@ -371,6 +366,7 @@ SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
     // velocity of the station: v = vF + omegaF x r
     return V_GF[1] + V_GF[0] % r + v;
 }
+
 SimTK::Vec3 MovingPathPoint::calcAccelerationInGround(const SimTK::State& state) const
 {
     //TODO: Enable Exception or Implement the method and add accompanying test.

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -134,6 +134,19 @@ void MovingPathPoint::extendConnectToModel(Model& model)
     if (getConnector<Coordinate>("z_coordinate").isConnected()) {
         _zCoordinate.reset(&getConnectee<Coordinate>("z_coordinate"));
     }
+
+    // As OpenSim 3.2 we correct for the Work along a Coordinate due to
+    // the generalized force that enforces the "gearing" that moves the point
+    // under tension. The work is attributed to a single Coordinate, so 
+    // we temporarily do not support independent components.
+    // TODO: If the coordinates are different then, getdPointdQ() should return a 
+    // 3x3 of partials or return a Vec3 w.r.t one coordinate at a time, where the
+    // specific Coordinate is an argument. 
+    OPENSIM_THROW_IF(!((_xCoordinate == _yCoordinate) && (_xCoordinate == _zCoordinate)),
+        Exception,
+        "MovingPathPoint:: Components of the path point location "
+        "must depend on the same Coordinate. Condition: "
+        "x_coordinate == y_coordinate == z_coordinate  FAILED.");
 }
 
 //_____________________________________________________________________________
@@ -327,8 +340,6 @@ void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
 
     updateGeometry();
 }
-
-
 
 
 SimTK::Vec3 MovingPathPoint::calcLocationInGround(const SimTK::State& s) const

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -366,6 +366,10 @@ SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
 SimTK::Vec3 MovingPathPoint::calcAccelerationInGround(const SimTK::State& state) const
 {
     //TODO: Enable Exception or Implement the method and add accompanying test.
+    //      Exception is disabled because testComponents automatically verifies that
+    //      Outputs are functional. My preference is to implement the method
     //OPENSIM_THROW(Exception, "MovingPathPoint::calcAccelerationInGround not implemented.");
+    std::cerr << "MovingPathPoint::calcAccelerationInGround() not implemented. "
+        << "It returns NaN" << std::endl;
     return Vec3(SimTK::NaN);
 }

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -147,6 +147,14 @@ void MovingPathPoint::extendConnectToModel(Model& model)
         "MovingPathPoint:: Components of the path point location "
         "must depend on the same Coordinate. Condition: "
         "x_coordinate == y_coordinate == z_coordinate  FAILED.");
+
+    // Overwrite any setting of a MovingPathPoint's location property.
+    // MovingPathPoint should NOT derive from Station.
+    // TODO: We should not have Path specific Points of any kind. They should
+    // be "path" Points by virtue of being subcomponents of a GeometryPath.
+    // Set it to NaN so it blows up if we attempt to use a MovingPathPoint
+    // as a Station.
+    set_location(SimTK::Vec3(SimTK::NaN));
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -199,8 +199,9 @@ SimTK::Vec3 MovingPathPoint::getVelocity(const SimTK::State& s) const
 
     if (!_zCoordinate.empty()){
         //Multiply the partial (derivative of point coordinate w.r.t. gencoord) by genspeed
-        vInF[2] = get_z_location().calcDerivative(derivComponents, SimTK::Vector(1, _zCoordinate->getValue(s)))*
-            _zCoordinate->getSpeedValue(s);
+        vInF[2] = get_z_location().calcDerivative(
+            derivComponents, SimTK::Vector(1, _zCoordinate->getValue(s)))*
+                _zCoordinate->getSpeedValue(s);
     }
     else
         vInF[2] = 0.0;

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -79,6 +79,19 @@ void MovingPathPoint::constructConnectors()
     constructConnector<Coordinate>("z_coordinate");
 }
 
+bool MovingPathPoint::hasXCoordinate() const
+{
+    return getConnector<Coordinate>("x_coordinate").isConnected();
+}
+bool MovingPathPoint::hasYCoordinate() const
+{
+    return getConnector<Coordinate>("y_coordinate").isConnected();
+}
+bool MovingPathPoint::hasZCoordinate() const
+{
+    return getConnector<Coordinate>("z_coordinate").isConnected();
+}
+
 const Coordinate& MovingPathPoint::getXCoordinate() const
 {
     return _xCoordinate.getRef();

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -165,12 +165,39 @@ void MovingPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionN
     Super::updateFromXMLNode(aNode, versionNumber);
 }
 
-//_____________________________________________________________________________
-/**
- * Get the velocity of the point in the body's local reference frame.
- *
- * @param aVelocity The velocity.
- */
+SimTK::Vec3 MovingPathPoint::getLocation(const SimTK::State& s) const
+{
+    SimTK::Vec3 pInF(0);
+    if (!_xCoordinate.empty()) {
+        const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
+            _xCoordinate->getValue(s),
+            _xCoordinate->getRangeMax());
+        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, xval));
+    }
+    else // assume a Constant
+        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, 0.0));
+
+    if (!_yCoordinate.empty()) {
+        const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
+            _yCoordinate->getValue(s),
+            _yCoordinate->getRangeMax());
+        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, yval));
+    }
+    else // type == Constant
+        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, 0.0));
+
+    if (_zCoordinate) {
+        const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
+            _zCoordinate->getValue(s),
+            _zCoordinate->getRangeMax());
+        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, zval));
+    }
+    else // type == Constant
+        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, 0.0));
+
+    return pInF;
+}
+
 
 SimTK::Vec3 MovingPathPoint::getVelocity(const SimTK::State& s) const
 {
@@ -288,38 +315,7 @@ void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
     updateGeometry();
 }
 
-SimTK::Vec3 MovingPathPoint::getLocation(const SimTK::State& s) const
-{
-    SimTK::Vec3 pInF(0);
-    if (!_xCoordinate.empty()) {
-        const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
-            _xCoordinate->getValue(s),
-            _xCoordinate->getRangeMax());
-        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, xval));
-    }
-    else // assume a Constant
-        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, 0.0));
 
-    if (!_yCoordinate.empty()) {
-        const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
-            _yCoordinate->getValue(s),
-            _yCoordinate->getRangeMax());
-        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, yval));
-    }
-    else // type == Constant
-        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, 0.0));
-
-    if (_zCoordinate) {
-        const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
-            _zCoordinate->getValue(s),
-            _zCoordinate->getRangeMax());
-        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, zval));
-    }
-    else // type == Constant
-        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, 0.0));
-
-    return pInF;
-}
 
 
 SimTK::Vec3 MovingPathPoint::calcLocationInGround(const SimTK::State& s) const
@@ -339,12 +335,13 @@ SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
 
 
     // The velocity of the station in ground is a function of its frame's
-    // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
+    // linear (vF = V_GF[1]) and angular (omegaF = V_GF[0]) velocity, such that
     // velocity of the station: v = vF + omegaF x r
     return V_GF[1] + V_GF[0] % r + v;
 }
 SimTK::Vec3 MovingPathPoint::calcAccelerationInGround(const SimTK::State& state) const
 {
-    OPENSIM_THROW(Exception, "MovingPathPoint::calcAccelerationInGround not implemented.");
+    //TODO: Enable Exception or Implement the method and add accompanying test.
+    //OPENSIM_THROW(Exception, "MovingPathPoint::calcAccelerationInGround not implemented.");
     return Vec3(SimTK::NaN);
 }

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -352,18 +352,21 @@ SimTK::Vec3 MovingPathPoint::calcLocationInGround(const SimTK::State& s) const
 
 SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
 {
-    // compute the local position vector of the station in its reference frame
-    // expressed in ground
+    // compute the local position vector, r, of the moving point in its
+    // parent reference frame, F, expressed in Ground, G.
     const auto& R_GF = getParentFrame().getTransformInGround(s).R();
     const Vec3 r = R_GF*getLocation(s);
-
-    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
+    
+    // express the local velocity of the moving point in Ground
     const Vec3 v = R_GF*getVelocity(s);
 
-
-    // The velocity of the station in ground is a function of its frame's
-    // linear (vF = V_GF[1]) and angular (omegaF = V_GF[0]) velocity, such that
-    // velocity of the station: v = vF + omegaF x r
+    // get the velocity of the parent frame, F,  in Ground, G.
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
+    
+    // The velocity of the moving point in Ground is a combination of its parent
+    // frame's linear (v_GF = V_GF[1]) and angular (omega_GF = V_GF[0]) velocity,
+    // and its local velocity in F, such that: 
+    // v_GP = v_GF + omega_GF x r_FP_G + v_FP_G
     return V_GF[1] + V_GF[0] % r + v;
 }
 

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -153,9 +153,12 @@ void MovingPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionN
             yCoord->getValueAs<std::string>(yCoord_name);
         if (zCoord != aNode.element_end())
             zCoord->getValueAs<std::string>(zCoord_name);
-        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "x_coordinate", xCoord_name);
-        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "y_coordinate", yCoord_name);
-        XMLDocument::addConnector(aNode, "Connector_Coordinate_", "z_coordinate", zCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", 
+            "x_coordinate", xCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", 
+            "y_coordinate", yCoord_name);
+        XMLDocument::addConnector(aNode, "Connector_Coordinate_", 
+            "z_coordinate", zCoord_name);
     }
 
     // Call base class now assuming _node has been corrected for current version

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -352,10 +352,10 @@ SimTK::Vec3 MovingPathPoint::calcVelocityInGround(const SimTK::State& s) const
     // compute the local position vector of the station in its reference frame
     // expressed in ground
     const auto& R_GF = getParentFrame().getTransformInGround(s).R();
-    Vec3 r = R_GF*getLocation(s);
+    const Vec3 r = R_GF*getLocation(s);
 
     const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(s);
-    Vec3 v = R_GF*getVelocity(s);
+    const Vec3 v = R_GF*getVelocity(s);
 
 
     // The velocity of the station in ground is a function of its frame's

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -107,19 +107,19 @@ void MovingPathPoint::setZCoordinate(const Coordinate& coordinate)
     updConnector<Coordinate>("z_coordinate").connect(coordinate);
 }
 
-
-void MovingPathPoint::extendFinalizeFromProperties()
+void MovingPathPoint::extendConnectToModel(Model& model)
 {
+    Super::extendConnectToModel(model);
     // Hang on to references to the Coordinates instead of
     // finding the connector each time we need a Coordinate value
     if (getConnector<Coordinate>("x_coordinate").isConnected()) {
-        _xCoordinate.reset(&getXCoordinate());
+        _xCoordinate.reset(&getConnectee<Coordinate>("x_coordinate"));
     }
     if (getConnector<Coordinate>("y_coordinate").isConnected()) {
-        _yCoordinate.reset(&getYCoordinate());
+        _yCoordinate.reset(&getConnectee<Coordinate>("y_coordinate"));
     }
     if (getConnector<Coordinate>("z_coordinate").isConnected()) {
-        _zCoordinate.reset(&getZCoordinate());
+        _zCoordinate.reset(&getConnectee<Coordinate>("z_coordinate"));
     }
 }
 

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -101,7 +101,7 @@ public:
 private:
     void constructProperties() override;
     void constructConnectors() override;
-    void extendFinalizeFromProperties() override;
+    void extendConnectToModel(Model& model) override;
 
     SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const override;
     SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const override;

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -78,6 +78,10 @@ public:
 
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
 
+    bool hasXCoordinate() const;
+    bool hasYCoordinate() const;
+    bool hasZCoordinate() const;
+
     const Coordinate& getXCoordinate() const;
     const Coordinate& getYCoordinate() const;
     const Coordinate& getZCoordinate() const;

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -23,19 +23,10 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-
 // INCLUDE
-#include <iostream>
-#include <string>
-#include <math.h>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include <OpenSim/Common/PropertyObjPtr.h>
-#include <OpenSim/Common/PropertyStr.h>
-#include <OpenSim/Common/Storage.h>
 #include <OpenSim/Common/Function.h>
 #include <OpenSim/Simulation/Model/PathPoint.h>
-#include "SimTKcommon.h"
-#include "SimTKsimbody.h"
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -62,36 +53,18 @@ class SimbodyEngine;
  */
 class OSIMSIMULATION_API MovingPathPoint : public PathPoint {
 OpenSim_DECLARE_CONCRETE_OBJECT(MovingPathPoint, PathPoint);
+public:
+//==============================================================================
+// PROPERTIES
+//==============================================================================
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(x_location, Function,
+        "Function defining the x component of the point's location.");
 
-//=============================================================================
-// DATA
-//=============================================================================
-private:
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(y_location, Function,
+        "Function defining the y component of the point's location.");
 
-protected:
-    PropertyObjPtr<Function> _xLocationProp;
-    Function* &_xLocation;
-
-    PropertyStr _xCoordinateNameProp;
-    std::string &_xCoordinateName;
-
-    const Coordinate* _xCoordinate;
-
-    PropertyObjPtr<Function> _yLocationProp;
-    Function* &_yLocation;
-
-    PropertyStr _yCoordinateNameProp;
-    std::string &_yCoordinateName;
-
-    const Coordinate* _yCoordinate;
-
-    PropertyObjPtr<Function> _zLocationProp;
-    Function* &_zLocation;
-
-    PropertyStr _zCoordinateNameProp;
-    std::string &_zCoordinateName;
-
-    const Coordinate* _zCoordinate;
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(z_location, Function,
+        "Function defining the z component of the point's location.");
 
 //=============================================================================
 // METHODS
@@ -101,49 +74,44 @@ protected:
     //--------------------------------------------------------------------------
 public:
     MovingPathPoint();
-    MovingPathPoint(const MovingPathPoint &aPoint);
     virtual ~MovingPathPoint();
 
-#ifndef SWIG
-    MovingPathPoint& operator=(const MovingPathPoint &aPoint);
-#endif
-    void copyData(const MovingPathPoint &aPoint);
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
-    void init(const PathPoint& aPoint) override;
 
-    const Coordinate* getXCoordinate() const { return _xCoordinate; }
-    const Coordinate* getYCoordinate() const { return _yCoordinate; }
-    const Coordinate* getZCoordinate() const { return _zCoordinate; }
-#ifndef SWIG
-    void setXCoordinate( const SimTK::State& s, Coordinate& aCoordinate);
-    void setYCoordinate( const SimTK::State& s, Coordinate& aCoordinate);
-    void setZCoordinate( const SimTK::State& s, Coordinate& aCoordinate);
+    const Coordinate& getXCoordinate() const;
+    const Coordinate& getYCoordinate() const;
+    const Coordinate& getZCoordinate() const;
+
+    void setXCoordinate(const Coordinate& coordinate);
+    void setYCoordinate(const Coordinate& coordinate);
+    void setZCoordinate(const Coordinate& coordinate);
 
     // Override methods from PathPoint.
     bool isActive(const SimTK::State& s) const override { return true; }
-    void connectToModelAndPath(Model& aModel, GeometryPath& aPath) 
-                                                                override;
-    void update(const SimTK::State& s) override;
-    void getVelocity(const SimTK::State& s, SimTK::Vec3& aVelocity) override;
-#endif
+
+    // Get the local location of the MovingPathPoint in its Frame
+    SimTK::Vec3 getLocation(const SimTK::State& s) const;
+    // Get the local velocity of the MovingPathPoint in its Frame
+    SimTK::Vec3 getVelocity(const SimTK::State& s) const;
+
     SimTK::Vec3 getdPointdQ(const SimTK::State& s) const override; 
 
-    const std::string& getXCoordinateName() const { return _xCoordinateName; }
-    const std::string& getYCoordinateName() const { return _yCoordinateName; }
-    const std::string& getZCoordinateName() const { return _zCoordinateName; }
-    virtual Function* getXFunction() const { return _xLocation; }
-    virtual Function* getYFunction() const { return _yLocation; }
-    virtual Function* getZFunction() const { return _zLocation; }
-#ifndef SWIG
-    void setXFunction( const SimTK::State& s, Function& aFunction);
-    void setYFunction( const SimTK::State& s, Function& aFunction);
-    void setZFunction( const SimTK::State& s, Function& aFunction);
-#endif
-   void scale(const SimTK::State& s, const SimTK::Vec3& aScaleFactors) override;
+   void scale(const SimTK::Vec3& aScaleFactors) override;
 
 private:
-    void setNull();
-    void setupProperties();
+    void constructProperties() override;
+    void constructConnectors() override;
+    void extendFinalizeFromProperties() override;
+
+    SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const override;
+    SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const override;
+    SimTK::Vec3 calcAccelerationInGround(const SimTK::State& state) const override;
+
+private:
+    SimTK::ReferencePtr<const Coordinate> _xCoordinate;
+    SimTK::ReferencePtr<const Coordinate> _yCoordinate;
+    SimTK::ReferencePtr<const Coordinate> _zCoordinate;
+
 //=============================================================================
 };  // END of class MovingPathPoint
 //=============================================================================

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -58,13 +58,16 @@ public:
 // PROPERTIES
 //==============================================================================
     OpenSim_DECLARE_OPTIONAL_PROPERTY(x_location, Function,
-        "Function defining the x component of the point's location.");
+        "Function defining the x component of the point's location expressed "
+        "in the Frame of the Point.");
 
     OpenSim_DECLARE_OPTIONAL_PROPERTY(y_location, Function,
-        "Function defining the y component of the point's location.");
+        "Function defining the y component of the point's location expressed "
+        "in the Frame of the Point.");
 
     OpenSim_DECLARE_OPTIONAL_PROPERTY(z_location, Function,
-        "Function defining the z component of the point's location.");
+        "Function defining the z component of the point's location expressed "
+        "in the Frame of the Point.");
 
 //=============================================================================
 // METHODS
@@ -93,9 +96,11 @@ public:
     // Override methods from PathPoint.
     bool isActive(const SimTK::State& s) const override { return true; }
 
-    // Get the local location of the MovingPathPoint in its Frame
+    /** Get the local location of the MovingPathPoint in its Frame */
     SimTK::Vec3 getLocation(const SimTK::State& s) const;
-    // Get the local velocity of the MovingPathPoint in its Frame
+    /** Get the local velocity of the MovingPathPoint w.r.t to and 
+        expressed in its Frame. To get the velocity of the point w.r.t.
+        and expressed in Ground, call getVelocityInGround(). */
     SimTK::Vec3 getVelocity(const SimTK::State& s) const;
 
     SimTK::Vec3 getdPointdQ(const SimTK::State& s) const override; 

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -25,12 +25,6 @@
 // INCLUDES
 //=============================================================================
 #include "PathPoint.h"
-#include "BodySet.h"
-#include "Model.h"
-#include "GeometryPath.h"
-#include <OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h> 
-#include <OpenSim/Simulation/Wrap/WrapObject.h>
-#include <OpenSim/Simulation/Model/Geometry.h>
 
 //=============================================================================
 // STATICS
@@ -47,7 +41,7 @@ changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& body)
         throw Exception("PathPoint::changeBodyPreserveLocation attempted to "
             " change the body on PathPoint which was not assigned to a body.");
     }
-    // if it is already assigned to aBody, do nothing
+    // if it is already assigned to body, do nothing
     const PhysicalFrame& currentFrame = getParentFrame();
 
     if (currentFrame == body)

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -46,45 +46,13 @@ using SimTK::Transform;
 //_____________________________________________________________________________
 
 
-//=============================================================================
-// CONSTRUCTION METHODS
-//=============================================================================
-//_____________________________________________________________________________
-/* Copy data members from one PathPoint to another.
- *
- * @param aPoint PathPoint to be copied.
- */
-void PathPoint::copyData(const PathPoint &aPoint)
-{
-    _path = aPoint._path;
-}
-
 /* TODO: All Points should be Components that use Connectors
 * and extendConnect(). This must go away! -aseth
 */
-void PathPoint::connectToModelAndPath(Model& model, GeometryPath& path)
+void PathPoint::connectToModelAndPath(Model& model, const GeometryPath& path)
 {
     Super::connectToModel(model);
     _path = &path;
-}
-
-
-PathPoint* PathPoint::makePathPointOfType(PathPoint* aPoint, const string& aNewTypeName)
-{
-    PathPoint* newPoint = NULL;
-    cout << "PathPoint::makePathPointOfType()" << endl;
-    if (aPoint != NULL) {
-        Object* newObject = Object::newInstanceOfType(aNewTypeName);
-        if (newObject) {
-            newPoint = dynamic_cast<PathPoint*>(newObject);
-            if (newPoint) {
-                // Copy the contents from aPoint.
-                newPoint->init(*aPoint);
-            }
-        }
-    }
-
-    return newPoint;
 }
 
 void PathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -57,7 +57,7 @@ changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& body)
     // the location of the point in the inertial reference frame.
     upd_location() = currentFrame.findLocationInAnotherFrame(s, get_location(), body);
 
-    // now assign this point's body to point to aBody
+    // now make "body" this PathPoint's parent Frame
     setParentFrame(body);
 }
 

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -129,7 +129,7 @@ public:
 
     GeometryPath* getPath() const { return _path.get(); }
 
-    virtual void scale(const SimTK::State& s, const SimTK::Vec3& scaleFactors) {
+    virtual void scale(const SimTK::Vec3& scaleFactors) {
         for (int i = 0; i < 3; i++)
             upd_location()[i] *= scaleFactors[i];
     }
@@ -138,7 +138,6 @@ public:
 
     virtual bool isActive(const SimTK::State& s) const { return true; }
     virtual void connectToModelAndPath(Model& aModel, GeometryPath& aPath);
-    virtual void update(const SimTK::State& s) { }
 
     // get the relative velocity of the path point with respect to the body
     // it is connected to.

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -32,10 +32,7 @@
 namespace OpenSim {
 
 class PhysicalFrame;
-class Model;
 class GeometryPath;
-class SimbodyEngine;
-class WrapObject;
 
 //=============================================================================
 //=============================================================================

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -50,14 +50,6 @@ class WrapObject;
 
 class OSIMSIMULATION_API PathPoint : public Station {
 OpenSim_DECLARE_CONCRETE_OBJECT(PathPoint, Station);
-
-//=============================================================================
-// DATA
-//=============================================================================
-protected:
-    // the path that owns this path point
-    SimTK::ReferencePtr<const GeometryPath> _path; 
-
 //=============================================================================
 // METHODS
 //=============================================================================
@@ -99,24 +91,8 @@ public:
         this->setParentFrame(body);
     }
 
-    void changeBodyPreserveLocation(const SimTK::State& s, PhysicalFrame& body){
-        if (!hasParent()) {
-            throw Exception("PathPoint::changeBodyPreserveLocation attempted to "
-                " change the body on PathPoint which was not assigned to a body.");
-        }
-        // if it is already assigned to aBody, do nothing
-        const PhysicalFrame& currentFrame = getParentFrame();
-
-        if (currentFrame == body)
-            return;
-
-        // Preserve location means to switch bodies without changing
-        // the location of the point in the inertial reference frame.
-        upd_location() = currentFrame.findLocationInAnotherFrame(s, get_location(), body);
-
-        // now assign this point's body to point to aBody
-        setParentFrame(body);
-    }
+    void changeBodyPreserveLocation(const SimTK::State& s,
+                                    const PhysicalFrame& body);
 
     const PhysicalFrame& getBody() const { return getParentFrame(); }
     const std::string& getBodyName() const { return getParentFrame().getName(); }
@@ -129,7 +105,6 @@ public:
     virtual const WrapObject* getWrapObject() const { return NULL; }
 
     virtual bool isActive(const SimTK::State& s) const { return true; }
-    virtual void connectToModelAndPath(Model& aModel, const GeometryPath& aPath);
 
     // get the relative velocity of the path point with respect to the body
     // it is connected to.
@@ -142,7 +117,6 @@ public:
         { return SimTK::Vec3(0); }
 
     virtual void updateGeometry() {}
-
 
     static void deletePathPoint(PathPoint* aPoint) { if (aPoint) delete aPoint; }
 

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -56,7 +56,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(PathPoint, Station);
 //=============================================================================
 protected:
     // the path that owns this path point
-    SimTK::ReferencePtr<GeometryPath> _path; 
+    SimTK::ReferencePtr<const GeometryPath> _path; 
 
 //=============================================================================
 // METHODS
@@ -66,12 +66,6 @@ protected:
     //--------------------------------------------------------------------------
 public:
     PathPoint() : Station() {}
-
-    virtual void init(const PathPoint& point) {
-        *this = point;
-        copyData(point);
-    }
-   void copyData(const PathPoint &aPoint);
 
 #ifndef SWIG
     const SimTK::Vec3& getLocation() const { return get_location(); }
@@ -127,8 +121,6 @@ public:
     const PhysicalFrame& getBody() const { return getParentFrame(); }
     const std::string& getBodyName() const { return getParentFrame().getName(); }
 
-    GeometryPath* getPath() const { return _path.get(); }
-
     virtual void scale(const SimTK::Vec3& scaleFactors) {
         for (int i = 0; i < 3; i++)
             upd_location()[i] *= scaleFactors[i];
@@ -137,7 +129,7 @@ public:
     virtual const WrapObject* getWrapObject() const { return NULL; }
 
     virtual bool isActive(const SimTK::State& s) const { return true; }
-    virtual void connectToModelAndPath(Model& aModel, GeometryPath& aPath);
+    virtual void connectToModelAndPath(Model& aModel, const GeometryPath& aPath);
 
     // get the relative velocity of the path point with respect to the body
     // it is connected to.
@@ -151,9 +143,6 @@ public:
 
     virtual void updateGeometry() {}
 
-    // Utility
-    static PathPoint* makePathPointOfType(PathPoint* aPoint,
-        const std::string& aNewTypeName);
 
     static void deletePathPoint(PathPoint* aPoint) { if (aPoint) delete aPoint; }
 

--- a/OpenSim/Simulation/Model/Point.cpp
+++ b/OpenSim/Simulation/Model/Point.cpp
@@ -129,9 +129,9 @@ double Point::calcDistanceBetween(const SimTK::State& s,
 
 double Point::calcSpeedBetween(const SimTK::State& s, const Point& o) const
 {
-    auto r = getLocationInGround(s) - o.getLocationInGround(s);
-    double d = r.norm();
-    auto v = getVelocityInGround(s) - o.getVelocityInGround(s);
+    const auto r = getLocationInGround(s) - o.getLocationInGround(s);
+    const double d = r.norm();
+    const auto v = getVelocityInGround(s) - o.getVelocityInGround(s);
     if (d < SimTK::Eps) // avoid divide by zero
         return v.norm();
     else // speed is the projection of relative velocity, v, onto the 

--- a/OpenSim/Simulation/Model/Point.cpp
+++ b/OpenSim/Simulation/Model/Point.cpp
@@ -129,7 +129,14 @@ double Point::calcDistanceBetween(const SimTK::State& s,
 
 double Point::calcSpeedBetween(const SimTK::State& s, const Point& o) const
 {
-    return (getVelocityInGround(s)-o.getVelocityInGround(s)).norm();
+    auto r = getLocationInGround(s) - o.getLocationInGround(s);
+    double d = r.norm();
+    auto v = getVelocityInGround(s) - o.getVelocityInGround(s);
+    if (d < SimTK::Eps) // avoid divide by zero
+        return v.norm();
+    else // speed is the projection of relative velocity, v, onto the 
+         // displacement unit vector, r_hat = r/d; 
+        return dot(v, r/d);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/Point.cpp
+++ b/OpenSim/Simulation/Model/Point.cpp
@@ -25,6 +25,7 @@
 // INCLUDES
 //=============================================================================
 #include "Point.h"
+#include "Frame.h"
 
 //=============================================================================
 // STATICS
@@ -113,9 +114,23 @@ const SimTK::Vec3& Point::getAccelerationInGround(const SimTK::State& s) const
 }
 
 //=============================================================================
-// POINT COMPUTATIONS
+// Helpful Point Calculations
 //=============================================================================
+double Point::calcDistanceBetween(const SimTK::State& s, const Point& o) const
+{
+    return (getLocationInGround(s) - o.getLocationInGround(s)).norm();
+}
 
+double Point::calcDistanceBetween(const SimTK::State& s,
+    const Frame& f, const SimTK::Vec3& p) const
+{
+    return (getLocationInGround(s) - f.getTransformInGround(s)*p).norm();
+}
+
+double Point::calcSpeedBetween(const SimTK::State& s, const Point& o) const
+{
+    return (getVelocityInGround(s)-o.getVelocityInGround(s)).norm();
+}
 
 //=============================================================================
 // Component level realizations

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -29,6 +29,7 @@
 
 namespace OpenSim {
 
+class Frame;
 //=============================================================================
 //=============================================================================
 /**
@@ -91,6 +92,27 @@ public:
 
     // End of Point's Spatial Kinematics
     ///@}
+
+    /** Calculate the distance between this Point and some other Point
+    @param state      The current State of the model.
+    @param other      The other Point to which we want to get the distance between.
+    @return distance  The distance (positive scalar). */
+    double calcDistanceBetween(const SimTK::State& state, const Point& other) const;
+
+    /** Calculate the distance between this Point and some other described as a
+    location in some other frame.
+    @param state      The current State of the model.
+    @param frame      The other frame in which the location is defined.
+    @param location   The location in the other frame.
+    @return distance  The distance (positive scalar). */
+    double calcDistanceBetween(const SimTK::State& state, const Frame& frame,
+        const SimTK::Vec3& location) const;
+    /** Calculate the speed of motion between this Point and some other Point.
+    A positive speed is growing apart and negative speed is coming closer.
+    @param state      The current State of the model.
+    @param other      The other Point to which we want to get the speed between.
+    @return distance  The speed between the Points (scalar). */
+    double calcSpeedBetween(const SimTK::State& state, const Point& other) const;
 
 protected:
     /** @name Point Extension methods.

--- a/OpenSim/Simulation/Model/Point.h
+++ b/OpenSim/Simulation/Model/Point.h
@@ -107,11 +107,13 @@ public:
     @return distance  The distance (positive scalar). */
     double calcDistanceBetween(const SimTK::State& state, const Frame& frame,
         const SimTK::Vec3& location) const;
-    /** Calculate the speed of motion between this Point and some other Point.
-    A positive speed is growing apart and negative speed is coming closer.
+
+    /** Calculate the relative speed between this Point and some other Point.
+    It is the derivative of the distance with respect to time.
+    A positive speed is growing the distance and negative is coming closer.
     @param state      The current State of the model.
     @param other      The other Point to which we want to get the speed between.
-    @return distance  The speed between the Points (scalar). */
+    @return speed     The speed (distance time derivative) which is a scalar. */
     double calcSpeedBetween(const SimTK::State& state, const Point& other) const;
 
 protected:

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -267,6 +267,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType(Connector<Frame>());
     Object::registerType(Connector<PhysicalFrame>());
     Object::registerType(Connector<Body>());
+    Object::registerType(Connector<Coordinate>());
 
     // OLD Versions
     // Associate an instance with old name to help deserialization.

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -121,7 +121,7 @@ void Coordinate::constructProperties(void)
     constructProperty_default_value(0.0);
     constructProperty_default_speed_value(0.0);
 
-    Array<double> defaultRange(-10.0, 2); //twp values in range
+    Array<double> defaultRange(-10.0, 2); //two values in range
     defaultRange[1] = 10.0; // second value in range is 10.0
     constructProperty_range(defaultRange);
 

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -101,11 +101,6 @@ void PathWrap::extendConnectToModel(Model& model)
         }
     }
 
-    // connectToModelAndPath() must be called after setBody() because it requires
-    // that _bodyName already be assigned.
-    updWrapPoint1().connectToModelAndPath(model, *_path);
-    updWrapPoint2().connectToModelAndPath(model, *_path);
-
     if (get_method() == "hybrid" || get_method() == "Hybrid" || get_method() == "HYBRID")
         _method = hybrid;
     else if (get_method() == "midpoint" || get_method() == "Midpoint" || get_method() == "MIDPOINT")

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -43,7 +43,7 @@ using namespace OpenSim;
 /**
  * Default constructor.
  */
-PathWrap::PathWrap() : Component()
+PathWrap::PathWrap() : ModelComponent()
 {
     setNull();
     constructProperties();
@@ -82,11 +82,12 @@ void PathWrap::constructProperties()
 }
 
 
-void PathWrap::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
+void PathWrap::extendConnectToModel(Model& model)
 {
-    _path = &aPath;
+    _path = dynamic_cast<const GeometryPath*>(&getParent());
 
-    ComponentList<PhysicalFrame> bodiesList = aModel.getComponentList<PhysicalFrame>();
+    ComponentList<PhysicalFrame> bodiesList = 
+        model.getComponentList<PhysicalFrame>();
     for (ComponentList<PhysicalFrame>::const_iterator it = bodiesList.begin();
             it != bodiesList.end(); ++it) {
         const WrapObject* wo = it->getWrapObject(getWrapObjectName());
@@ -102,8 +103,8 @@ void PathWrap::connectToModelAndPath(Model& aModel, GeometryPath& aPath)
 
     // connectToModelAndPath() must be called after setBody() because it requires
     // that _bodyName already be assigned.
-    updWrapPoint1().connectToModelAndPath(aModel, aPath);
-    updWrapPoint2().connectToModelAndPath(aModel, aPath);
+    updWrapPoint1().connectToModelAndPath(model, *_path);
+    updWrapPoint2().connectToModelAndPath(model, *_path);
 
     if (get_method() == "hybrid" || get_method() == "Hybrid" || get_method() == "HYBRID")
         _method = hybrid;

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -84,7 +84,12 @@ void PathWrap::constructProperties()
 
 void PathWrap::extendConnectToModel(Model& model)
 {
+    Super::extendConnectToModel(model);
+
     _path = dynamic_cast<const GeometryPath*>(&getParent());
+    std::string msg = "PathWrap '" + getName()
+        + "' must have a GeometryPath as its parent.";
+    OPENSIM_THROW_IF(_path == nullptr, Exception, msg);
 
     ComponentList<PhysicalFrame> bodiesList = 
         model.getComponentList<PhysicalFrame>();

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -23,12 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-
 // INCLUDE
-#include <iostream>
-#include <string>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include <OpenSim/Common/Object.h>
 #include "PathWrapPoint.h"
 #include "WrapResult.h"
 
@@ -41,8 +37,8 @@
 
 namespace OpenSim {
 
+class Model;
 class WrapObject;
-class SimbodyEngine;
 class GeometryPath;
 
 //=============================================================================
@@ -55,8 +51,8 @@ class GeometryPath;
  * @author Peter Loan
  * @version 1.0
  */
-class OSIMSIMULATION_API PathWrap : public Component {
-OpenSim_DECLARE_CONCRETE_OBJECT(PathWrap, Component);
+class OSIMSIMULATION_API PathWrap : public ModelComponent {
+OpenSim_DECLARE_CONCRETE_OBJECT(PathWrap, ModelComponent);
 public:
     //==============================================================================
     // PROPERTIES
@@ -82,7 +78,7 @@ protected:
     WrapMethod _method;
 
     const WrapObject* _wrapObject;
-    GeometryPath* _path;
+    const GeometryPath* _path;
 
     WrapResult _previousWrap;  // results from previous wrapping
 
@@ -102,7 +98,6 @@ public:
     ~PathWrap();
 
 #ifndef SWIG
-    void connectToModelAndPath(Model& aModel, GeometryPath& aPath);
     void setStartPoint( const SimTK::State& s, int aIndex);
     void setEndPoint( const SimTK::State& s, int aIndex);
 #endif
@@ -125,11 +120,9 @@ public:
         return updMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
     }
 
-
     WrapMethod getMethod() const { return _method; }
     void setMethod(WrapMethod aMethod);
     const std::string& getMethodName() const { return get_method(); }
-    GeometryPath* getPath() const { return _path; }
 
     const WrapResult& getPreviousWrap() const { return _previousWrap; }
     void setPreviousWrap(const WrapResult& aWrapResult);
@@ -137,6 +130,7 @@ public:
 
 private:
     void constructProperties() override;
+    void extendConnectToModel(Model& model) override;
     void setNull();
 //=============================================================================
 };  // END of class PathWrap

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -62,9 +62,9 @@ public:
     OpenSim_DECLARE_PROPERTY(method, std::string,
         "The wrapping method used to solve the path around the wrap object.");
 
-    // Range should not be exposed as far as one can tell, since al instances are
-    // -1, -1 which is the default value, which means the PathWrap is overwriting
-    // anyways.
+    // TODO Range should not be exposed as far as one can tell, since all instances
+    // are (-1, -1), which is the default value, and that means the PathWrap is
+    // ignoring/overwriting this property anyways.
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(range, int, 2,
         "The range of indices to use to compute the path over the wrap object.")
 
@@ -73,19 +73,6 @@ public:
         midpoint,
         axial
     };
-
-protected:
-    WrapMethod _method;
-
-    const WrapObject* _wrapObject;
-    const GeometryPath* _path;
-
-    WrapResult _previousWrap;  // results from previous wrapping
-
-    MemberSubcomponentIndex _wrapPoint1Ix {
-        constructSubcomponent<PathWrapPoint>("pwpt1") };
-    MemberSubcomponentIndex _wrapPoint2Ix {
-        constructSubcomponent<PathWrapPoint>("pwpt2") };
 
 //=============================================================================
 // METHODS
@@ -132,6 +119,19 @@ private:
     void constructProperties() override;
     void extendConnectToModel(Model& model) override;
     void setNull();
+
+private:
+    WrapMethod _method;
+
+    const WrapObject* _wrapObject;
+    const GeometryPath* _path;
+
+    WrapResult _previousWrap;  // results from previous wrapping
+
+    MemberSubcomponentIndex _wrapPoint1Ix{
+        constructSubcomponent<PathWrapPoint>("pwpt1") };
+    MemberSubcomponentIndex _wrapPoint2Ix{
+        constructSubcomponent<PathWrapPoint>("pwpt2") };
 //=============================================================================
 };  // END of class PathWrap
 //=============================================================================

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -182,6 +182,29 @@ void testComponent(const Component& instanceToTest)
             string dependencyTypeName = connector.getConnecteeTypeName();
             cout << "Connector '" << connector.getName() <<
                 "' has dependency on: " << dependencyTypeName << endl;
+
+            // Dependency on a Coordinate needs special treatment.
+            // A Coordinate is defined by a Joint and cannot stand on its own.
+            // Here we see if there is a Coordinate already in the model, 
+            // otherwise we add a Body and Joint so we can connect to its
+            // Coordinate.
+            if (dynamic_cast<Connector<Coordinate> *>(&connector)) {
+                while (!connector.isConnected()) {
+                    // Dependency on a coordinate, check if there is one in the model already
+                    auto coordinates = model.getComponentList<Coordinate>();
+                    if(coordinates.begin() != coordinates.end()) {
+                        connector.connect(*coordinates.begin());
+                        break;
+                    }
+                    // no luck finding a Coordinate already in the Model
+                    Body* body = new Body();
+                    randomize(body);
+                    model.addBody(body);
+                    model.addJoint(new PinJoint("pin", model.getGround(), *body));
+                }
+                continue;
+            }
+
             Object* dependency =
                 Object::newInstanceOfType(dependencyTypeName);
 

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -1034,32 +1034,35 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
         if (pt.getConcreteClassName()==("ConditionalPathPoint")) {
             ConditionalPathPoint* mvp = (ConditionalPathPoint*)(&pt);
             Vec3& attachment = mvp->getLocation();
-            Array<double>& range = mvp->getRange();
+            double range[]{ mvp->get_range(0), mvp->get_range(1) };
             aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << mvp->getBody().getName();
-            const Coordinate* coord = mvp->getCoordinate();
-            if (coord) {
-                if (coord->getMotionType() == Coordinate::Rotational)
-                    aStream << " ranges 1 " << coord->getName() << " (" << range[0] * SimTK_RADIAN_TO_DEGREE << ", " << range[1] * SimTK_RADIAN_TO_DEGREE << ")" << endl;
+            
+            if (mvp->hasCoordinate()) {
+                const Coordinate& coord = mvp->getCoordinate();
+                if (coord.getMotionType() == Coordinate::Rotational)
+                    aStream << " ranges 1 " << coord.getName() << " (" << range[0] * SimTK_RADIAN_TO_DEGREE << ", " << range[1] * SimTK_RADIAN_TO_DEGREE << ")" << endl;
                 else
-                    aStream << " ranges 1 " << coord->getName() << " (" << range[0] << ", " << range[1] << ")" << endl;
+                    aStream << " ranges 1 " << coord.getName() << " (" << range[0] << ", " << range[1] << ")" << endl;
             } else {
-                aStream << " ranges 1 " << mvp->getCoordinateName() << " (0.0, 1.0)" << endl;
+                aStream << " ranges 1 " 
+                    << mvp->getConnector<Coordinate>("coordinate").getConnecteeName()
+                    << " (0.0, 1.0)" << endl;
             }
         } else if (pt.getConcreteClassName()==("MovingPathPoint")) {
             MovingPathPoint* mpp = (MovingPathPoint*)(&pt);
-            Vec3& attachment = mpp->getLocation();
-            if (mpp->getXCoordinate()) {
-                aStream << "f" << addMuscleFunction(mpp->getXFunction(), mpp->getXCoordinate()->getMotionType(), Coordinate::Translational) << "(" << mpp->getXCoordinateName() << ") ";
+            const Vec3& attachment = mpp->get_location();
+            if (mpp->hasXCoordinate()) {
+                aStream << "f" << addMuscleFunction(&mpp->get_x_location(), mpp->getXCoordinate().getMotionType(), Coordinate::Translational) << "(" << mpp->getXCoordinate().getName() << ") ";
             } else {
                 aStream << attachment[0] << " ";
             }
-            if (mpp->getYCoordinate()) {
-                aStream << "f" << addMuscleFunction(mpp->getYFunction(), mpp->getYCoordinate()->getMotionType(), Coordinate::Translational) << "(" << mpp->getYCoordinateName() << ") ";
+            if (mpp->hasYCoordinate()) {
+                aStream << "f" << addMuscleFunction(&mpp->get_y_location(), mpp->getYCoordinate().getMotionType(), Coordinate::Translational) << "(" << mpp->getYCoordinate().getName() << ") ";
             } else {
                 aStream << attachment[1] << " ";
             }
-            if (mpp->getZCoordinate()) {
-                aStream << "f" << addMuscleFunction(mpp->getZFunction(), mpp->getZCoordinate()->getMotionType(), Coordinate::Translational) << "(" << mpp->getZCoordinateName() << ")";
+            if (mpp->hasZCoordinate()) {
+                aStream << "f" << addMuscleFunction(&mpp->get_z_location(), mpp->getZCoordinate().getMotionType(), Coordinate::Translational) << "(" << mpp->getZCoordinate().getName() << ")";
             } else {
                 aStream << attachment[2];
             }


### PR DESCRIPTION
Computations by `GeometryPath` to determine the location of and speed between points are delegated to `Point`, which is now performing these calculations and reduce duplication. This greatly simplifies `GeometryPath`, but more importantly allows us to eliminate a major source of property mangling during a simulation: `GeometryPath` no longer updates a `MovingPathPoint`'s `location` property during a simulation. We are a lot closer towards enforcing that properties must be `const` during a simulation (`GeometryPath` being the primary violator). I agree with arguments that `MovingPathPoint` should not even have a `location` property, which it inherits from its `Station` super class. `PathPoint` then, should not be a `Station` either. I will leave that for another PR. 

I also made  `PathPoint` (and its children) conform to the Component API and eliminated custom *connect* like methods, which required a confusing call sequence (e.g. called when adding a Point). From the API perspective there was no need or use of the `PathPoint`'s reference (pointer)  back to a `GeometryPath` and all the `connectToModelAndPath` and `connectToModelAndBody` were removed. We are one step closer to eliminating `PathPoint` altogether and having `GeometryPath` being composed by `Points`. 

Nonetheless, the updated PathPoints are included in `testComponents` with some added handling for `Connector<Coordinate>`.

I detected no change in test performances (timings) due to these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/990)
<!-- Reviewable:end -->
