### PR TITLE
fix model load from file with missing <VisibleObject> or <WrapObjectSet> tags

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -166,12 +166,16 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                     }
 
                     SimTK::Xml::element_iterator visObjIter = bodyIter->element_begin("VisibleObject");
-                    SimTK::Xml::Element cloneOfVisObj = visObjIter->clone();
-                    newGroundElement.insertNodeAfter(newGroundElement.node_end(), cloneOfVisObj);
+                    if (visObjIter != bodyIter->element_end()) {
+                        SimTK::Xml::Element cloneOfVisObj = visObjIter->clone();
+                        newGroundElement.insertNodeAfter(newGroundElement.node_end(), cloneOfVisObj);
+                    }
 
                     SimTK::Xml::element_iterator wrapSetIter = bodyIter->element_begin("WrapObjectSet");
-                    SimTK::Xml::Element cloneOfWrapSet = wrapSetIter->clone();
-                    newGroundElement.insertNodeAfter(newGroundElement.node_end(), cloneOfWrapSet);
+                    if (wrapSetIter != bodyIter->element_end()) {
+                        SimTK::Xml::Element cloneOfWrapSet = wrapSetIter->clone();
+                        newGroundElement.insertNodeAfter(newGroundElement.node_end(), cloneOfWrapSet);
+                    }
 
                     String test;
                     newGroundElement.writeToString(test);


### PR DESCRIPTION
Addresses #1175. I tested this locally by using testModelCopy. I removed the <VisibleObject> and <WrapObjectSet> tags from arm26.osim, then ran the test in Debug mode, which confirmed an Exception being thrown at the lines mentioned in the issue. I ran the test after the committed changes with the tags missing, and the test passed.

@aymanhab 