### PR TITLE
Fix gcc 5.2 error about "duplicate const" in bindings.

### DIFF
--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -86,9 +86,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
         ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # We purposefully wrap deprecated functions, so no need to see such warnings.
     set(COMPILE_FLAGS "-Wno-deprecated-declarations")
-    # C++ does not allow "const const T," but SWIG generates "const const T"
-    # even if we did not use it in the orignal source code (bug in SWIG).
-    set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-duplicate-decl-specifier")
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
     # Don't warn about:
     # 4996: deprecated functions.

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -124,9 +124,6 @@ macro(OpenSimAddPythonModule)
         # Note that the last optimization flag is what counts for GCC. So an -O0
         # later on the command line overrides a previous -O2.
         set(_COMPILE_FLAGS "-O0 -Wno-deprecated-declarations")
-        # C++ does not allow "const const T," but SWIG generates "const const T"
-        # even if we did not use it in the orignal source code (bug in SWIG).
-        set(_COMPILE_FLAGS "${_COMPILE_FLAGS} -Wno-duplicate-decl-specifier")
     elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "MSVC")
         # TODO disable optimization on Windows.
         # Don't warn about:

--- a/OpenSim/Common/ArrayPtrs.h
+++ b/OpenSim/Common/ArrayPtrs.h
@@ -86,6 +86,10 @@ protected:
 // CONSTRUCTION
 //=============================================================================
 public:
+
+// This typedef is used to avoid "duplicate const" errors with SWIG.
+typedef typename std::add_const<T>::type ConstT;
+
 //_____________________________________________________________________________
 /**
  * Destructor.
@@ -556,7 +560,7 @@ int size() const {return getSize();}
  * @return Index of the object with the address aObject.  If no such object
  * exists in the array, -1 is returned.
  */
-int getIndex(const T *aObject,int aStartIndex=0) const
+int getIndex(ConstT *aObject,int aStartIndex=0) const
 {
     if(aStartIndex<0) aStartIndex=0;
     if(aStartIndex>=getSize()) aStartIndex=0;
@@ -770,7 +774,7 @@ bool remove(int aIndex)
  * specified address is not found, no action is taken.
  * @return True if the removal was successful, false otherwise.
  */
-bool remove(const T* aObject)
+bool remove(ConstT* aObject)
 {
     int index = getIndex(aObject);
     return( remove(index) );
@@ -968,7 +972,7 @@ T* getLast() const
  * is empty), or the array contains no element that is less than or equal
  * to aValue, -1 is returned.
  */
-int searchBinary(const T &aObject,bool aFindFirst=false,
+int searchBinary(ConstT& aObject,bool aFindFirst=false,
                       int aLo=-1,int aHi=-1) const
 {
     if(_size<=0) return(-1);

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -112,12 +112,17 @@ public:
 
     static_assert(std::is_base_of<Component, T>::value,
         "Can only create a ComponentList of Components.");
+
+    // This typedef is used to avoid "duplicate const" errors with SWIG,
+    // caused when "T" is "const Component," leading to
+    // "const const Component."
+    typedef typename std::add_const<T>::type ConstT;
     
     /** A const forward iterator for iterating through ComponentList<T>.
     The const indicates that the iterator provides only 
     const references/pointers, and that components can't be modified 
     through this iterator. */
-    typedef ComponentListIterator<const T> const_iterator;
+    typedef ComponentListIterator<ConstT> const_iterator;
     
     /** If T is const (e.g., ComponentList<const Body>), then this is
     the same as const_iterator, and does not allow modifying the elements.
@@ -226,6 +231,10 @@ template <typename T>
 class ComponentListIterator :
     public std::iterator<std::forward_iterator_tag, Component>
 {
+    // This typedef is used to avoid "duplicate const" errors with SWIG,
+    // caused when "T" is "const Component," leading to
+    // "const const Component."
+    typedef typename std::add_const<T>::type ConstT;
     // The template argument T may be const or non-const; this typedef is
     // always the non-const variant of T. The typedef is useful for friend
     // declarations and casting.
@@ -322,7 +331,7 @@ public:
     
     /** @internal ComponentListIterator<const T> needs access to the members
     of ComponentListIterator<T> for the templated constructor above. */
-    friend class ComponentListIterator<const T>;
+    friend class ComponentListIterator<ConstT>;
     /** @internal Comparison operators for ComponentListIterator<T> need
     access to members of ComponentListIterator<const T> (e.g., when invoking
     operator==() with a ComponentListIterator<T> as the left operand and a


### PR DESCRIPTION
This PR fixes a compiler error with newer versions of gcc, related to duplicate const (`const const T`) that occurs in bindings. This fixes #1096.