### PR TITLE
[appveyor] Workaround for MSVC Update 3 bug

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@
   
 shallow_clone: true
 
-os: Visual Studio 2015
+os: Previous Visual Studio 2015
 
 platform: x64
 


### PR DESCRIPTION
Update 3 to MSVC 2015 might be causing "internal compiler errors." This PR avoids this error by using the previous version of MSVC.

Thanks @carmichaelong for the detective work.

https://www.appveyor.com/updates
https://connect.microsoft.com/VisualStudio/Feedback/Details/2896447
https://connect.microsoft.com/VisualStudio/feedback/details/2869042/new-internal-compiler-error-only-in-vs2015-update-3