### PR TITLE
Fix typo in comment [ci skip]

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -179,7 +179,7 @@ protected:
     /** Validate the given row. 
 
     \throws InvalidRow If the timestamp for the row breaks strictly increasing
-                       property of the indepedent column.                     */
+                       property of the independent column.                     */
     void validateRow(size_t rowIndex,
                      const double& time, 
                      const RowVector& row) const override {


### PR DESCRIPTION
PR fixes the typo in TimeSeriesTable.h