### PR TITLE
Add non-const accessors for Coordinates and disseminate

### DIFF
--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -118,9 +118,9 @@ void testMcKibbenActuator()
     Vec3 locationInParent(0, ball_radius, 0), orientationInParent(0), locationInBody(0), orientationInBody(0);
     SliderJoint *ballToGround = new SliderJoint("ballToGround", ground, locationInParent, orientationInParent, *ball, locationInBody, orientationInBody);
 
-    ballToGround->upd_coordinates(0).setName("ball_d");
-    ballToGround->upd_coordinates(0).setPrescribedFunction(LinearFunction(20 * 10e-4, 0.5 * 264.1 * 10e-4));
-    ballToGround->upd_coordinates(0).set_prescribed(true);
+    ballToGround->updCoordinate().setName("ball_d");
+    ballToGround->updCoordinate().setPrescribedFunction(LinearFunction(20 * 10e-4, 0.5 * 264.1 * 10e-4));
+    ballToGround->updCoordinate().set_prescribed(true);
 
     model->addBody(ball);
     model->addJoint(ballToGround);
@@ -393,8 +393,8 @@ void testClutchedPathSpring()
 
     double positionRange[2] = {-10, 10};
     // Rename coordinates for a slider joint
-    slider->upd_coordinates(0).setName("block_h");
-    slider->upd_coordinates(0).setRange(positionRange);
+    slider->updCoordinate().setName("block_h");
+    slider->updCoordinate().setRange(positionRange);
 
     model->addBody(pulleyBody);
     model->addJoint(weld);

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -253,7 +253,7 @@ void simulateMuscle(
                         Vec3(0), 
                         Vec3(0));
 
-    auto& sliderCoord = slider->upd_coordinates(0);
+    auto& sliderCoord = slider->updCoordinate();
     sliderCoord.setName("tx");
     sliderCoord.setDefaultValue(1.0);
     sliderCoord.setRangeMin(0); 

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -102,14 +102,14 @@ int main()
             locationInChild, orientationInChild);
         
         double range[2] = {-SimTK::Pi*2, SimTK::Pi*2};
-        ankle->upd_coordinates(0).setName("q1");
-        ankle->upd_coordinates(0).setRange(range);
+        ankle->updCoordinate().setName("q1");
+        ankle->updCoordinate().setRange(range);
 
-        knee->upd_coordinates(0).setName("q2");
-        knee->upd_coordinates(0).setRange(range);
+        knee->updCoordinate().setName("q2");
+        knee->updCoordinate().setRange(range);
 
-        hip->upd_coordinates(0).setName("q3");
-        hip->upd_coordinates(0).setRange(range);
+        hip->updCoordinate().setName("q3");
+        hip->updCoordinate().setRange(range);
 
         // Add the bodies to the model
         osimModel.addBody(linkage1);

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -144,21 +144,24 @@ int main()
         // joint between the block and ground frames.
         double angleRange[2] = {-SimTK::Pi/2, SimTK::Pi/2};
         double positionRange[2] = {-1, 1};
-        blockToGround->upd_coordinates(0).setRange(angleRange);
-        blockToGround->upd_coordinates(1).setRange(angleRange);
-        blockToGround->upd_coordinates(2).setRange(angleRange);
-        blockToGround->upd_coordinates(3).setRange(positionRange);
-        blockToGround->upd_coordinates(4).setRange(positionRange);
-        blockToGround->upd_coordinates(5).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation1X).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation2Y).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation3Z).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationX).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationY).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationZ).setRange(positionRange);
 
         // GRAVITY
         // Obtain the default acceleration due to gravity
         Vec3 gravity = osimModel.getGravity();
 
         // Define non-zero default states for the free joint
-        blockToGround->upd_coordinates(3).setDefaultValue(constantDistance); // set x-translation value
-        double h_start = blockMass*gravity[1]/(stiffness*blockSideLength*blockSideLength);
-        blockToGround->upd_coordinates(4).setDefaultValue(h_start); // set y-translation which is height
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationX)
+                       .setDefaultValue(constantDistance);
+        double h_start = blockMass*gravity[1] /
+                         (stiffness*blockSideLength*blockSideLength);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationY)
+                       .setDefaultValue(h_start); //y-translation is height
 
         // Add the block and joint to the model
         osimModel.addBody(block);

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -100,12 +100,12 @@ int main()
         // joint between the block and ground frames.
         double angleRange[2] = {-SimTK::Pi/2, SimTK::Pi/2};
         double positionRange[2] = {-1, 1};
-        blockToGround->upd_coordinates(0).setRange(angleRange);
-        blockToGround->upd_coordinates(1).setRange(angleRange);
-        blockToGround->upd_coordinates(2).setRange(angleRange);
-        blockToGround->upd_coordinates(3).setRange(positionRange);
-        blockToGround->upd_coordinates(4).setRange(positionRange);
-        blockToGround->upd_coordinates(5).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation1X).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation2Y).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation3Z).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationX).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationY).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationZ).setRange(positionRange);
 
         // Add the block body to the model
         osimModel.addBody(block);
@@ -173,7 +173,7 @@ int main()
 
         // Add a Muscle analysis
         MuscleAnalysis* muscAnalysis = new MuscleAnalysis(&osimModel);
-        Array<std::string> coords(blockToGround->get_coordinates(5).getName(),1);
+        Array<std::string> coords(blockToGround->getCoordinate(FreeJoint::Coord::TranslationZ).getName(),1);
         muscAnalysis->setCoordinates(coords);
         muscAnalysis->setComputeMoments(false);
         osimModel.addAnalysis(muscAnalysis);

