### PR TITLE
Do not test branches starting with `devprop`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ matrix:
     - os: osx
       compiler: clang
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=yes
+      
+branches:
+  exclude:
+  # Branches containing Development Proposals do not need to be tested.
+  # Exclude any branch whose name starts with devprop (case-insensitive).
+  # For example, devprop-feature and DEVPROP_feature are ignored.
+  - /^(?i:devprop).*$/
 
 env:
   global:

--- a/DevelopmentProposals/readme.md
+++ b/DevelopmentProposals/readme.md
@@ -8,6 +8,8 @@ This directory contains all the development proposals for OpenSim.
 2. Copy ***template.md*** into the new directory, and rename it appropriately.
 3. Fill in the proposal details, and add any relevant code snippet files and media files to the directory.
  * Please keep the files under 1MB and as few media files (like jpg, gif, png, etc) as possible.
-4. Submit a pull-request to review the proposal. Make sure to *label* the pull-request with the label ***DevProp***.
-5. Once approved, start work on the implementation of the proposed changes.
-6. Remember to get any significant changes to proposal approved before starting to work on implementation.
+4. Commit your proposal to a new branch whose name begins with `devprop` (e.g., `devprop_myFeature`);
+   this will tell Travis-CI and AppVeyor (automated testing servers) to not run tests on the branch.
+5. Submit a pull-request to review the proposal. Make sure to *label* the pull-request with the label ***DevProp***.
+6. Once approved, start work on the implementation of the proposed changes.
+7. Remember to get any significant changes to proposal approved before starting to work on implementation.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,14 @@ environment:
       JAVA_DIR: "C:\\Program Files\\Java\\jdk1.8.0"
       PYTHON_DIR: "C:\\Python27-x64"
 
+branches:
+  exclude:
+  # Branches containing Development Proposals do not need to be tested.
+  # Exclude any branch whose name starts with devprop (case-insensitive).
+  # For example, devprop-feature and DEVPROP_feature are ignored.
+  # The forward slashes indicate to AppVeyor that we are giving a regex.
+  - /^(?i:devprop).*$/
+
 init:
   # Note: python 2.7 32bit is already on the path. We want v2.7 64bit,
   # so we must add v2.7 64bit earlier on the PATH so that CMake finds it when

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ environment:
       PYTHON_DIR: "C:\\Python27-x64"
 
 branches:
-  exclude:
+  except:
   # Branches containing Development Proposals do not need to be tested.
   # Exclude any branch whose name starts with devprop (case-insensitive).
   # For example, devprop-feature and DEVPROP_feature are ignored.


### PR DESCRIPTION
I noticed that @tkuchida was `[ci skip]`ing his commits to his devprops. This PR tells travis and appveyor not to test any branches whose name starts with `devprop`. Accordingly, I think future devprops should be named with `devprop` at the front.

The only downside I foresee is that people will be able to put tabs into the devprop folder, and it won't be caught until someone later on tries to make a PR unrelated to the devprop.