### PR TITLE
Fix hopper visualization failure 

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -122,12 +122,6 @@ const Array<PathPoint*>& OpenSimContext::getCurrentPath(Muscle& m) {
   return m.getGeometryPath().getCurrentPath(*_configState);
 }
 
-const Array<PathPoint*>& OpenSimContext::getCurrentDisplayPath(GeometryPath& g) {
-  g.updateGeometry(*_configState);
-  _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Velocity);
-  return g.getCurrentDisplayPath(*_configState);
-}
-
 void OpenSimContext::copyMuscle(Muscle& from, Muscle& to) {
   to = from;
   _configState->invalidateAll(SimTK::Stage::Position);

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -136,7 +136,6 @@ public:
     double getActivation(Muscle& act);
     double getMuscleLength(Muscle& act);
     const Array<PathPoint*>& getCurrentPath(Muscle& act);
-    const Array<PathPoint*>& getCurrentDisplayPath(GeometryPath& path);
     void copyMuscle(Muscle& from, Muscle& to);
     void replacePropertyFunction(OpenSim::Object& obj, OpenSim::Function* aOldFunction, OpenSim::Function* aNewFunction);
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -144,9 +144,11 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
         if (pwp) {
             // A PathWrapPoint provides points on the wrapping surface as Vec3s
             Array<Vec3>& surfacePoints = pwp->getWrapPath();
-            // The surface points are expressed w.r.t. the wrap surface's body 
+            // The surface points are expressed w.r.t. the wrap surface's body frame.
+            // Transform the surface points into the ground reference frame to draw
+            // the surface point as the wrapping portion of the GeometryPath
             const Transform& X_BG = pwp->getBody().getTransformInGround(state);
-            // Cycle through each surface point and draw it
+            // Cycle through each surface point and draw it the Ground frame
             for (int j = 0; j<surfacePoints.getSize(); ++j) {
                 // transform the surface point into the Ground reference frame
                 pos = X_BG*surfacePoints[j];

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -136,28 +136,27 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
         DefaultGeometry::drawPathPoint(mbix, lastPos, getColor(state), appendToThis);
 
     Vec3 pos;
-    for (int j = 1; j < pathPoints.getSize(); j++) {
-        PathPoint* point = pathPoints[j];
-        PathWrapPoint* mwp = dynamic_cast<PathWrapPoint*>(point);
+    int cnt = 0;
+    for (int i = 1; i < pathPoints.getSize(); ++i) {
+        PathPoint* point = pathPoints[i];
+        PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
 
-        if (mwp) {
-            // If the point is a PathWrapPoint and has surfacePoints,
-            // then this is the second of two tangent points for the
-            // wrap instance. So add the surface points to the display
-            // path before adding the second tangent point.
-            // Note: the first surface point is coincident with the
-            // first tangent point, so don't add it to the path.
-            Array<Vec3>& surfacePoints = mwp->getWrapPath();
-            const Transform& X_BG = mwp->getBody().getTransformInGround(state);
-            for (int j = 1; j<surfacePoints.getSize(); j++) {
-                pos = X_BG*surfacePoints.get(j);
+        if (pwp) {
+            // A PathWrapPoint provides points on the wrapping surface as Vec3s
+            Array<Vec3>& surfacePoints = pwp->getWrapPath();
+            // The surface points are expressed w.r.t. the wrap surface's body 
+            const Transform& X_BG = pwp->getBody().getTransformInGround(state);
+            // Cycle through each surface point and draw it
+            for (int j = 0; j<surfacePoints.getSize(); ++j) {
+                // transform the surface point into the Ground reference frame
+                pos = X_BG*surfacePoints[j];
                 if (hints.get_show_path_points())
                     DefaultGeometry::drawPathPoint(mbix, pos, getColor(state),
                         appendToThis);
                 // Line segments will be in ground frame
                 appendToThis.push_back(DecorativeLine(lastPos, pos)
                     .setLineThickness(4)
-                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(j));
+                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(cnt++));
                 lastPos = pos;
             }
         } 
@@ -169,7 +168,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
             // Line segments will be in ground frame
             appendToThis.push_back(DecorativeLine(lastPos, pos)
                 .setLineThickness(4)
-                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(j));
+                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(cnt++));
             lastPos = pos;
         }
     }

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -421,10 +421,6 @@ void GeometryPath::updateGeometry(const SimTK::State& s) const
 {
     // Check if the current path needs to recomputed.
     computePath(s);
-
-    // If display path is current do not need to recompute it.
-    if (isCacheVariableValid(s, "current_display_path"))
-        return;
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -89,9 +89,6 @@ void GeometryPath::extendConnectToModel(Model& aModel)
     Array<PathPoint *> pathPrototype;
     addCacheVariable<Array<PathPoint *> >
         ("current_path", pathPrototype, SimTK::Stage::Position);
-    // When displaying, cache the set of points to be used to draw the path.
-    addCacheVariable<Array<PathPoint *> >
-        ("current_display_path", pathPrototype, SimTK::Stage::Position);
 
     // We consider this cache entry valid any time after it has been created
     // and first marked valid, and we won't ever invalidate it.
@@ -414,22 +411,6 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
 
 //_____________________________________________________________________________
 /*
- * get the current display path of the path
- *
- * @return The array of currently active path points, plus points along the
- * surfaces of the wrap objects (if any).
- * 
- */
-const OpenSim::Array<PathPoint*>& GeometryPath::
-getCurrentDisplayPath(const SimTK::State& s) const
-{
-    // update the geometry to make sure the current display path is up to date.
-    // updateGeometry(s);
-    return getCacheVariableValue<Array <PathPoint*> >(s, "current_display_path" );
-}
-
-//_____________________________________________________________________________
-/*
  * Update the geometric representation of the path.
  * The resulting geometry is maintained at the VisibleObject layer.
  * This function should not be made public. It is called internally
@@ -444,10 +425,6 @@ void GeometryPath::updateGeometry(const SimTK::State& s) const
     // If display path is current do not need to recompute it.
     if (isCacheVariableValid(s, "current_display_path"))
         return;
-   
-    // Updating the display path will also validate the current_display_path 
-    // cache variable.
-    updateDisplayPath(s);
 }
 
 //=============================================================================
@@ -1205,18 +1182,6 @@ computeMomentArm(const SimTK::State& s, const Coordinate& aCoord) const
         const_cast<Self*>(this)->_maSolver.reset(new MomentArmSolver(*_model));
 
     return _maSolver->solve(s, aCoord,  *this);
-}
-
-//_____________________________________________________________________________
-/*
- * Update the cache entry for current_display_path
- */
-void GeometryPath::updateDisplayPath(const SimTK::State& s) const
-{
-    Array<PathPoint*>& currentDisplayPath = 
-        updCacheVariableValue<Array<PathPoint*> >(s, "current_display_path");
-
-    currentDisplayPath.setSize(0);
 }
 
 void GeometryPath::extendFinalizeFromProperties()

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -136,7 +136,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
         DefaultGeometry::drawPathPoint(mbix, lastPos, getColor(state), appendToThis);
 
     Vec3 pos;
-    int cnt = 0;
+
     for (int i = 1; i < pathPoints.getSize(); ++i) {
         PathPoint* point = pathPoints[i];
         PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
@@ -156,7 +156,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
                 // Line segments will be in ground frame
                 appendToThis.push_back(DecorativeLine(lastPos, pos)
                     .setLineThickness(4)
-                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(cnt++));
+                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(j));
                 lastPos = pos;
             }
         } 
@@ -168,7 +168,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
             // Line segments will be in ground frame
             appendToThis.push_back(DecorativeLine(lastPos, pos)
                 .setLineThickness(4)
-                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(cnt++));
+                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(i));
             lastPos = pos;
         }
     }

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -150,8 +150,6 @@ public:
     void setPreScaleLength( const SimTK::State& s, double preScaleLength);
     const Array<PathPoint*>& getCurrentPath( const SimTK::State& s) const;
 
