### PR TITLE
ID and IK Tools throw for empty model filename

### DIFF
--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -103,11 +103,11 @@ Object::Object(const string &aFileName, bool aUpdateFromXMLNode)
     // going all the way down to the parser to throw an exception for null document!
     // -Ayman 8/06
     OPENSIM_THROW_IF(aFileName.empty(), Exception,
-        "Object::Cannot construct from empty filename. No filename specified.");
+        "Object: Cannot construct from empty filename. No filename specified.");
 
     OPENSIM_THROW_IF(!ifstream(aFileName.c_str(), ios_base::in).good(),
         Exception,
-        "Object::Cannot not open file " + aFileName +
+        "Object: Cannot not open file " + aFileName +
         ". It may not exist or you do not have permission to read it.");
 
     _document = new XMLDocument(aFileName);

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -102,16 +102,13 @@ Object::Object(const string &aFileName, bool aUpdateFromXMLNode)
     // This maybe slower than we like but definitely faster than 
     // going all the way down to the parser to throw an exception for null document!
     // -Ayman 8/06
-    if(aFileName.empty()) {
-        string msg =
-            "Object: ERR- Empty filename encountered.";
-        throw Exception(msg,__FILE__,__LINE__);
-    } else 
-        if(!ifstream(aFileName.c_str(), ios_base::in).good()) {
-        string msg =
-            "Object: ERR- Could not open file " + aFileName+ ". It may not exist or you don't have permission to read it.";
-        throw Exception(msg,__FILE__,__LINE__);
-    }   
+    OPENSIM_THROW_IF(aFileName.empty(), Exception,
+        "Object::Cannot construct from empty filename. No filename specified.");
+
+    OPENSIM_THROW_IF(!ifstream(aFileName.c_str(), ios_base::in).good(),
+        Exception,
+        "Object::Cannot not open file " + aFileName +
+        ". It may not exist or you do not have permission to read it.");
 
     _document = new XMLDocument(aFileName);
 

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -244,8 +244,12 @@ bool InverseDynamicsTool::run()
     bool modelFromFile=true;
     try{
         //Load and create the indicated model
-        if (!_model) 
+        if (!_model) {
+            OPENSIM_THROW_IF_FRMOBJ(_modelFileName.empty(), Exception,
+                "No model filename was provided.")
+
             _model = new Model(_modelFileName);
+        }
         else
             modelFromFile = false;
         _model->printBasicInfo(cout);

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -261,8 +261,11 @@ bool InverseKinematicsTool::run()
     bool modelFromFile=true;
     try{
         //Load and create the indicated model
-        if (!_model) 
+        if (!_model) {
+            OPENSIM_THROW_IF_FRMOBJ(_modelFileName.empty(), Exception,
+                "No model filename was provided.");
             _model = new Model(_modelFileName);
+        }
         else
             modelFromFile = false;
 


### PR DESCRIPTION
Added an explicit check for unspecified model file in `InverseDynamicsTool` and `InverseKinematicsTool` and to provide an appropriate error message.
Addresses #1099