### PR TITLE
[bindings] Test SimbodyMatterSubsystem::calcResidualForce().

### DIFF
--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_dependencies(RunMatlabTests JavaBindings)
 OpenSimAddMatlabTest(TugOfWar ../examples/OpenSimCreateTugOfWarModel.m)
 OpenSimAddMatlabTest(ConnectorsInputsOutputs testConnectorsInputsOutputs.m)
 OpenSimAddMatlabTest(AccessSubcomponents testAccessSubcomponents.m)
+OpenSimAddMatlabTest(Simbody testSimbody.m)
 
 # Copy resources.
 file(COPY "${OPENSIM_SHARED_TEST_FILES_DIR}/arm26.osim"

--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -1,0 +1,21 @@
+
+import org.opensim.modeling.*
+
+% Create a model.
+model = Model('arm26.osim');
+
+s = model.initSystem();
+
+model.realizeDynamics(s);
+appliedMobilityForces = Vector();
+appliedBodyForces = VectorOfSpatialVec();
+knownUdot = Vector();
+knownLambda = Vector();
+residualMobilityForces = Vector();
+smss = model.getMatterSubsystem();
+smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces, ...
+                  knownUdot, knownLambda, residualMobilityForces);
+
+idsolver = InverseDynamicsSolver(model);
+residual = idsolver.solve(s, knownUdot);
+

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -36,3 +36,15 @@ class TestSimbody(unittest.TestCase):
         assert J.nrow() == 3
         assert J.ncol() == model.getCoordinateSet().getSize()
 
+        # Inverse dynamics.
+        model.realizeDynamics(s)
+        appliedMobilityForces = osim.Vector()
+        appliedBodyForces = osim.VectorOfSpatialVec()
+        knownUdot = osim.Vector()
+        knownLambda = osim.Vector()
+        residualMobilityForces = osim.Vector()
+        smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces,
+                          knownUdot, knownLambda, residualMobilityForces)
+
+        idsolver = osim.InverseDynamicsSolver(model)
+        residual = idsolver.solve(s, knownUdot)


### PR DESCRIPTION
This PR just makes sure that the method `SimbodyMatterSubsystem::calcResidualForce()` and the class `OpenSim::InverseDynamicsSolver` are accessible from MATLAB/Python.