### PR TITLE
Throw exception if user forgot to call initSystem()

### DIFF
--- a/OpenSim/Analyses/PointKinematics.cpp
+++ b/OpenSim/Analyses/PointKinematics.cpp
@@ -51,7 +51,6 @@ const int PointKinematics::BUFFER_LENGTH = PointKinematicsBUFFER_LENGTH;
  */
 PointKinematics::~PointKinematics()
 {
-    if(_dy!=NULL) { delete[] _dy;  _dy=NULL; }
     deleteStorage();
 }
 //_____________________________________________________________________________
@@ -150,7 +149,6 @@ void PointKinematics::
 setNull()
 {
     // POINTERS
-    _dy = NULL;
     _kin = NULL;
     _pStore = NULL;
     _vStore = NULL;
@@ -314,12 +312,6 @@ setModel(Model& aModel)
     _body = &aModel.updBodySet().get(_bodyName);
     if (aModel.updBodySet().contains(_relativeToBodyName))
         _relativeToBody = &aModel.updBodySet().get(_relativeToBodyName);
-
-    // ALLOCATIONS
-    if (_dy != 0)
-        delete[] _dy;
-
-    _dy = new double[_model->getNumStateVariables()];
 
     // DESCRIPTION AND LABELS
     constructDescription();

--- a/OpenSim/Analyses/PointKinematics.h
+++ b/OpenSim/Analyses/PointKinematics.h
@@ -85,7 +85,6 @@ protected:
     std::string &_pointName;
     std::string &_relativeToBodyName;
 
-    double *_dy;
     double *_kin;
     Storage *_pStore;
     Storage *_vStore;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -566,7 +566,7 @@ unsigned Component::printComponentsMatching(const std::string& substring) const
 int Component::getNumStateVariables() const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     //Get the number of state variables added (or exposed) by this Component
     int ns = getNumStateVariablesAddedByComponent(); 
@@ -727,7 +727,7 @@ const Component::StateVariable* Component::
     findStateVariable(const std::string& name) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     // first assume that the state variable named belongs to this
     // top level component
@@ -771,7 +771,7 @@ const Component::StateVariable* Component::
 Array<std::string> Component::getStateVariableNames() const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     Array<std::string> names = getStateVariablesNamesAddedByComponent();
 
@@ -842,7 +842,7 @@ double Component::
     getStateVariableValue(const SimTK::State& s, const std::string& name) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     // find the state variable with this component or its subcomponents
     const StateVariable* rsv = findStateVariable(name);
@@ -864,7 +864,7 @@ double Component::
                                 const std::string& name) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     computeStateVariableDerivatives(state);
     
@@ -897,7 +897,7 @@ void Component::
     setStateVariableValue(State& s, const std::string& name, double value) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     // find the state variable
     const StateVariable* rsv = findStateVariable(name);
@@ -947,7 +947,7 @@ SimTK::Vector Component::
     getStateVariableValues(const SimTK::State& state) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     int nsv = getNumStateVariables();
     // if the StateVariables are invalid (see above) rebuild the list
@@ -974,7 +974,7 @@ void Component::
     setStateVariableValues(SimTK::State& state, const SimTK::Vector& values)
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     int nsv = getNumStateVariables();
 
@@ -1024,7 +1024,7 @@ double Component::
 getDiscreteVariableValue(const SimTK::State& s, const std::string& name) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     std::map<std::string, DiscreteVariableInfo>::const_iterator it;
     it = _namedDiscreteVariableInfo.find(name);