--- a/OpenSim/Examples/checkEnvironment/test.cpp
+++ b/OpenSim/Examples/checkEnvironment/test.cpp
@@ -81,12 +81,12 @@ int main()
         // joint between the block and ground frames.
         double angleRange[2] = {-SimTK::Pi/2, SimTK::Pi/2};
         double positionRange[2] = {-1, 1};
-        blockToGround->upd_coordinates(0).setRange(angleRange);
-        blockToGround->upd_coordinates(1).setRange(angleRange);
-        blockToGround->upd_coordinates(2).setRange(angleRange);
-        blockToGround->upd_coordinates(3).setRange(positionRange);
-        blockToGround->upd_coordinates(4).setRange(positionRange);
-        blockToGround->upd_coordinates(5).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation1X).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation2Y).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::Rotation3Z).setRange(angleRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationX).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationY).setRange(positionRange);
+        blockToGround->updCoordinate(FreeJoint::Coord::TranslationZ).setRange(positionRange);
 
         // Add the block body to the model
         osimModel.addBody(block);

--- a/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
+++ b/OpenSim/Sandbox/ExampleHopperDevice/helperMethods.h
@@ -234,7 +234,7 @@ inline Model buildTestbed()
     // Attach the load to ground with a FreeJoint and set the location of the
     // load to (1,0,0).
     auto gndToLoad = new FreeJoint("gndToLoad", testbed.getGround(), *load);
-    gndToLoad->upd_coordinates(3).setDefaultValue(1.0);
+    gndToLoad->updCoordinate(FreeJoint::Coord::TranslationX).setDefaultValue(1.0);
     testbed.addJoint(gndToLoad);
 
     // Add a spring between the ground's origin and the load.

--- a/OpenSim/Sandbox/futureIKListOutputs.cpp
+++ b/OpenSim/Sandbox/futureIKListOutputs.cpp
@@ -268,7 +268,7 @@ void createModel(Model& model) {
                              *pelvis, Vec3(0), Vec3(0),
                              *femur,  Vec3(0, 1, 0), Vec3(0));
     model.addJoint(hip);
-    hog->upd_coordinates(0).setDefaultValue(0.5 * SimTK::Pi);
+    hog->updCoordinate().setDefaultValue(0.5 * SimTK::Pi);
     
     auto* asis = new OpenSim::Marker();
     asis->setName("asis"); asis->setParentFrame(*pelvis);

--- a/OpenSim/Simulation/SimbodyEngine/BallJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/BallJoint.cpp
@@ -54,9 +54,9 @@ void BallJoint::extendInitStateFromProperties(SimTK::State& s) const
     if (matter.getUseEulerAngles(s))
         return;
 
-    double xangle = get_coordinates(0).getDefaultValue();
-    double yangle = get_coordinates(1).getDefaultValue();
-    double zangle = get_coordinates(2).getDefaultValue();
+    double xangle = getCoordinate(BallJoint::Coord::Rotation1X).getDefaultValue();
+    double yangle = getCoordinate(BallJoint::Coord::Rotation2Y).getDefaultValue();
+    double zangle = getCoordinate(BallJoint::Coord::Rotation3Z).getDefaultValue();
     Rotation r(BodyRotationSequence, xangle, XAxis, yangle, YAxis, zangle, ZAxis);
     //BallJoint* mutableThis = const_cast<BallJoint*>(this);
     getChildFrame().getMobilizedBody().setQToFitRotation(s, r);
@@ -73,8 +73,8 @@ void BallJoint::extendSetPropertiesFromState(const SimTK::State& state)
         Rotation r = getChildFrame().getMobilizedBody().getBodyRotation(state);
         Vec3 angles = r.convertRotationToBodyFixedXYZ();
     
-        upd_coordinates(0).setDefaultValue(angles[0]);
-        upd_coordinates(1).setDefaultValue(angles[1]);
-        upd_coordinates(2).setDefaultValue(angles[2]);
+        updCoordinate(BallJoint::Coord::Rotation1X).setDefaultValue(angles[0]);
+        updCoordinate(BallJoint::Coord::Rotation2Y).setDefaultValue(angles[1]);
+        updCoordinate(BallJoint::Coord::Rotation3Z).setDefaultValue(angles[2]);
     }
 }

