### PR TITLE
Silence clang warning about static function.

### DIFF
--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -122,7 +122,7 @@ do { \
     } \
 } while(false) 
 
-static OpenSim::Object* randomize(OpenSim::Object* obj)
+OpenSim::Object* randomize(OpenSim::Object* obj)
 {
     using namespace OpenSim;
     using namespace std;


### PR DESCRIPTION
Removes `static` from the `randomize()` function in `auxiliaryTestFunctions.h` to silence a warning from clang.