### PR TITLE
[doxygen] Added missing escapes to `<` and `>`

### DIFF
--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -232,7 +232,7 @@ public:
     ///@}
 
     /** Attach Geometry to this Frame and have this Frame take ownership of
-        it by adding it to this Frame's <attached_geometry> property list.
+        it by adding it to this Frame's \<attached_geometry\> property list.
         The Geometry is treated as being fixed to this Frame such that the
         transform used to position the Geometry is that of this Frame. */
     void attachGeometry(OpenSim::Geometry* geom);


### PR DESCRIPTION
Doxygen was attempting to interpret `<attached_geometry>` as an html tag. [ci skip]