### PR TITLE
Simple python API example

### DIFF
--- a/Bindings/Python/simple-arm.py
+++ b/Bindings/Python/simple-arm.py
@@ -1,27 +1,33 @@
-# ----------------------------------------------------------------------- %
-# The OpenSim API is a toolkit for musculoskeletal modeling and           %
-# simulation. See http://opensim.stanford.edu and the NOTICE file         %
-# for more information. OpenSim is developed at Stanford University       %
-# and supported by the US National Institutes of Health (U54 GM072970,    %
-# R24 HD065690) and by DARPA through the Warrior Web program.             %
-#                                                                         %   
-# Copyright (c) 2005-2012 Stanford University and the Authors             %
-# Author(s): Dominic Farris                                               %
-#                                                                         %
-# Licensed under the Apache License, Version 2.0 (the "License");         %
-# you may not use this file except in compliance with the License.        %
-# You may obtain a copy of the License at                                 %
-# http://www.apache.org/licenses/LICENSE-2.0.                             %
-#                                                                         % 
-# Unless required by applicable law or agreed to in writing, software     %
-# distributed under the License is distributed on an "AS IS" BASIS,       %
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or         %
-# implied. See the License for the specific language governing            %
-# permissions and limitations under the License.                          %
-# ----------------------------------------------------------------------- %
+# ----------------------------------------------------------------------- #
+# The OpenSim API is a toolkit for musculoskeletal modeling and           #
+# simulation. See http://opensim.stanford.edu and the NOTICE file         #
+# for more information. OpenSim is developed at Stanford University       #
+# and supported by the US National Institutes of Health (U54 GM072970,    #
+# R24 HD065690) and by DARPA through the Warrior Web program.             #
+#                                                                         #   
+# Copyright (c) 2005-2012 Stanford University and the Authors             #
+# Author(s): Neil Dhir                                                    #
+#                                                                         #
+# Licensed under the Apache License, Version 2.0 (the "License");         #
+# you may not use this file except in compliance with the License.        #
+# You may obtain a copy of the License at                                 #
+# http://www.apache.org/licenses/LICENSE-2.0.                             #
+#                                                                         # 
+# Unless required by applicable law or agreed to in writing, software     #
+# distributed under the License is distributed on an "AS IS" BASIS,       #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or         #
+# implied. See the License for the specific language governing            #
+# permissions and limitations under the License.                          #
+# ----------------------------------------------------------------------- #
 
 # simple-arm.py                                                        
 # Author: Neil Dhir
+# ------------------------------------------------------------------------#
+# ABSTRACT: This short piece of OpenSim python API example mimics         #
+# the simple-arm example found on the core landing page. Though it does   #
+# not include forward simulation, but instead saves the model to an .osim #
+# file which can be used in the GUI for further analysis.		  #
+# ------------------------------------------------------------------------#
 
 import opensim as osim
 
@@ -80,14 +86,14 @@ biceps.addNewPathPoint("insertion",
    	radius,
    	osim.Vec3(0, 0.7, 0))
 
-# # ---------------------------------------------------------------------------
-# # Add a controller that specifies the excitation of the muscle.
-# # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Add a controller that specifies the excitation of the muscle.
+# ---------------------------------------------------------------------------
 
 brain = osim.PrescribedController()
 brain.addActuator(biceps)
-brain.prescribeControlForActuator(1,					
-	osim.StepFunction(0.5,3.0,0.3,1.0))
+brain.prescribeControlForActuator(1, # Actuator's index in controller set					
+	osim.StepFunction(0.5, 3.0, 0.3, 1.0))
 	
 # ---------------------------------------------------------------------------
 # Build model with components created above.
@@ -104,12 +110,12 @@ arm.addController(brain)
 # Add a console reporter to print the muscle fibre force and elbow angle.
 # ---------------------------------------------------------------------------
 
-# We want to write our simulation to a file in the end
+# We want to write our simulation to a file in the end.
 reporter = osim.TableReporter()				
 reporter.set_report_time_interval(1.0)
 reporter.updInput("inputs").connect(biceps.getOutput("fiber_force"))
-reporter.updInput("inputs").connect(elbow.getCoordinateSet().get(0)\
-	.getOutput("value"), "elbow_angle")
+elbow_cord = elbow.getCoordinateSet().get(0).getOutput("value")
+reporter.updInput("inputs").connect(elbow_cord, "elbow_angle")
 arm.addComponent(reporter)
 
 # ---------------------------------------------------------------------------
