### PR TITLE
Create methodComponent::printComponentsMatching().

### DIFF
--- a/Bindings/Python/tests/test_component_interface.py
+++ b/Bindings/Python/tests/test_component_interface.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+
+import opensim as osim
+
+test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
+                        'tests')
+
+class TestComponentInterface(unittest.TestCase):
+    def test_printComponentsMatching(self):
+        model = osim.Model(os.path.join(test_dir,
+            "gait10dof18musc_subject01.osim"))
+        num_matches = model.printComponentsMatching("_r")
+        self.assertEquals(num_matches, 80)

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -27,8 +27,6 @@
 #include "OpenSim/Common/Set.h"
 #include "OpenSim/Common/IO.h"
 
-#include <regex>
-
 using namespace SimTK;
 
 namespace OpenSim {
@@ -543,11 +541,11 @@ setModelingOption(SimTK::State& s, const std::string& name, int flag) const
     }
 }
 
-int Component::printComponentsMatching(const std::string& substring) {
+unsigned Component::printComponentsMatching(const std::string& substring) const
+{
     auto components = getComponentList();
-    std::regex expr(".*" + substring + ".*");
-    components.setFilter(ComponentFilterFullPathNameRegex(expr));
-    int count = 0;
+    components.setFilter(ComponentFilterFullPathNameContainsString(substring));
+    unsigned count = 0;
     for (const auto& comp : components) {
         std::cout << comp.getFullPathName() << std::endl;
         ++count;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -27,6 +27,8 @@
 #include "OpenSim/Common/Set.h"
 #include "OpenSim/Common/IO.h"
 
+#include <regex>
+
 using namespace SimTK;
 
 namespace OpenSim {
@@ -541,6 +543,17 @@ setModelingOption(SimTK::State& s, const std::string& name, int flag) const
     }
 }
 
+int Component::printComponentsMatching(const std::string& substring) {
+    auto components = getComponentList();
+    std::regex expr(".*" + substring + ".*");
+    components.setFilter(ComponentFilterFullPathNameRegex(expr));
+    int count = 0;
+    for (const auto& comp : components) {
+        std::cout << comp.getFullPathName() << std::endl;
+        ++count;
+    }
+    return count;
+}
 
 int Component::getNumStateVariables() const
 {

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -444,6 +444,33 @@ public:
     /** Get the relative pathname of this Component with respect to another one */
     std::string getRelativePathName(const Component& wrt) const;
 
+    /** Query if there is a component (of any type) at the specified
+     * path name. For example,
+     * @code 
+     * bool exists = model.hasComponent("right_elbow/elbow_flexion");
+     * @endcode
+     * checks if `model` has a subcomponent "right_elbow," which has a
+     * subcomponent "elbow_flexion." */
+    bool hasComponent(const std::string& pathname) const {
+        const auto* comp = this->template traversePathToComponent<Component>(pathname);
+        return comp;
+    }
+
+    /** Query if there is a component of a given type at the specified
+     * path name. For example,
+     * @code 
+     * bool exists = model.hasComponent<Coordinate>("right_elbow/elbow_flexion");
+     * @endcode
+     * checks if `model` has a subcomponent "right_elbow," which has a
+     * subcomponent "elbow_flexion," and that "elbow_flexion" is of type
+     * Coordinate. This method cannot be used from scripting; see the
+     * non-templatized hasComponent(). */
+    template <class C>
+    bool hasComponent(const std::string& pathname) const {
+        const C* comp = this->template traversePathToComponent<C>(pathname);
+        return comp;
+    }
+
     /**
      * Get a unique subcomponent of this Component by its path name and type 'C'. 
      * Throws ComponentNotFoundOnSpecifiedPath exception if the component at
@@ -455,7 +482,7 @@ public:
      * returns coord which is a Coordinate named "elbow_flexion" from a Joint
      * named "right_elbow" given it is a child of the Component (Model) model.
      * If unsure of a Component's path or whether or not it exists in the model,
-     * use findComponent() 
+     * use printComponentsMatching() or hasComponent().
      *
      * @param  pathname        a pathname (string) of a Component of interest
      * @return const reference to component of type C at 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -485,6 +485,15 @@ public:
         return *const_cast<C*>(&(this->template getComponent<C>(name)));
     }
 
+    /** Print a list to the console of all components whose full path name
+     * contains the given string. You might use this if (a) you know the name of
+     * a component in your model but don't know its full path, (b) if you want
+     * to find all components with a given name, or (c) to get a list of all
+     * components on the right leg of a model (if all components on the right
+     * side have "_r" in their name).
+     * @returns The number of matches. */
+    int printComponentsMatching(const std::string& substring);
+
     /**
      * Get the number of "Continuous" state variables maintained by the Component
      * and its subcomponents

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -491,8 +491,19 @@ public:
      * to find all components with a given name, or (c) to get a list of all
      * components on the right leg of a model (if all components on the right
      * side have "_r" in their name).
+     *
+     * A function call like:
+     * @code{.cpp}
+     * unsigned num = comp.printComponentsMatching("rotation");
+     * @endcode
+     * may produce output like:
+     * @verbatim
+     * /leg_model/right_hip/rotation
+     * /leg_model/left_hip/rotation
+     * @endverbatim
+     *
      * @returns The number of matches. */
-    int printComponentsMatching(const std::string& substring);
+    unsigned printComponentsMatching(const std::string& substring) const;
 
     /**
      * Get the number of "Continuous" state variables maintained by the Component
@@ -1603,7 +1614,6 @@ protected:
     friend void Connector<C>::findAndConnect(const Component& root);
 #pragma clang diagnostic pop
 
-public:
     /** Utility method to find a component in the list of sub components of this
         component and any of their sub components, etc..., by name or state variable name.
         The search can be sped up considerably if the "path" or even partial path name
@@ -1704,6 +1714,7 @@ public:
     }
 #endif
 
+public:
     /** Similarly find a Connector of this Component (includes its subcomponents) */
     const AbstractConnector* findConnector(const std::string& name) const;
     /** Similarly find a StateVariable of this Component (includes its subcomponents) */

--- a/OpenSim/Common/ComponentList.cpp
+++ b/OpenSim/Common/ComponentList.cpp
@@ -1,0 +1,32 @@
+/* -------------------------------------------------------------------------- *
+ *                             OpenSim: ComponentList.cpp                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2014-2014 Stanford University and the Authors                *
+ * Authors: Ayman Habib                                                       *
+ * Contributers : Chris Dembia                                                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "ComponentList.h"
+#include "Component.h"
+
+using namespace OpenSim;
+
+bool ComponentFilterFullPathNameRegex::isMatch(const Component& comp) const {
+    return std::regex_match(comp.getFullPathName(), _expr);
+}

--- a/OpenSim/Common/ComponentList.cpp
+++ b/OpenSim/Common/ComponentList.cpp
@@ -27,6 +27,7 @@
 
 using namespace OpenSim;
 
-bool ComponentFilterFullPathNameRegex::isMatch(const Component& comp) const {
-    return std::regex_match(comp.getFullPathName(), _expr);
+bool ComponentFilterFullPathNameContainsString::isMatch(const Component& comp)
+        const {
+    return comp.getFullPathName().find(_substring) != std::string::npos;
 }

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -28,8 +28,6 @@
 #include <OpenSim/Common/osimCommonDLL.h>
 #include "Simbody.h"
 
-#include <regex>
-
 namespace OpenSim {
 
 class Component;
@@ -79,17 +77,18 @@ public:
     }
 };
 
-/** A component is considered a match if its full path name matches the 
-provided regular expression. */
-class ComponentFilterFullPathNameRegex : public ComponentFilter {
+/** A component is considered a match if its full path name contains the
+given string. */
+class ComponentFilterFullPathNameContainsString : public ComponentFilter {
 public:
-    ComponentFilterFullPathNameRegex(const std::regex& expr) : _expr(expr) {}
+    ComponentFilterFullPathNameContainsString(const std::string& substring)
+        : _substring(substring) {}
     bool isMatch(const Component& comp) const override;
-    ComponentFilterFullPathNameRegex* clone() const override {
-        return new ComponentFilterFullPathNameRegex(*this);
+    ComponentFilterFullPathNameContainsString* clone() const override {
+        return new ComponentFilterFullPathNameContainsString(*this);
     }
 private:
-    std::regex _expr;
+    std::string _substring;
 };
 
 

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -28,6 +28,8 @@
 #include <OpenSim/Common/osimCommonDLL.h>
 #include "Simbody.h"
 
+#include <regex>
+
 namespace OpenSim {
 
 class Component;
@@ -76,6 +78,21 @@ public:
         return new ComponentFilterMatchAll(*this);
     }
 };
+
+/** A component is considered a match if its full path name matches the 
+provided regular expression. */
+class ComponentFilterFullPathNameRegex : public ComponentFilter {
+public:
+    ComponentFilterFullPathNameRegex(const std::regex& expr) : _expr(expr) {}
+    bool isMatch(const Component& comp) const override;
+    ComponentFilterFullPathNameRegex* clone() const override {
+        return new ComponentFilterFullPathNameRegex(*this);
+    }
+private:
+    std::regex _expr;
+};
+
+
 /**
  Collection (linked list) of components to iterate through.  Typical use is to
  call getComponentList() on a component (e.g. model) to obtain an instance of 

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -79,7 +79,8 @@ public:
 
 /** A component is considered a match if its full path name contains the
 given string. */
-class ComponentFilterFullPathNameContainsString : public ComponentFilter {
+class OSIMCOMMON_API ComponentFilterFullPathNameContainsString
+        : public ComponentFilter {
 public:
     ComponentFilterFullPathNameContainsString(const std::string& substring)
         : _substring(substring) {}

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -467,6 +467,15 @@ void testMisc() {
         std::cout << "Iter at: " << component.getFullPathName() << std::endl;
     }
 
+    // Query existing components.
+    theWorld.printComponentsMatching("");
+    SimTK_TEST(theWorld.hasComponent("Foo"));
+    SimTK_TEST(!theWorld.hasComponent("Nonexistant"));
+    SimTK_TEST(theWorld.hasComponent<Foo>("Foo"));
+    SimTK_TEST(!theWorld.hasComponent<Bar>("Foo"));
+    SimTK_TEST(!theWorld.hasComponent<Foo>("Nonexistant"));
+
+
     bar.updConnector<Foo>("childFoo").connect(foo2);
     string connectorName = bar.updConnector<Foo>("childFoo").getConcreteClassName();
 


### PR DESCRIPTION
This PR introduces a method on Component to help users discover the full path names of components in their model. This came out of the discussion in #1025. To facilitate this method, I created a new ComponentList filter: ComponentFilterFullPathNameRegex.

@tkuchida @klshrinidhi please review!