@@ -1049,7 +1049,7 @@ void Component::
 setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value) const
 {
     // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     std::map<std::string, DiscreteVariableInfo>::const_iterator it;
     it = _namedDiscreteVariableInfo.find(name);

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -896,6 +896,9 @@ double Component::
 void Component::
     setStateVariableValue(State& s, const std::string& name, double value) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     // find the state variable
     const StateVariable* rsv = findStateVariable(name);
 
@@ -999,9 +1002,6 @@ void Component::
     setStateVariableDerivativeValue(const State& state, 
                                const std::string& name, double value) const
 {
-    // Must have already called initSystem.
-    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
-
     std::map<std::string, StateVariableInfo>::const_iterator it;
     it = _namedStateVariableInfo.find(name);
 

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -565,6 +565,9 @@ unsigned Component::printComponentsMatching(const std::string& substring) const
 
 int Component::getNumStateVariables() const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     //Get the number of state variables added (or exposed) by this Component
     int ns = getNumStateVariablesAddedByComponent(); 
     // And then include the states of its subcomponents
@@ -723,6 +726,9 @@ const AbstractConnector* Component::findConnector(const std::string& name) const
 const Component::StateVariable* Component::
     findStateVariable(const std::string& name) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     // first assume that the state variable named belongs to this
     // top level component
     std::string::size_type back = name.rfind("/");
@@ -764,6 +770,9 @@ const Component::StateVariable* Component::
 // its subcomponents.
 Array<std::string> Component::getStateVariableNames() const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     Array<std::string> names = getStateVariablesNamesAddedByComponent();
 
 /** TODO: Use component iterator  like below
@@ -832,6 +841,9 @@ Array<std::string> Component::getStateVariableNames() const
 double Component::
     getStateVariableValue(const SimTK::State& s, const std::string& name) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     // find the state variable with this component or its subcomponents
     const StateVariable* rsv = findStateVariable(name);
     if (rsv) {
@@ -851,6 +863,9 @@ double Component::
     getStateVariableDerivativeValue(const SimTK::State& state, 
                                 const std::string& name) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     computeStateVariableDerivatives(state);
     
     std::map<std::string, StateVariableInfo>::const_iterator it;
@@ -928,6 +943,9 @@ bool Component::isAllStatesVariablesListValid() const
 SimTK::Vector Component::
     getStateVariableValues(const SimTK::State& state) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     int nsv = getNumStateVariables();
     // if the StateVariables are invalid (see above) rebuild the list
     if (!isAllStatesVariablesListValid()) {
@@ -952,6 +970,9 @@ SimTK::Vector Component::
 void Component::
     setStateVariableValues(SimTK::State& state, const SimTK::Vector& values)
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     int nsv = getNumStateVariables();
 
     SimTK_ASSERT(values.size() == nsv,
@@ -978,6 +999,9 @@ void Component::
     setStateVariableDerivativeValue(const State& state, 
                                const std::string& name, double value) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     std::map<std::string, StateVariableInfo>::const_iterator it;
     it = _namedStateVariableInfo.find(name);
 
@@ -999,6 +1023,9 @@ void Component::
 double Component::
 getDiscreteVariableValue(const SimTK::State& s, const std::string& name) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     std::map<std::string, DiscreteVariableInfo>::const_iterator it;
     it = _namedDiscreteVariableInfo.find(name);
 
@@ -1021,6 +1048,9 @@ getDiscreteVariableValue(const SimTK::State& s, const std::string& name) const
 void Component::
 setDiscreteVariableValue(SimTK::State& s, const std::string& name, double value) const
 {
+    // Must have already called initSystem.
+    OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
     std::map<std::string, DiscreteVariableInfo>::const_iterator it;
     it = _namedDiscreteVariableInfo.find(name);
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -89,7 +89,6 @@ public:
     }
 };
 
-
 class ComponentAlreadyPartOfOwnershipTree : public Exception {
 public:
     ComponentAlreadyPartOfOwnershipTree(const std::string& file,
@@ -101,6 +100,20 @@ public:
         std::string msg = "Component '" + compName;
         msg += "' already owned by tree to which '" + thisName;
         msg += "' belongs. Clone the component to adopt a fresh copy.";
+        addMessage(msg);
+    }
+};
+
+class ComponentHasNoSystem : public Exception {
+public:
+    ComponentHasNoSystem(const std::string& file,
+                         size_t line,
+                         const std::string& func,
+                         const std::string& thisName) :
+        Exception(file, line, func) {
+        std::string msg = "Component '" + thisName;
+        msg += "' has not been added to a System.\nYou must call initSystem ";
+        msg += "on the top-level Component (i.e., Model) first.";
         addMessage(msg);
     }
 };
@@ -627,16 +640,18 @@ public:
     unsigned printComponentsMatching(const std::string& substring) const;
 
     /**
-     * Get the number of "Continuous" state variables maintained by the Component
-     * and its subcomponents
+     * Get the number of "continuous" state variables maintained by the
+     * Component and its subcomponents.
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     int getNumStateVariables() const;
 
     /**
      * Get the names of "continuous" state variables maintained by the Component
-     * and its subcomponents. Note that states are defined when the system is 
-     * created. Make sure to call initSystem on the top  level Component
-     * (e.g. Model)
+     * and its subcomponents.
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     Array<std::string> getStateVariableNames() const;
 
@@ -1050,6 +1065,8 @@ public:
      *
      * @param state   the State for which to get the value
      * @param name    the name (string) of the state variable of interest
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     double getStateVariableValue(const SimTK::State& state, const std::string& name) const;
 
@@ -1059,6 +1076,8 @@ public:
      * @param state  the State for which to set the value
      * @param name   the name of the state variable
      * @param value  the value to set
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     void setStateVariableValue(SimTK::State& state, const std::string& name, double value) const;
 
@@ -1070,6 +1089,8 @@ public:
      * @param state   the State for which to get the value
      * @return Vector of state variable values of length getNumStateVariables()
      *                in the order returned by getStateVariableNames()
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     SimTK::Vector getStateVariableValues(const SimTK::State& state) const;
 
@@ -1078,8 +1099,11 @@ public:
      * Includes state variables allocated by its subcomponents.
      *
      * @param state   the State for which to get the value
-     * @param values  Vector of state variable values of length getNumStateVariables()
-     *                in the order returned by getStateVariableNames()
+     * @param values  Vector of state variable values of length
+     *                getNumStateVariables() in the order returned by
+     *                getStateVariableNames()
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     void setStateVariableValues(SimTK::State& state, const SimTK::Vector& values);
 
@@ -1088,6 +1112,8 @@ public:
      *
      * @param state   the State for which to get the derivative value
      * @param name    the name (string) of the state variable of interest
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     double getStateVariableDerivativeValue(const SimTK::State& state, 
         const std::string& name) const;
@@ -1098,8 +1124,11 @@ public:
      * @param state   the State from which to get the value
      * @param name    the name of the state variable
      * @return value  the discrete variable value
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
-    double getDiscreteVariableValue(const SimTK::State& state, const std::string& name) const;
+    double getDiscreteVariableValue(const SimTK::State& state,
+                                    const std::string& name) const;
 
     /**
      * %Set the value of a discrete variable allocated by this Component by name.
@@ -1107,8 +1136,11 @@ public:
      * @param state  the State for which to set the value
      * @param name   the name of the discrete variable
      * @param value  the value to set
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
-    void setDiscreteVariableValue(SimTK::State& state, const std::string& name, double value) const;
+    void setDiscreteVariableValue(SimTK::State& state, const std::string& name,
+                                  double value) const;
 
     /**
      * Get the value of a cache variable allocated by this Component by name.
@@ -1116,10 +1148,15 @@ public:
      * @param state  the State from which to get the value
      * @param name   the name of the cache variable
      * @return T     const reference to the cache variable's value
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     template<typename T> const T& 
     getCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1136,18 +1173,23 @@ public:
         }
     }
     /**
-     * Obtain a writable cache variable value allocated by this Component by name.
-     * Do not forget to mark the cache value as valid after updating, otherwise it
-     * will force a reevaluation if the evaluation method is monitoring the 
-     * validity of the cache value.
+     * Obtain a writable cache variable value allocated by this Component by
+     * name. Do not forget to mark the cache value as valid after updating,
+     * otherwise it will force a re-evaluation if the evaluation method is
+     * monitoring the validity of the cache value.
      *
      * @param state  the State for which to set the value
      * @param name   the name of the state variable
      * @return value modifiable reference to the cache variable's value
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     template<typename T> T& 
     updCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1167,17 +1209,23 @@ public:
     }
 
     /**
-     * After updating a cache variable value allocated by this Component, you can
-     * mark its value as valid, which will not change until the realization stage 
-     * falls below the minimum set at the time the cache variable was created. If 
-     * not marked as valid, the evaluation method monitoring this flag will force 
-     * a re-evaluation rather that just reading the value from the cache.
+     * After updating a cache variable value allocated by this Component, you
+     * can mark its value as valid, which will not change until the realization
+     * stage falls below the minimum set at the time the cache variable was
+     * created. If not marked as valid, the evaluation method monitoring this
+     * flag will force a re-evaluation rather that just reading the value from
+     * the cache.
      *
      * @param state  the State containing the cache variable
      * @param name   the name of the cache variable
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     void markCacheVariableValid(const SimTK::State& state, const std::string& name) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1195,24 +1243,29 @@ public:
     }
 
     /**
-     * Mark a cache variable value allocated by this Component as invalid.
-     * When the system realization drops to below the lowest valid stage, cache 
+     * Mark a cache variable value allocated by this Component as invalid. When
+     * the system realization drops to below the lowest valid stage, cache
      * variables are automatically marked as invalid. There are instances when
-     * component added state variables require invalidating a cache at a lower 
-     * stage. For example, a component may have a length state variable which 
-     * should invalidate calculations involving it and other positions when the 
-     * state variable is set. Changing the component state variable automatically
-     * invalidates Dynamics and higher realizations, but to force realizations
-     * at Position and Velocity requires setting the lowest valid stage to 
-     * Position and marking the cache variable as invalid whenver the length
-     * state variable value is set/changed.
+     * component-added state variables require invalidating a cache at a lower
+     * stage. For example, a component may have a "length" state variable which
+     * should invalidate calculations involving it and other positions when the
+     * state variable is set. Changing the component state variable
+     * automatically invalidates Dynamics and higher realizations, but to force
+     * realizations at Position and Velocity requires setting the lowest valid
+     * stage to Position and marking the cache variable as invalid whenever the
+     * "length" state variable value is set/changed.
      *
      * @param state  the State containing the cache variable
      * @param name   the name of the cache variable
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     void markCacheVariableInvalid(const SimTK::State& state, 
                                   const std::string& name) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1230,17 +1283,22 @@ public:
     }
 
     /**
-     * Enables the user to monitor the validity of the cache variable value using the
-     * returned flag. For components performing a costly evaluation, use this 
-     * method to force a re-evaluation cache variable value only when necessary 
-     * (returns false).
+     * Enables the user to monitor the validity of the cache variable value
+     * using the returned flag. For components performing a costly evaluation,
+     * use this method to force a re-evaluation of a cache variable value only
+     * when necessary (i.e., returns false).
      *
      * @param state  the State in which the cache value resides
      * @param name   the name of the cache variable
      * @return bool  whether the cache variable value is valid or not
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     bool isCacheVariableValid(const SimTK::State& state, const std::string& name) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1258,18 +1316,23 @@ public:
     }
 
     /**
-     *  %Set cache variable value allocated by this Component by name.
-     *  All cache entries are lazily evaluated (on a need basis) so a set
-     *  also marks the cache as valid.
+     * %Set cache variable value allocated by this Component by name. All cache
+     * entries are lazily evaluated (on a need basis) so a set also marks the
+     * cache as valid.
      *
      * @param state  the State in which to store the new value
      * @param name   the name of the cache variable
      * @param value  the new value for this cache variable
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
      */
     template<typename T> void 
     setCacheVariableValue(const SimTK::State& state, const std::string& name, 
                      const T& value) const
     {
+        // Must have already called initSystem.
+        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
 
@@ -1617,7 +1680,7 @@ protected:
     virtual void computeStateVariableDerivatives(const SimTK::State& s) const;
 
     /**
-     * %Set the derivative of a state variable by name when computed inside of  
+     * %Set the derivative of a state variable by name when computed inside of
      * this Component's computeStateVariableDerivatives() method.
      *
      * @param state  the State for which to set the value
@@ -1815,17 +1878,19 @@ protected:
     const int getStateIndex(const std::string& name) const;
 
    /**
-     * Get the System Index of a state variable allocated by this Component.  
+     * Get the System Index of a state variable allocated by this Component.
      * Returns an InvalidIndex if no state variable with the name provided is
      * found.
-     * @param stateVariableName   the name of the state variable 
+     * @param stateVariableName   the name of the state variable
      */
     SimTK::SystemYIndex 
         getStateVariableSystemIndex(const std::string& stateVariableName) const;
 
-    /** Get the index of a Component's discrete variable in the Subsystem for allocations.
-        This method is intended for derived Components that may need direct access
-        to its underlying Subsystem.*/
+   /**
+     * Get the index of a Component's discrete variable in the Subsystem for
+     * allocations. This method is intended for derived Components that may need
+     * direct access to its underlying Subsystem.
+     */
     const SimTK::DiscreteVariableIndex 
     getDiscreteVariableIndex(const std::string& name) const;
 
@@ -1946,10 +2011,14 @@ protected:
 #endif
 
 public:
-    /** Similarly find a Connector of this Component (includes its subcomponents) */
+    /** Find a Connector of this Component (includes its subcomponents). */
     const AbstractConnector* findConnector(const std::string& name) const;
-    /** Similarly find a StateVariable of this Component (includes its subcomponents) */
 #ifndef SWIG // StateVariable is protected.
+    /**
+     * Find a StateVariable of this Component (includes its subcomponents).
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
+     */
     const StateVariable* findStateVariable(const std::string& name) const;
 #endif
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -109,11 +109,11 @@ public:
     ComponentHasNoSystem(const std::string& file,
                          size_t line,
                          const std::string& func,
-                         const std::string& thisName) :
-        Exception(file, line, func) {
-        std::string msg = "Component '" + thisName;
-        msg += "' has not been added to a System.\nYou must call initSystem ";
-        msg += "on the top-level Component (i.e., Model) first.";
+                         const Object& obj) :
+        Exception(file, line, func, obj) {
+        std::string msg = "This Component has not been added to a System.\n";
+        msg += "You must call initSystem on the top-level Component ";
+        msg += "(i.e., Model) first.";
         addMessage(msg);
     }
 };
@@ -1155,7 +1155,7 @@ public:
     getCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
@@ -1188,7 +1188,7 @@ public:
     updCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
@@ -1224,7 +1224,7 @@ public:
     void markCacheVariableValid(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
@@ -1264,7 +1264,7 @@ public:
                                   const std::string& name) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
@@ -1297,7 +1297,7 @@ public:
     bool isCacheVariableValid(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);
@@ -1331,7 +1331,7 @@ public:
                      const T& value) const
     {
         // Must have already called initSystem.
-        OPENSIM_THROW_IF(!hasSystem(), ComponentHasNoSystem, getName().c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
         std::map<std::string, CacheInfo>::const_iterator it;
         it = _namedCacheVariableInfo.find(name);

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -388,6 +388,42 @@ void testMisc() {
     theWorld.setName("World");
     theWorld.finalizeFromProperties();
 
+    // ComponentHasNoSystem exception should be thrown if user attempts to read
+    // or write state, discrete, or cache variables before Component has an
+    // underlying MultibodySystem.
+    {
+        SimTK::State sBlank;
+        ASSERT_THROW(ComponentHasNoSystem, theWorld.findStateVariable("waldo"));
+        ASSERT_THROW(ComponentHasNoSystem, theWorld.getNumStateVariables());
+        ASSERT_THROW(ComponentHasNoSystem, theWorld.getStateVariableNames());
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.getStateVariableValue(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.setStateVariableValue(sBlank, "waldo", 0.));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.getStateVariableValues(sBlank));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.setStateVariableValues(sBlank, SimTK::Vector(1, 0.)));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.getStateVariableDerivativeValue(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.getDiscreteVariableValue(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.setDiscreteVariableValue(sBlank, "waldo", 0.));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.getCacheVariableValue<double>(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.setCacheVariableValue(sBlank, "waldo", 0.));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.updCacheVariableValue<double>(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.markCacheVariableValid(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.markCacheVariableInvalid(sBlank, "waldo"));
+        ASSERT_THROW(ComponentHasNoSystem,
+            theWorld.isCacheVariableValid(sBlank, "waldo"));
+    }
+
     TheWorld* cloneWorld = theWorld.clone();
     cloneWorld->setName("ClonedWorld");
     cloneWorld->finalizeFromProperties();

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -393,35 +393,37 @@ void testMisc() {
     // underlying MultibodySystem.
     {
         SimTK::State sBlank;
-        ASSERT_THROW(ComponentHasNoSystem, theWorld.findStateVariable("waldo"));
+        const std::string varName = "waldo"; //dummy name
+
+        ASSERT_THROW(ComponentHasNoSystem, theWorld.findStateVariable(varName));
         ASSERT_THROW(ComponentHasNoSystem, theWorld.getNumStateVariables());
         ASSERT_THROW(ComponentHasNoSystem, theWorld.getStateVariableNames());
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.getStateVariableValue(sBlank, "waldo"));
+            theWorld.getStateVariableValue(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.setStateVariableValue(sBlank, "waldo", 0.));
+            theWorld.setStateVariableValue(sBlank, varName, 0.));
         ASSERT_THROW(ComponentHasNoSystem,
             theWorld.getStateVariableValues(sBlank));
         ASSERT_THROW(ComponentHasNoSystem,
             theWorld.setStateVariableValues(sBlank, SimTK::Vector(1, 0.)));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.getStateVariableDerivativeValue(sBlank, "waldo"));
+            theWorld.getStateVariableDerivativeValue(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.getDiscreteVariableValue(sBlank, "waldo"));
+            theWorld.getDiscreteVariableValue(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.setDiscreteVariableValue(sBlank, "waldo", 0.));
+            theWorld.setDiscreteVariableValue(sBlank, varName, 0.));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.getCacheVariableValue<double>(sBlank, "waldo"));
+            theWorld.getCacheVariableValue<double>(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.setCacheVariableValue(sBlank, "waldo", 0.));
+            theWorld.setCacheVariableValue(sBlank, varName, 0.));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.updCacheVariableValue<double>(sBlank, "waldo"));
+            theWorld.updCacheVariableValue<double>(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.markCacheVariableValid(sBlank, "waldo"));
+            theWorld.markCacheVariableValid(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.markCacheVariableInvalid(sBlank, "waldo"));
+            theWorld.markCacheVariableInvalid(sBlank, varName));
         ASSERT_THROW(ComponentHasNoSystem,
-            theWorld.isCacheVariableValid(sBlank, "waldo"));
+            theWorld.isCacheVariableValid(sBlank, varName));
     }
 
     TheWorld* cloneWorld = theWorld.clone();

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -622,13 +622,11 @@ void compareUmbergerProbeToPublishedResults()
 //   - total energy at final time equals integral of total rate
 //   - multiple muscles are correctly handled
 //   - less energy is liberated with lower activation
