### PR TITLE
Default constructor for Joint in bindings.

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -51,6 +51,9 @@ constructors because they have additional arguments.
 */
 %define EXPOSE_JOINT_CONSTRUCTORS_HELPER(NAME)
 %extend OpenSim::NAME {
+    NAME() {
+        return new NAME();
+    }
     NAME(const std::string& name,
          const PhysicalFrame& parent,
          const PhysicalFrame& child) {

--- a/Bindings/Java/tests/TestBasics.java
+++ b/Bindings/Java/tests/TestBasics.java
@@ -17,6 +17,10 @@ class TestBasics {
          }
          fi.next();
     }
+
+    // Ensure Joint has a default constructor.
+    PinJoint pj = new PinJoint();
+
     System.out.println("Test finished!");
     // TODO to cause test to fail: System.exit(-1);
   }

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -84,6 +84,9 @@ constructors because they have additional arguments.
 */
 %define EXPOSE_JOINT_CONSTRUCTORS_HELPER(NAME)
 %extend OpenSim::NAME {
+    NAME() {
+        return new NAME();
+    }
 	NAME(const std::string& name,
          const PhysicalFrame& parent,
          const PhysicalFrame& child) {


### PR DESCRIPTION
This PR introduces default constructors for Joint into swig. In C++, one can default-construct Joints. This was missing in wrapping.

@aymanhab would you be willing to review this?