### PR TITLE
[gitignore] Ignore settings directory from CLion IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 tmp
 # Ignore build trees.
 build*
+# Ignore settings from the CLion IDE (from JetBrains).
+.idea
 
 # python
 *.pyc


### PR DESCRIPTION
The CLion C++ IDE creates a settings directory `.idea` that should not be committed to the repo. This makes sure it doesn't happen by accident.

I cancelled the CI because I forgot to do `[ci skip]`.