### PR TITLE
use std::vector with CHECK_STORAGE_AGAINST_STANDARD

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTutorialOne.cpp
+++ b/Applications/Analyze/test/testAnalyzeTutorialOne.cpp
@@ -39,7 +39,9 @@ int main()
          * to a validated standard. Let's make sure we don't crash during run first! -Ayman 5/29/12 */
         Storage resultFiberLength("testPlotterTool/BothLegs__FiberLength.sto");
         Storage standardFiberLength("std_BothLegs_fiberLength.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(resultFiberLength, standardFiberLength, Array<double>(0.0001, 100), __FILE__, __LINE__, "testAnalyzeTutorialOne failed");
+        CHECK_STORAGE_AGAINST_STANDARD(resultFiberLength, standardFiberLength,
+            std::vector<double>(100, 0.0001), __FILE__, __LINE__,
+            "testAnalyzeTutorialOne failed");
         // const Model& mdl = analyze1.getModel();
         //mdl.updMultibodySystem()
         analyze1.setStatesFileName("plotterGeneratedStatesHip45.sto");
@@ -48,7 +50,9 @@ int main()
         analyze1.run();
         Storage resultFiberLengthHip45("testPlotterTool/BothLegsHip45__FiberLength.sto");
         Storage standardFiberLength45("std_BothLegsHip45__FiberLength.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(resultFiberLengthHip45, standardFiberLength45, Array<double>(0.0001, 100), __FILE__, __LINE__, "testAnalyzeTutorialOne at Hip45 failed");        
+        CHECK_STORAGE_AGAINST_STANDARD(resultFiberLengthHip45, 
+            standardFiberLength45, std::vector<double>(100, 0.0001),
+            __FILE__, __LINE__, "testAnalyzeTutorialOne at Hip45 failed");
         cout << "testAnalyzeTutorialOne passed" << endl;
     }
     catch (const exception& e) {

--- a/Applications/Analyze/test/testInducedAccelerations.cpp
+++ b/Applications/Analyze/test/testInducedAccelerations.cpp
@@ -52,7 +52,9 @@ int main()
         AnalyzeTool analyze("subject02_Setup_IAA_02_232.xml");
         analyze.run();
         Storage result1("ResultsInducedAccelerations/subject02_running_arms_InducedAccelerations_center_of_mass.sto"), standard1("std_subject02_running_arms_InducedAccelerations_CENTER_OF_MASS.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, Array<double>(0.15, result1.getSmallestNumberOfStates()), __FILE__, __LINE__, "Induced Accelerations of Running failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
+            std::vector<double>(result1.getSmallestNumberOfStates(), 0.15),
+            __FILE__, __LINE__, "Induced Accelerations of Running failed");
         cout << "Induced Accelerations of Running passed\n" << endl;
     }
     catch (const OpenSim::Exception& e) {

--- a/Applications/Analyze/test/testJointReactions.cpp
+++ b/Applications/Analyze/test/testJointReactions.cpp
@@ -34,13 +34,17 @@ int main()
         AnalyzeTool analyze("SinglePin_Setup_JointReaction.xml");
         analyze.run();
         Storage result1("SinglePin_JointReaction_ReactionLoads.sto"), standard1("std_SinglePin_JointReaction_ReactionLoads.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, Array<double>(1e-5, 24), __FILE__, __LINE__, "SinglePin failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
+            std::vector<double>(24, 1e-5), __FILE__, __LINE__,
+            "SinglePin failed");
         cout << "SinglePin passed" << endl;
 
         AnalyzeTool analyze2("DoublePendulum3D_Setup_JointReaction.xml");
         analyze2.run();
         Storage result2("DoublePendulum3D_JointReaction_ReactionLoads.sto"), standard2("std_DoublePendulum3D_JointReaction_ReactionLoads.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, Array<double>(1e-5, 24), __FILE__, __LINE__, "DoublePendulum3D failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
+            std::vector<double>(24, 1e-5), __FILE__, __LINE__,
+            "DoublePendulum3D failed");
         cout << "DoublePendulum3D passed" << endl;
     }
     catch (const Exception& e) {

--- a/Applications/Analyze/test/testStaticOptimization.cpp
+++ b/Applications/Analyze/test/testStaticOptimization.cpp
@@ -135,14 +135,14 @@ void testArm26(const string& muscleModelClassName, double actTol, double forceTo
     //Storage stdForces1("std_arm26_"+muscName+"_SO_force.sto");
 
     CHECK_STORAGE_AGAINST_STANDARD(activations1, stdActivations1, 
-                                    Array<double>(actTol, 6),
-                                    __FILE__, __LINE__, 
-                                    "Arm26 activations "+muscName+" failed");
+                                   std::vector<double>(6, actTol),
+                                   __FILE__, __LINE__, 
+                                   "Arm26 activations "+muscName+" failed");
 
     CHECK_STORAGE_AGAINST_STANDARD(forces1, stdForces1, 
-                                    Array<double>(forceTol, 6),
-                                    __FILE__, __LINE__, 
-                                    "Arm26 forces "+muscName+" failed.");
+                                   std::vector<double>(6, forceTol),
+                                   __FILE__, __LINE__, 
+                                   "Arm26 forces "+muscName+" failed.");
     cout << resultsDir <<": test Arm26 passed." << endl;
   
     
@@ -164,12 +164,12 @@ void testArm26(const string& muscleModelClassName, double actTol, double forceTo
     //Storage stdForces2("std_arm26_bounds_"+muscName+"_SO_force.sto");
 
     CHECK_STORAGE_AGAINST_STANDARD(activations2, stdActivations2,
-        Array<double>(actTol, 6), 
+        std::vector<double>(6, actTol),
         __FILE__, __LINE__, 
         "Arm26 activation "+muscName+" with bounds failed.");
 
     CHECK_STORAGE_AGAINST_STANDARD(forces2, stdForces2, 
-        Array<double>(forceTol, 6),
+        std::vector<double>(6, forceTol),
         __FILE__,  __LINE__, 
         "Arm26 forces "+muscName+" with bounds failed.");
  
@@ -188,12 +188,12 @@ void testModelWithPassiveForces() {
     Storage stdForces("std_walk_subject01_ankle_spring_StaticOptimization_force.sto");
 
     CHECK_STORAGE_AGAINST_STANDARD(activations, stdActivations,
-        Array<double>(0.025, 28),
+        std::vector<double>(28, 0.025),
         __FILE__, __LINE__,
         "ModelWithPassiveForces activations failed");
 
     CHECK_STORAGE_AGAINST_STANDARD(forces, stdForces,
-        Array<double>(2.5, 48),
+        std::vector<double>(48, 2.5),
         __FILE__, __LINE__,
         "ModelWithPassiveForces forces failed.");
     cout << resultsDir << ": test ModelWithPassiveForces passed." << endl;

--- a/Applications/CMC/test/testCMCArm26_Millard.cpp
+++ b/Applications/CMC/test/testCMCArm26_Millard.cpp
@@ -45,7 +45,7 @@ void testCMCArm26() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    std::vector<double> rms_tols(2*2+2*6, 0.02); // activations within 2%, angles within .6 degrees
+    std::vector<double> rms_tols(2*2+2*6, 0.02);
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
     string base = "testCMCArm26 "+ muscleType;
 

--- a/Applications/CMC/test/testCMCArm26_Millard.cpp
+++ b/Applications/CMC/test/testCMCArm26_Millard.cpp
@@ -45,7 +45,7 @@ void testCMCArm26() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    Array<double> rms_tols(0.02, 2*2+2*6); // activations within 2%, angles within .6 degrees
+    std::vector<double> rms_tols(2*2+2*6, 0.02); // activations within 2%, angles within .6 degrees
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
     string base = "testCMCArm26 "+ muscleType;
 

--- a/Applications/CMC/test/testCMCArm26_Thelen.cpp
+++ b/Applications/CMC/test/testCMCArm26_Thelen.cpp
@@ -41,7 +41,7 @@ void testCMCArm26() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    std::vector<double> rms_tols(2*2+2*6, 0.02); // activations within 2%, angles within .6 degrees
+    std::vector<double> rms_tols(2*2+2*6, 0.02);
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
     string base = "testCMCArm26 "+ muscleType;
 

--- a/Applications/CMC/test/testCMCArm26_Thelen.cpp
+++ b/Applications/CMC/test/testCMCArm26_Thelen.cpp
@@ -41,7 +41,7 @@ void testCMCArm26() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    Array<double> rms_tols(0.02, 2*2+2*6); // activations within 2%, angles within .6 degrees
+    std::vector<double> rms_tols(2*2+2*6, 0.02); // activations within 2%, angles within .6 degrees
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
     string base = "testCMCArm26 "+ muscleType;
 

--- a/Applications/CMC/test/testCMCEMGDrivenArm_Millard.cpp
+++ b/Applications/CMC/test/testCMCEMGDrivenArm_Millard.cpp
@@ -42,7 +42,7 @@ void testCMCEMGDrivenArm() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    Array<double> rms_tols(0.02, 2*2+2*6);
+    std::vector<double> rms_tols(2*2+2*6, 0.02);
     rms_tols[4] = 0.10;  // trilong
     rms_tols[6] = 0.25;  // trilat normally off but because of bicep long EMG tracking it turns on
     rms_tols[8] = 0.25;  // trimed normally off but because of bicep long EMG tracking it turns on

--- a/Applications/CMC/test/testCMCEMGDrivenArm_Thelen.cpp
+++ b/Applications/CMC/test/testCMCEMGDrivenArm_Thelen.cpp
@@ -42,7 +42,7 @@ void testCMCEMGDrivenArm() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    Array<double> rms_tols(0.02, 2*2+2*6);
+    std::vector<double> rms_tols(2*2+2*6, 0.02);
     rms_tols[4] = 0.10;  // trilong
     rms_tols[6] = 0.25;  // trilat normally off but because of bicep long EMG tracking it turns on
     rms_tols[8] = 0.25;  // trimed normally off but because of bicep long EMG tracking it turns on

--- a/Applications/CMC/test/testCMCGait10dof18musc.cpp
+++ b/Applications/CMC/test/testCMCGait10dof18musc.cpp
@@ -66,7 +66,7 @@ void testGait10dof18musc() {
     Storage *standard = new Storage();
     cmc.getModel().formStateStorage(temp, *standard);
 
-    Array<double> rms_tols(0.02, 2*10+2*18); // activations within 2%
+    std::vector<double> rms_tols(2*10+2*18, 0.02); // activations within 2%
     for(int i=0; i<20; ++i){
         rms_tols[i] = 0.01;  // angles and speeds within .6 degrees .6 degs/s 
     }

--- a/Applications/CMC/test/testCMCSingleMuscle.cpp
+++ b/Applications/CMC/test/testCMCSingleMuscle.cpp
@@ -83,9 +83,9 @@ void testSingleMuscle() {
     Storage fwd_states("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
     Storage cmc_states("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
 
-    Array<double> control_tols(4.0e-3, 1); // peak control is 0.2 so this is 2% of peak
-    Array<double> force_tols(1.0e-1, 1);   // 0.1 N 
-    Array<double> state_tols(1.0e-3, 4);   // errors: q<1mm, u<1mm/s, a<0.001, fl<1mm
+    std::vector<double> control_tols(1, 4.0e-3); // peak control is 0.2 so this is 2% of peak
+    std::vector<double> force_tols(1, 1.0e-1);   // 0.1 N 
+    std::vector<double> state_tols(4, 1.0e-3);   // errors: q<1mm, u<1mm/s, a<0.001, fl<1mm
 
     CHECK_STORAGE_AGAINST_STANDARD(cmc_controls, fwd_controls, control_tols,
         __FILE__, __LINE__, base + " controls failed");

--- a/Applications/CMC/test/testCMCSingleRigidTendonMuscle.cpp
+++ b/Applications/CMC/test/testCMCSingleRigidTendonMuscle.cpp
@@ -81,7 +81,9 @@ void testSingleRigidTendonMuscle() {
     Storage cmc_result("block_hanging_from_rigid_thelen_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
 
     // Tolerance of 2mm or position error and 2mm/s translational velocity of the block
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, Array<double>(0.002, 4), __FILE__, __LINE__, "testSingleRigidTendonMuscle failed");
+    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, 
+        std::vector<double>(4, 0.002), __FILE__, __LINE__,
+        "testSingleRigidTendonMuscle failed");
     
     cout << "testSingleRigidTendonMuscle passed\n" << endl;
 }
@@ -109,7 +111,9 @@ void testSingleMillardRigidTendonMuscle() {
     Storage fwd_result("block_hanging_from_rigid_millard_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
     Storage cmc_result("block_hanging_from_rigid_millard_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
 
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, Array<double>(0.002, 3), __FILE__, __LINE__, "testSingleMillardRigidTendonMuscle failed");
+    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, 
+        std::vector<double>(3, 0.002), __FILE__, __LINE__,
+        "testSingleMillardRigidTendonMuscle failed");
 
     cout << "testSingleMillardRigidTendonMuscle passed\n" << endl;
 }

--- a/Applications/CMC/test/testCMCTwoMusclesOnBlock.cpp
+++ b/Applications/CMC/test/testCMCTwoMusclesOnBlock.cpp
@@ -83,7 +83,9 @@ void testSingleRigidTendonMuscle() {
     Storage cmc_result("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
 
     // Tolerance of 2mm or position error and 2mm/s translational velocity of the block
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, Array<double>(0.0025, 4), __FILE__, __LINE__, "testSingleRigidTendonMuscle failed");
+    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, 
+        std::vector<double>(4, 0.0025), __FILE__, __LINE__,
+        "testSingleRigidTendonMuscle failed");
     
     cout << "testSingleRigidTendonMuscle passed\n" << endl;
 }
@@ -106,7 +108,9 @@ void testSingleMillardRigidTendonMuscle() {
     Storage fwd_result("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
     Storage cmc_result("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
 
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, Array<double>(0.002, 3), __FILE__, __LINE__, "testSingleMillardRigidTendonMuscle failed");
+    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, 
+        std::vector<double>(3, 0.002), __FILE__, __LINE__,
+        "testSingleMillardRigidTendonMuscle failed");
 
     cout << "testSingleMillardRigidTendonMuscle passed\n" << endl;
 }
@@ -125,7 +129,7 @@ void testTwoMusclesOnBlock() {
     Storage fwd_result("twoMusclesOnBlock_ForwardResults/twoMusclesOnBlock_forward_states.sto");
     Storage cmc_result("twoMusclesOnBlock_ResultsCMC/twoMusclesOnBlock_tugOfWar_states.sto");
 
-    Array<double> rms_tols(0.001, 6);
+    std::vector<double> rms_tols(6, 0.001);
     rms_tols[1] = 0.0025; // block_u
     rms_tols[2] = 0.05;  // muscle 1 activation
     rms_tols[4] = 0.05;  // muscle 2 activation
@@ -133,8 +137,8 @@ void testTwoMusclesOnBlock() {
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
     string base = "testTwoMusclesOnBlock "+ muscleType;
 
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, rms_tols, __FILE__, __LINE__,
-        base+" failed");
+    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, rms_tols, 
+        __FILE__, __LINE__, base+" failed");
     
     cout << "\n" << base << " passed\n" << endl;
 }

--- a/Applications/CMC/test/testCMCWithControlConstraintsGait2354.cpp
+++ b/Applications/CMC/test/testCMCWithControlConstraintsGait2354.cpp
@@ -82,7 +82,7 @@ void testGait2354() {
     for (int i = 23; i < 46; ++i){
         rms_tols2[i] = 0.75; // velocities
     }
-    for (int i = 46; i < rms_tols2.size(); ++i){
+    for (size_t i = 46; i < rms_tols2.size(); ++i){
         rms_tols2[i] = 0.15; // muscle activations and fiber-lengths
     }
 

--- a/Applications/CMC/test/testCMCWithControlConstraintsGait2354.cpp
+++ b/Applications/CMC/test/testCMCWithControlConstraintsGait2354.cpp
@@ -66,26 +66,28 @@ void testGait2354() {
     int nq = results.getColumnLabels().getSize()-1;
 
     // Tracking kinematics angles in degrees should be within 2 degrees
-    Array<double> rms_tols(2.0, nq);
+    std::vector<double> rms_tols(nq, 2.0);
     rms_tols[3] = 0.005; // pelvis translations in m should be with 5mm
     rms_tols[4] = 0.005;
     rms_tols[5] = 0.005;
 
-    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols, __FILE__, __LINE__, "testGait2354 tracking failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols, 
+        __FILE__, __LINE__, "testGait2354 tracking failed");
 
     Storage results2("subject01_ResultsCMC/subject01_walk1_states.sto");
     Storage standard2("std_subject01_walk1_states.sto");
 
     Array<string> col_labels = standard2.getColumnLabels();
-    Array<double> rms_tols2(0.1, col_labels.getSize()-1);
+    std::vector<double> rms_tols2(col_labels.getSize()-1, 0.1);
     for (int i = 23; i < 46; ++i){
         rms_tols2[i] = 0.75; // velocities
     }
-    for (int i = 46; i < rms_tols2.getSize(); ++i){
+    for (int i = 46; i < rms_tols2.size(); ++i){
         rms_tols2[i] = 0.15; // muscle activations and fiber-lengths
     }
 
-    CHECK_STORAGE_AGAINST_STANDARD(results2, standard2, rms_tols2, __FILE__, __LINE__, "testGait2354 states failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results2, standard2, rms_tols2, 
+        __FILE__, __LINE__, "testGait2354 states failed");
 
     cout << "\n testGait2354 passed\n" << endl;
 }

--- a/Applications/CMC/test/testCMCWithControlConstraintsRunningModel.cpp
+++ b/Applications/CMC/test/testCMCWithControlConstraintsRunningModel.cpp
@@ -66,12 +66,13 @@ void testRunningModel()
     int nq = results.getColumnLabels().getSize()-1;
 
     // Tracking kinematics angles in degrees should be within 3 degrees (see standard versus input)
-    Array<double> rms_tols(3.00, nq);
+    std::vector<double> rms_tols(nq, 3.00);
     rms_tols[3] = 0.0025; // pelvis translations in m should be with 2.5mm
     rms_tols[4] = 0.0025;
     rms_tols[5] = 0.0025;
 
-    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols, __FILE__, __LINE__, "testRunningModel tracking failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols, 
+        __FILE__, __LINE__, "testRunningModel tracking failed");
 
     Storage results_states("runningModel_CMC_Results/runningModel_CMC_test_states.sto");
     Storage standard_states("std_runningModel_CMC_states.sto");
@@ -79,13 +80,14 @@ void testRunningModel()
     int nc = results_states.getColumnLabels().getSize()-1;
 
     // already passed tracking kinematics so focus on muscle states
-    Array<double> rms_states_tols(0.6, nc);
+    std::vector<double> rms_states_tols(nc, 0.6);
     for(int i = nq; i< 2*nq; ++i)
     {
         rms_states_tols[i] = 0.2; // velocities
     }
 
-    CHECK_STORAGE_AGAINST_STANDARD(results_states, standard_states, rms_states_tols, __FILE__, __LINE__, "testRunningModel activations failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results_states, standard_states, rms_states_tols, 
+        __FILE__, __LINE__, "testRunningModel activations failed");
 
     cout << "\n testRunningModel passed\n" << endl;
 }

--- a/Applications/Forward/test/testForward.cpp
+++ b/Applications/Forward/test/testForward.cpp
@@ -212,14 +212,15 @@ void testGait2354()
     
     int nstates = forward.getModel().getNumStateVariables();
     int nq = forward.getModel().getNumCoordinates();
-    Array<double> rms_tols(0.001, 2*nstates); //activations and fiber-lengths
+    std::vector<double> rms_tols(2*nstates, 0.001); //activations and fiber-lengths
 
     for(int i=0; i<nq; ++i){
         rms_tols[2*i] = 0.035; // coordinates at less than 2degrees
         rms_tols[2*i+1] = 2.5; // speeds can deviate by a lot due to open-loop test
     }
     
-    CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__, __LINE__, "testGait2354 failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols,
+        __FILE__, __LINE__, "testGait2354 failed");
 }
 
 void testGait2354WithController() {
@@ -233,12 +234,13 @@ void testGait2354WithController() {
 
     int nstates = forward.getModel().getNumStateVariables();
     int nq = forward.getModel().getNumCoordinates();
-    Array<double> rms_tols(0.001, 2*nstates); //activations and fiber-lengths
+    std::vector<double> rms_tols(2*nstates, 0.001); //activations and fiber-lengths
 
     for(int i=0; i<nq; ++i){
         rms_tols[2*i] = 0.01; // coordinates at less than 0.6 degree
         rms_tols[2*i+1] = 0.1; // speeds should deviate less with feedback controller
     }
     
-    CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__, __LINE__, "testGait2354WithController failed");
+    CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols,
+        __FILE__, __LINE__, "testGait2354WithController failed");
 }

--- a/Applications/ID/test/testID.cpp
+++ b/Applications/ID/test/testID.cpp
@@ -39,13 +39,17 @@ int main()
         InverseDynamicsTool id1("arm26_Setup_InverseDynamics.xml");
         id1.run();
         Storage result1("Results/arm26_InverseDynamics.sto"), standard1("std_arm26_InverseDynamics.sto");
-        CHECK_STORAGE_AGAINST_STANDARD( result1, standard1, Array<double>(1e-2, 23), __FILE__, __LINE__, "testArm failed");
+        CHECK_STORAGE_AGAINST_STANDARD( result1, standard1, 
+            std::vector<double>(23, 1e-2), __FILE__, __LINE__,
+            "testArm failed");
         cout << "testArm passed" << endl;
 
         InverseDynamicsTool id2("subject01_Setup_InverseDynamics.xml");
         id2.run();
         Storage result2("Results/subject01_InverseDynamics.sto"), standard2("std_subject01_InverseDynamics.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, Array<double>(2.0, 23), __FILE__, __LINE__, "testGait failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
+            std::vector<double>(23, 2.0), __FILE__, __LINE__,
+            "testGait failed");
         cout << "testGait passed" << endl;
     }
     catch (const Exception& e) {

--- a/Applications/IK/test/testIK.cpp
+++ b/Applications/IK/test/testIK.cpp
@@ -40,7 +40,9 @@ int main()
         InverseKinematicsTool ik1("subject01_Setup_InverseKinematics.xml");
         ik1.run();
         Storage result1(ik1.getOutputMotionFileName()), standard("std_subject01_walk1_ik.mot");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard, Array<double>(0.2, 24), __FILE__, __LINE__, "testInverseKinematicsGait2354 failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result1, standard, 
+            std::vector<double>(24, 0.2), __FILE__, __LINE__, 
+            "testInverseKinematicsGait2354 failed");
         cout << "testInverseKinematicsGait2354 passed" << endl;
 
         InverseKinematicsTool ik2("subject01_Setup_InverseKinematics_NoModel.xml");
