### PR TITLE
Fix typo in BushingForce.h documentation

### DIFF
--- a/OpenSim/Simulation/Model/BushingForce.h
+++ b/OpenSim/Simulation/Model/BushingForce.h
@@ -63,7 +63,7 @@ public:
     OpenSim_DECLARE_PROPERTY(rotational_damping, SimTK::Vec3,
         "Damping parameters resisting angular deviation rate. (Nm/(rad/s))");
     OpenSim_DECLARE_PROPERTY(translational_damping, SimTK::Vec3,
-        "Damping parameters resisting relative translational velocity. (N/(m/s)");
+        "Damping parameters resisting relative translational velocity. (N/(m/s))");
 //==============================================================================
 // PUBLIC METHODS
 //==============================================================================


### PR DESCRIPTION
This PR fixes a typo in the property documentation for BushingForce.h: `(N/(m/s)` -> `(N/(m/s))`.