### PR TITLE
Add progress messages to tests

### DIFF
--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -129,5 +129,7 @@ int main() {
 
     std::remove(tmpfile.c_str());
 
+    std::cout << "\nAll tests passed!" << std::endl;
+
     return 0;
 }

--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -97,14 +97,20 @@ int main() {
     filenames.push_back("subject01_walk1_grf.mot");
     std::string tmpfile{"testmotfileadapter.mot"};
 
+    std::cout << "Testing STOFileAdapter::read() and STOFileAdapter::write()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         STOFileAdapter stofileadapter{};
         auto table = stofileadapter.read(filename);
         stofileadapter.write(table, tmpfile);
         compareFiles(filename, tmpfile);
     }
 
+    std::cout << "Testing FileAdapter::readFile() and FileAdapter::writeFile()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         auto table = FileAdapter::readFile(filename).at("table");
         DataAdapter::InputTables tables{};
         tables.emplace(std::string{"table"}, table.get());
@@ -112,7 +118,10 @@ int main() {
         compareFiles(filename, tmpfile);
     }
 
+    std::cout << "Testing TimeSeriesTable and STOFileAdapter::write()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         TimeSeriesTable table{filename};
         STOFileAdapter::write(table, tmpfile);
         compareFiles(filename, tmpfile);

--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -130,5 +130,7 @@ int main() {
 
     std::remove(tmpfile.c_str());
 
+    std::cout << "\nAll tests passed!" << std::endl;
+
     return 0;
 }

--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -98,14 +98,20 @@ int main() {
     filenames.push_back("subject01_static.trc");
     std::string tmpfile{"testtrcfileadapter.trc"};
 
+    std::cout << "Testing TRCFileAdapter::read() and TRCFileAdapter::write()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         TRCFileAdapter trcfileadapter{};
         auto table = trcfileadapter.read(filename);
         trcfileadapter.write(table, tmpfile);
         compareFiles(filename, tmpfile);
     }
 
+    std::cout << "Testing FileAdapter::readFile() and FileAdapter::writeFile()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         auto table = FileAdapter::readFile(filename).at("markers");
         DataAdapter::InputTables tables{};
         tables.emplace(std::string{"markers"}, table.get());
@@ -113,7 +119,10 @@ int main() {
         compareFiles(filename, tmpfile);
     }
 
+    std::cout << "Testing TimeSeriesTableVec3 and TRCFileAdapter::write()"
+              << std::endl;
     for(const auto& filename : filenames) {
+        std::cout << "  " << filename << std::endl;
         TimeSeriesTableVec3 table{filename};
         TRCFileAdapter::write(table, tmpfile);
         compareFiles(filename, tmpfile);


### PR DESCRIPTION
Currently, testSTOFileAdapter and testTRCFileAdapter don't display anything while they are running, which is indistinguishable from malfunction. Added progress messages.