### PR TITLE
[doxygen] Remove autolink to Exception

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -574,7 +574,7 @@ public:
      * Coordinate.safeDownCast(coord).getDefaultClamped() % now accessible.
      * @endcode
      *
-     * Exception: in Python, you will get the concrete type (in most cases):
+     * %Exception: in Python, you will get the concrete type (in most cases):
      * @code{.py}
      * coord = model.getComponent('right_elbow/elbow_flexion')
      * coord.getDefaultClamped() # works; no downcasting necessary. 


### PR DESCRIPTION
[ci skip]

I wanted to use the word Exception in a doxygen comment, but not refer to `OpenSim::Exception`. I replaced `Exception` with `%Exception` to remove the autolink to `OpenSim::Exception`.