### PR TITLE
Replaced DecorativeEllipsoids with Ellipsoids in README example

### DIFF
--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -94,19 +94,17 @@ int main() {
     model.addComponent(reporter);
 
     // Add display geometry.
-#ifdef VISUALIZE
-    Ellipsoid* bodyGeometry = new Ellipsoid(0.1, 0.5, 0.1);
-    bodyGeometry->setColor(Gray);
+    Ellipsoid bodyGeometry(0.1, 0.5, 0.1);
+    bodyGeometry.setColor(Gray);
     // Attach an ellipsoid to a frame located at the center of each body.
     PhysicalOffsetFrame* humerusCenter = new PhysicalOffsetFrame(
         "humerusCenter", "humerus", Transform(Vec3(0, 0.5, 0)));
     humerus->addComponent(humerusCenter);
-    humerusCenter->attachGeometry(bodyGeometry->clone());
+    humerusCenter->attachGeometry(bodyGeometry.clone());
     PhysicalOffsetFrame* radiusCenter = new PhysicalOffsetFrame(
         "radiusCenter", "radius", Transform(Vec3(0, 0.5, 0)));
     radius->addComponent(radiusCenter);
-    radiusCenter->attachGeometry(bodyGeometry->clone());
-#endif
+    radiusCenter->attachGeometry(bodyGeometry.clone());
 
     // Configure the model.
     State& state = model.initSystem();

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -93,6 +93,21 @@ int main() {
         "elbow_angle");
     model.addComponent(reporter);
 
+    // Add display geometry.
+#ifdef VISUALIZE
+    Ellipsoid* bodyGeometry = new Ellipsoid(0.1, 0.5, 0.1);
+    bodyGeometry->setColor(Gray);
+    // Attach an ellipsoid to a frame located at the center of each body.
+    PhysicalOffsetFrame* humerusCenter = new PhysicalOffsetFrame(
+        "humerusCenter", "humerus", Transform(Vec3(0, 0.5, 0)));
+    humerus->addComponent(humerusCenter);
+    humerusCenter->attachGeometry(bodyGeometry->clone());
+    PhysicalOffsetFrame* radiusCenter = new PhysicalOffsetFrame(
+        "radiusCenter", "radius", Transform(Vec3(0, 0.5, 0)));
+    radius->addComponent(radiusCenter);
+    radiusCenter->attachGeometry(bodyGeometry->clone());
+#endif
+
     // Configure the model.
     State& state = model.initSystem();
     // Fix the shoulder at its default angle and begin with the elbow flexed.
@@ -100,15 +115,11 @@ int main() {
     elbow->getCoordinate().setValue(state, 0.5 * Pi);
     model.equilibrateMuscles(state);
 
-    // Add display geometry.
+    // Configure the visualizer.
 #ifdef VISUALIZE
     model.updMatterSubsystem().setShowDefaultGeometry(true);
     Visualizer& viz = model.updVisualizer().updSimbodyVisualizer();
     viz.setBackgroundColor(White);
-    // Ellipsoids: 0.5 m radius along y-axis, centered 0.5 m up along y-axis.
-    DecorativeEllipsoid geom(Vec3(0.1, 0.5, 0.1)); Vec3 center(0, 0.5, 0);
-    viz.addDecoration(humerus->getMobilizedBodyIndex(), Transform(center), geom);
-    viz.addDecoration( radius->getMobilizedBodyIndex(), Transform(center), geom);
 #endif
 
     // Simulate.

--- a/README.md
+++ b/README.md
@@ -78,17 +78,17 @@ int main() {
     model.addComponent(reporter);
 
     // Add display geometry.
-    Ellipsoid* bodyGeometry = new Ellipsoid(0.1, 0.5, 0.1);
-    bodyGeometry->setColor(Gray);
+    Ellipsoid bodyGeometry(0.1, 0.5, 0.1);
+    bodyGeometry.setColor(Gray);
     // Attach an ellipsoid to a frame located at the center of each body.
     PhysicalOffsetFrame* humerusCenter = new PhysicalOffsetFrame(
         "humerusCenter", "humerus", Transform(Vec3(0, 0.5, 0)));
     humerus->addComponent(humerusCenter);
-    humerusCenter->attachGeometry(bodyGeometry->clone());
+    humerusCenter->attachGeometry(bodyGeometry.clone());
     PhysicalOffsetFrame* radiusCenter = new PhysicalOffsetFrame(
         "radiusCenter", "radius", Transform(Vec3(0, 0.5, 0)));
     radius->addComponent(radiusCenter);
-    radiusCenter->attachGeometry(bodyGeometry->clone());
+    radiusCenter->attachGeometry(bodyGeometry.clone());
 
     // Configure the model.
     State& state = model.initSystem();

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ int main() {
         "elbow_angle");
     model.addComponent(reporter);
 
+    // Add display geometry.
+    Ellipsoid* bodyGeometry = new Ellipsoid(0.1, 0.5, 0.1);
+    bodyGeometry->setColor(Gray);
+    // Attach an ellipsoid to a frame located at the center of each body.
+    PhysicalOffsetFrame* humerusCenter = new PhysicalOffsetFrame(
+        "humerusCenter", "humerus", Transform(Vec3(0, 0.5, 0)));
+    humerus->addComponent(humerusCenter);
+    humerusCenter->attachGeometry(bodyGeometry->clone());
+    PhysicalOffsetFrame* radiusCenter = new PhysicalOffsetFrame(
+        "radiusCenter", "radius", Transform(Vec3(0, 0.5, 0)));
+    radius->addComponent(radiusCenter);
+    radiusCenter->attachGeometry(bodyGeometry->clone());
+
     // Configure the model.
     State& state = model.initSystem();
     // Fix the shoulder at its default angle and begin with the elbow flexed.
@@ -84,14 +97,10 @@ int main() {
     elbow->getCoordinate().setValue(state, 0.5 * Pi);
     model.equilibrateMuscles(state);
 
-    // Add display geometry.
+    // Configure the visualizer.
     model.updMatterSubsystem().setShowDefaultGeometry(true);
     Visualizer& viz = model.updVisualizer().updSimbodyVisualizer();
     viz.setBackgroundColor(White);
-    // Ellipsoids: 0.5 m radius along y-axis, centered 0.5 m up along y-axis.
-    DecorativeEllipsoid geom(Vec3(0.1, 0.5, 0.1)); Vec3 center(0, 0.5, 0);
-    viz.addDecoration(humerus->getMobilizedBodyIndex(), Transform(center), geom);
-    viz.addDecoration( radius->getMobilizedBodyIndex(), Transform(center), geom);
 
     // Simulate.
     RungeKuttaMersonIntegrator integrator(model.getSystem());


### PR DESCRIPTION
Attached Ellipsoids to PhysicalOffsetFrames located at the center of each Body. A positive side effect is that we are now demonstrating Frames in the README example. Did not generate new gif because appearance of visualization did not change substantially. Fixes #1254.