### PR TITLE
Fix xml version number check

### DIFF
--- a/OpenSim/Simulation/Model/PrescribedForce.cpp
+++ b/OpenSim/Simulation/Model/PrescribedForce.cpp
@@ -75,9 +75,7 @@ PrescribedForce::PrescribedForce(SimTK::Xml::Element& aNode) :
 void PrescribedForce::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
 {
     // Base class
-    // This test for veversion number needs to change when we have a new version number otherwise 
-    // subsequent versions will continue to trigger the conversion below. -Ayman 4/16
-    if (versionNumber != 30505) { 
+    if (versionNumber < 30506) {
         // Convert body property into a connector to PhysicalFrame with name "frame"
         SimTK::Xml::element_iterator bodyElement = aNode.element_begin("body");
         std::string frame_name("");


### PR DESCRIPTION
Replaced `!=` with `<` when checking xml version number to avoid running conversion code for *more recent* versions. The check `versionNumber < 30506` is different from the original `versionNumber != 30505` at @aymanhab's request (see #1006). There are no other instances of `versionNumber != ...`.