### PR TITLE
[bindings] Test SimbodyMatterSubsystem::calcResidualForce()

### DIFF
--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_dependencies(RunMatlabTests JavaBindings)
 OpenSimAddMatlabTest(TugOfWar ../examples/OpenSimCreateTugOfWarModel.m)
 OpenSimAddMatlabTest(ConnectorsInputsOutputs testConnectorsInputsOutputs.m)
 OpenSimAddMatlabTest(AccessSubcomponents testAccessSubcomponents.m)
+OpenSimAddMatlabTest(Simbody testSimbody.m)
 
 # Copy resources.
 file(COPY "${OPENSIM_SHARED_TEST_FILES_DIR}/arm26.osim"

--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -6,7 +6,14 @@ model = Model('arm26.osim');
 
 s = model.initSystem();
 
-model.realizeDynamics(s);
+% Test SimbodyMatterSubsystem.calcResidualForce().
+% ------------------------------------------------
+% For the given inputs, we will actually be computing the first column
+% of the mass matrix. We accomplish this by setting all inputs to 0
+% except for the acceleration of the first coordinate.
+%   f_residual = M udot + f_inertial + f_applied 
+%              = M ~[1, 0, ...] + 0 + 0
+model.realizeVelocity(s);
 appliedMobilityForces = Vector();
 appliedBodyForces = VectorOfSpatialVec();
 knownUdot = Vector(s.getNU(), 0.0);
@@ -14,10 +21,6 @@ knownUdot.set(0, 1.0);
 knownLambda = Vector();
 residualMobilityForces = Vector();
 smss = model.getMatterSubsystem();
-% For the given inputs, we will actually be computing the first column
-% of the mass matrix.
-%   f_residual = M udot + f_inertial + f_applied 
-%              = M ~[1, 0, ...] + 0 + 0
 smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces, ...
                   knownUdot, knownLambda, residualMobilityForces);
 assert(residualMobilityForces.size() == s.getNU());
@@ -30,6 +33,8 @@ for i = 0:massMatrixFirstColumn.size()-1
     assert(abs(massMatrixFirstColumn.get(i) - residualMobilityForces.get(i)) < 1e-10);
 end
 
+% Test InverseDynamicsSolver.
+% ---------------------------
 model.realizeAcceleration(s);
 idsolver = InverseDynamicsSolver(model);
 residual = idsolver.solve(s, s.getUDot());

--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -9,13 +9,31 @@ s = model.initSystem();
 model.realizeDynamics(s);
 appliedMobilityForces = Vector();
 appliedBodyForces = VectorOfSpatialVec();
-knownUdot = Vector();
+knownUdot = Vector(s.getNU(), 0.0);
+knownUdot.set(0, 1.0);
 knownLambda = Vector();
 residualMobilityForces = Vector();
 smss = model.getMatterSubsystem();
+% For the given inputs, we will actually be computing the first column
+% of the mass matrix.
+%   f_residual = M udot + f_inertial + f_applied 
+%              = M ~[1, 0, ...] + 0 + 0
 smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces, ...
                   knownUdot, knownLambda, residualMobilityForces);
 
+% Explicitly compute the first column of the mass matrix, then copmare.
+massMatrixFirstColumn = Vector();
+smss.multiplyByM(s, knownUdot, massMatrixFirstColumn);
+assert(massMatrixFirstColumn.size() == residualMobilityForces.size());
+for i = 0:massMatrixFirstColumn.size()-1
+    assert(abs(massMatrixFirstColumn.get(i) - residualMobilityForces.get(i)) < 1e-10);
+end
+
+model.realizeAcceleration(s);
 idsolver = InverseDynamicsSolver(model);
-residual = idsolver.solve(s, knownUdot);
+residual = idsolver.solve(s, s.getUDot());
+assert(residual.size() == s.getNU());
+for i = 0:residual.size()-1
+    assert(abs(residual.get(i)) < 1e-10);
+end
 

--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -1,0 +1,21 @@
+
+import org.opensim.modeling.*
+
+% Create a model.
+model = Model('arm26.osim');
+
+s = model.initSystem();
+
+model.realizeDynamics(s);
+appliedMobilityForces = Vector();
+appliedBodyForces = VectorOfSpatialVec();
+knownUdot = Vector();
+knownLambda = Vector();
+residualMobilityForces = Vector();
+smss = model.getMatterSubsystem();
+smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces, ...
+                  knownUdot, knownLambda, residualMobilityForces);
+
+idsolver = InverseDynamicsSolver(model);
+residual = idsolver.solve(s, knownUdot);
+

