### PR TITLE
Fix python memory management for prescribeControlForActuator.

### DIFF
--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -77,6 +77,14 @@ MODEL_ADOPT_HELPER(Controller);
     geom._markAdopted()
 %}
 
+// PrescribedController::prescribeControlForActuator takes ownership of
+// the passed-in function.
+// There are two overloads of this function; we append to both of them.
+// arg[1] is `Function* prescribedFunction`.
+%pythonappend OpenSim::PrescribedController::prescribeControlForActuator %{
+    args[1]._markAdopted()
+%}
+
 
 // Compensate for insufficient C++11 support in SWIG
 // =================================================

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -80,7 +80,7 @@ MODEL_ADOPT_HELPER(Controller);
 // PrescribedController::prescribeControlForActuator takes ownership of
 // the passed-in function.
 // There are two overloads of this function; we append to both of them.
-// arg[1] is `Function* prescribedFunction`.
+// args[1] is `Function* prescribedFunction`.
 %pythonappend OpenSim::PrescribedController::prescribeControlForActuator %{
     args[1]._markAdopted()
 %}

--- a/Bindings/Python/tests/test_swig_additional_interface.py
+++ b/Bindings/Python/tests/test_swig_additional_interface.py
@@ -272,6 +272,30 @@ class TestSwigAddtlInterface(unittest.TestCase):
         constr.setBody2PointLocation(osim.Vec3(1, 0, 0))
         constr.setConstantDistance(1)
         a.addConstraint(constr)
+
+    def test_PrescribedController_prescribeControlForActuator(self):
+        # Test memory management for
+        # PrescribedController::prescribeControlForActuator().
+        model = osim.Model()
+        # Body.
+        body = osim.Body('b1', 1.0, osim.Vec3(0, 0, 0), osim.Inertia(0, 0, 0))
+        model.addBody(body)
+        # Joint.
+        joint = osim.PinJoint('j1', model.getGround(), body)
+        model.addJoint(joint)
+        # Actuator.
+        actu = osim.CoordinateActuator()
+        actu.setName('actu')
+        actu.setCoordinate(joint.getCoordinateSet().get(0))
+        model.addForce(actu)
+        # Controller.
+        contr = osim.PrescribedController()
+        contr.addActuator(actu)
+        self.assertRaises(RuntimeError,
+                contr.prescribeControlForActuator, 1, osim.Constant(3))
+        # The following calls should not cause a memory leak:
+        contr.prescribeControlForActuator(0, osim.Constant(2))
+        contr.prescribeControlForActuator('actu', osim.Constant(4))
     
     def test_vec3_operators(self):
         v1 = osim.Vec3(1, 2, 3)

--- a/Bindings/Python/tests/test_swig_additional_interface.py
+++ b/Bindings/Python/tests/test_swig_additional_interface.py
@@ -286,7 +286,7 @@ class TestSwigAddtlInterface(unittest.TestCase):
         # Actuator.
         actu = osim.CoordinateActuator()
         actu.setName('actu')
-        actu.setCoordinate(joint.getCoordinateSet().get(0))
+        actu.setCoordinate(joint.get_CoordinateSet().get(0))
         model.addForce(actu)
         # Controller.
         contr = osim.PrescribedController()

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -177,10 +177,13 @@ void PrescribedController::computeControls(const SimTK::State& s, SimTK::Vector&
 void PrescribedController::
     prescribeControlForActuator(int index, Function *prescribedFunction)
 {
-    SimTK_ASSERT( index < getActuatorSet().getSize(), 
-        "PrescribedController::computeControl:  index > number of actuators" );
-    SimTK_ASSERT( index >= 0,  
-        "PrescribedController::computeControl:  index < 0" );
+    OPENSIM_THROW_IF_FRMOBJ(index < 0,  
+            Exception, "Index was " + std::to_string(index) +
+                       " but must be nonnegative." );
+    OPENSIM_THROW_IF(index >= getActuatorSet().getSize(),
+            IndexOutOfRange, (size_t)index, 0,
+            (size_t)getActuatorSet().getSize() - 1);
+
     if(index >= get_ControlFunctions().getSize())
         upd_ControlFunctions().setSize(index+1);
     upd_ControlFunctions().set(index, prescribedFunction);  


### PR DESCRIPTION
This PR addresses memory management for `PrescribedController::prescribeControlForActuator`, which adopts the passed-in Function.

This bug came up in PR #1162.

I also changed the error-handling within `prescribeControlForActuator`, since the pre-existing asserts would not cause any error message to bubble up to python.