### PR TITLE
Fix markPropertiesAsSubcomponents invalidate bug

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1102,36 +1102,25 @@ void Component::markPropertiesAsSubcomponents()
 void Component::markAsPropertySubcomponent(const Component* component)
 {
     // Only add if the component is not already a part of this Component
-    // So, add if empty
     SimTK::ReferencePtr<Component> compRef(const_cast<Component*>(component));
-    if (_propertySubcomponents.empty() ){
+    auto it =
+        std::find(_propertySubcomponents.begin(), _propertySubcomponents.end(), compRef);
+    if ( it == _propertySubcomponents.end() ){
         // Must reconstruct the reference pointer in place in order
         // to invoke move constuctor from SimTK::Array::push_back 
         // otherwise it will copy and reset the Component pointer to null.
         _propertySubcomponents.push_back(
             SimTK::ReferencePtr<Component>(const_cast<Component*>(component)));
     }
-    else{ //otherwise check that it isn't a part of the component already
-        auto it =
-            std::find(_propertySubcomponents.begin(), _propertySubcomponents.end(), compRef);
-        if ( it == _propertySubcomponents.end() ){
-            // Must reconstruct the reference pointer in place in order
-            // to invoke move constuctor from SimTK::Array::push_back 
-            // otherwise it will copy and reset the Component pointer to null.
-            _propertySubcomponents.push_back(
-                SimTK::ReferencePtr<Component>(const_cast<Component*>(component)));
-        }
-        else{
-            auto compPath = component->getFullPathName();
-            auto foundPath = it->get()->getFullPathName();
-            OPENSIM_THROW( ComponentAlreadyPartOfOwnershipTree,
-                           component->getName(), getName());
-        }
+    else{
+        auto compPath = component->getFullPathName();
+        auto foundPath = it->get()->getFullPathName();
+        OPENSIM_THROW( ComponentAlreadyPartOfOwnershipTree,
+                       component->getName(), getName());
     }
 
     compRef->setParent(*this);
 }
-
 
 // Include another Component as a subcomponent of this one. If already a
 // subcomponent, it is not added to the list again.

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1105,13 +1105,21 @@ void Component::markAsPropertySubcomponent(const Component* component)
     // So, add if empty
     SimTK::ReferencePtr<Component> compRef(const_cast<Component*>(component));
     if (_propertySubcomponents.empty() ){
-        _propertySubcomponents.push_back(compRef);
+        // Must reconstruct the reference pointer in place in order
+        // to invoke move constuctor from SimTK::Array::push_back 
+        // otherwise it will copy and reset the Component pointer to null.
+        _propertySubcomponents.push_back(
+            SimTK::ReferencePtr<Component>(const_cast<Component*>(component)));
     }
     else{ //otherwise check that it isn't a part of the component already
         auto it =
             std::find(_propertySubcomponents.begin(), _propertySubcomponents.end(), compRef);
         if ( it == _propertySubcomponents.end() ){
-            _propertySubcomponents.push_back(compRef);
+            // Must reconstruct the reference pointer in place in order
+            // to invoke move constuctor from SimTK::Array::push_back 
+            // otherwise it will copy and reset the Component pointer to null.
+            _propertySubcomponents.push_back(
+                SimTK::ReferencePtr<Component>(const_cast<Component*>(component)));
         }
         else{
             auto compPath = component->getFullPathName();


### PR DESCRIPTION
in Component::markPropertiesAsSubcomponents(), calls to updPropertyByIndex(), updPropertyByName(), and updValueAsObject() trigger the component to be marked as invalid. Therefore, changed these to getXXX(). But we still want the _propertySubcomponents list to be a vector of non-const references so in Component::markAsPropertySubcomponent() we const_cast before appending to the list.

Note: this is a proposed fix, but has not been tested (was just done at workshop). Perhaps it should be moved to a new branch for testing. I'm not sure how to PR to create a new branch...