### PR TITLE
Removed "auto" from user-facing code

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -755,7 +755,7 @@ Array<std::string> Component::getStateVariableNames() const
         stateNames[i] = (getFullPathName() + "/" + stateNames[i]);
     }
 
-    for (auto& comp : getComponentList<Component>()) {
+    for (Component& comp : getComponentList<Component>()) {
         const std::string& pathName = comp.getFullPathName();// *this);
         Array<std::string> subStateNames = 
             comp.getStateVariablesNamesAddedByComponent();

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -590,7 +590,7 @@ public:
      * that path name location does not exist OR it is not of the correct type.
      * For example, 
      * @code 
-     *    Coordinate& coord = model.getComponent<Coordinate>("right_elbow/elbow_flexion");
+     *    auto& coord = model.getComponent<Coordinate>("right_elbow/elbow_flexion");
      * @endcode
      * returns coord which is a Coordinate named "elbow_flexion" from a Joint
      * named "right_elbow" given it is a child of the Component (Model) model.

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -495,7 +495,7 @@ public:
      * component is traversed before its subcomponents.
      *
      * @code{.cpp}
-     * for (const auto& muscle : model.getComponentList<Muscle>()) {
+     * for (const Muscle& muscle : model.getComponentList<Muscle>()) {
      *     muscle.get_max_isometric_force();
      * }
      * @endcode
@@ -518,7 +518,7 @@ public:
     the max isometric force of all muscles:
     
     @code{.cpp}
-    for (auto& muscle : model.updComponentList<Muscle>()) {
+    for (Muscle& muscle : model.updComponentList<Muscle>()) {
         muscle.set_max_isometric_force(...);
     }
     @endcode
@@ -590,7 +590,7 @@ public:
      * that path name location does not exist OR it is not of the correct type.
      * For example, 
      * @code 
-     *    auto& coord = model.getComponent<Coordinate>("right_elbow/elbow_flexion");
+     *    Coordinate& coord = model.getComponent<Coordinate>("right_elbow/elbow_flexion");
      * @endcode
      * returns coord which is a Coordinate named "elbow_flexion" from a Joint
      * named "right_elbow" given it is a child of the Component (Model) model.
@@ -1000,7 +1000,7 @@ public:
     /** Iterate through all Outputs of this component. The intent is to use
      * this in a loop as such:
      * @code
-     * for (const auto& entry : comp.getOutputs()) {
+     * for (const AbstractOutput& entry : comp.getOutputs()) {
      *     const std::string& name = entry.first;
      *     const AbstractOutput* output = entry.second.get();
      *     std::cout << output->getTypeName() << std::endl;

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -589,7 +589,7 @@ public:
     /** Get const access to the channels connected to this input.
         You can use this to iterate through the channels.
         @code{.cpp}
-        for (const auto& chan : getChannels()) {
+        for (const Channel& chan : getChannels()) {
             std::cout << chan.getValue(state) << std::endl;
         }
         @endcode

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -251,7 +251,7 @@ public:
      (even for single-value Channels).
      
      @code{.cpp}
-     for (const auto& chan : getChannels()) {
+     for (const std::pair<std::string, Channel>& chan : getChannels()) {
         std::cout << chan.second->getName() << std::endl;
      }
      @endcode
@@ -417,7 +417,7 @@ private:
  * protected:
  *     void extendFinalizeFromProperties() {
  *          Super::extendFinalizeFromProperties();
- *          for (const auto& name : getChannelsToAdd()) {
+ *          for (const std::string& name : getChannelsToAdd()) {
  *              updOutput("data").addChannel(name);
  *          }
  *     }

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -122,8 +122,8 @@ public:
 
     /** Convenience method that can be used in place of `updInput("inputs")`. 
     @code
-    ConsoleReporter* reporter = new ConsoleReporter();
-    DataSource* src = new DataSource();
+    auto* reporter = new ConsoleReporter();
+    auto* src = new DataSource();
     reporter->updInput().connect(src->getOutput("outputName"));
     @endcode
     */

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -122,8 +122,8 @@ public:
 
     /** Convenience method that can be used in place of `updInput("inputs")`. 
     @code
-    auto* reporter = new ConsoleReporter();
-    auto* src = new DataSource();
+    ConsoleReporter* reporter = new ConsoleReporter();
+    DataSource* src = new DataSource();
     reporter->updInput().connect(src->getOutput("outputName"));
     @endcode
     */

--- a/OpenSim/Examples/ControllerExample/ControllerExample.cpp
+++ b/OpenSim/Examples/ControllerExample/ControllerExample.cpp
@@ -111,8 +111,8 @@ public:
         double blockMass = getModel().getBodySet().get( "block" ).getMass();
 
         // Get pointers to each of the muscles in the model.
-        const Muscle* leftMuscle  = dynamic_cast<const Muscle*> ( &getActuatorSet().get(0) );
-        const Muscle* rightMuscle = dynamic_cast<const Muscle*> ( &getActuatorSet().get(1) );
+        auto leftMuscle  = dynamic_cast<const Muscle*> ( &getActuatorSet().get(0) );
+        auto rightMuscle = dynamic_cast<const Muscle*> ( &getActuatorSet().get(1) );
 
         // Compute the desired position of the block in the tug-of-war
         // model.

--- a/OpenSim/Examples/ControllerExample/ControllerExample.cpp
+++ b/OpenSim/Examples/ControllerExample/ControllerExample.cpp
@@ -111,8 +111,8 @@ public:
         double blockMass = getModel().getBodySet().get( "block" ).getMass();
 
         // Get pointers to each of the muscles in the model.
-        auto leftMuscle = dynamic_cast<const Muscle*>  ( &getActuatorSet().get(0) );
-        auto rightMuscle = dynamic_cast<const Muscle*> ( &getActuatorSet().get(1) );
+        const Muscle* leftMuscle  = dynamic_cast<const Muscle*> ( &getActuatorSet().get(0) );
+        const Muscle* rightMuscle = dynamic_cast<const Muscle*> ( &getActuatorSet().get(1) );
 
         // Compute the desired position of the block in the tug-of-war
         // model.
@@ -318,10 +318,10 @@ int main()
         manager.integrate( si );
 
         // Save the simulation results.
-        auto controlsTable = osimModel.getControlsTable();
+        TimeSeriesTable controlsTable = osimModel.getControlsTable();
         STOFileAdapter::write(controlsTable, "tugOfWar_controls.sto");
 
-        auto statesTable = manager.getStatesTable();
+        TimeSeriesTable statesTable = manager.getStatesTable();
         STOFileAdapter::write(statesTable, "tugOfWar_states.sto");
     }
     catch (const std::exception &ex) {

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -218,15 +218,15 @@ int main()
         manager.integrate(si);
 
         // Save results
-        auto controlsTable = osimModel.getControlsTable();
+        TimeSeriesTable controlsTable = osimModel.getControlsTable();
         STOFileAdapter::write(controlsTable, "SpringActuatedLeg_controls.sto");
 
-        auto statesTable = manager.getStatesTable();
+        TimeSeriesTable statesTable = manager.getStatesTable();
         osimModel.updSimbodyEngine().convertRadiansToDegrees(statesTable);
         STOFileAdapter::write(statesTable, 
                               "SpringActuatedLeg_states_degrees.sto");
 
-        auto forcesTable = forces->getForcesTable();
+        TimeSeriesTable forcesTable = forces->getForcesTable();
         STOFileAdapter::write(forcesTable, "actuator_forces.sto");
     }
     catch (const std::exception& ex)

--- a/OpenSim/Examples/DataTable/example1.cpp
+++ b/OpenSim/Examples/DataTable/example1.cpp
@@ -40,19 +40,19 @@ int main() {
     
     table.appendRow(0.00, row0);
 
-    auto row1 = row0 + 1;
+    SimTK::RowVector_<double> row1 = row0 + 1;
 
     table.appendRow(0.25, row1);
 
-    auto row2 = row1 + 1;
+    SimTK::RowVector_<double> row2 = row1 + 1;
 
     table.appendRow(0.50, row2);
 
-    auto row3 = row2 + 1;
+    SimTK::RowVector_<double> row3 = row2 + 1;
 
     table.appendRow(0.75, row3);
     
-    auto row4 = row3 + 1;
+    SimTK::RowVector_<double> row4 = row3 + 1;
 
     table.appendRow(1.00, row4);
 

--- a/OpenSim/Examples/DataTable/example2.cpp
+++ b/OpenSim/Examples/DataTable/example2.cpp
@@ -40,19 +40,19 @@ int main() {
     
     dataTable.appendRow(0.00, row0);
 
-    auto row1 = row0 + 1;
+    SimTK::RowVector_<double> row1 = row0 + 1;
 
     dataTable.appendRow(0.25, row1);
 
-    auto row2 = row1 + 1;
+    SimTK::RowVector_<double> row2 = row1 + 1;
 
     dataTable.appendRow(0.50, row2);
 
-    auto row3 = row2 + 1;
+    SimTK::RowVector_<double> row3 = row2 + 1;
 
     dataTable.appendRow(0.75, row3);
     
-    auto row4 = row3 + 1;
+    SimTK::RowVector_<double> row4 = row3 + 1;
 
     dataTable.appendRow(1.00, row4);
 
@@ -62,7 +62,7 @@ int main() {
 
     // Editing the DataTable to not have strictly increasing independent column
     // will fail the construction of TimeSeriesTable.
-    auto row5 = row4 + 1;
+    SimTK::RowVector_<double> row5 = row4 + 1;
     
     dataTable.appendRow(0.9, row5); // 0.9 is less than previous value (1.00).
 

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -333,10 +333,10 @@ int main()
         // SAVE THE RESULTS TO FILE //
         //////////////////////////////
         // Save the model states from forward integration
-        auto statesTable = manager.getStatesTable();
+        TimeSeriesTable statesTable = manager.getStatesTable();
         STOFileAdapter::write(statesTable, "tugOfWar_states.sto");
 
-        auto forcesTable = reporter->getForcesTable();
+        TimeSeriesTable forcesTable = reporter->getForcesTable();
         STOFileAdapter::write(forcesTable, "tugOfWar_forces.sto");
     }
     catch (const std::exception& ex)

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -234,10 +234,10 @@ int main()
 
         // Save the simulation results
         // Save the states
-        auto statesTable = manager.getStatesTable();
+        TimeSeriesTable statesTable = manager.getStatesTable();
         STOFileAdapter::write(statesTable, "tugOfWar_fatigue_states.sto");
 
-        auto forcesTable = reporter->getForcesTable();
+        TimeSeriesTable forcesTable = reporter->getForcesTable();
         STOFileAdapter::write(forcesTable, "tugOfWar_fatigue_forces.sto");
 
         // Save the muscle analysis results

--- a/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
+++ b/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
@@ -210,7 +210,7 @@ int main()
         osimModel.getMultibodySystem().realize(si, Stage::Acceleration);
         manager.integrate(si);
 
-        auto statesTable = manager.getStatesTable();
+        TimeSeriesTable statesTable = manager.getStatesTable();
         STOFileAdapter::write(statesTable, "Arm26_optimized_states.sto");
     }
     catch (const std::exception& ex)

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
@@ -48,26 +48,26 @@ Device* buildDevice() {
     using SimTK::Inertia;
 
     // Create the device.
-    Device* device = new Device();
+    auto* device = new Device();
     device->setName("device");
 
     // The device's mass is distributed between two identical cuffs that attach
     // to the hopper via WeldJoints (to be added below).
     double deviceMass = 2.0;
-    Body* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
+    auto* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
     //TODO: Repeat for cuffB.
 
     //TODO: Add the cuff Components to the device.
 
     // Attach a sphere to each cuff for visualization.
-    Sphere* sphere = new Sphere(0.01);
+    auto* sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
     cuffA->attachGeometry(sphere);
     //cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
-    WeldJoint* anchorA = new WeldJoint();
+    auto* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
     //TODO: Connect the "child_frame" (a PhysicalFrame) Connector of anchorA to
     //      cuffA. Note that only the child frame is connected now; the parent
@@ -80,7 +80,7 @@ Device* buildDevice() {
     //      device.
 
     // Attach a PathActuator between the two cuffs.
-    PathActuator* pathActuator = new PathActuator();
+    auto* pathActuator = new PathActuator();
     pathActuator->setName("cableAtoB");
     pathActuator->set_optimal_force(OPTIMAL_FORCE);
     pathActuator->addNewPathPoint("pointA", *cuffA, Vec3(0));
@@ -88,7 +88,7 @@ Device* buildDevice() {
     device->addComponent(pathActuator);
 
     // Create a PropMyoController.
-    PropMyoController* controller = new PropMyoController();
+    auto* controller = new PropMyoController();
     controller->setName("controller");
     controller->set_gain(GAIN);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  buildDevice.cpp                          *
+ *                       OpenSim:  buildDeviceModel.cpp                       *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -48,26 +48,26 @@ Device* buildDevice() {
     using SimTK::Inertia;
 
     // Create the device.
-    auto device = new Device();
+    Device* device = new Device();
     device->setName("device");
 
     // The device's mass is distributed between two identical cuffs that attach
     // to the hopper via WeldJoints (to be added below).
     double deviceMass = 2.0;
-    auto cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
+    Body* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
     //TODO: Repeat for cuffB.
 
     //TODO: Add the cuff Components to the device.
 
     // Attach a sphere to each cuff for visualization.
-    auto sphere = new Sphere(0.01);
+    Sphere* sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
     cuffA->attachGeometry(sphere);
     //cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
-    auto anchorA = new WeldJoint();
+    WeldJoint* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
     //TODO: Connect the "child_frame" (a PhysicalFrame) Connector of anchorA to
     //      cuffA. Note that only the child frame is connected now; the parent
@@ -80,7 +80,7 @@ Device* buildDevice() {
     //      device.
 
     // Attach a PathActuator between the two cuffs.
-    auto pathActuator = new PathActuator();
+    PathActuator* pathActuator = new PathActuator();
     pathActuator->setName("cableAtoB");
     pathActuator->set_optimal_force(OPTIMAL_FORCE);
     pathActuator->addNewPathPoint("pointA", *cuffA, Vec3(0));
@@ -88,7 +88,7 @@ Device* buildDevice() {
     device->addComponent(pathActuator);
 
     // Create a PropMyoController.
-    auto controller = new PropMyoController();
+    PropMyoController* controller = new PropMyoController();
     controller->setName("controller");
     controller->set_gain(GAIN);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  buildDevice.cpp                          *
+ *                   OpenSim:  buildDeviceModel_answers.cpp                   *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -48,17 +48,17 @@ Device* buildDevice() {
     using SimTK::Inertia;
 
     // Create the device.
-    auto device = new Device();
+    Device* device = new Device();
     device->setName("device");
 
     // The device's mass is distributed between two identical cuffs that attach
     // to the hopper via WeldJoints (to be added below).
     double deviceMass = 2.0;
-    auto cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
+    Body* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
     //TODO: Repeat for cuffB.
     #pragma region Step2_TaskC_solution
 
-    auto cuffB = new Body("cuffB", deviceMass/2., Vec3(0), Inertia(0.5));
+    Body* cuffB = new Body("cuffB", deviceMass/2., Vec3(0), Inertia(0.5));
 
     #pragma endregion
 
@@ -71,14 +71,14 @@ Device* buildDevice() {
     #pragma endregion
 
     // Attach a sphere to each cuff for visualization.
-    auto sphere = new Sphere(0.01);
+    Sphere* sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
     cuffA->attachGeometry(sphere);
     cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
-    auto anchorA = new WeldJoint();
+    WeldJoint* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
     //TODO: Connect the "child_frame" (a PhysicalFrame) Connector of anchorA to
     //      cuffA. Note that only the child frame is connected now; the parent
@@ -101,7 +101,7 @@ Device* buildDevice() {
     //      device.
     #pragma region Step2_TaskC_solution
 
-    auto anchorB = new WeldJoint();
+    WeldJoint* anchorB = new WeldJoint();
     anchorB->setName("anchorB");
     anchorB->updConnector("child_frame").connect(*cuffB);
     device->addComponent(anchorB);
@@ -109,7 +109,7 @@ Device* buildDevice() {
     #pragma endregion
 
     // Attach a PathActuator between the two cuffs.
-    auto pathActuator = new PathActuator();
+    PathActuator* pathActuator = new PathActuator();
     pathActuator->setName("cableAtoB");
     pathActuator->set_optimal_force(OPTIMAL_FORCE);
     pathActuator->addNewPathPoint("pointA", *cuffA, Vec3(0));
@@ -117,7 +117,7 @@ Device* buildDevice() {
     device->addComponent(pathActuator);
 
     // Create a PropMyoController.
-    auto controller = new PropMyoController();
+    PropMyoController* controller = new PropMyoController();
     controller->setName("controller");
     controller->set_gain(GAIN);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -48,17 +48,17 @@ Device* buildDevice() {
     using SimTK::Inertia;
 
     // Create the device.
-    Device* device = new Device();
+    auto* device = new Device();
     device->setName("device");
 
     // The device's mass is distributed between two identical cuffs that attach
     // to the hopper via WeldJoints (to be added below).
     double deviceMass = 2.0;
-    Body* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
+    auto* cuffA = new Body("cuffA", deviceMass/2., Vec3(0), Inertia(0.5));
     //TODO: Repeat for cuffB.
     #pragma region Step2_TaskC_solution
 
-    Body* cuffB = new Body("cuffB", deviceMass/2., Vec3(0), Inertia(0.5));
+    auto* cuffB = new Body("cuffB", deviceMass/2., Vec3(0), Inertia(0.5));
 
     #pragma endregion
 
@@ -71,14 +71,14 @@ Device* buildDevice() {
     #pragma endregion
 
     // Attach a sphere to each cuff for visualization.
-    Sphere* sphere = new Sphere(0.01);
+    auto* sphere = new Sphere(0.01);
     sphere->setName("sphere");
     sphere->setColor(SimTK::Red);
     cuffA->attachGeometry(sphere);
     cuffB->attachGeometry(sphere->clone());
 
     // Create a WeldJoint to anchor cuffA to the hopper.
-    WeldJoint* anchorA = new WeldJoint();
+    auto* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
     //TODO: Connect the "child_frame" (a PhysicalFrame) Connector of anchorA to
     //      cuffA. Note that only the child frame is connected now; the parent
@@ -101,7 +101,7 @@ Device* buildDevice() {
     //      device.
     #pragma region Step2_TaskC_solution
 
-    WeldJoint* anchorB = new WeldJoint();
+    auto* anchorB = new WeldJoint();
     anchorB->setName("anchorB");
     anchorB->updConnector("child_frame").connect(*cuffB);
     device->addComponent(anchorB);
@@ -109,7 +109,7 @@ Device* buildDevice() {
     #pragma endregion
 
     // Attach a PathActuator between the two cuffs.
-    PathActuator* pathActuator = new PathActuator();
+    auto* pathActuator = new PathActuator();
     pathActuator->setName("cableAtoB");
     pathActuator->set_optimal_force(OPTIMAL_FORCE);
     pathActuator->addNewPathPoint("pointA", *cuffA, Vec3(0));
@@ -117,7 +117,7 @@ Device* buildDevice() {
     device->addComponent(pathActuator);
 
     // Create a PropMyoController.
-    PropMyoController* controller = new PropMyoController();
+    auto* controller = new PropMyoController();
     controller->setName("controller");
     controller->set_gain(GAIN);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/buildHopperModel.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/buildHopperModel.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  buildHopper.cpp                          *
+ *                       OpenSim:  buildHopperModel.cpp                       *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -47,20 +47,20 @@ Model buildHopper() {
     using SimTK::Inertia;
 
     // Create a new OpenSim model on earth.
-    auto hopper = Model();
+    Model hopper = Model();
     hopper.setName("Dennis");
     hopper.setGravity(Vec3(0, -9.80665, 0));
 
     // Create the pelvis, thigh, and shank bodies.
     double pelvisMass = 30., pelvisSideLength = 0.2;
-    auto pelvisInertia = pelvisMass * Inertia::brick(Vec3(pelvisSideLength/2.));
-    auto pelvis = new Body("pelvis", pelvisMass, Vec3(0), pelvisInertia);
+    Inertia pelvisInertia = pelvisMass * Inertia::brick(Vec3(pelvisSideLength/2.));
+    Body* pelvis = new Body("pelvis", pelvisMass, Vec3(0), pelvisInertia);
 
     double linkMass = 10., linkLength = 0.5, linkRadius = 0.035;
-    auto linkInertia = linkMass *
-                       Inertia::cylinderAlongY(linkRadius, linkLength/2.);
-    auto thigh = new Body("thigh", linkMass, Vec3(0), linkInertia);
-    auto shank = new Body("shank", linkMass, Vec3(0), linkInertia);
+    Inertia linkInertia = linkMass *
+                          Inertia::cylinderAlongY(linkRadius, linkLength/2.);
+    Body* thigh = new Body("thigh", linkMass, Vec3(0), linkInertia);
+    Body* shank = new Body("shank", linkMass, Vec3(0), linkInertia);
 
     // Add the bodies to the model (the model takes ownership).
     hopper.addBody(pelvis);
@@ -70,68 +70,74 @@ Model buildHopper() {
     // Attach the pelvis to ground with a vertical slider joint, and attach the
     // pelvis, thigh, and shank bodies to each other with pin joints.
     Vec3 sliderOrientation(0, 0, SimTK::Pi/2.);
-    auto sliderToGround = new SliderJoint("slider", hopper.getGround(), Vec3(0),
-                        sliderOrientation, *pelvis, Vec3(0), sliderOrientation);
+    SliderJoint* sliderToGround = new SliderJoint("slider",
+        hopper.getGround(), Vec3(0), sliderOrientation,
+        *pelvis, Vec3(0), sliderOrientation);
     Vec3 linkDistalPoint(0, -linkLength/2., 0);
     Vec3 linkProximalPoint(0, linkLength/2., 0);
     // Define the pelvis as the parent so the reported value is hip flexion.
-    auto hip = new PinJoint("hip", *pelvis, Vec3(0), Vec3(0), *thigh,
-                            linkProximalPoint, Vec3(0));
+    PinJoint* hip = new PinJoint("hip", *pelvis, Vec3(0), Vec3(0),
+                                        *thigh, linkProximalPoint, Vec3(0));
     // Define the shank as the parent so the reported value is knee flexion.
-    auto knee = new PinJoint("knee", *shank, linkProximalPoint, Vec3(0), *thigh,
-                             linkDistalPoint, Vec3(0));
+    PinJoint* knee = new PinJoint("knee", *shank, linkProximalPoint, Vec3(0),
+                                          *thigh, linkDistalPoint, Vec3(0));
 
     // Add the joints to the model.
     hopper.addJoint(sliderToGround);
     hopper.addJoint(hip);
     hopper.addJoint(knee);
 
-    // Set the coordinate names and default values. Note that we need "auto&"
-    // here so that we get a reference to the CoordinateSet rather than a copy.
-    auto& sliderCoord = sliderToGround->upd_CoordinateSet()[0];
+    // Set the coordinate names and default values. Note that we need the
+    // ampersand in "Coordinate&" so that we get a reference to the Coordinate
+    // rather than a copy.
+    Coordinate& sliderCoord = sliderToGround->upd_CoordinateSet()[0];
     sliderCoord.setName("yCoord");
     sliderCoord.setDefaultValue(1.);
 
-    auto& hipCoord = hip->upd_CoordinateSet()[0];
+    Coordinate& hipCoord = hip->upd_CoordinateSet()[0];
     hipCoord.setName("hipFlexion");
     hipCoord.setDefaultValue(0.35);
 
-    auto& kneeCoord = knee->upd_CoordinateSet()[0];
+    Coordinate& kneeCoord = knee->upd_CoordinateSet()[0];
     kneeCoord.setName("kneeFlexion");
     kneeCoord.setDefaultValue(0.75);
 
     // Limit the range of motion for the hip and knee joints.
     double hipRange[2] = {110., -90.};
     double hipStiff[2] = {20., 20.}, hipDamping = 5., hipTransition = 10.;
-    auto hipLimitForce = new CoordinateLimitForce("hipFlexion", hipRange[0],
-        hipStiff[0], hipRange[1], hipStiff[1], hipDamping, hipTransition);
+    CoordinateLimitForce* hipLimitForce = new CoordinateLimitForce("hipFlexion",
+        hipRange[0], hipStiff[0], hipRange[1], hipStiff[1], hipDamping,
+        hipTransition);
     hip->addComponent(hipLimitForce);
 
     double kneeRange[2] = {140., 10.};
     double kneeStiff[2] = {50., 40.}, kneeDamping = 2., kneeTransition = 10.;
-    auto kneeLimitForce = new CoordinateLimitForce("kneeFlexion", kneeRange[0],
-        kneeStiff[0], kneeRange[1], kneeStiff[1], kneeDamping, kneeTransition);
+    CoordinateLimitForce* kneeLimitForce = new CoordinateLimitForce("kneeFlexion",
+        kneeRange[0], kneeStiff[0], kneeRange[1], kneeStiff[1], kneeDamping,
+        kneeTransition);
     knee->addComponent(kneeLimitForce);
 
     // Create a constraint to keep the foot (distal end of the shank) directly
     // beneath the pelvis (the Y-axis points upwards).
-    auto constraint = new PointOnLineConstraint(hopper.getGround(), Vec3(0,1,0),
-                      Vec3(0), *shank, linkDistalPoint);
+    PointOnLineConstraint* constraint = new PointOnLineConstraint(
+        hopper.getGround(), Vec3(0,1,0), Vec3(0), *shank, linkDistalPoint);
     shank->addComponent(constraint);
 
     // Use a contact model to prevent the foot (ContactSphere) from passing
     // through the floor (ContactHalfSpace).
-    auto floor = new ContactHalfSpace(Vec3(0), Vec3(0, 0, -SimTK::Pi/2.),
-                                      hopper.getGround(), "floor");
+    ContactHalfSpace* floor = new ContactHalfSpace(Vec3(0),
+        Vec3(0, 0, -SimTK::Pi/2.), hopper.getGround(), "floor");
     double footRadius = 0.1;
-    auto foot = new ContactSphere(footRadius, linkDistalPoint, *shank, "foot");
+    ContactSphere* foot = new ContactSphere(footRadius, linkDistalPoint, *shank,
+                                            "foot");
 
     double stiffness = 1.e8, dissipation = 0.5, friction[3] = {0.9, 0.9, 0.6};
-    auto contactParams = new HuntCrossleyForce::ContactParameters(stiffness,
-                         dissipation, friction[0], friction[1], friction[2]);
+    HuntCrossleyForce::ContactParameters* contactParams =
+        new HuntCrossleyForce::ContactParameters(
+            stiffness, dissipation, friction[0], friction[1], friction[2]);
     contactParams->addGeometry("floor");
     contactParams->addGeometry("foot");
-    auto contactForce = new HuntCrossleyForce(contactParams);
+    HuntCrossleyForce* contactForce = new HuntCrossleyForce(contactParams);
 
     // Add the contact-related components to the model.
     hopper.addContactGeometry(floor);
@@ -141,8 +147,8 @@ Model buildHopper() {
     // Create the vastus muscle and set its origin and insertion points.
     double mclFmax = 4000., mclOptFibLen = 0.55, mclTendonSlackLen = 0.25,
            mclPennAng = 0.;
-    auto vastus = new Thelen2003Muscle("vastus", mclFmax, mclOptFibLen,
-                                       mclTendonSlackLen, mclPennAng);
+    Thelen2003Muscle* vastus = new Thelen2003Muscle("vastus", mclFmax,
+                               mclOptFibLen, mclTendonSlackLen, mclPennAng);
     vastus->addNewPathPoint("origin", *thigh, Vec3(linkRadius, 0.1, 0));
     vastus->addNewPathPoint("insertion", *shank, Vec3(linkRadius, 0.15, 0));
     hopper.addForce(vastus);
@@ -151,7 +157,7 @@ Model buildHopper() {
     // vastus muscle can wrap. In the future, we will be able to attach wrap
     // objects to PhysicalOffsetFrames; for now, we will use the existing
     // "translation" property.
-    auto patella = new WrapCylinder();
+    WrapCylinder* patella = new WrapCylinder();
     patella->setName("patella");
     patella->set_radius(0.08);
     patella->set_length(linkRadius*2.);
@@ -163,27 +169,30 @@ Model buildHopper() {
     vastus->updGeometryPath().addPathWrap(*patella);
 
     // Create a controller to excite the vastus muscle.
-    auto brain = new PrescribedController();
+    PrescribedController* brain = new PrescribedController();
     brain->setActuators(hopper.updActuators());
     double t[3] = {0.0, 2.0, 3.9}, x[3] = {0.3, 1.0, 0.1};
-    auto controlFunction = new PiecewiseConstantFunction(3, t, x);
+    PiecewiseConstantFunction* controlFunction =
+        new PiecewiseConstantFunction(3, t, x);
     brain->prescribeControlForActuator("vastus", controlFunction);
     hopper.addController(brain);
 
     // Create frames on the thigh and shank segments for attaching the device.
-    auto thighAttachment = new PhysicalOffsetFrame("deviceAttachmentPoint",
-                           *thigh, SimTK::Transform(Vec3(linkRadius, 0.15, 0)));
-    auto shankAttachment = new PhysicalOffsetFrame("deviceAttachmentPoint",
-                           *shank, SimTK::Transform(Vec3(linkRadius, 0, 0)));
+    PhysicalOffsetFrame* thighAttachment =
+        new PhysicalOffsetFrame("deviceAttachmentPoint", *thigh,
+                                SimTK::Transform(Vec3(linkRadius, 0.15, 0)));
+    PhysicalOffsetFrame* shankAttachment =
+        new PhysicalOffsetFrame("deviceAttachmentPoint", *shank,
+                                SimTK::Transform(Vec3(linkRadius, 0, 0)));
     thigh->addComponent(thighAttachment);
     shank->addComponent(shankAttachment);
 
     // Attach geometry to the bodies and enable the visualizer.
-    auto pelvisGeometry = new Brick(Vec3(pelvisSideLength/2.));
+    Brick* pelvisGeometry = new Brick(Vec3(pelvisSideLength/2.));
     pelvisGeometry->setColor(Vec3(0.8, 0.1, 0.1));
     pelvis->attachGeometry(pelvisGeometry);
 
-    auto linkGeometry = new Cylinder(linkRadius, linkLength/2.);
+    Cylinder* linkGeometry = new Cylinder(linkRadius, linkLength/2.);
     linkGeometry->setColor(Vec3(0.8, 0.1, 0.1));
     thigh->attachGeometry(linkGeometry);
     shank->attachGeometry(linkGeometry->clone());

--- a/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController.h
@@ -103,7 +103,7 @@ public:
 protected:
     // Change the color of the device's path as its tension changes.
     void extendRealizeDynamics(const SimTK::State& s) const override {
-        const auto& actuator = getComponent<PathActuator>("cableAtoB");
+        const PathActuator& actuator = getComponent<PathActuator>("cableAtoB");
         double level = fmin(1., getTension(s) / actuator.get_optimal_force());
         actuator.getGeometryPath().setColor(s, SimTK::Vec3(0.1, level, 0.1));
     }
@@ -160,7 +160,7 @@ public:
                          SimTK::Vector& controls) const override
     {
         double signal = computeControl(s);
-        const auto& actuator = getConnectee<ScalarActuator>("actuator");
+        const ScalarActuator& actuator = getConnectee<ScalarActuator>("actuator");
         SimTK::Vector thisActuatorsControls(1, signal);
         actuator.addInControls(thisActuatorsControls, controls);
     }

--- a/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/defineDeviceAndController_answers.h
@@ -1,7 +1,7 @@
-#ifndef _defineDeviceAndController_h_
-#define _defineDeviceAndController_h_
+#ifndef _defineDeviceAndController_answers_h_
+#define _defineDeviceAndController_answers_h_
 /* -------------------------------------------------------------------------- *
- *                   OpenSim:  defineDeviceAndController.h                    *
+ *               OpenSim:  defineDeviceAndController_answers.h                *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -151,7 +151,7 @@ public:
 protected:
     // Change the color of the device's path as its tension changes.
     void extendRealizeDynamics(const SimTK::State& s) const override {
-        const auto& actuator = getComponent<PathActuator>("cableAtoB");
+        const PathActuator& actuator = getComponent<PathActuator>("cableAtoB");
         double level = fmin(1., getTension(s) / actuator.get_optimal_force());
         actuator.getGeometryPath().setColor(s, SimTK::Vec3(0.1, level, 0.1));
     }
@@ -217,7 +217,7 @@ public:
                          SimTK::Vector& controls) const override
     {
         double signal = computeControl(s);
-        const auto& actuator = getConnectee<ScalarActuator>("actuator");
+        const ScalarActuator& actuator = getConnectee<ScalarActuator>("actuator");
         SimTK::Vector thisActuatorsControls(1, signal);
         actuator.addInControls(thisActuatorsControls, controls);
     }
@@ -231,4 +231,4 @@ private:
 
 } // end of namespace OpenSim
 
-#endif // _defineDeviceAndController_h_
+#endif // _defineDeviceAndController_answers_h_

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -149,7 +149,7 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
     const std::vector<std::string>& deviceControllerOutputs)
 {
     // Create a new ConsoleReporter. Set its name and reporting interval.
-    ConsoleReporter* reporter = new ConsoleReporter();
+    auto* reporter = new ConsoleReporter();
     reporter->setName(model.getName() + "_" + device.getName() + "_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -98,9 +98,9 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
     if (model.hasComponent<WrapCylinder>("thigh/patella")) {
-        auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
-        auto& frame = model.updComponent<PhysicalFrame>("thigh");
-        auto& wrapObject = frame.upd_WrapObjectSet().get("patella");
+        PathActuator& cable = model.updComponent<PathActuator>("device/cableAtoB");
+        PhysicalFrame& frame = model.updComponent<PhysicalFrame>("thigh");
+        WrapObject& wrapObject = frame.upd_WrapObjectSet().get("patella");
         cable.updGeometryPath().addPathWrap(wrapObject);
     }
 }
@@ -149,17 +149,17 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
     const std::vector<std::string>& deviceControllerOutputs)
 {
     // Create a new ConsoleReporter. Set its name and reporting interval.
-    auto reporter = new ConsoleReporter();
+    ConsoleReporter* reporter = new ConsoleReporter();
     reporter->setName(model.getName() + "_" + device.getName() + "_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 
     // Loop through the desired device outputs and add them to the reporter.
-    for (auto thisOutputName : deviceOutputs)
+    for (const std::string& thisOutputName : deviceOutputs)
         reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
 
-    for (auto thisOutputName : deviceControllerOutputs)
-        reporter->updInput("inputs").
-        connect(device.getComponent("controller").getOutput(thisOutputName));
+    for (const std::string& thisOutputName : deviceControllerOutputs)
+        reporter->updInput("inputs").connect(
+            device.getComponent("controller").getOutput(thisOutputName));
 
     // Add the reporter to the model.
     model.addComponent(reporter);
@@ -183,7 +183,7 @@ int main()
     if (true)
     {
         // Build the hopper.
-        auto hopper = buildHopper();
+        Model hopper = buildHopper();
         // Update the hopper model's internal data members, which includes
         // identifying its subcomponents from its properties.
         hopper.finalizeFromProperties();
@@ -219,7 +219,7 @@ int main()
     if (false)
     {
         // Build the testbed and device.
-        auto testbed = buildTestbed();
+        Model testbed = buildTestbed();
         testbed.finalizeFromProperties();
 
         // Step 2, Task A
@@ -235,7 +235,7 @@ int main()
         // Step 2, Task C
         // ==============
         // Go to buildDeviceModel.cpp and complete the "TODO"s in buildDevice().
-        auto device = buildDevice();
+        Device* device = buildDevice();
         device->finalizeFromProperties();
 
         // Show all Components in the device and testbed.
@@ -277,9 +277,9 @@ int main()
     if (false)
     {
         // Build the hopper and device.
-        auto assistedHopper = buildHopper();
+        Model assistedHopper = buildHopper();
         assistedHopper.finalizeFromProperties();
-        auto kneeDevice = buildDevice();
+        Device* kneeDevice = buildDevice();
         kneeDevice->finalizeFromProperties();
 
         // Step 3, Task A

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -145,7 +145,7 @@ void addConsoleReporterToHopper(Model& hopper)
     //TODO: Create a new ConsoleReporter. Set its name and reporting interval.
     #pragma region Step1_TaskB_solution
 
-    ConsoleReporter* reporter = new ConsoleReporter();
+    auto* reporter = new ConsoleReporter();
     reporter->setName("hopper_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 
@@ -192,7 +192,7 @@ void addSignalGeneratorToDevice(Device& device)
     //TODO: Create a new SignalGenerator and set its name.
     #pragma region Step2_TaskE_solution
 
-    SignalGenerator* signalGen = new SignalGenerator();
+    auto* signalGen = new SignalGenerator();
     signalGen->setName("signalGen");
 
     #pragma endregion
@@ -221,7 +221,7 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
     const std::vector<std::string>& deviceControllerOutputs)
 {
     // Create a new ConsoleReporter. Set its name and reporting interval.
-    ConsoleReporter* reporter = new ConsoleReporter();
+    auto* reporter = new ConsoleReporter();
     reporter->setName(model.getName() + "_" + device.getName() + "_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 

--- a/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Sandbox/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                     OpenSim:  exampleHopperDevice.cpp                      *
+ *                 OpenSim:  exampleHopperDevice_answers.cpp                  *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -100,8 +100,8 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     //TODO: Get writable references to the "anchor" joints in the device.
     #pragma region Step2_TaskD_solution
 
-    auto& anchorA = device.updComponent<WeldJoint>("anchorA");
-    auto& anchorB = device.updComponent<WeldJoint>("anchorB");
+    WeldJoint& anchorA = device.updComponent<WeldJoint>("anchorA");
+    WeldJoint& anchorB = device.updComponent<WeldJoint>("anchorB");
 
     #pragma endregion
 
@@ -113,9 +113,9 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     //      anchor. (2 lines of code for each anchor.)
     #pragma region Step2_TaskD_solution
 
-    const auto& frameA = model.getComponent<PhysicalFrame>(modelFrameAname);
+    const PhysicalFrame& frameA = model.getComponent<PhysicalFrame>(modelFrameAname);
     anchorA.updConnector("parent_frame").connect(frameA);
-    const auto& frameB = model.getComponent<PhysicalFrame>(modelFrameBname);
+    const PhysicalFrame& frameB = model.getComponent<PhysicalFrame>(modelFrameBname);
     anchorB.updConnector("parent_frame").connect(frameB);
 
     #pragma endregion
@@ -128,9 +128,9 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
     if (model.hasComponent<WrapCylinder>("thigh/patella")) {
-        auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
-        auto& frame = model.updComponent<PhysicalFrame>("thigh");
-        auto& wrapObject = frame.upd_WrapObjectSet().get("patella");
+        PathActuator& cable = model.updComponent<PathActuator>("device/cableAtoB");
+        PhysicalFrame& frame = model.updComponent<PhysicalFrame>("thigh");
+        WrapObject& wrapObject = frame.upd_WrapObjectSet().get("patella");
         cable.updGeometryPath().addPathWrap(wrapObject);
     }
 }
@@ -145,7 +145,7 @@ void addConsoleReporterToHopper(Model& hopper)
     //TODO: Create a new ConsoleReporter. Set its name and reporting interval.
     #pragma region Step1_TaskB_solution
 
-    auto reporter = new ConsoleReporter();
+    ConsoleReporter* reporter = new ConsoleReporter();
     reporter->setName("hopper_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 
@@ -192,7 +192,7 @@ void addSignalGeneratorToDevice(Device& device)
     //TODO: Create a new SignalGenerator and set its name.
     #pragma region Step2_TaskE_solution
 
-    auto signalGen = new SignalGenerator();
+    SignalGenerator* signalGen = new SignalGenerator();
     signalGen->setName("signalGen");
 
     #pragma endregion
@@ -221,15 +221,15 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
     const std::vector<std::string>& deviceControllerOutputs)
 {
     // Create a new ConsoleReporter. Set its name and reporting interval.
-    auto reporter = new ConsoleReporter();
+    ConsoleReporter* reporter = new ConsoleReporter();
     reporter->setName(model.getName() + "_" + device.getName() + "_results");
     reporter->set_report_time_interval(REPORTING_INTERVAL);
 
     // Loop through the desired device outputs and add them to the reporter.
-    for (auto thisOutputName : deviceOutputs)
+    for (const std::string& thisOutputName : deviceOutputs)
         reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
 
-    for (auto thisOutputName : deviceControllerOutputs)
+    for (const std::string& thisOutputName : deviceControllerOutputs)
         reporter->updInput("inputs").
             connect(device.getComponent("controller").getOutput(thisOutputName));
 
@@ -255,7 +255,7 @@ int main()
     if (true)
     {
         // Build the hopper.
-        auto hopper = buildHopper();
+        Model hopper = buildHopper();
         // Update the hopper model's internal data members, which includes
         // identifying its subcomponents from its properties.
         hopper.finalizeFromProperties();
@@ -291,7 +291,7 @@ int main()
     if (true)
     {
         // Build the testbed and device.
-        auto testbed = buildTestbed();
+        Model testbed = buildTestbed();
         testbed.finalizeFromProperties();
 
         // Step 2, Task A
@@ -307,7 +307,7 @@ int main()
         // Step 2, Task C
         // ==============
         // Go to buildDeviceModel.cpp and complete the "TODO"s in buildDevice().
-        auto device = buildDevice();
+        Device* device = buildDevice();
         device->finalizeFromProperties();
 
         // Show all Components in the device and testbed.
@@ -349,9 +349,9 @@ int main()
     if (true)
     {
         // Build the hopper and device.
-        auto assistedHopper = buildHopper();
+        Model assistedHopper = buildHopper();
         assistedHopper.finalizeFromProperties();
-        auto kneeDevice = buildDevice();
+        Device* kneeDevice = buildDevice();
         kneeDevice->finalizeFromProperties();
 
         // Step 3, Task A

--- a/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
@@ -224,8 +224,8 @@ inline Model buildTestbed()
     testbed.setGravity(Vec3(0));
 
     // Create a 2500 kg load and add geometry for visualization.
-    Body* load = new Body("load", 2500., Vec3(0), Inertia(1.));
-    Sphere* sphere = new Sphere(0.02);
+    auto* load = new Body("load", 2500., Vec3(0), Inertia(1.));
+    auto* sphere = new Sphere(0.02);
     sphere->setFrame(*load);
     sphere->setOpacity(0.5);
     sphere->setColor(SimTK::Blue);
@@ -234,12 +234,12 @@ inline Model buildTestbed()
 
     // Attach the load to ground with a FreeJoint and set the location of the
     // load to (1,0,0).
-    FreeJoint* gndToLoad = new FreeJoint("gndToLoad", testbed.getGround(), *load);
+    auto* gndToLoad = new FreeJoint("gndToLoad", testbed.getGround(), *load);
     gndToLoad->upd_coordinates(3).setDefaultValue(1.0);
     testbed.addJoint(gndToLoad);
 
     // Add a spring between the ground's origin and the load.
-    PointToPointSpring* spring = new PointToPointSpring(
+    auto* spring = new PointToPointSpring(
         testbed.getGround(), Vec3(0),   //frame G and location in G of point 1
         *load, Vec3(0),                 //frame F and location in F of point 2
         5000., 1.);                     //stiffness and rest length

--- a/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
@@ -118,7 +118,7 @@ inline void showSubcomponentInfo(const Component& comp)
     // Step through compList once to find the longest concrete class name.
     unsigned maxlen = 0;
     for (const C& thisComp : compList) {
-        auto len = thisComp.getConcreteClassName().length();
+        int len = thisComp.getConcreteClassName().length();
         maxlen = std::max(maxlen, static_cast<unsigned>(len));
     }
     maxlen += 4; //padding
@@ -144,7 +144,8 @@ inline void showAllOutputs(const Component& comp, bool includeDescendants)
         cout << endl;
 
         std::vector<std::string> outputNames = comp.getOutputNames();
-        for (auto thisName : outputNames) { cout << "  " << thisName << endl; }
+        for (std::string& thisName : outputNames)
+            cout << "  " << thisName << endl;
         cout << endl;
     }
 
@@ -217,14 +218,14 @@ inline Model buildTestbed()
     using SimTK::Inertia;
 
     // Create a new OpenSim model.
-    auto testbed = Model();
+    Model testbed = Model();
     testbed.setName("testbed");
     testbed.setUseVisualizer(true);
     testbed.setGravity(Vec3(0));
 
     // Create a 2500 kg load and add geometry for visualization.
-    auto load = new Body("load", 2500., Vec3(0), Inertia(1.));
-    auto sphere = new Sphere(0.02);
+    Body* load = new Body("load", 2500., Vec3(0), Inertia(1.));
+    Sphere* sphere = new Sphere(0.02);
     sphere->setFrame(*load);
     sphere->setOpacity(0.5);
     sphere->setColor(SimTK::Blue);
@@ -233,12 +234,12 @@ inline Model buildTestbed()
 
     // Attach the load to ground with a FreeJoint and set the location of the
     // load to (1,0,0).
-    auto gndToLoad = new FreeJoint("gndToLoad", testbed.getGround(), *load);
+    FreeJoint* gndToLoad = new FreeJoint("gndToLoad", testbed.getGround(), *load);
     gndToLoad->getCoordinateSet()[3].setDefaultValue(1.0);
     testbed.addJoint(gndToLoad);
 
     // Add a spring between the ground's origin and the load.
-    auto spring = new PointToPointSpring(
+    PointToPointSpring* spring = new PointToPointSpring(
         testbed.getGround(), Vec3(0),   //frame G and location in G of point 1
         *load, Vec3(0),                 //frame F and location in F of point 2
         5000., 1.);                     //stiffness and rest length

--- a/OpenSim/Simulation/Model/ContactGeometry.h
+++ b/OpenSim/Simulation/Model/ContactGeometry.h
@@ -107,12 +107,12 @@ public:
      * Ground) `B` in which this geometry is fixed, you can use the following
      * code:
      * @code{.cpp}
-     * const auto& X_BF = geom.getFrame().findTransformInBaseFrame();
-     * const auto X_FP = geom.getTransform();
-     * const auto X_BP = X_BF * X_FP;
+     * const SimTK::Transform& X_BF = geom.getFrame().findTransformInBaseFrame();
+     * const SimTK::Transform  X_FP = geom.getTransform();
+     * const SimTK::Transform  X_BP = X_BF * X_FP;
      * @endcode
      *
-     * Prior to OpenSim 4.0, there wwas no intermediate PhysicalFrame `F`, so
+     * Prior to OpenSim 4.0, there was no intermediate PhysicalFrame `F`, so
      * this method essentially returned `X_BP`. */
     SimTK::Transform getTransform() const;
 

--- a/OpenSim/Simulation/SimbodyEngine/BallJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/BallJoint.h
@@ -56,7 +56,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rx = myBallJoint.getCoordinate(BallJoint::Coord::Rotation1X);
+        const Coordinate& rx = myBallJoint.
+                               getCoordinate(BallJoint::Coord::Rotation1X);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
@@ -107,7 +107,7 @@ public:
     const Coordinate& getCoordinate(unsigned idx) const {
         OPENSIM_THROW_IF(numCoordinates() == 0,
                          JointHasNoCoordinates);
-        OPENSIM_THROW_IF(idx > numCoordinates()-1,
+        OPENSIM_THROW_IF((int)idx > numCoordinates()-1,
                          InvalidCall,
                          "Index passed to getCoordinate() exceeds the largest "
                          "index available");

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
@@ -52,8 +52,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rx = myEllipsoidJoint.
-                         getCoordinate(EllipsoidJoint::Coord::Rotation1X);
+        const Coordinate& rx = myEllipsoidJoint.
+                               getCoordinate(EllipsoidJoint::Coord::Rotation1X);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
@@ -54,7 +54,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rx = myFreeJoint.getCoordinate(FreeJoint::Coord::Rotation1X);
+        const Coordinate& rx = myFreeJoint.
+                               getCoordinate(FreeJoint::Coord::Rotation1X);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
@@ -48,8 +48,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rx = myGimbalJoint.
-                         getCoordinate(GimbalJoint::Coord::Rotation1X);
+        const Coordinate& rx = myGimbalJoint.
+                               getCoordinate(GimbalJoint::Coord::Rotation1X);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/PinJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PinJoint.h
@@ -50,7 +50,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rz = myPinJoint.getCoordinate(PinJoint::Coord::RotationZ);
+        const Coordinate& rz = myPinJoint.
+                               getCoordinate(PinJoint::Coord::RotationZ);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
@@ -48,8 +48,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rz = myPlanarJoint.
-                         getCoordinate(PlanarJoint::Coord::RotationZ);
+        const Coordinate& rz = myPlanarJoint.
+                               getCoordinate(PlanarJoint::Coord::RotationZ);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
@@ -47,8 +47,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& tx = mySliderJoint.
-                         getCoordinate(SliderJoint::Coord::TranslationX);
+        const Coordinate& tx = mySliderJoint.
+                               getCoordinate(SliderJoint::Coord::TranslationX);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
@@ -50,8 +50,8 @@ public:
 
         <b>C++ example</b>
         \code{.cpp}
-        const auto& rx = myUniversalJoint.
-                         getCoordinate(UniversalJoint::Coord::Rotation1X);
+        const Coordinate& rx = myUniversalJoint.
+                               getCoordinate(UniversalJoint::Coord::Rotation1X);
         \endcode
     */
     enum class Coord: unsigned {

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -154,7 +154,7 @@ class Model;
  * You can iterate through a trajectory to access the value of a state variable
  * at each time in the trajectory.
  * @code{.cpp}
- * for (const auto& state : states) {
+ * for (const SimTK::State& state : states) {
  *     std::cout << state.getTime() << " "
  *               << model.getStateVariableValue(state, "knee/flexion/value")
  *               << std::endl;
@@ -177,7 +177,7 @@ public:
      * @code{.cpp}
      * Model model("subject01.osim");
      * const StatesTrajectory states = getStatesTrajectorySomehow();
-     * const auto& state = states[0];
+     * const SimTK::State& state = states[0];
      * model.getStateVariableValue(state, "knee/flexion/value");
      * @endcode
      * This function does not check if the index is larger than the size of
@@ -301,9 +301,9 @@ public:
      * (e.g., `knee/flexion/angle`).
      *
      * @code
-     * auto allStateVars = states.exportToTable(model);
-     * auto kneeStates = states.exportToTable(model, {"knee/flexion/value",
-     *                                                "knee/flexion/speed"});
+     * TimeSeriesTable allStateVars = states.exportToTable(model);
+     * TimeSeriesTable kneeStates = states.exportToTable(model,
+     *                              {"knee/flexion/value", "knee/flexion/speed"});
      * @endcode
      *
      * @throws IncompatibleModel Thrown if the Model fails the check

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -91,7 +91,7 @@ void testPopulateTrajectoryAndStatesTrajectoryReporter() {
         SimTK_TEST_EQ((int)states.getSize(), (int)times.size());
         SimTK_TEST_EQ((int)statesCol->getStates().getSize(), (int)times.size());
         // ...and that they aren't all just references to the same single state.
-        for (int i = 0; i < states.getSize(); ++i) {
+        for (int i = 0; i < (int)states.getSize(); ++i) {
             SimTK_TEST_EQ(states[i].getTime(), times[i]);
             SimTK_TEST_EQ(statesCol->getStates()[i].getTime(), times[i]);
         }


### PR DESCRIPTION
## Main changes
Removed "auto" from examples and example code in doxygen to avoid encouraging its use (and potential misuse), per discussion in #1209.

## Minor changes
1. Suppressed compiler warnings about unsigned ints.
2. Corrected headers in hopper example.

## Omissions
This PR does not repair the hopper example, which is again broken on master; noted in #1205. The hopper example should be added as a test so it doesn't keep breaking (see #1128).