### PR TITLE
Randomize bool properties when testing Components

### DIFF
--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -146,7 +146,7 @@ OpenSim::Object* randomize(OpenSim::Object* obj)
         if (ap.isOptionalProperty()) 
             continue;
         if (ts == "bool"&& !isList) 
-            ap.updValue<bool>() = !ap.getValue<bool>();
+            ap.updValue<bool>() = (rand() % 2 == 0);
         else if (ts == "integer"&& !isList) 
             ap.updValue<int>() = rand();
         else if (ts == "double" && !isList) 


### PR DESCRIPTION
Current `randomize()` method randomizes non-Boolean properties but _always_ toggles Boolean properties.