@@ -123,9 +129,6 @@ arm.updCoordinateSet().get(1).setValue(state, 0.5 * osim.SimTK_PI)
 arm.equilibrateMuscles(state)
 
 # ---------------------------------------------------------------------------
-# We don't care about graphical simulation so we won't do that.
-# Python API currently does not support forward simulation.
-# 
 # Print/save model file
 # ---------------------------------------------------------------------------
 

--- a/Bindings/Python/simple-arm.py
+++ b/Bindings/Python/simple-arm.py
@@ -69,16 +69,16 @@ elbow = osim.PinJoint("elbow",
 
 biceps = osim.Millard2012AccelerationMuscle("biceps", 	# 	Muscle name
    	200.0, 	 	#	Max isometric force
-    0.6, 		# 	Optimal fibre length
-    0.55, 		# 	Tendon slack length
-    0.0)		# 	Pennation angle
+    	0.6, 		# 	Optimal fibre length
+    	0.55, 		# 	Tendon slack length
+    	0.0)		# 	Pennation angle
 biceps.addNewPathPoint("origin",						
-   humerus, 						
-   osim.Vec3(0, 0.8, 0))			
+   	humerus, 						
+   	osim.Vec3(0, 0.8, 0))			
 
 biceps.addNewPathPoint("insertion",
-   radius,
-   osim.Vec3(0, 0.7, 0))
+   	radius,
+   	osim.Vec3(0, 0.7, 0))
 
 # # ---------------------------------------------------------------------------
 # # Add a controller that specifies the excitation of the muscle.
@@ -88,11 +88,7 @@ brain = osim.PrescribedController()
 brain.addActuator(biceps)
 brain.prescribeControlForActuator(1,					
 	osim.StepFunction(0.5,3.0,0.3,1.0))
-# chrisdembia: I'm also pretty sure "1" would be incorrect as the index.
-#              Why doesn't it work to pass a name?
-# neildhir: adding a string causes python to crash with this error:
-# neildhir: [Finished in 0.9s with exit code -11]
-
+	
 # ---------------------------------------------------------------------------
 # Build model with components created above.
 # ---------------------------------------------------------------------------
@@ -128,9 +124,9 @@ arm.equilibrateMuscles(state)
 
 # ---------------------------------------------------------------------------
 # We don't care about graphical simulation so we won't do that.
-# Python API currently lacking forward simulation.
+# Python API currently does not support forward simulation.
 # 
-# Print model file
+# Print/save model file
 # ---------------------------------------------------------------------------
 
 arm.printToXML("SimpleArm.osim")