--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -20,6 +20,7 @@ smss = model.getMatterSubsystem();
 %              = M ~[1, 0, ...] + 0 + 0
 smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces, ...
                   knownUdot, knownLambda, residualMobilityForces);
+assert(residualMobilityForces.size() == s.getNU());
 
 % Explicitly compute the first column of the mass matrix, then copmare.
 massMatrixFirstColumn = Vector();

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -36,3 +36,15 @@ class TestSimbody(unittest.TestCase):
         assert J.nrow() == 3
         assert J.ncol() == model.getCoordinateSet().getSize()
 
+        # Inverse dynamics.
+        model.realizeDynamics(s)
+        appliedMobilityForces = osim.Vector()
+        appliedBodyForces = osim.VectorOfSpatialVec()
+        knownUdot = osim.Vector()
+        knownLambda = osim.Vector()
+        residualMobilityForces = osim.Vector()
+        smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces,
+                          knownUdot, knownLambda, residualMobilityForces)
+
+        idsolver = osim.InverseDynamicsSolver(model)
+        residual = idsolver.solve(s, knownUdot)

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -36,17 +36,18 @@ class TestSimbody(unittest.TestCase):
         assert J.nrow() == 3
         assert J.ncol() == model.getCoordinateSet().getSize()
 
-        # Inverse dynamics.
-        model.realizeDynamics(s)
+        # Inverse dynamics from SimbodyMatterSubsystem.calcResidualForce().
+        # For the given inputs, we will actually be computing the first column
+        # of the mass matrix. We accomplish this by setting all inputs to 0
+        # except for the acceleration of the first coordinate.
+        #   f_residual = M udot + f_inertial + f_applied 
+        #              = M ~[1, 0, ...] + 0 + 0
+        model.realizeVelocity(s)
         appliedMobilityForces = osim.Vector()
         appliedBodyForces = osim.VectorOfSpatialVec()
         knownUdot = osim.Vector(s.getNU(), 0.0); knownUdot[0] = 1.0
         knownLambda = osim.Vector()
         residualMobilityForces = osim.Vector()
-        # For the given inputs, we will actually be computing the first column
-        # of the mass matrix.
-        #   f_residual = M udot + f_inertial + f_applied 
-        #              = M ~[1, 0, ...] + 0 + 0
         smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces,
                           knownUdot, knownLambda, residualMobilityForces)
         assert residualMobilityForces.size() == s.getNU()

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -49,6 +49,7 @@ class TestSimbody(unittest.TestCase):
         #              = M ~[1, 0, ...] + 0 + 0
         smss.calcResidualForce(s, appliedMobilityForces, appliedBodyForces,
                           knownUdot, knownLambda, residualMobilityForces)
+        assert residualMobilityForces.size() == s.getNU()
 
         # Explicitly compute the first column of the mass matrix, then copmare.
         massMatrixFirstColumn = osim.Vector() 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ The following classes are no longer supported in OpenSim and are removed in Open
 MATLAB and Python interfaces
 ----------------------------
 - The SimbodyMatterSubsystem class--which provides operators related to the mass
-matrix, jacobians, inverse dynamics, etc.--is now accessible in MATLAB and
+matrix, Jacobians, inverse dynamics, etc.--is now accessible in MATLAB and
 Python (PR #930).
 
 Python interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,14 @@ Removed Classes
 The following classes are no longer supported in OpenSim and are removed in OpenSim 4.0.
 - Muscle class `ContDerivMuscle_Depredated`.
 
-Python
-------
+MATLAB and Python interfaces
+----------------------------
+- The SimbodyMatterSubsystem class--which provides operators related to the mass
+matrix, jacobians, inverse dynamics, etc.--is now accessible in MATLAB and
+Python (PR #930).
+
+Python interface
+----------------
 - Improved error handling. Now, OpenSim's error messages show up as exceptions
 in Python.
 


### PR DESCRIPTION
This PR just makes sure that the method SimbodyMatterSubsystem::calcResidualForce() and the class OpenSim::InverseDynamicsSolver are accessible from MATLAB/Python.