--- a/OpenSim/Simulation/SimbodyEngine/BallJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/BallJoint.h
@@ -52,7 +52,8 @@ class OSIMSIMULATION_API BallJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(BallJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -82,9 +83,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
@@ -103,7 +103,11 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint. */
     const Coordinate& getCoordinate(unsigned idx) const {
         OPENSIM_THROW_IF(numCoordinates() == 0,
                          JointHasNoCoordinates);
@@ -113,6 +117,18 @@ public:
                          "index available");
 
         return get_coordinates(idx);
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint. */
+    Coordinate& updCoordinate(unsigned idx) {
+        OPENSIM_THROW_IF(numCoordinates() == 0,
+                         JointHasNoCoordinates);
+        OPENSIM_THROW_IF(idx > numCoordinates()-1,
+                         InvalidCall,
+                         "Index passed to updCoordinate() exceeds the largest "
+                         "index available");
+
+        return upd_coordinates(idx);
     }
 
     // SCALE

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -165,9 +165,9 @@ void EllipsoidJoint::extendInitStateFromProperties(SimTK::State& s) const
     const SimbodyMatterSubsystem& matter = getModel().getMatterSubsystem();
     
     if (!matter.getUseEulerAngles(s)){
-        double xangle = get_coordinates(0).getDefaultValue();
-        double yangle = get_coordinates(1).getDefaultValue();
-        double zangle = get_coordinates(2).getDefaultValue();
+        double xangle = getCoordinate(EllipsoidJoint::Coord::Rotation1X).getDefaultValue();
+        double yangle = getCoordinate(EllipsoidJoint::Coord::Rotation2Y).getDefaultValue();
+        double zangle = getCoordinate(EllipsoidJoint::Coord::Rotation3Z).getDefaultValue();
         Rotation r(BodyRotationSequence, xangle, XAxis, 
                                          yangle, YAxis, zangle, ZAxis);
 
@@ -187,9 +187,9 @@ void EllipsoidJoint::extendSetPropertiesFromState(const SimTK::State& state)
         Rotation r = getChildFrame().getMobilizedBody().getBodyRotation(state);
         Vec3 angles = r.convertRotationToBodyFixedXYZ();
 
-        upd_coordinates(0).setDefaultValue(angles[0]);
-        upd_coordinates(1).setDefaultValue(angles[1]);
-        upd_coordinates(2).setDefaultValue(angles[2]);
+        updCoordinate(EllipsoidJoint::Coord::Rotation1X).setDefaultValue(angles[0]);
+        updCoordinate(EllipsoidJoint::Coord::Rotation2Y).setDefaultValue(angles[1]);
+        updCoordinate(EllipsoidJoint::Coord::Rotation3Z).setDefaultValue(angles[2]);
     }
 }
 

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
@@ -48,7 +48,8 @@ class OSIMSIMULATION_API EllipsoidJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(EllipsoidJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -109,9 +110,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
     // SCALE

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.cpp
@@ -52,13 +52,13 @@ void FreeJoint::extendInitStateFromProperties(SimTK::State& s) const
     const MultibodySystem& system = _model->getMultibodySystem();
     const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
     if (!matter.getUseEulerAngles(s)){
-        double xangle = get_coordinates(0).getDefaultValue();
-        double yangle = get_coordinates(1).getDefaultValue();
-        double zangle = get_coordinates(2).getDefaultValue();
+        double xangle = getCoordinate(FreeJoint::Coord::Rotation1X).getDefaultValue();
+        double yangle = getCoordinate(FreeJoint::Coord::Rotation2Y).getDefaultValue();
+        double zangle = getCoordinate(FreeJoint::Coord::Rotation3Z).getDefaultValue();
         Rotation r(BodyRotationSequence, xangle, XAxis, yangle, YAxis, zangle, ZAxis);
-        Vec3 t(get_coordinates(3).getDefaultValue(),
-            get_coordinates(4).getDefaultValue(),
-            get_coordinates(5).getDefaultValue());
+        Vec3 t(getCoordinate(FreeJoint::Coord::TranslationX).getDefaultValue(),
+               getCoordinate(FreeJoint::Coord::TranslationY).getDefaultValue(),
+               getCoordinate(FreeJoint::Coord::TranslationZ).getDefaultValue());
 
         //FreeJoint* mutableThis = const_cast<FreeJoint*>(this);
         getChildFrame().getMobilizedBody().setQToFitTransform(s, Transform(r, t));
@@ -77,11 +77,11 @@ void FreeJoint::extendSetPropertiesFromState(const SimTK::State& state)
         Vec3 t = getChildFrame().getMobilizedBody().getMobilizerTransform(state).p();
 
         Vec3 angles = r.convertRotationToBodyFixedXYZ();
-        upd_coordinates(0).setDefaultValue(angles[0]);
-        upd_coordinates(1).setDefaultValue(angles[1]);
-        upd_coordinates(2).setDefaultValue(angles[2]);
-        upd_coordinates(3).setDefaultValue(t[0]); 
-        upd_coordinates(4).setDefaultValue(t[1]); 
-        upd_coordinates(5).setDefaultValue(t[2]);
+        updCoordinate(FreeJoint::Coord::Rotation1X).setDefaultValue(angles[0]);
+        updCoordinate(FreeJoint::Coord::Rotation2Y).setDefaultValue(angles[1]);
+        updCoordinate(FreeJoint::Coord::Rotation3Z).setDefaultValue(angles[2]);
+        updCoordinate(FreeJoint::Coord::TranslationX).setDefaultValue(t[0]); 
+        updCoordinate(FreeJoint::Coord::TranslationY).setDefaultValue(t[1]); 
+        updCoordinate(FreeJoint::Coord::TranslationZ).setDefaultValue(t[2]);
     }
 }

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
@@ -50,7 +50,8 @@ class OSIMSIMULATION_API FreeJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(FreeJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -89,9 +90,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.cpp
@@ -54,9 +54,9 @@ void GimbalJoint::extendInitStateFromProperties(SimTK::State& s) const
     if (matter.getUseEulerAngles(s))
         return;
 
-    double xangle = get_coordinates(0).getDefaultValue();
-    double yangle = get_coordinates(1).getDefaultValue();
-    double zangle = get_coordinates(2).getDefaultValue();
+    double xangle = getCoordinate(GimbalJoint::Coord::Rotation1X).getDefaultValue();
+    double yangle = getCoordinate(GimbalJoint::Coord::Rotation2Y).getDefaultValue();
+    double zangle = getCoordinate(GimbalJoint::Coord::Rotation3Z).getDefaultValue();
     Rotation r(BodyRotationSequence, xangle, XAxis, yangle, YAxis, zangle, ZAxis);
 
     //GimbalJoint* mutableThis = const_cast<GimbalJoint*>(this);
@@ -74,8 +74,8 @@ void GimbalJoint::extendSetPropertiesFromState(const SimTK::State& state)
         Rotation r = getChildFrame().getMobilizedBody().getBodyRotation(state);
 
         Vec3 angles = r.convertRotationToBodyFixedXYZ();
-        upd_coordinates(0).setDefaultValue(angles[0]);
-        upd_coordinates(1).setDefaultValue(angles[1]);
-        upd_coordinates(2).setDefaultValue(angles[2]);
+        updCoordinate(GimbalJoint::Coord::Rotation1X).setDefaultValue(angles[0]);
+        updCoordinate(GimbalJoint::Coord::Rotation2Y).setDefaultValue(angles[1]);
+        updCoordinate(GimbalJoint::Coord::Rotation3Z).setDefaultValue(angles[2]);
     }
 }

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
@@ -44,7 +44,8 @@ class OSIMSIMULATION_API GimbalJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(GimbalJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -75,9 +76,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -217,9 +217,8 @@ const Coordinate& Joint::getCoordinate() const {
                      JointHasNoCoordinates);
     OPENSIM_THROW_IF(numCoordinates() > 1,
                      InvalidCall,
-                     "Coordinate set has more than one coordinate. Use "
-                     "getCoordinate method defined in the concrete class "
-                     "instead.");
+                     "Joint has more than one coordinate. Use the getCoordinate "
+                     "method defined in the concrete class instead.");
 
     return get_coordinates(0);
 }
