### PR TITLE
Update testComponents to use addComponent

### DIFF
--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -217,7 +217,8 @@ void testComponent(const Component& instanceToTest)
 
             if (dependency == nullptr){
                 // Get a concrete instance of a PhysicalFrame, which is a Body
-                if (dependencyTypeName == "PhysicalFrame"){
+                size_t n = dependencyTypeName.length();
+                if (n > 4 && dependencyTypeName.substr(n-5) == "Frame") {
                     dependency = Object::newInstanceOfType("Body");
                 }
             }
@@ -467,7 +468,7 @@ void addObjectAsComponentToModel(Object* instance, Model& model)
     const string& className = instance->getConcreteClassName();
     cout << "Adding " << className << " to the model." << endl;
 
-    try{
+   // try{
         if (Object::isObjectTypeDerivedFrom< Analysis >(className))
             model.addAnalysis(dynamic_cast<Analysis*>(instance));
         else if (Object::isObjectTypeDerivedFrom< Body >(className))
@@ -486,21 +487,23 @@ void addObjectAsComponentToModel(Object* instance, Model& model)
             model.addJoint(dynamic_cast<Joint*>(instance));
         else if (Object::isObjectTypeDerivedFrom< Frame >(className))
             model.addFrame(dynamic_cast<Frame*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< ModelComponent >(className))
+        else if (Object::isObjectTypeDerivedFrom< Component >(className))
             model.addComponent(dynamic_cast<Component*>(instance));
         else
         {
             throw Exception(className + " is not a Component.",
                 __FILE__, __LINE__);
         }
-    }
+   // }
     // It is more than likely that connect() will fail, but the subcomponents tree
     // will be traversable, so we can continue to resolve dependencies by visiting
     // subcomponents' connectors
+    /*
     catch (const std::exception& e) {
         cout << "testComponents: Model unable to connect after adding ";
         cout << instance->getName() << endl;
         cout << "ERROR: " << e.what() << "'" << endl;
         cout << "Possible that dependency was not added yet. Continuing...." << endl;
     }
+    */
 }

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -466,7 +466,7 @@ void addObjectAsComponentToModel(Object* instance, Model& model)
     cout << "Adding " << className << " to the model." << endl;
 
     if (Object::isObjectTypeDerivedFrom< Analysis >(className))
-        model.addAnalysis(dynamic_cast<Analysis*>(instance));
+        throw Exception("Analysis is not a Component.", __FILE__, __LINE__);
     else if (Object::isObjectTypeDerivedFrom< Body >(className))
         model.addBody(dynamic_cast<Body*>(instance));
     else if (Object::isObjectTypeDerivedFrom< Constraint >(className))

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -487,10 +487,10 @@ void addObjectAsComponentToModel(Object* instance, Model& model)
         else if (Object::isObjectTypeDerivedFrom< Frame >(className))
             model.addFrame(dynamic_cast<Frame*>(instance));
         else if (Object::isObjectTypeDerivedFrom< ModelComponent >(className))
-            model.addModelComponent(dynamic_cast<ModelComponent*>(instance));
+            model.addComponent(dynamic_cast<Component*>(instance));
         else
         {
-            throw Exception(className + " is not a ModelComponent.",
+            throw Exception(className + " is not a Component.",
                 __FILE__, __LINE__);
         }
     }

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -468,42 +468,28 @@ void addObjectAsComponentToModel(Object* instance, Model& model)
     const string& className = instance->getConcreteClassName();
     cout << "Adding " << className << " to the model." << endl;
 
-   // try{
-        if (Object::isObjectTypeDerivedFrom< Analysis >(className))
-            model.addAnalysis(dynamic_cast<Analysis*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Body >(className))
-            model.addBody(dynamic_cast<Body*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Constraint >(className))
-            model.addConstraint(dynamic_cast<Constraint*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< ContactGeometry >(className))
-            model.addContactGeometry(dynamic_cast<ContactGeometry*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Controller >(className))
-            model.addController(dynamic_cast<Controller*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Force >(className))
-            model.addForce(dynamic_cast<Force*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Probe >(className))
-            model.addProbe(dynamic_cast<Probe*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Joint >(className))
-            model.addJoint(dynamic_cast<Joint*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Frame >(className))
-            model.addFrame(dynamic_cast<Frame*>(instance));
-        else if (Object::isObjectTypeDerivedFrom< Component >(className))
-            model.addComponent(dynamic_cast<Component*>(instance));
-        else
-        {
-            throw Exception(className + " is not a Component.",
-                __FILE__, __LINE__);
-        }
-   // }
-    // It is more than likely that connect() will fail, but the subcomponents tree
-    // will be traversable, so we can continue to resolve dependencies by visiting
-    // subcomponents' connectors
-    /*
-    catch (const std::exception& e) {
-        cout << "testComponents: Model unable to connect after adding ";
-        cout << instance->getName() << endl;
-        cout << "ERROR: " << e.what() << "'" << endl;
-        cout << "Possible that dependency was not added yet. Continuing...." << endl;
+    if (Object::isObjectTypeDerivedFrom< Analysis >(className))
+        model.addAnalysis(dynamic_cast<Analysis*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Body >(className))
+        model.addBody(dynamic_cast<Body*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Constraint >(className))
+        model.addConstraint(dynamic_cast<Constraint*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< ContactGeometry >(className))
+        model.addContactGeometry(dynamic_cast<ContactGeometry*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Controller >(className))
+        model.addController(dynamic_cast<Controller*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Force >(className))
+        model.addForce(dynamic_cast<Force*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Probe >(className))
+        model.addProbe(dynamic_cast<Probe*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Joint >(className))
+        model.addJoint(dynamic_cast<Joint*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Frame >(className))
+        model.addFrame(dynamic_cast<Frame*>(instance));
+    else if (Object::isObjectTypeDerivedFrom< Component >(className))
+        model.addComponent(dynamic_cast<Component*>(instance));
+    else {
+        throw Exception(className + " is not a Component.",
+            __FILE__, __LINE__);
     }
-    */
 }

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -215,12 +215,9 @@ void testComponent(const Component& instanceToTest)
             Object* dependency =
                 Object::newInstanceOfType(dependencyTypeName);
 
-            if (dependency == nullptr){
-                // Get a concrete instance of a PhysicalFrame, which is a Body
-                size_t n = dependencyTypeName.length();
-                if (n > 4 && dependencyTypeName.substr(n-5) == "Frame") {
-                    dependency = Object::newInstanceOfType("Body");
-                }
+            if (dynamic_cast< Connector<Frame>*>(&connector) ||
+                dynamic_cast< Connector<PhysicalFrame>*>(&connector)) {
+                dependency = Object::newInstanceOfType("Body");
             }
 
             if (dependency) {


### PR DESCRIPTION
testComponents is no longer limited to ModelComponents.  Now that any component can be added to Model, we do not need to limit to tested components to be of type `ModelComponent`. It now throws if the object being tested is not a `Component` and causes the test to fail.