-Storage simulateModel(Model& model,double t0, double t1)
+Storage simulateModel(Model& model, double t0, double t1)
 {
     // Initialize model and state.
     cout << "- initializing" << endl;
     SimTK::State& state = model.initSystem();
-
-    
 
     for (int i=0; i<model.getMuscles().getSize(); ++i)
         model.getMuscles().get(i).setIgnoreActivationDynamics(state, true);
@@ -640,8 +638,7 @@ Storage simulateModel(Model& model,double t0, double t1)
     SimTK::RungeKuttaMersonIntegrator integrator(model.getMultibodySystem());
     integrator.setAccuracy(integrationAccuracy);
 
-    Manager manager(model,integrator);
-
+    Manager manager(model, integrator);
     manager.setInitialTime(t0);
     manager.setFinalTime(t1);
 
@@ -1047,13 +1044,11 @@ void testProbesUsingMillardMuscleSimulation()
     //--------------------------------------------------------------------------
     const double t0 = 0.0;
     const double t1 = 2.0;
-    Manager manager(model);
-    simulateModel(model, t0, t1);
+    auto stateStorage = simulateModel(model, t0, t1);
 
     // Output results files.
     if (OUTPUT_FILES) {
         std::string fname = baseFilename + "_states.sto";
-        Storage stateStorage(manager.getStateStorage());
         stateStorage.print(fname);
         cout << "+ saved state storage file: " << fname << endl;
 

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -745,11 +745,12 @@ void testExport() {
     // Trying to export the trajectory with an incompatible model.
     {
         Model arm26("arm26.osim");
+        SimTK::State differentState = arm26.initSystem();
         SimTK_TEST_MUST_THROW_EXC(states.exportToTable(arm26),
                                   StatesTrajectory::IncompatibleModel);
     }
 
-    // Exception if given a non-existant column name.
+    // Exception if given a non-existent column name.
     SimTK_TEST_MUST_THROW_EXC(
             states.exportToTable(gait, {"knee_l/knee_angle_l/value",
                                         "not_an_actual_state",


### PR DESCRIPTION
Added checks to ensure initSystem() has been called before attempting to access state, discrete, or cache variables owned by a Component or its descendants. An exception will be thrown that instructs the user to call initSystem() first (rather than reporting that the specified state variable was not found, for example). Added tests to testComponentInterface.cpp. Fixes #729 and propagated to include the following methods:

StateVariable
-------------
* findStateVariable
* getNumStateVariables
* getStateVariableNames
* getStateVariableValue, setStateVariableValue
* getStateVariableValues, setStateVariableValues
* getStateVariableDerivativeValue

DiscreteVariable
----------------
* getDiscreteVariableValue, setDiscreteVariableValue

CacheVariable
-------------
* getCacheVariableValue, setCacheVariableValue, updCacheVariableValue
* markCacheVariableValid, markCacheVariableInvalid, isCacheVariableValid