### PR TITLE
Fix to GeometryPath for MovingPathPoints

### DIFF
--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -153,7 +153,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 
         // the body (PhysicalFrame) IS part of the actual Model and its system
         // so we can ask it for its transform w.r.t. Ground
-        pos = point->getBody().getTransformInGround(state)*point->getLocation();
+        pos = point->getLocationInGround(state);
 
         if (hints.get_show_path_points())
             DefaultGeometry::drawPathPoint(mbix, pos, getColor(state), appendToThis);


### PR DESCRIPTION
This change ends up calling `MovingPathPoint::getLocation(state)` rather than `get_location()` (the latter returns the MovingPathPoint's unused "location" property). Full explanation at the bottom of #1104. Results from visual test using gait10dof18musc.osim:

| Before | After
| --- | ---
| ![before](https://cloud.githubusercontent.com/assets/4203505/17585639/e218ff74-5f71-11e6-9ed2-63bf68812a9c.png) | ![after](https://cloud.githubusercontent.com/assets/4203505/17585642/e7245fae-5f71-11e6-8f13-bea3cbee513a.png)

Fixes #1104