### PR TITLE
Allow building and running the answers for hopper.

### DIFF
--- a/OpenSim/Sandbox/ExampleHopperDevice/CMakeLists.txt
+++ b/OpenSim/Sandbox/ExampleHopperDevice/CMakeLists.txt
@@ -1,7 +1,25 @@
-add_executable(exampleHopperDevice exampleHopperDevice.cpp buildHopperModel.cpp buildDeviceModel.cpp defineDeviceAndController.h helperMethods.h)
+add_executable(exampleHopperDevice
+    exampleHopperDevice.cpp
+    buildHopperModel.cpp
+    buildDeviceModel.cpp
+    defineDeviceAndController.h
+    helperMethods.h)
 target_link_libraries(exampleHopperDevice osimTools)
 set_target_properties(exampleHopperDevice PROPERTIES
     PROJECT_LABEL "Hopper Device"
     FOLDER "Examples"
+    EXCLUDE_FROM_ALL TRUE
+    )
+
+add_executable(exampleHopperDeviceAnswers
+    exampleHopperDevice_answers.cpp
+    buildHopperModel.cpp
+    buildDeviceModel_answers.cpp
+    defineDeviceAndController_answers.h
+    helperMethods.h)
+target_link_libraries(exampleHopperDeviceAnswers osimTools)
+set_target_properties(exampleHopperDeviceAnswers PROPERTIES
+    PROJECT_LABEL "Hopper Device Answers"
+    FOLDER "Example answers"
     EXCLUDE_FROM_ALL TRUE
     )

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -34,7 +34,7 @@ Several lines of code need to be added to this file; see exampleHopperDevice.cpp
 and the "TODO" comments below for instructions. */
 
 #include <OpenSim/OpenSim.h>
-#include "defineDeviceAndController.h"
+#include "defineDeviceAndController_answers.h"
 #include "helperMethods.h"
 
 static const double OPTIMAL_FORCE{ 4000. };

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -37,7 +37,7 @@ From there, you will be directed to specific files and methods in this project
 that need to be completed. Now, hop to it! */
 
 #include <OpenSim/OpenSim.h>
-#include "defineDeviceAndController.h"
+#include "defineDeviceAndController_answers.h"
 #include "helperMethods.h"
 
 static const double SIGNAL_GEN_CONSTANT{ 0.33 };
@@ -211,7 +211,7 @@ int main()
     //==========================================================================
     // Step 2. Build an assistive device and test it on a simple testbed.
     //==========================================================================
-    if (false)
+    if (true)
     {
         // Build the testbed and device.
         auto testbed = buildTestbed();
@@ -266,7 +266,7 @@ int main()
     //==========================================================================
     // Step 3. Connect the device to the hopper to increase hop height.
     //==========================================================================
-    if (false)
+    if (true)
     {
         // Build the hopper and device.
         auto assistedHopper = buildHopper();


### PR DESCRIPTION
I changed my mind about creating a cmake target for the answers. It is very useful for development to have a target for the answers (for debugging, and future incorporating fixes from the API). This PR creates a target for the answers.

If we really want to, we can remove the target before the workshop.