### PR TITLE
Improvements to hopper example

### DIFF
--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
@@ -63,8 +63,8 @@ Device* buildDevice() {
     auto sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
-    sphere->setFrame(*cuffA); cuffA->attachGeometry(sphere);
-    //sphere->setFrame(*cuffB); cuffB->attachGeometry(sphere->clone());
+    cuffA->attachGeometry(sphere);
+    //cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
     auto anchorA = new WeldJoint();

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -74,8 +74,8 @@ Device* buildDevice() {
     auto sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
-    sphere->setFrame(*cuffA); cuffA->attachGeometry(sphere);
-    sphere->setFrame(*cuffB); cuffB->attachGeometry(sphere->clone());
+    cuffA->attachGeometry(sphere);
+    cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
     auto anchorA = new WeldJoint();

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildHopperModel.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildHopperModel.cpp
@@ -89,7 +89,7 @@ Model buildHopper() {
     // Set the coordinate names and default values. Note that we need "auto&"
     // here so that we get a reference to the CoordinateSet rather than a copy.
     auto& sliderCoord = sliderToGround->upd_CoordinateSet()[0];
-    sliderCoord.setName("height");
+    sliderCoord.setName("yCoord");
     sliderCoord.setDefaultValue(1.);
 
     auto& hipCoord = hip->upd_CoordinateSet()[0];

--- a/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController.h
@@ -45,7 +45,7 @@ namespace OpenSim {
 // [Step 2, Task A]
 //------------------------------------------------------------------------------
 class Device : public ModelComponent {
-    OpenSim_DECLARE_CONCRETE_OBJECT(Device, Component);
+    OpenSim_DECLARE_CONCRETE_OBJECT(Device, ModelComponent);
 
 public:
     // Outputs that report quantities in which we are interested.

--- a/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
@@ -45,7 +45,7 @@ namespace OpenSim {
 // [Step 2, Task A]
 //------------------------------------------------------------------------------
 class Device : public ModelComponent {
-    OpenSim_DECLARE_CONCRETE_OBJECT(Device, Component);
+    OpenSim_DECLARE_CONCRETE_OBJECT(Device, ModelComponent);
 
 public:
     // Outputs that report quantities in which we are interested.

--- a/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
@@ -129,7 +129,7 @@ public:
         //const std::string hopperHeightOutput = "/Dennis/?????"; //fill this in
         #pragma region Step2_TaskA_solution
 
-        const std::string hopperHeightOutput = "/Dennis/slider/height/value";
+        const std::string hopperHeightOutput = "/Dennis/slider/yCoord/value";
 
         #pragma endregion
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -53,7 +53,7 @@ static const std::string testbedAttachment2{"load"};
 //static const std::string hopperHeightOutput{"/Dennis/?????"}; //fill this in
 #pragma region Step1_TaskA_solution
 
-static const std::string hopperHeightOutput{"/Dennis/slider/height/value"};
+static const std::string hopperHeightOutput{"/Dennis/slider/yCoord/value"};
 
 #pragma endregion
 


### PR DESCRIPTION
Changed from "height" to "yCoord" to avoid confusion with output not being "height" but rather "height/value". We may also want a unique delimiter between Component path and Output; added to discussion at #1069.

[ci skip]