@@ -49,7 +51,9 @@ int main()
         ik2.setModel(mdl);
         ik2.run();
         Storage result2(ik2.getOutputMotionFileName());
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard, Array<double>(0.2, 24), __FILE__, __LINE__, "testInverseKinematicsGait2354 GUI workflow failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result2, standard, 
+            std::vector<double>(24, 0.2), __FILE__, __LINE__, 
+            "testInverseKinematicsGait2354 GUI workflow failed");
         cout << "testInverseKinematicsGait2354 GUI workflow passed" << endl;
 
         InverseKinematicsTool ik3("constraintTest_setup_ik.xml");

--- a/Applications/RRA/test/testRRA.cpp
+++ b/Applications/RRA/test/testRRA.cpp
@@ -38,7 +38,7 @@ int main() {
         if (rra.run()){
             checkCOM("subject01_RRA_adjusted.osim", "torso", SimTK::Vec3(0.00598028440188985017, 0.34551, 0.1), Array<double>(1e-4, 3));
             Storage result("ResultsRRA/subject01_walk1_RRA_Kinematics_q.sto"), standard("subject01_walk1_RRA_Kinematics_q_standard.sto");
-            CHECK_STORAGE_AGAINST_STANDARD(result, standard, Array<double>(0.5, 24), __FILE__, __LINE__, "testRRA: kinematics comparison failed");
+            CHECK_STORAGE_AGAINST_STANDARD(result, standard, std::vector<double>(24, 0.5), __FILE__, __LINE__, "testRRA: kinematics comparison failed");
         }
         else{
             throw(Exception("testRRA FAILED to run to completion."));

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -79,7 +79,7 @@ inline void ASSERT(bool cond,
  */
 void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result, 
                                     OpenSim::Storage& standard, 
-                                    OpenSim::Array<double> tolerances, 
+                                    std::vector<double> tolerances, 
                                     std::string testFile, 
                                     int testFileLine, 
                                     std::string errorMessage)

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -80,9 +80,9 @@ inline void ASSERT(bool cond,
 void CHECK_STORAGE_AGAINST_STANDARD(const OpenSim::Storage& result, 
                                     const OpenSim::Storage& standard, 
                                     const std::vector<double>& tolerances, 
-                                    const std::string testFile, 
+                                    const std::string& testFile, 
                                     const int testFileLine, 
-                                    const std::string errorMessage)
+                                    const std::string& errorMessage)
 {
     std::vector<std::string> columnsUsed;
     std::vector<double> comparisons;

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -84,11 +84,11 @@ void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result,
                                     int testFileLine, 
                                     std::string errorMessage)
 {
-    OpenSim::Array<std::string> columnsUsed;
-    OpenSim::Array<double> comparisons;
+    std::vector<std::string> columnsUsed;
+    std::vector<double> comparisons;
     result.compareWithStandard(standard, columnsUsed, comparisons);
 
-    int ncolumns = columnsUsed.getSize();
+    int ncolumns = columnsUsed.size();
 
     ASSERT(ncolumns > 0, testFile, testFileLine, 
            errorMessage + "- no common columns to compare!");

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -77,12 +77,12 @@ inline void ASSERT(bool cond,
  * specified tolerances. If RMS error for any column is outside the
  * tolerance, throw an Exception.
  */
-void CHECK_STORAGE_AGAINST_STANDARD(OpenSim::Storage& result, 
-                                    OpenSim::Storage& standard, 
-                                    std::vector<double> tolerances, 
-                                    std::string testFile, 
-                                    int testFileLine, 
-                                    std::string errorMessage)
+void CHECK_STORAGE_AGAINST_STANDARD(const OpenSim::Storage& result, 
+                                    const OpenSim::Storage& standard, 
+                                    const std::vector<double>& tolerances, 
+                                    const std::string testFile, 
+                                    const int testFileLine, 
+                                    const std::string errorMessage)
 {
     std::vector<std::string> columnsUsed;
     std::vector<double> comparisons;

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -3328,23 +3328,19 @@ double Storage::compareColumnRMS(Storage& aOtherStorage, const std::string& aCol
  * errors for columns occurring in both storage objects, and record the
  * values and column names in the comparisons and columnsUsed Arrays.
  */
-void Storage::compareWithStandard(Storage& standard, Array<string> &columnsUsed, Array<double> &comparisons)
+void Storage::compareWithStandard(Storage& standard, std::vector<string> &columnsUsed, std::vector<double> &comparisons)
 {
     int maxColumns = _columnLabels.getSize();
-    columnsUsed.ensureCapacity(maxColumns);
-    comparisons.ensureCapacity(maxColumns);
+    columnsUsed.reserve(maxColumns);
+    comparisons.reserve(maxColumns);
 
-    int columns = 0;
     for (int i = 1; i < maxColumns; ++i) {
         double comparison = compareColumnRMS(standard, _columnLabels[i]);
         if (!SimTK::isNaN(comparison)) {
-            comparisons[columns] = comparison;
-            columnsUsed[columns++] = _columnLabels[i];
+            comparisons.push_back(comparison);
+            columnsUsed.push_back(_columnLabels[i]);
         }
     }
-
-    columnsUsed.setSize(columns);
-    comparisons.setSize(columns);
 }
 
 bool Storage::makeStorageLabelsUnique() {

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -3282,7 +3282,7 @@ double Storage::compareColumn(Storage& aOtherStorage, const std::string& aColumn
  * If endTime is not specified the comparison goes to the end of the file
  * @returns the root mean square, using a spline to calculate values where the times do not match up.
  */
-double Storage::compareColumnRMS(Storage& aOtherStorage, const std::string& aColumnName, double startTime, double endTime)
+double Storage::compareColumnRMS(const Storage& aOtherStorage, const std::string& aColumnName, double startTime, double endTime) const
 {
     int thisColumnIndex = getStateIndex(aColumnName);
     int otherColumnIndex = aOtherStorage.getStateIndex(aColumnName);
@@ -3328,11 +3328,9 @@ double Storage::compareColumnRMS(Storage& aOtherStorage, const std::string& aCol
  * errors for columns occurring in both storage objects, and record the
  * values and column names in the comparisons and columnsUsed Arrays.
  */
-void Storage::compareWithStandard(Storage& standard, std::vector<string> &columnsUsed, std::vector<double> &comparisons)
+void Storage::compareWithStandard(const Storage& standard, std::vector<string>& columnsUsed, std::vector<double>& comparisons) const
 {
     int maxColumns = _columnLabels.getSize();
-    columnsUsed.reserve(maxColumns);
-    comparisons.reserve(maxColumns);
 
     for (int i = 1; i < maxColumns; ++i) {
         double comparison = compareColumnRMS(standard, _columnLabels[i]);

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -299,11 +299,13 @@ public:
     double compareColumn(Storage& aOtherStorage, 
                          const std::string& aColumnName,
                          double startTime, double endTime=-1.0);
-    double compareColumnRMS(Storage& aOtherStorage, 
-                         const std::string& aColumnName,
-                         double startTime=SimTK::NaN, double endTime=SimTK::NaN);
+    double compareColumnRMS(const Storage& aOtherStorage, 
+                            const std::string& aColumnName,
+                            double startTime=SimTK::NaN, double endTime=SimTK::NaN) const;
     //void checkAgainstStandard(Storage standard, Array<double> &tolerances, std::string testFile = "", int testFileLine = -1, std::string errorMessage = "Exception");
-    void compareWithStandard(Storage& standard, std::vector<std::string> &columnsUsed, std::vector<double> &comparisons);
+    void compareWithStandard(const Storage& standard, 
+                             std::vector<std::string>& columnsUsed, 
+                             std::vector<double>& comparisons) const;
     /** Force column labels for a Storage object to become unique. This is done
      * by prepending the string (n_) as needed where n=1, 2, ...
      *

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -303,7 +303,7 @@ public:
                          const std::string& aColumnName,
                          double startTime=SimTK::NaN, double endTime=SimTK::NaN);
     //void checkAgainstStandard(Storage standard, Array<double> &tolerances, std::string testFile = "", int testFileLine = -1, std::string errorMessage = "Exception");
-    void compareWithStandard(Storage& standard, Array<std::string> &columnsUsed, Array<double> &comparisons);
+    void compareWithStandard(Storage& standard, std::vector<std::string> &columnsUsed, std::vector<double> &comparisons);
     /** Force column labels for a Storage object to become unique. This is done
      * by prepending the string (n_) as needed where n=1, 2, ...
      *

--- a/OpenSim/Simulation/Test/testContactGeometry.cpp
+++ b/OpenSim/Simulation/Test/testContactGeometry.cpp
@@ -356,21 +356,21 @@ void compareHertzAndMeshContactResults()
 
     // Hertz theory and ElasticFoundation will not be the same, but they should
     // yield similar results, to withing
-    Array<double> rms_tols_1(12, nforces);
+    std::vector<double> rms_tols_1(nforces, 12);
     CHECK_STORAGE_AGAINST_STANDARD(meshToMesh, hertz, rms_tols_1,
             __FILE__, __LINE__,
             "ElasticFoundation FAILED to Match Hertz Contact ");
 
     // ElasticFoundation on mesh to mesh and mesh to non-mesh should be
     // virtually identical
-    Array<double> rms_tols_2(0.5, nforces);
+    std::vector<double> rms_tols_2(nforces, 0.5);
     CHECK_STORAGE_AGAINST_STANDARD(meshToMesh, meshToNoMesh, rms_tols_2,
             __FILE__, __LINE__,
             "ElasticFoundation Mesh-Mesh FAILED to match Mesh-noMesh Case ");
 
     // ElasticFoundation on non-mesh to mesh and mesh to non-mesh should be
     // identical
-    Array<double> rms_tols_3(integ_accuracy, nforces);
+    std::vector<double> rms_tols_3(nforces, integ_accuracy);
     CHECK_STORAGE_AGAINST_STANDARD(noMeshToMesh, meshToNoMesh, rms_tols_3,
             __FILE__, __LINE__,
             "ElasticFoundation noMesh-Mesh FAILED to match Mesh-noMesh Case ");

--- a/OpenSim/Tests/AddComponents/testAddComponents.cpp
+++ b/OpenSim/Tests/AddComponents/testAddComponents.cpp
@@ -303,14 +303,14 @@ void compareResultsToStandard() {
             standard1("std_tugOfWar_states.sto");
 
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
-            Array<double>(0.02, 16), __FILE__, __LINE__,
+            std::vector<double>(16, 0.02), __FILE__, __LINE__,
             "testAddComponents::tugOfWar states failed");
         cout << "testAddComponents::tugOfWar states passed\n";
 
         Storage result2("tugOfWar_forces.sto"),
             standard2("std_tugOfWar_forces.mot");
 
-        Array<double> tols(1.0, 20);
+        std::vector<double> tols(20, 1.0);
         // 10N is 1% of the muscles maximum isometric force
         tols[0] = tols[1] = 10;
 

--- a/OpenSim/Tests/ControllerExample/testControllerExample.cpp
+++ b/OpenSim/Tests/ControllerExample/testControllerExample.cpp
@@ -38,13 +38,13 @@ int main()
         Storage result1("tugOfWar_controls.sto"), 
                 standard1("std_tugOfWar_controls.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       Array<double>(0.01, 2), 
+                                       std::vector<double>(2, 0.01),
                                        __FILE__, 
                                        __LINE__, 
                                        "tugOfWar controls failed");
         cout << "tugOfWar controls passed\n" << endl;
 
-        Array<double> tols(0.01, 16);
+        std::vector<double> tols(16, 0.01);
         // speeds are not matched as precisely
         for(int i =0; i < 6; ++i)
             tols[2*i+1] = 0.03;

--- a/OpenSim/Tests/CustomActuatorExample/testCustomActuatorExample.cpp
+++ b/OpenSim/Tests/CustomActuatorExample/testCustomActuatorExample.cpp
@@ -36,17 +36,19 @@ int main()
 {
     try {
         Storage result1("SpringActuatedLeg_states_degrees.sto"), standard1("std_SpringActuatedLeg_states_degrees.mot");
-        Array<double> tolerances(1.0, 6);   // angles have 1 deg tolerance
+        std::vector<double> tolerances(6, 1.0);   // angles have 1 deg tolerance
         tolerances[1] = tolerances[3] = tolerances[5] = 5.0; // angular speeds have a 5 deg/s tolerance
 
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, tolerances, __FILE__, __LINE__, "spring actuated leg states degrees failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, tolerances, 
+            __FILE__, __LINE__, "spring actuated leg states degrees failed");
         cout << "spring actuated leg states degrees passed\n";
 
-        Array<double> forceTol(1.0, 2); // piston actuator has a tolerance of 1N
+        std::vector<double> forceTol(2, 1.0); // piston actuator has a tolerance of 1N
         forceTol[1] = 5.0; // spring has a tolerance of 5N 
 
         Storage result2("actuator_forces.sto"), standard2("std_actuator_forces.mot");
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, forceTol, __FILE__, __LINE__, "actuator forces failed");
+        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, forceTol, 
+            __FILE__, __LINE__, "actuator forces failed");
         cout << "actuator forces passed\n";
     }
     catch (const Exception& e) {

--- a/OpenSim/Tests/ExampleMain/testExampleMain.cpp
+++ b/OpenSim/Tests/ExampleMain/testExampleMain.cpp
@@ -38,7 +38,7 @@ int main()
         Storage result1("tugOfWar_states.sto"), 
                 standard1("std_tugOfWar_states.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       Array<double>(0.1, 16), 
+                                       std::vector<double>(16, 0.1),
                                        __FILE__, 
                                        __LINE__, 
                                        "tugOfWar states failed");
@@ -47,7 +47,7 @@ int main()
         Storage result3("tugOfWar_forces.sto"), 
                 standard3("std_tugOfWar_forces.mot");
         
-        Array<double> tols(1.0, 20);
+        std::vector<double> tols(20, 1.0);
         // 10N is 1% of the muscles maximum isometric force
         tols[0] = tols[1] = 10;
 

--- a/OpenSim/Tests/MuscleExample/testMuscleExample.cpp
+++ b/OpenSim/Tests/MuscleExample/testMuscleExample.cpp
@@ -39,7 +39,7 @@ int main()
                 standard1("std_tugOfWar_fatigue_states.sto");
         int ncols = result1.getColumnLabels().getSize();
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       Array<double>(0.01, ncols), 
+                                       std::vector<double>(ncols, 0.01),
                                        __FILE__, 
                                        __LINE__, 
                                        "tugOfWar fatigue states failed");
@@ -49,7 +49,7 @@ int main()
                 standard2("std_tugOfWar_forces.mot");
         ncols = result2.getColumnLabels().getSize();
         CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
-                                       Array<double>(20.0, ncols), 
+                                       std::vector<double>(ncols, 20.0),
                                        __FILE__, 
                                        __LINE__, 
                                        "tugOfWar forces failed");

--- a/OpenSim/Tests/OptimizationExample_Arm26/testOptimizationExample.cpp
+++ b/OpenSim/Tests/OptimizationExample_Arm26/testOptimizationExample.cpp
@@ -52,7 +52,7 @@ int main()
         Storage result("Arm26_optimized_states.sto"),
                 standard("std_Arm26_optimized_states.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result, standard, 
-                                       Array<double>(0.01, 16),
+                                       std::vector<double>(16, 0.01),
                                        __FILE__, 
                                        __LINE__, 
                                        "Arm26 states failed comparison test");

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -403,11 +403,11 @@ void testPrescribedControllerFromFile(const std::string& modelFile,
     /*int ncontrols = */osimModel.getNumControls();
 
     CHECK_STORAGE_AGAINST_STANDARD(states, std_states, 
-        Array<double>(0.005, nstates), __FILE__, __LINE__,
+        std::vector<double>(nstates, 0.005), __FILE__, __LINE__,
         "testPrescribedControllerFromFile '"+modelName+"'states failed");
 
     CHECK_STORAGE_AGAINST_STANDARD(controls, std_controls, 
-        Array<double>(0.01, nstates), __FILE__, __LINE__,
+        std::vector<double>(nstates, 0.01), __FILE__, __LINE__,
         "testPrescribedControllerFromFile '"+modelName+"'controls failed");
      
     osimModel.disownAllComponents();


### PR DESCRIPTION
This PR starts to address #1194 by accomplishing two things:
1) CHECK_STORAGE_AGAINST_STANDARD now expects tolerances to be passed in by `std::vector` (instead of `OpenSim::Array`)
2) Changes `Storage::compareWithStandard()` to use `std::vector` internally.