### PR TITLE
Allow SWIG to recognize that Mat33, etc is wrapped.

### DIFF
--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -18,6 +18,7 @@ namespace SimTK {
 
 // Mat33
 %include <SWIGSimTK/Mat.h>
+%include <SimTKcommon/SmallMatrix.h> // for typedefs like Mat33.
 namespace SimTK {
 %template(Mat33) Mat<3, 3>;
 }


### PR DESCRIPTION
Previously, SWIG did not know about the Mat33 typedef, so if SWIG saw
Mat33 in a header file, it would not know that it was the same type that it
had already wrapped.

@aymanhab or @klshrinidhi, could you review please?

This bug was discovered by @humphreysb.