### PR TITLE
Improvements to Reporter labels

### DIFF
--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -169,12 +169,13 @@ protected:
 
         std::vector<std::string> labels;
         for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
-            const auto& chan = input.getChannel(idx);
-            std::string label = chan.getName();
-            if (label.empty()) {
-                label = chan.getOutput().getName();
-            }
-            labels.push_back(label);
+            // Always set the label to the full path name.
+            // TODO: Currently, a default annotation is set by Input::connect()
+            //       if none was provided by the user. Because the user may have
+            //       explicitly specified an annotation equal to the default, it
+            //       is impossible to determine whether the annotation should be
+            //       used here instead of the full path name.
+            labels.push_back( input.getChannel(idx).getPathName() );
         }
         const_cast<Self*>(this)->_outputTable.setColumnLabels(labels);
     }
@@ -215,8 +216,10 @@ private:
             std::cout << "[" << this->getName() << "] " << "\n";
             std::cout << std::setw(_width) << "time" << "| ";
             for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
-                const auto& chan = input.getChannel(idx);
-                const auto& outName = chan.getName();
+                // Always set the label to the Input's annotation, which will be
+                // either the annotation provided by the user or a default
+                // annotation set by Input::connect().
+                const auto& outName = input.getAnnotation(idx);
                 const auto& truncName = 
                     static_cast<int>(outName.size()) <= _width ?
                     outName : outName.substr(outName.size() - _width);

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -132,11 +132,12 @@ void addConsoleReporterToHopper(Model& hopper)
     //TODO: Connect outputs from the hopper to the reporter's inputs. Try
     //      reporting the hopper's height, the vastus muscle's activation, the
     //      knee angle, and any other variables of interest.
-    reporter->updInput("inputs").connect(hopper.getOutput(hopperHeightOutput));
+    reporter->updInput("inputs").connect(
+        hopper.getOutput(hopperHeightOutput), "height");
     reporter->updInput("inputs").connect(
         hopper.getOutput("/Dennis/vastus/activation"));
     reporter->updInput("inputs").connect(
-        hopper.getOutput("/Dennis/knee/kneeFlexion/value"));
+        hopper.getOutput("/Dennis/knee/kneeFlexion/value"), "knee_angle");
 
     //TODO: Add the reporter to the model.
     hopper.addComponent(reporter);

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -89,7 +89,7 @@ int main() {
     reporter->set_report_time_interval(1.0);
     reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
     reporter->updInput("inputs").connect(
-        elbow->getCoordinateSet()[0].getOutput("value"));
+        elbow->getCoordinateSet()[0].getOutput("value"), "elbow_angle");
     model.addComponent(reporter);
 
     // Configure the model.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ int main() {
     reporter->set_report_time_interval(1.0);
     reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
     reporter->updInput("inputs").connect(
-        elbow->getCoordinateSet()[0].getOutput("value"));
+        elbow->getCoordinateSet()[0].getOutput("value"), "elbow_angle");
     model.addComponent(reporter);
 
     // Configure the model.
@@ -104,7 +104,7 @@ This code produces the following animation:
 and prints the following information to the console:
 
         [reporter]
-                time|  fiber_force|       value|
+                time|  fiber_force| elbow_angle|
                    0|     1.180969|   1.5707963|
                    1|     57.27509|  0.77066412|
                    2|    19.728411|   1.5680456|


### PR DESCRIPTION
ConsoleReporters now set labels using Input annotations, which can be specified by the user; TableReporters use full path names because, presumably, a user would want this detailed information in a file (and we are currently unable to determine the user's intent if they happen to specify an annotation that is the same as the default; added TODO in Reporter.h). Updates to hopper example and README.

Fixes #1034