-    const Array<PathPoint*>& getCurrentDisplayPath(const SimTK::State& s) const;
-
     double getLengtheningSpeed(const SimTK::State& s) const;
     void setLengtheningSpeed( const SimTK::State& s, double speed ) const;
 
@@ -220,7 +218,6 @@ private:
        (const SimTK::State& s, const Array<PathPoint*>& currentPath) const;
 
     void constructProperties();
-    void updateDisplayPath(const SimTK::State& s) const;
     void namePathPoints(int aStartingIndex);
     void placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, 
                            int aIndex, const PhysicalFrame& aBody);


### PR DESCRIPTION
In #1230 the `!hasSystem()` Exception was being thrown because `PathWrapPoint`s were being asked their location in Ground, but they are not "Components" of the Model. They are "ethereal" in the sense that a `WrapObject` creates points on its surface (for the purpose of being drawn it would seem). These points (as Vec3s) were being used to construct PathPoints and being cached as a `display_path` but they are not part of the `Model` or the `System` being simulated- they were only being used to be drawn. It seems completely unnecessary to cache `display_path` especially now that the the `GeometryPath` can draw  itself based on the actual (current) path.

There are two significant changes:

1. `GeometryPath::generateDecorations()` was updated so the the surface points are simply drawn and are no longer required to exist as ethereal/orphan `PathWrapPoint`s.
2.  Since the surface points can be drawn directly from the current path, there is no need for the cached `display_path` and all related methods and members have been removed, including from the OpenSimContext. @aymanhab please let me know if this is a problem for the GUI. I don't think PathWrapPoints were ever select-able or editable, if they were it would have had little effect since on the next frame they would have been replaced.
