### PR TITLE
Remove OpenSim::Array use from Component

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -415,13 +415,14 @@ void OpenSimContext::restoreStateFromCachedModel()
     _model->initSystem();
     clonedModel->initSystem();
 
-    Array<std::string> modelVariableNames = _model->getStateVariableNames();
-    Array<std::string> clonedModelVariableNames = clonedModel->getStateVariableNames();
+    std::vector<std::string> modelVariableNames = _model->getStateVariableNames();
+    std::vector<std::string> clonedModelVariableNames = clonedModel->getStateVariableNames();
 
-    for(int i = 0; i < modelVariableNames.getSize(); i++)
+    for(auto const& name : modelVariableNames)
     {
-        std::string name = modelVariableNames.get(i);
-        if(clonedModelVariableNames.findIndex(name) >= 0)
+        std::vector<std::string>::iterator it;
+        it = std::find(clonedModelVariableNames.begin(), clonedModelVariableNames.end(), name);
+        if(it != clonedModelVariableNames.end())
         {
             double value = clonedModel->getStateVariableValue(clonedState, name);
             _model->setStateVariableValue(_model->updWorkingState(), name, value);

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -89,7 +89,7 @@ int main()
     SimTK::State stateCopy = context->getCurrentStateCopy();
     assert(context->getCurrentStateRef().toString()==stateCopy.toString());
 
-    Array<std::string> stateNames = model->getStateVariableNames();
+    std::vector<std::string> stateNames = model->getStateVariableNames();
     OpenSim::Force* dForce=&(model->updForceSet().get("TRIlong"));
     Muscle* dTRIlong = dynamic_cast<Muscle*>(dForce);
     assert(dTRIlong);

--- a/OpenSim/Analyses/StatesReporter.cpp
+++ b/OpenSim/Analyses/StatesReporter.cpp
@@ -182,9 +182,13 @@ constructColumnLabels()
     if (_model)
     {
         // ASSIGN
-        Array<string> columnLabels = _model->getStateVariableNames();
-        columnLabels.insert(0, "time");     
-        _statesStore.setColumnLabels(columnLabels);
+        std::vector<string> columnLabels = _model->getStateVariableNames();
+        columnLabels.insert(columnLabels.begin(), "time");
+        Array<string> columnLabelsArray;
+        for (auto const& label : columnLabels) {
+            columnLabelsArray.append(label);
+        }
+        _statesStore.setColumnLabels(columnLabelsArray);
     }
 }
 

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -775,7 +775,7 @@ std::vector<std::string> Component::getStateVariableNames() const
         std::string prefix = "";
         if (back > front) // have non-whitespace name
             prefix = subCompName + "/";
-        for (auto& subname : subnames) {
+        for (auto const& subname : subnames) {
             names.push_back(prefix + subname);
         }
     }
@@ -789,7 +789,7 @@ std::vector<std::string> Component::getStateVariableNames() const
         std::string prefix = "";
         if(back > front) // have non-whitespace name
             prefix = subCompName + "/";
-        for (auto& subname : subnames) {
+        for (auto const& subname : subnames) {
             names.push_back(prefix + subname);
         }
     }
@@ -802,7 +802,7 @@ std::vector<std::string> Component::getStateVariableNames() const
         std::string prefix = "";
         if (back > front) // have non-whitespace name
             prefix = subCompName + "/";
-        for (auto& subname : subnames) {
+        for (auto const& subname : subnames) {
             names.push_back(prefix + subname);
         }
     }
@@ -1240,7 +1240,7 @@ getStateVariablesNamesAddedByComponent() const
     std::map<std::string, StateVariableInfo>::const_iterator it;
     it = _namedStateVariableInfo.begin();
     
-    std::vector<std::string> names(_namedStateVariableInfo.size()); // ("", (int));
+    std::vector<std::string> names(_namedStateVariableInfo.size());
 
     while(it != _namedStateVariableInfo.end()){
         names[it->second.order] = it->first;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -743,12 +743,12 @@ const Component::StateVariable* Component::
 
 // Get the names of "continuous" state variables maintained by the Component and
 // its subcomponents.
-Array<std::string> Component::getStateVariableNames() const
+std::vector<std::string> Component::getStateVariableNames() const
 {
     // Must have already called initSystem.
     OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
-    Array<std::string> names = getStateVariablesNamesAddedByComponent();
+    std::vector<std::string> names = getStateVariablesNamesAddedByComponent();
 
 /** TODO: Use component iterator  like below
     for (int i = 0; i < stateNames.size(); ++i) {
@@ -767,21 +767,20 @@ Array<std::string> Component::getStateVariableNames() const
 
     // Include the states of its subcomponents
     for (unsigned int i = 0; i<_memberSubcomponents.size(); i++) {
-        Array<std::string> subnames = _memberSubcomponents[i]->getStateVariableNames();
-        int nsubs = subnames.getSize();
+        std::vector<std::string> subnames = _memberSubcomponents[i]->getStateVariableNames();
+        //int nsubs = subnames.getSize();
         const std::string& subCompName = _memberSubcomponents[i]->getName();
         std::string::size_type front = subCompName.find_first_not_of(" \t\r\n");
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
         if (back > front) // have non-whitespace name
             prefix = subCompName + "/";
-        for (int j = 0; j<nsubs; ++j) {
-            names.append(prefix + subnames[j]);
+        for (auto& subname : subnames) {
+            names.push_back(prefix + subname);
         }
     }
     for(unsigned int i=0; i<_propertySubcomponents.size(); i++){
-        Array<std::string> subnames = _propertySubcomponents[i]->getStateVariableNames();
-        int nsubs = subnames.getSize();
+        std::vector<std::string> subnames = _propertySubcomponents[i]->getStateVariableNames();
         const std::string& subCompName =  _propertySubcomponents[i]->getName();
         // TODO: We should implement checks that names do not have whitespace at the time 
         // they are assigned and not here where it is a waste of time - aseth
@@ -789,23 +788,22 @@ Array<std::string> Component::getStateVariableNames() const
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
         if(back > front) // have non-whitespace name
-            prefix = subCompName+"/";
-        for(int j =0; j<nsubs; ++j){
-            names.append(prefix+subnames[j]);
+            prefix = subCompName + "/";
+        for (auto& subname : subnames) {
+            names.push_back(prefix + subname);
         }
     }
 
     for (unsigned int i = 0; i<_adoptedSubcomponents.size(); i++) {
-        Array<std::string> subnames = _adoptedSubcomponents[i]->getStateVariableNames();
-        int nsubs = subnames.getSize();
+        std::vector<std::string> subnames = _adoptedSubcomponents[i]->getStateVariableNames();
         const std::string& subCompName = _adoptedSubcomponents[i]->getName();
         std::string::size_type front = subCompName.find_first_not_of(" \t\r\n");
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
         if (back > front) // have non-whitespace name
             prefix = subCompName + "/";
-        for (int j = 0; j<nsubs; ++j) {
-            names.append(prefix + subnames[j]);
+        for (auto& subname : subnames) {
+            names.push_back(prefix + subname);
         }
     }
 
@@ -930,7 +928,7 @@ SimTK::Vector Component::
         _statesAssociatedSystem.reset(&getSystem());
         _allStateVariables.clear();
         _allStateVariables.resize(nsv);
-        Array<std::string> names = getStateVariableNames();
+        std::vector<std::string> names = getStateVariableNames();
         for (int i = 0; i < nsv; ++i)
             _allStateVariables[i].reset(findStateVariable(names[i]));
     }
@@ -962,7 +960,7 @@ void Component::
         _statesAssociatedSystem.reset(&getSystem());
         _allStateVariables.clear();
         _allStateVariables.resize(nsv);
-        Array<std::string> names = getStateVariableNames();
+        std::vector<std::string> names = getStateVariableNames();
         for (int i = 0; i < nsv; ++i)
             _allStateVariables[i].reset(findStateVariable(names[i]));
     }
@@ -1236,13 +1234,13 @@ getCacheVariableIndex(const std::string& name) const
     return it->second.index;
 }
 
-Array<std::string> Component::
+std::vector<std::string> Component::
 getStateVariablesNamesAddedByComponent() const
 {
     std::map<std::string, StateVariableInfo>::const_iterator it;
     it = _namedStateVariableInfo.begin();
     
-    Array<std::string> names("",(int)_namedStateVariableInfo.size());
+    std::vector<std::string> names(_namedStateVariableInfo.size()); // ("", (int));
 
     while(it != _namedStateVariableInfo.end()){
         names[it->second.order] = it->first;

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -696,7 +696,7 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    Array<std::string> getStateVariableNames() const;
+    std::vector<std::string> getStateVariableNames() const;
 
 
     /** @name Component Connector Access methods
@@ -2347,7 +2347,7 @@ private:
     // managed by this Component.
     int getNumStateVariablesAddedByComponent() const 
     {   return (int)_namedStateVariableInfo.size(); }
-    Array<std::string> getStateVariablesNamesAddedByComponent() const;
+    std::vector<std::string> getStateVariablesNamesAddedByComponent() const;
 
     const SimTK::DefaultSystemSubsystem& getDefaultSubsystem() const
         {   return getSystem().getDefaultSubsystem(); }

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -46,7 +46,6 @@
 #include "OpenSim/Common/Object.h"
 #include "OpenSim/Common/ComponentConnector.h"
 #include "OpenSim/Common/ComponentOutput.h"
-#include "OpenSim/Common/Array.h"
 #include "ComponentList.h"
 #include <functional>
 

--- a/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
@@ -222,11 +222,11 @@ record(const SimTK::State& s)
     // MAKE SURE ALL QUANTITIES ARE VALID
     _model->getMultibodySystem().realize(s, SimTK::Stage::Velocity );
     // Get state variable names and values in same order and use that to update map
-    Array<std::string> stateNames = _model->getStateVariableNames();
+    std::vector<std::string> stateNames = _model->getStateVariableNames();
     SimTK::Vector rStateValues = _model->getStateVariableValues(s);
 
     // update map between names and values, then pass it to expression evaluator
-    for(int i=0; i<stateNames.getSize(); i++){
+    for(int i=0; i<stateNames.size(); i++){
         _variables.find(stateNames[i])->second = rStateValues[i];
     }
     double value = Lepton::Parser::parse(_expressionStr).evaluate(_variables);
@@ -260,9 +260,9 @@ begin( SimTK::State& s)
     // RESET STORAGE
     _resultStore.reset(s.getTime());
     // Populate list of names, initial values from s
-    Array<std::string> stateNames = _model->getStateVariableNames();
-    for(int i=0; i< stateNames.getSize(); i++){
-        _variables.insert(pair<string, double>(stateNames[i], 0.0));
+    std::vector<std::string> stateNames = _model->getStateVariableNames();
+    for(auto const& name : stateNames){
+        _variables.insert(pair<string, double>(name, 0.0));
     }
     // RECORD
     int status = 0;

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -136,12 +136,13 @@ constructStorage()
     Array<string> columnLabels;
 
     // STATES
-    Array<string> stateNames = _model->getStateVariableNames();
-    int ny = stateNames.getSize();
+    std::vector<string> stateNames = _model->getStateVariableNames();
     _stateStore.reset(new Storage(512,"states"));
     columnLabels.setSize(0);
     columnLabels.append("time");
-    for(int i=0;i<ny;i++) columnLabels.append(stateNames[i]);
+    for (auto const& name : stateNames) {
+        columnLabels.append(name);
+    }
     _stateStore->setColumnLabels(columnLabels);
 
     return(true);

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
@@ -240,9 +240,9 @@ void ActivationFiberLengthMuscle::computeForce(const SimTK::State& s,
         // in the case the actuation is being overridden, the states aren't 
         // being used but a valid derivative cache entry is still required
         int numStateVariables = getNumStateVariables();
-        Array<std::string> stateVariableNames = getStateVariableNames();
-        for (int i = 0; i < numStateVariables; ++i) {
-            setStateVariableDerivativeValue(s, stateVariableNames[i], 0.0);
+        std::vector<std::string> stateVariableNames = getStateVariableNames();
+        for (auto const& name : stateVariableNames) {
+            setStateVariableDerivativeValue(s, name, 0.0);
         }
     } 
 }

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
@@ -402,9 +402,9 @@ void ActivationFiberLengthMuscle_Deprecated::computeForce(const SimTK::State& s,
         // in the case the force is being overridden, the states aren't being used
         // but a valid derivative cache entry is still required
         int numStateVariables = getNumStateVariables();
-        Array<std::string> stateVariableNames = getStateVariableNames();
-        for (int i = 0; i < numStateVariables; ++i) {
-            setStateVariableDeriv(s, stateVariableNames[i], 0.0);
+        std::vector<std::string> stateVariableNames = getStateVariableNames();
+        for (auto const& name : stateVariableNames) {
+            setStateVariableDeriv(s, name, 0.0);
         }
     } 
 

--- a/OpenSim/Simulation/Model/ForceSet.cpp
+++ b/OpenSim/Simulation/Model/ForceSet.cpp
@@ -367,7 +367,9 @@ getStateVariableNames(OpenSim::Array<std::string> &rNames) const
         ScalarActuator *act = dynamic_cast<ScalarActuator*>(&get(i));
        
         if(act) {
-            rNames.append(act->getStateVariableNames());
+            for (auto const& name : act->getStateVariableNames()) {
+                rNames.append(name);
+            }
         }
     }
 }

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1462,9 +1462,11 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
     aOStream<<"\nCONTACTS ("<<n<<")" << std::endl;
 
 */
-    Array<string> stateNames = getStateVariableNames();
-    aOStream<<"\nSTATES (total: "<<stateNames.getSize()<<")"<<std::endl;
-    for(int i=0;i<stateNames.getSize();i++) aOStream<<"y["<<i<<"] = "<<stateNames[i]<<std::endl;
+    std::vector<string> stateNames = getStateVariableNames();
+    aOStream << "\nSTATES (total: " << stateNames.size() << ")" << std::endl;
+    for (int i = 0; i < stateNames.size(); i++) {
+        aOStream << "y[" << i << "] = " << stateNames[i] << std::endl;
+    }
 }
 
 //--------------------------------------------------------------------------
@@ -1824,16 +1826,16 @@ void Model::setAllControllersEnabled( bool enabled ) {
  */
 void Model::formStateStorage(const Storage& originalStorage, Storage& statesStorage)
 {
-    Array<string> rStateNames = getStateVariableNames();
+    std::vector<string> rStateNames = getStateVariableNames();
     int numStates = getNumStateVariables();
     // make sure same size, otherwise warn
-    if (originalStorage.getSmallestNumberOfStates() != rStateNames.getSize()){
+    if (originalStorage.getSmallestNumberOfStates() != rStateNames.size()){
         cout << "Number of columns does not match in formStateStorage. Found "
-            << originalStorage.getSmallestNumberOfStates() << " Expected  " << rStateNames.getSize() << "." << endl;
+            << originalStorage.getSmallestNumberOfStates() << " Expected  " << rStateNames.size() << "." << endl;
     }
     // Create a list with entry for each desiredName telling which column in originalStorage has the data
-    int* mapColumns = new int[rStateNames.getSize()];
-    for(int i=0; i< rStateNames.getSize(); i++){
+    int* mapColumns = new int[rStateNames.size()];
+    for(int i=0; i< rStateNames.size(); i++){
         // the index is -1 if not found, >=1 otherwise since time has index 0 by defn.
         int fix = originalStorage.getColumnLabels().findIndex(rStateNames[i]);
         if (fix==-1){
@@ -1890,8 +1892,12 @@ void Model::formStateStorage(const Storage& originalStorage, Storage& statesStor
         }
         statesStorage.append(*stateVec);
     }
-    rStateNames.insert(0, "time");
-    statesStorage.setColumnLabels(rStateNames);
+    rStateNames.insert(rStateNames.begin(), "time");
+    OpenSim::Array<std::string> rStateNamesArray;
+    for (auto const& name : rStateNames) {
+        rStateNamesArray.append(name);
+    }
+    statesStorage.setColumnLabels(rStateNamesArray);
 
     delete[] mapColumns;
 }

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -804,7 +804,8 @@ formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
     int nu = _model->getNumSpeeds();
 
     // Get coordinate file indices
-    Array<string> columnLabels, speedLabels, coordStateNames;
+    Array<string> columnLabels, speedLabels;
+    std::vector<string> coordStateNames;
     columnLabels.append("time");
     speedLabels = columnLabels;
 

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -208,13 +208,13 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
     // Also, assemble the names of the states that we will actually set in the
     // trajectory, along with the corresponding state index.
     std::map<int, std::string> statesToFillUp;
-    for (int is = 0; is < modelStateNames.getSize(); ++is) {
+    for (const auto& name : modelStateNames) {
         // getStateIndex() will check for pre-4.0 column names.
-        const int stateIndex = sto.getStateIndex(modelStateNames[is]);
+        const int stateIndex = sto.getStateIndex(name);
         if (stateIndex == -1) {
-            missingColumnNames.push_back(modelStateNames[is]);
+            missingColumnNames.push_back(name);
         } else {
-            statesToFillUp[stateIndex] = modelStateNames[is];
+            statesToFillUp[stateIndex] = name;
         }
     }
     OPENSIM_THROW_IF(!allowMissingColumns && !missingColumnNames.empty(),

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -690,7 +690,7 @@ void tableAndTrajectoryMatch(const Model& model,
 
     size_t numColumns{};
     if (columns.empty()) {
-        numColumns = stateNames.getSize();
+        numColumns = stateNames.size();
     } else {
         numColumns = columns.size();
     }

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -285,11 +285,11 @@ createStatesStorageFromCoordinatesAndSpeeds(const Model& aModel, const Storage& 
     if(aQStore.getSize() != aUStore.getSize())
         throw Exception("AnalyzeTool.initializeFromFiles: ERROR- The coordinates storage and speeds storage should have the same number of rows, but do not.",__FILE__,__LINE__);
 
-    Array<string> stateNames("", ny);
+    std::vector<string> stateNames(ny);
     Array<string> qLabels = aQStore.getColumnLabels();
     Array<string> uLabels = aUStore.getColumnLabels();
     stateNames = aModel.getStateVariableNames();
-    stateNames.insert(0, "time");
+    stateNames.insert(stateNames.begin(), "time");
     
     // Preserve the labels from the data file which are typically abbreviated
     // label[0] = time
@@ -304,7 +304,11 @@ createStatesStorageFromCoordinatesAndSpeeds(const Model& aModel, const Storage& 
     const SimTK::State &s = aModel.getWorkingState();
 
     Storage *statesStore = new Storage(512,"states");
-    statesStore->setColumnLabels(stateNames);
+    Array<string> stateNamesArray;
+    for (auto const& name : stateNames) {
+        stateNamesArray.append(name);
+    }
+    statesStore->setColumnLabels(stateNamesArray);
     Array<double> y(0.0,ny);
 
     // initialize the state storage from the default state so that states have relevant values
@@ -622,7 +626,7 @@ void AnalyzeTool::run(SimTK::State& s, Model &aModel, int iInitial, int iFinal, 
     // compare to the column labels of the storage and construct a dataToModel
     // mapping.
     const Array<std::string>& stateNames = aStatesStore.getColumnLabels();
-    Array<std::string> modelStateNames = aModel.getStateVariableNames();
+    std::vector<std::string> modelStateNames = aModel.getStateVariableNames();
 
     int nsData = stateNames.size() - 1;  //-1 since time is a column
     Array<int> dataToModel(-1, nsData);

--- a/OpenSim/Tools/ForwardTool.cpp
+++ b/OpenSim/Tools/ForwardTool.cpp
@@ -294,7 +294,7 @@ bool ForwardTool::run()
         _yStore->getData(startIndexForYStore,numStateVariables,&rawData[0]);
     }
     if (_yStore!=NULL || startIndexForYStore >= 0){
-        Array<std::string> stateNames = _model->getStateVariableNames();
+        std::vector<std::string> stateNames = _model->getStateVariableNames();
         for (int i=0; i<numStateVariables; i++)
             _model->setStateVariableValue(s, stateNames[i], rawData[i]);
     }


### PR DESCRIPTION
Continue to address #1194. Removes use of and returning OpenSim::Array from the Component class, in favor of std::vector. With the heavy use of the Component class, this should limit further usage of OpenSim::Array.