@@ -229,9 +228,8 @@ Coordinate& Joint::updCoordinate() {
                      JointHasNoCoordinates);
     OPENSIM_THROW_IF(numCoordinates() > 1,
                      InvalidCall,
-                     "Coordinate set has more than one coordinate. Use "
-                     "updCoordinate method defined in the concrete class "
-                     "instead.");
+                     "Joint has more than one coordinate. Use the updCoordinate "
+                     "method defined in the concrete class instead.");
 
     return upd_coordinates(0);
 }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -224,6 +224,18 @@ const Coordinate& Joint::getCoordinate() const {
     return get_coordinates(0);
 }
 
+Coordinate& Joint::updCoordinate() {
+    OPENSIM_THROW_IF(numCoordinates() == 0,
+                     JointHasNoCoordinates);
+    OPENSIM_THROW_IF(numCoordinates() > 1,
+                     InvalidCall,
+                     "Coordinate set has more than one coordinate. Use "
+                     "updCoordinate method defined in the concrete class "
+                     "instead.");
+
+    return upd_coordinates(0);
+}
+
 Coordinate::MotionType Joint::getMotionType(CoordinateIndex cix) const
 {
     OPENSIM_THROW_IF(cix >= _motionTypes.size(), Exception,

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -224,11 +224,17 @@ public:
      */
     const OpenSim::PhysicalFrame& getParentFrame() const;
 
-    /** Convenience method to get the Coordinate associated with a
-        single-degree-of-freedom Joint. If the Joint has more than one
+    /** Convenience method to get a const reference to the Coordinate associated
+        with a single-degree-of-freedom Joint. If the Joint has more than one
         Coordinate, you must provide the appropriate argument to the
         getCoordinate() method defined in the derived class. */
     const Coordinate& getCoordinate() const;
+
+    /** Convenience method to get a writable reference to the Coordinate
+        associated with a single-degree-of-freedom Joint. If the Joint has more
+        than one Coordinate, you must provide the appropriate argument to the
+        updCoordinate() method defined in the derived class. */
+    Coordinate& updCoordinate();
 
     bool getReverse() const { return get_reverse(); }
 

--- a/OpenSim/Simulation/SimbodyEngine/PinJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PinJoint.h
@@ -46,7 +46,8 @@ class OSIMSIMULATION_API PinJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(PinJoint, Joint);
 
 public:
-    /** Index of Coordinate for use as an argument to getCoordinate().
+    /** Index of Coordinate for use as an argument to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -70,9 +71,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get the Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to the Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to the Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
@@ -44,7 +44,8 @@ class OSIMSIMULATION_API PlanarJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(PlanarJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -75,9 +76,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
@@ -43,7 +43,8 @@ class OSIMSIMULATION_API SliderJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(SliderJoint, Joint);
 
 public:
-    /** Index of Coordinate for use as an argument to getCoordinate().
+    /** Index of Coordinate for use as an argument to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -68,9 +69,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get the Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to the Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to the Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -487,7 +487,7 @@ void testCoordinateLocking()
     // create hip as a pin joint
     PinJoint hip("hip",ground, hipInGround, Vec3(0), osim_thigh, hipInFemur, Vec3(0));
     // Rename hip coordinates for a pin joint
-    hip.upd_coordinates(0).setName("hip_flex");
+    hip.updCoordinate().setName("hip_flex");
 
     // Add the thigh body 
     osimModel->addBody(&osim_thigh);
@@ -837,7 +837,7 @@ void testCoordinateCouplerConstraint()
     PinJoint hip("hip",ground, hipInGround, Vec3(0), osim_thigh, hipInFemur, Vec3(0));
 
     // Rename hip coordinates for a pin joint
-    hip.upd_coordinates(0).setName("hip_flex");
+    hip.updCoordinate().setName("hip_flex");
     
     // Add the thigh body which now also contains the hip joint to the model
     osimModel->addBody(&osim_thigh);

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -891,6 +891,7 @@ void testEllipsoidJoint()
     // Test accessors.
     {
         EllipsoidJoint myEllipsoidJt;
+
         ASSERT(myEllipsoidJt.getCoordinate(EllipsoidJoint::Coord::Rotation1X) ==
                myEllipsoidJt.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
@@ -901,6 +902,11 @@ void testEllipsoidJoint()
                myEllipsoidJt.get_coordinates(2),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myEllipsoidJt.getCoordinate());
+
+        ASSERT(myEllipsoidJt.updCoordinate(EllipsoidJoint::Coord::Rotation1X) ==
+               myEllipsoidJt.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myEllipsoidJt.updCoordinate());
     }
 
 } // end testEllipsoidJoint
@@ -1082,6 +1088,8 @@ void testWeldJoint(bool randomizeBodyOrder)
         WeldJoint myWeldJoint;
         ASSERT_THROW(OpenSim::JointHasNoCoordinates,
                      myWeldJoint.getCoordinate());
+        ASSERT_THROW(OpenSim::JointHasNoCoordinates,
+                     myWeldJoint.updCoordinate());
     }
 }
 
@@ -1178,6 +1186,7 @@ void testFreeJoint()
     // Test accessors.
     {
         FreeJoint myFreeJoint;
+
         ASSERT(myFreeJoint.getCoordinate(FreeJoint::Coord::Rotation1X) ==
                myFreeJoint.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
@@ -1197,6 +1206,11 @@ void testFreeJoint()
                myFreeJoint.get_coordinates(5),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myFreeJoint.getCoordinate());
+
+        ASSERT(myFreeJoint.updCoordinate(FreeJoint::Coord::Rotation1X) ==
+               myFreeJoint.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myFreeJoint.updCoordinate());
     }
 
 } // end testFreeJoint
@@ -1289,6 +1303,7 @@ void testBallJoint()
     // Test accessors.
     {
         BallJoint myBallJoint;
+
         ASSERT(myBallJoint.getCoordinate(BallJoint::Coord::Rotation1X) ==
                myBallJoint.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
@@ -1299,6 +1314,11 @@ void testBallJoint()
                myBallJoint.get_coordinates(2),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myBallJoint.getCoordinate());
+
+        ASSERT(myBallJoint.updCoordinate(BallJoint::Coord::Rotation1X) ==
+               myBallJoint.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myBallJoint.updCoordinate());
     }
 
 } // end testBallJoint
@@ -1451,11 +1471,19 @@ void testPinJoint()
     // Test accessors.
     {
         PinJoint myPinJoint;
+
         ASSERT(myPinJoint.getCoordinate(PinJoint::Coord::RotationZ) ==
                myPinJoint.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT(myPinJoint.getCoordinate() ==
                myPinJoint.get_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+
+        ASSERT(myPinJoint.updCoordinate(PinJoint::Coord::RotationZ) ==
+               myPinJoint.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT(myPinJoint.updCoordinate() ==
+               myPinJoint.upd_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
     }
 
@@ -1554,11 +1582,19 @@ void testSliderJoint()
     // Test accessors.
     {
         SliderJoint mySliderJoint;
+
         ASSERT(mySliderJoint.getCoordinate(SliderJoint::Coord::TranslationX) ==
                mySliderJoint.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT(mySliderJoint.getCoordinate() ==
                mySliderJoint.get_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+
+        ASSERT(mySliderJoint.updCoordinate(SliderJoint::Coord::TranslationX) ==
+               mySliderJoint.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT(mySliderJoint.updCoordinate() ==
+               mySliderJoint.upd_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
     }
 
@@ -1655,6 +1691,7 @@ void testPlanarJoint()
     // Test accessors.
     {
         PlanarJoint myPlanarJoint;
+
         ASSERT(myPlanarJoint.getCoordinate(PlanarJoint::Coord::RotationZ) ==
                myPlanarJoint.get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
@@ -1665,6 +1702,11 @@ void testPlanarJoint()
                myPlanarJoint.get_coordinates(2),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myPlanarJoint.getCoordinate());
+
+        ASSERT(myPlanarJoint.updCoordinate(PlanarJoint::Coord::RotationZ) ==
+               myPlanarJoint.upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myPlanarJoint.updCoordinate());
     }
 
 } // end testPlanarJoint
@@ -2375,6 +2417,11 @@ void testCustomJointAccessors()
                      myCustomJoint0->getCoordinate(0));
         ASSERT_THROW(OpenSim::JointHasNoCoordinates,
                      myCustomJoint0->getCoordinate(1));
+
+        ASSERT_THROW(OpenSim::JointHasNoCoordinates,
+                     myCustomJoint0->updCoordinate());
+        ASSERT_THROW(OpenSim::JointHasNoCoordinates,
+                     myCustomJoint0->updCoordinate(0));
     }
     {
         Model myModel;
@@ -2393,6 +2440,14 @@ void testCustomJointAccessors()
                myCustomJoint1->get_coordinates(0),
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint1->getCoordinate(1));
+
+        ASSERT(myCustomJoint1->updCoordinate() ==
+               myCustomJoint1->upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT(myCustomJoint1->updCoordinate(0) ==
+               myCustomJoint1->upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint1->updCoordinate(1));
     }
     {
         Model myModel;
@@ -2415,12 +2470,22 @@ void testCustomJointAccessors()
                __FILE__, __LINE__, "Coordinate accessor failed");
         ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint2->getCoordinate());
         ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint2->getCoordinate(2));
+
+        ASSERT(myCustomJoint2->updCoordinate(0) ==
+               myCustomJoint2->upd_coordinates(0),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT(myCustomJoint2->updCoordinate(1) ==
+               myCustomJoint2->upd_coordinates(1),
+               __FILE__, __LINE__, "Coordinate accessor failed");
+        ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint2->updCoordinate());
+        ASSERT_THROW(OpenSim::InvalidCall, myCustomJoint2->updCoordinate(2));
     }
 }
 
 void testGimbalJointAccessors()
 {
     GimbalJoint myGimbalJoint;
+
     ASSERT(myGimbalJoint.getCoordinate(GimbalJoint::Coord::Rotation1X) ==
            myGimbalJoint.get_coordinates(0),
            __FILE__, __LINE__, "Coordinate accessor failed");
@@ -2431,11 +2496,17 @@ void testGimbalJointAccessors()
            myGimbalJoint.get_coordinates(2),
            __FILE__, __LINE__, "Coordinate accessor failed");
     ASSERT_THROW(OpenSim::InvalidCall, myGimbalJoint.getCoordinate());
+
+    ASSERT(myGimbalJoint.updCoordinate(GimbalJoint::Coord::Rotation1X) ==
+           myGimbalJoint.upd_coordinates(0),
+           __FILE__, __LINE__, "Coordinate accessor failed");
+    ASSERT_THROW(OpenSim::InvalidCall, myGimbalJoint.updCoordinate());
 }
 
 void testUniversalJointAccessors()
 {
     UniversalJoint myUniversalJoint;
+
     ASSERT(myUniversalJoint.getCoordinate(UniversalJoint::Coord::Rotation1X) ==
            myUniversalJoint.get_coordinates(0),
            __FILE__, __LINE__, "Coordinate accessor failed");
@@ -2443,4 +2514,9 @@ void testUniversalJointAccessors()
            myUniversalJoint.get_coordinates(1),
            __FILE__, __LINE__, "Coordinate accessor failed");
     ASSERT_THROW(OpenSim::InvalidCall, myUniversalJoint.getCoordinate());
+
+    ASSERT(myUniversalJoint.updCoordinate(UniversalJoint::Coord::Rotation1X) ==
+           myUniversalJoint.upd_coordinates(0),
+           __FILE__, __LINE__, "Coordinate accessor failed");
+    ASSERT_THROW(OpenSim::InvalidCall, myUniversalJoint.updCoordinate());
 }

--- a/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
@@ -46,7 +46,8 @@ class OSIMSIMULATION_API UniversalJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(UniversalJoint, Joint);
 
 public:
-    /** Indices of Coordinates for use as arguments to getCoordinate().
+    /** Indices of Coordinates for use as arguments to getCoordinate() and
+        updCoordinate().
 
         <b>C++ example</b>
         \code{.cpp}
@@ -74,9 +75,20 @@ public:
         @see Joint */
     using Joint::getCoordinate;
 
-    /** Get a Coordinate associated with this Joint. @see Coord */
+    /** Exposes updCoordinate() method defined in base class (overloaded below).
+        @see Joint */
+    using Joint::updCoordinate;
+
+    /** Get a const reference to a Coordinate associated with this Joint.
+        @see Coord */
     const Coordinate& getCoordinate(Coord idx) const {
         return get_coordinates( static_cast<unsigned>(idx) );
+    }
+
+    /** Get a writable reference to a Coordinate associated with this Joint.
+        @see Coord */
+    Coordinate& updCoordinate(Coord idx) {
+        return upd_coordinates( static_cast<unsigned>(idx) );
     }
 
 protected:

--- a/OpenSim/Simulation/Test/testContactGeometry.cpp
+++ b/OpenSim/Simulation/Test/testContactGeometry.cpp
@@ -490,7 +490,7 @@ void testIntermediateFrames() {
         // Initialize and set state.
         SimTK::State& state = model.initSystem();
         const auto& hinge = model.getJointSet().get("hinge");
-        const auto& coord = hinge.get_coordinates(0);
+        const auto& coord = hinge.getCoordinate();
         coord.setValue(state, 0.15 * SimTK::Pi);
 
         // Integrate.

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -185,8 +185,8 @@ void testExpressionBasedCoordinateForce()
     SliderJoint slider("slider", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
 
@@ -385,8 +385,8 @@ void testPathSpring()
     SliderJoint slider("slider", ground, Vec3(0), Vec3(0,0,Pi/2), block, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("block_h");
     sliderCoord.setRange(positionRange);
 
@@ -490,8 +490,8 @@ void testSpringMass()
     SliderJoint slider("slider", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
 
@@ -588,8 +588,8 @@ void testBushingForce()
     SliderJoint slider("slider", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
 
@@ -703,8 +703,8 @@ void testFunctionBasedBushingForce()
                                  ball, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
 
@@ -811,8 +811,8 @@ void testExpressionBasedBushingForceTranslational()
     SliderJoint sliderY("slider", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
     
     double positionRange[2] = {-10, 10};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = sliderY.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = sliderY.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
     
@@ -942,8 +942,8 @@ void testExpressionBasedBushingForceRotational()
         ball, Vec3(0), Vec3(Pi / 2, 0, 0));
 
     double thetaRange[2] = { -2*Pi, 2*Pi };
-    // Rename coordinates for a pin joint
-    auto& pinCoord = pin.upd_coordinates(0);
+    // Rename coordinate for the pin joint
+    auto& pinCoord = pin.updCoordinate();
     pinCoord.setName("ball_theta");
     pinCoord.setRange(thetaRange);
 
@@ -1217,8 +1217,8 @@ void testCoordinateLimitForce()
     SliderJoint slider("slider", ground, Vec3(0), Vec3(0,0,Pi/2), ball, Vec3(0), Vec3(0,0,Pi/2));
 
     double positionRange[2] = {0.1, 2};
-    // Rename coordinates for a slider joint
-    auto& sliderCoord = slider.upd_coordinates(0);
+    // Rename coordinate for the slider joint
+    auto& sliderCoord = slider.updCoordinate();
     sliderCoord.setName("ball_h");
     sliderCoord.setRange(positionRange);
 
@@ -1362,8 +1362,8 @@ void testCoordinateLimitForceRotational()
 
     // NOTE: Angular limits are in degrees NOT radians
     double positionRange[2] = {-30, 90};
-    // Rename coordinates for a pin joint
-    auto& pinCoord = pin.upd_coordinates(0);
+    // Rename coordinate for the pin joint
+    auto& pinCoord = pin.updCoordinate();
     pinCoord.setName("theta");
     pinCoord.setRange(positionRange);
 
@@ -1522,7 +1522,7 @@ void testExternalForce()
     SimTK::State& s = model.initSystem();
 
     // set the starting location of the tower to be right over the point
-    freeJoint.upd_coordinates(3).setValue(s, 0.1);
+    freeJoint.getCoordinate(FreeJoint::Coord::TranslationX).setValue(s, 0.1);
 
     double accuracy = 1e-6;
     RungeKuttaMersonIntegrator integrator(model.getMultibodySystem());
@@ -1567,7 +1567,7 @@ void testExternalForce()
 
     // set the starting location of the tower to be offset as to counter-balance the torque
     // point is 0.1, by moving fwd to 0.3, force has -0.2m moment-arm to generate -2Nm
-    freeJoint.upd_coordinates(3).setValue(s2, 0.3);
+    freeJoint.getCoordinate(FreeJoint::Coord::TranslationX).setValue(s2, 0.3);
     model.setPropertiesFromState(s2);
 
     RungeKuttaMersonIntegrator integrator2(model.getMultibodySystem());
@@ -1604,7 +1604,7 @@ void testExternalForce()
     SimTK::State& s3 = model.initSystem();
 
     // only xf4 is should be affected and set it to offset Tz+px*Fy = 2+0.1*10 = 3.
-    freeJoint.upd_coordinates(3).setValue(s3, 0.4); // yield -3Nm for force only
+    freeJoint.getCoordinate(FreeJoint::Coord::TranslationX).setValue(s3, 0.4); // yield -3Nm for force only
     model.setPropertiesFromState(s3);
 
     RungeKuttaMersonIntegrator integrator3(model.getMultibodySystem());
@@ -1653,7 +1653,7 @@ void testExternalForce()
     model.getGravityForce().disable(s4);
 
     // only xf4 is should be affected and set it to offset Tz+px*Fy = 2+0.1*10 = 3.
-    freeJoint.upd_coordinates(3).setValue(s4, 0);
+    freeJoint.getCoordinate(FreeJoint::Coord::TranslationX).setValue(s4, 0);
     model.setPropertiesFromState(s4);
 
     RungeKuttaMersonIntegrator integrator4(model.getMultibodySystem());

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -378,7 +378,7 @@ void generateUmbergerMuscleData(const std::string& muscleName,
     // Create slider joint between ground and block.
     SliderJoint* prismatic = new SliderJoint("prismatic", ground, Vec3(0), Vec3(0),
                                                 *block, Vec3(0), Vec3(0));
-    prismatic->upd_coordinates(0).setName("xTranslation");
+    prismatic->updCoordinate().setName("xTranslation");
     model.addBody(block);
     model.addJoint(prismatic);
 
@@ -671,7 +671,7 @@ void testProbesUsingMillardMuscleSimulation()
     // Create slider joint between ground and block.
     SliderJoint* prismatic = new SliderJoint("prismatic", ground, Vec3(0), Vec3(0),
                                                 *block, Vec3(0), Vec3(0));
-    auto& prisCoord = prismatic->upd_coordinates(0);
+    auto& prisCoord = prismatic->updCoordinate();
     prisCoord.setName("xTranslation");
     prisCoord.setRangeMin(-1);
     prisCoord.setRangeMax(1);

--- a/OpenSim/Simulation/Test/testPoints.cpp
+++ b/OpenSim/Simulation/Test/testPoints.cpp
@@ -181,10 +181,10 @@ void testStationOnOffsetFrame()
     SimTK::State state = pendulum.initSystem();
 
     // set the model coordinates and coordinate speeds
-    hip->upd_coordinates(0).setValue(state, 0.29);
-    hip->upd_coordinates(0).setSpeedValue(state, 0.1);
-    hip->upd_coordinates(1).setValue(state, -0.38);
-    hip->upd_coordinates(1).setSpeedValue(state, -0.13);
+    hip->getCoordinate(GimbalJoint::Coord::Rotation1X).setValue(state, 0.29);
+    hip->getCoordinate(GimbalJoint::Coord::Rotation1X).setSpeedValue(state, 0.1);
+    hip->getCoordinate(GimbalJoint::Coord::Rotation2Y).setValue(state, -0.38);
+    hip->getCoordinate(GimbalJoint::Coord::Rotation2Y).setSpeedValue(state, -0.13);
 
     // Get the frame's mobilized body
     const OpenSim::PhysicalFrame&  frame = myStation->getParentFrame();

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -225,7 +225,7 @@ void simulateMuscle(
         Vec3(0),
                         Vec3(0));
 
-    auto& sliderCoord = slider->upd_coordinates(0);
+    auto& sliderCoord = slider->updCoordinate();
     sliderCoord.setName("tx");
     sliderCoord.setDefaultValue(1.0);
     sliderCoord.setRangeMin(0);

--- a/OpenSim/Tests/AddComponents/testAddComponents.cpp
+++ b/OpenSim/Tests/AddComponents/testAddComponents.cpp
@@ -146,21 +146,24 @@ void addComponentsToModel(Model& osimModel)
     // joint between the block and ground frames.
     double angleRange[2] = { -SimTK::Pi / 2, SimTK::Pi / 2 };
     double positionRange[2] = { -1, 1 };
-    blockToGround->upd_coordinates(0).setRange(angleRange);
-    blockToGround->upd_coordinates(1).setRange(angleRange);
-    blockToGround->upd_coordinates(2).setRange(angleRange);
-    blockToGround->upd_coordinates(3).setRange(positionRange);
-    blockToGround->upd_coordinates(4).setRange(positionRange);
-    blockToGround->upd_coordinates(5).setRange(positionRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::Rotation1X).setRange(angleRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::Rotation2Y).setRange(angleRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::Rotation3Z).setRange(angleRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::TranslationX).setRange(positionRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::TranslationY).setRange(positionRange);
+    blockToGround->updCoordinate(FreeJoint::Coord::TranslationZ).setRange(positionRange);
 
     // GRAVITY
     // Obtain the default acceleration due to gravity
     Vec3 gravity = osimModel.getGravity();
 
     // Define non-zero default states for the free joint
-    blockToGround->upd_coordinates(3).setDefaultValue(constantDistance); // set x-translation value
-    double h_start = blockMass*gravity[1] / (stiffness*blockSideLength*blockSideLength);
-    blockToGround->upd_coordinates(4).setDefaultValue(h_start); // set y-translation which is height
+    blockToGround->updCoordinate(FreeJoint::Coord::TranslationX)
+                   .setDefaultValue(constantDistance);
+    double h_start = blockMass*gravity[1] /
+                     (stiffness*blockSideLength*blockSideLength);
+    blockToGround->updCoordinate(FreeJoint::Coord::TranslationY)
+                   .setDefaultValue(h_start); //y-translation is height
 
     // Add the block and joint to the model
     osimModel.addComponent(block);

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -96,8 +96,8 @@ int main() {
     // Configure the model.
     State& state = model.initSystem();
     // Fix the shoulder at its default angle and begin with the elbow flexed.
-    shoulder->upd_coordinates(0).setLocked(state, true);
-    elbow->upd_coordinates(0).setValue(state, 0.5 * Pi);
+    shoulder->getCoordinate().setLocked(state, true);
+    elbow->getCoordinate().setValue(state, 0.5 * Pi);
     model.equilibrateMuscles(state);
 
     // Add display geometry.

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -373,7 +373,7 @@ void testWrapCylinder()
     //model.setUseVisualizer(true);
 
     SimTK::State& s = model.initSystem();
-    auto& coord = joint->upd_coordinates(0);
+    auto& coord = joint->updCoordinate();
 
     int nsteps = 10;
     for (int i = 0; i < nsteps; ++i) {

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -86,12 +86,12 @@ void testControlSetControllerOnBlock()
 
     OpenSim::Body block("block", blockMass, blockMassCenter, blockMass*blockInertia);
 
-    //Create a free joint with 6 degrees-of-freedom
+    // Create a slider joint with 1 degree of freedom
     SimTK::Vec3 noRotation(0);
     SliderJoint blockToGround("slider",ground, blockInGround, noRotation, block, blockMassCenter, noRotation);
     
-    // Create coordinates (degrees-of-freedom) between the ground and block
-    auto& sliderCoord = blockToGround.upd_coordinates(0);
+    // Create coordinate (degree of freedom) between the ground and block
+    auto& sliderCoord = blockToGround.updCoordinate();
     double posRange[2] = {-1, 1};
     sliderCoord.setName("xTranslation");
     sliderCoord.setRange(posRange);
@@ -181,11 +181,12 @@ void testPrescribedControllerOnBlock(bool disabled)
 
     OpenSim::Body block("block", blockMass, blockMassCenter, blockMass*blockInertia);
 
-    //Create a free joint with 6 degrees-of-freedom
+    // Create a slider joint with 1 degree of freedom
     SimTK::Vec3 noRotation(0);
     SliderJoint blockToGround("slider",ground, blockInGround, noRotation, block, blockMassCenter, noRotation);
-    // Create 6 coordinates (degrees-of-freedom) between the ground and block
-    auto& sliderCoord = blockToGround.upd_coordinates(0);
+
+    // Create 1 coordinate (degree of freedom) between the ground and block
+    auto& sliderCoord = blockToGround.updCoordinate();
     double posRange[2] = {-1, 1};
     sliderCoord.setRange(posRange);
 
@@ -274,11 +275,12 @@ void testCorrectionControllerOnBlock()
 
     OpenSim::Body block("block", blockMass, blockMassCenter, blockMass*blockInertia);
 
-    //Create a free joint with 6 degrees-of-freedom
+    // Create a slider joint with 1 degree of freedom
     SimTK::Vec3 noRotation(0);
     SliderJoint blockToGround("slider",ground, blockInGround, noRotation, block, blockMassCenter, noRotation);
-    // Create coordinates (degrees-of-freedom) between the ground and block
-    auto& sliderCoord = blockToGround.upd_coordinates(0);
+
+    // Create coordinate (degree of freedom) between the ground and block
+    auto& sliderCoord = blockToGround.updCoordinate();
     double posRange[2] = {-1, 1};
     sliderCoord.setName("xTranslation");
     sliderCoord.setRange(posRange);

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ int main() {
     // Configure the model.
     State& state = model.initSystem();
     // Fix the shoulder at its default angle and begin with the elbow flexed.
-    shoulder->upd_coordinates(0).setLocked(state, true);
-    elbow->upd_coordinates(0).setValue(state, 0.5 * Pi);
+    shoulder->getCoordinate().setLocked(state, true);
+    elbow->getCoordinate().setValue(state, 0.5 * Pi);
     model.equilibrateMuscles(state);
 
     // Add display geometry.


### PR DESCRIPTION
## Summary
- Added `updCoordinate()` methods and corresponding test cases (analogous to the `getCoordinate()` methods added in #1116).
- Replaced existing accessors with the new enum-argumented ones to improve code readability.

Addresses last two checkboxes of #1066.