--- a/Bindings/Python/simple-arm.py
+++ b/Bindings/Python/simple-arm.py
@@ -1,0 +1,136 @@
+# ----------------------------------------------------------------------- %
+# The OpenSim API is a toolkit for musculoskeletal modeling and           %
+# simulation. See http://opensim.stanford.edu and the NOTICE file         %
+# for more information. OpenSim is developed at Stanford University       %
+# and supported by the US National Institutes of Health (U54 GM072970,    %
+# R24 HD065690) and by DARPA through the Warrior Web program.             %
+#                                                                         %   
+# Copyright (c) 2005-2012 Stanford University and the Authors             %
+# Author(s): Dominic Farris                                               %
+#                                                                         %
+# Licensed under the Apache License, Version 2.0 (the "License");         %
+# you may not use this file except in compliance with the License.        %
+# You may obtain a copy of the License at                                 %
+# http://www.apache.org/licenses/LICENSE-2.0.                             %
+#                                                                         % 
+# Unless required by applicable law or agreed to in writing, software     %
+# distributed under the License is distributed on an "AS IS" BASIS,       %
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or         %
+# implied. See the License for the specific language governing            %
+# permissions and limitations under the License.                          %
+# ----------------------------------------------------------------------- %
+
+# simple-arm.py                                                        
+# Author: Neil Dhir
+
+import opensim as osim
+
+# Define global model where the arm lives.
+arm = osim.Model()
+
+# ---------------------------------------------------------------------------
+# Create two links, each with a mass of 1 kg, centre of mass at the body's
+# origin, and moments and products of inertia of zero.
+# ---------------------------------------------------------------------------
+
+# chrisdembia: use 4 spaces instead of tabs
+humerus = osim.Body('humerus',
+	1.0,
+	osim.Vec3(0, 0, 0),
+	osim.Inertia(0, 0, 0))
+radius = osim.Body('radius',
+	1.0,
+	osim.Vec3(0, 0, 0),
+	osim.Inertia(0, 0, 0))
+
+# ---------------------------------------------------------------------------
+# Connect the bodies with pin joints. Assume each body is 1m long.
+# ---------------------------------------------------------------------------
+
+shoulder = osim.PinJoint("shoulder",
+	arm.getGround(), 	    # PhysicalFrame
+	osim.Vec3(0, 0, 0),
+	osim.Vec3(0, 0, 0),
+	humerus, 				# PhysicalFrame
+	osim.Vec3(0, 0, 0),
+	osim.Vec3(0, 1, 0))
+
+elbow = osim.PinJoint("elbow",
+	humerus, 				# PhysicalFrame
+	osim.Vec3(0, 0, 0),
+	osim.Vec3(0, 0, 0),
+	radius, 				# PhysicalFrame
+	osim.Vec3(0, 0, 0),
+	osim.Vec3(0, 1, 0))
+
+# ---------------------------------------------------------------------------
+# Add a muscle that flexes the elbow (actuator for robotics people).
+# ---------------------------------------------------------------------------
+
+biceps = osim.Millard2012AccelerationMuscle("biceps", 	# 	Muscle name
+   	200.0, 	 	#	Max isometric force
+    0.6, 		# 	Optimal fibre length
+    0.55, 		# 	Tendon slack length
+    0.0)		# 	Pennation angle
+biceps.addNewPathPoint("origin",						
+   humerus, 						
+   osim.Vec3(0, 0.8, 0))			
+
+biceps.addNewPathPoint("insertion",
+   radius,
+   osim.Vec3(0, 0.7, 0))
+
+# # ---------------------------------------------------------------------------
+# # Add a controller that specifies the excitation of the muscle.
+# # ---------------------------------------------------------------------------
+
+brain = osim.PrescribedController()
+brain.addActuator(biceps)
+brain.prescribeControlForActuator(1,					
+	osim.StepFunction(0.5,3.0,0.3,1.0))
+# chrisdembia: I'm also pretty sure "1" would be incorrect as the index.
+#              Why doesn't it work to pass a name?
+# neildhir: adding a string causes python to crash with this error:
+# neildhir: [Finished in 0.9s with exit code -11]
+
+# ---------------------------------------------------------------------------
+# Build model with components created above.
+# ---------------------------------------------------------------------------
+
+arm.addBody(humerus)
+arm.addBody(radius)
+arm.addJoint(shoulder)			# Now required in OpenSim4.0 
+arm.addJoint(elbow)				
+arm.addForce(biceps)
+arm.addController(brain)
+
+# ---------------------------------------------------------------------------
+# Add a console reporter to print the muscle fibre force and elbow angle.
+# ---------------------------------------------------------------------------
+
+# We want to write our simulation to a file in the end
+reporter = osim.TableReporter()				
+reporter.set_report_time_interval(1.0)
+reporter.updInput("inputs").connect(biceps.getOutput("fiber_force"))
+reporter.updInput("inputs").connect(elbow.getCoordinateSet().get(0)\
+	.getOutput("value"), "elbow_angle")
+arm.addComponent(reporter)
+
+# ---------------------------------------------------------------------------
+# Configure the model.
+# ---------------------------------------------------------------------------
+
+state = arm.initSystem()
+# Fix the shoulder at its default angle and begin with the elbow flexed.
+arm.updCoordinateSet().get(0).setLocked(state, True) 
+arm.updCoordinateSet().get(1).setValue(state, 0.5 * osim.SimTK_PI)
+arm.equilibrateMuscles(state)
+
+# ---------------------------------------------------------------------------
+# We don't care about graphical simulation so we won't do that.
+# Python API currently lacking forward simulation.
+# 
+# Print model file
+# ---------------------------------------------------------------------------
+
+arm.printToXML("SimpleArm.osim")

--- a/Bindings/Python/simple-arm.py
+++ b/Bindings/Python/simple-arm.py
@@ -48,7 +48,7 @@ radius = osim.Body('radius',
 # ---------------------------------------------------------------------------
 
 shoulder = osim.PinJoint("shoulder",
-	arm.getGround(), 	    # PhysicalFrame
+	arm.getGround(), 	    		# PhysicalFrame
 	osim.Vec3(0, 0, 0),
 	osim.Vec3(0, 0, 0),
 	humerus, 				# PhysicalFrame


### PR DESCRIPTION
This example is provided to demonstrate the utility of the python OpenSim API. It mimics the simple-arm example found on the [core landing page](https://github.com/opensim-org/opensim-core). Though it does not include forward simulation, but instead saves the model to an .osim file which can be used in the GUI for fort further analysis. 

Currently there seems to be an issue with the `prescribeControlForActuator` function which crashes python if passed a string (see line 89 of the example file), instead a integer index needs to be passed. 