### PR TITLE
Remove clutter in AppVeyor/Travis output

### DIFF
--- a/Bindings/Python/tests/test_access_subcomponents.py
+++ b/Bindings/Python/tests/test_access_subcomponents.py
@@ -7,6 +7,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 class TestAccessSubcomponents(unittest.TestCase):
     def test_individual_components(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -11,6 +11,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 class TestBasics(unittest.TestCase):
     def test_version(self):
         print(osim.__version__)

--- a/Bindings/Python/tests/test_component_interface.py
+++ b/Bindings/Python/tests/test_component_interface.py
@@ -6,6 +6,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 class TestComponentInterface(unittest.TestCase):
     def test_printComponentsMatching(self):
         model = osim.Model(os.path.join(test_dir,

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -7,6 +7,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 # TODO in Component:
 #
 # SimTK::IteratorPair<...> Component::getConnectors()

--- a/Bindings/Python/tests/test_consistent_with_jython.py
+++ b/Bindings/Python/tests/test_consistent_with_jython.py
@@ -12,6 +12,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 def assert_almost_equal(valA, valB, tol=1e-5):
     assert abs(valA - valB) < 1e-5
 

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -10,6 +10,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 class TestSimbody(unittest.TestCase):
     def test_SimbodyMatterSubsystem(self):
         model = osim.Model(os.path.join(test_dir,

--- a/Bindings/Python/tests/test_states_trajectory.py
+++ b/Bindings/Python/tests/test_states_trajectory.py
@@ -6,6 +6,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 # TODO add more tests of the integrity checks.
 
 class TestStatesTrajectory(unittest.TestCase):

--- a/Bindings/Python/tests/test_swig_additional_interface.py
+++ b/Bindings/Python/tests/test_swig_additional_interface.py
@@ -18,6 +18,9 @@ import opensim as osim
 test_dir = os.path.join(os.path.dirname(os.path.abspath(osim.__file__)),
                         'tests')
 
+# Silence warning messages if mesh (.vtp) files cannot be found.
+osim.Model.setDebugLevel(0)
+
 class TestSwigAddtlInterface(unittest.TestCase):
     def test_markAdopted1(self):
         """Ensures that we can tell an object that some other object is managing

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -207,7 +207,7 @@ void Mesh::extendFinalizeFromProperties() {
     if (!isObjectUpToDateWithProperties()) {
         const Component* rootModel = nullptr;
         if (!hasParent()) {
-            std::clog << "Mesh " << get_mesh_file() << " not connected to model..ignoring\n";
+            std::cout << "Mesh " << get_mesh_file() << " not connected to model..ignoring\n";
             return;   // Orphan Mesh not part of a model yet
         }
         const Component* parent = &getParent();
@@ -223,7 +223,7 @@ void Mesh::extendFinalizeFromProperties() {
         }
 
         if (rootModel == nullptr) {
-            std::clog << "Mesh " << get_mesh_file() << " not connected to model..ignoring\n";
+            std::cout << "Mesh " << get_mesh_file() << " not connected to model..ignoring\n";
             return;   // Orphan Mesh not descendent of a model
         }
         // Current interface to Visualizer calls generateDecorations on every frame.
@@ -235,7 +235,7 @@ void Mesh::extendFinalizeFromProperties() {
             isAbsolutePath, directory, fileName, extension);
         const string lowerExtension = SimTK::String::toLower(extension);
         if (lowerExtension != ".vtp" && lowerExtension != ".obj" && lowerExtension != ".stl") {
-            std::clog << "ModelVisualizer ignoring '" << file
+            std::cout << "ModelVisualizer ignoring '" << file
                 << "'; only .vtp .stl and .obj files currently supported.\n";
             return;
         }
@@ -246,13 +246,15 @@ void Mesh::extendFinalizeFromProperties() {
         bool foundIt = ModelVisualizer::findGeometryFile(model, file, isAbsolutePath, attempts);
 
         if (!foundIt) {
-            std::clog << "ModelVisualizer couldn't find file '" << file
+            if (getDebugLevel()==0) { return; }
+
+            std::cout << "ModelVisualizer couldn't find file '" << file
                 << "'; tried\n";
             for (unsigned i = 0; i < attempts.size(); ++i)
-                std::clog << "  " << attempts[i] << "\n";
+                std::cout << "  " << attempts[i] << "\n";
             if (!isAbsolutePath &&
                 !Pathname::environmentVariableExists("OPENSIM_HOME"))
-                std::clog << "Set environment variable OPENSIM_HOME "
+                std::cout << "Set environment variable OPENSIM_HOME "
                 << "to search $OPENSIM_HOME/Geometry.\n";
             return;
         }
@@ -266,7 +268,7 @@ void Mesh::extendFinalizeFromProperties() {
 
         }
         catch (const std::exception& e) {
-            std::clog << "Visualizer couldn't read "
+            std::cout << "Visualizer couldn't read "
                 << attempts.back() << " because:\n"
                 << e.what() << "\n";
             return;

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
@@ -107,7 +107,7 @@ public:
     const Coordinate& getCoordinate(unsigned idx) const {
         OPENSIM_THROW_IF(numCoordinates() == 0,
                          JointHasNoCoordinates);
-        OPENSIM_THROW_IF(idx > numCoordinates()-1,
+        OPENSIM_THROW_IF((int)idx > numCoordinates()-1,
                          InvalidCall,
                          "Index passed to getCoordinate() exceeds the largest "
                          "index available");


### PR DESCRIPTION
## Summary
- Suppressed "ModelVisualizer couldn't find file" warning messages.
- Suppressed compiler warning about signed/unsigned mismatch.
- Also replaced `clog` with `cout` in Geometry.cpp because we don't use `clog` in any disciplined way (`clog` doesn't appear *anywhere else* in OpenSim).