### PR TITLE
add #ifdef WITH_BTK to Adapters.h

### DIFF
--- a/OpenSim/Common/Adapters.h
+++ b/OpenSim/Common/Adapters.h
@@ -26,4 +26,9 @@
 #include "DelimFileAdapter.h"
 #include "STOFileAdapter.h"
 #include "CSVFileAdapter.h"
+
+#ifdef WITH_BTK
+
 #include "C3DFileAdapter.h"
+
+#endif


### PR DESCRIPTION
Necessary when WITH_BTK is unchecked since C3DFileAdapter.h will not be installed.

@chrisdembia 