### PR TITLE
Fix documentation for AbstractChannel and AbstractOutput

### DIFF
--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -38,6 +38,27 @@ namespace OpenSim {
 
 class Component;
 
+/** One of the values of an Output. */
+class AbstractChannel {
+public:
+    virtual ~AbstractChannel() = default;
+    /** The name of this channel, or the name of the output that
+    contains this Channel if it's in a single-value Output. */
+    virtual const std::string& getChannelName() const = 0;
+    /** The name of this channel appended to the name of the output that
+     * contains this channel. The output name and channel name are separated by
+     * a colon (e.g., "markers:medial_knee"). If the output that contains
+     * this channel is a single-value Output, then this is just the Output's 
+     * name. */
+    virtual std::string getName() const = 0;
+    /** This returns the full path name of the component to which this channel
+     * belongs prepended to the channel's name. For example, this 
+     * method might return something like "/model/metabolics/heat_rate:soleus_r".
+     */
+    virtual std::string getPathName() const = 0;
+};
+
+
 //=============================================================================
 //                           OPENSIM COMPONENT OUTPUT
 //=============================================================================
@@ -67,26 +88,6 @@ class Component;
  * to Inputs.
  * @author  Ajay Seth
  */
-
-/** One of the values of an Output. */
-class AbstractChannel {
-public:
-    virtual ~AbstractChannel() = default;
-    /** The name of this channel, or the name of the output that
-    contains this Channel if it's in a single-value Output. */
-    virtual const std::string& getChannelName() const = 0;
-    /** The name of this channel appended to the name of the output that
-     * contains this channel. The output name and channel name are separated by
-     * a colon (e.g., "markers:medial_knee"). If the output that contains
-     * this channel is a single-value Output, then this is just the Output's 
-     * name. */
-    virtual std::string getName() const = 0;
-    /** This returns the full path name of the component to which this channel
-     * belongs prepended to the channel's name. For example, this 
-     * method might return something like "/model/metabolics/heat_rate:soleus_r".
-     */
-    virtual std::string getPathName() const = 0;
-};
 
 class OSIMCOMMON_API AbstractOutput {
 public:


### PR DESCRIPTION
The `AbstractChannel` class had been inserted between AbstractOutput's documentation and definition, mangling the resulting doxygen. [ci skip] @chrisdembia