### PR TITLE
Fix to Millard2012AccelerationMuscle initialization method

### DIFF
--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -711,7 +711,8 @@ void Millard2012AccelerationMuscle::
         "Millard2012AccelerationMuscle: Muscle is not"
         " to date with properties");
 
-        //Initial fiber length, fiber velocity, activation from input State s
+        // Initialize the multibody system to the initial state vector.
+        setFiberLength(s, getOptimalFiberLength());
         _model->getMultibodySystem().realize(s, SimTK::Stage::Velocity);
 
         //Compute an initial muscle state that develops the desired force and
@@ -804,7 +805,7 @@ void Millard2012AccelerationMuscle::
             default:
                 std::string muscleName = getName();            
                 printf(
-                    "\n\nWARNING: Millard2012EquilibriumMuscle Initialization:"
+                    "\n\nWARNING: Millard2012AccelerationMuscle Initialization:"
                     " %s invalid error flag, setting tendon force to 0.0, "
                     "the fiber length to the optimal fiber length, "
                     "and a fiber velocity equal to 0.0 ",


### PR DESCRIPTION
Now setting guess for initial fiber length to optimal fiber length. The same line was added [to the analogous method in Millard2012EquilibriumMuscle](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp#L412) at some point. The Millard2012AccelerationMuscle has not been thoroughly tested, and many changes have been made to EquilibriumMuscle that were not propagated to AccelerationMuscle. This PR addresses #399 only.