### PR TITLE
Switch to "Visual Studio 2015" AppVeyor image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@
   
 shallow_clone: true
 
-os: Previous Visual Studio 2015
+os: Visual Studio 2015
 
 platform: x64
 


### PR DESCRIPTION
AppVeyor has been failing recently; testing to see whether today's platform update helps. If not, we could potentially ask for a "Visual Studio 2015 Update 2" image on our account (see [here](https://github.com/appveyor/ci/issues/890)) since the "Previous Visual Studio 2015" image changes with each platform update.