### PR TITLE
Improve memory usage estimates and apply to testInitStates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ before_install:
   # Initialize environment variable.
   - export TESTS_TO_EXCLUDE="unmatched" # This is just for the regex.
   ## On OSX, we know that testInitState fails; exclude it.
-  ##- if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
   ## If we are building in debug, there are some tests to ignore.
   - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMC|testOptimizationExample|testWrapping"; fi
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ before_install:
   # Initialize environment variable.
   - export TESTS_TO_EXCLUDE="unmatched" # This is just for the regex.
   ## On OSX, we know that testInitState fails; exclude it.
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
+  ##- if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
   ## If we are building in debug, there are some tests to ignore.
   - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMC|testOptimizationExample|testWrapping"; fi
   

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -286,7 +286,15 @@ void validateMemoryUseEstimates(const size_t nSamples = 11)
         return new Block(size);
     };
 
-    size_t delta = estimateMemoryChangeForCreator<Block>(creator, nSamples);
+    size_t delta = 0;
+    try {
+        delta = estimateMemoryChangeForCreator<Block>(creator, nSamples);
+    }
+    catch (const std::exception& ex) {
+        OPENSIM_THROW(OpenSim::Exception,
+            "Failed to estimate change in memory usage. Details:\n"
+            + std::string(ex.what()) );
+    }
 
     OPENSIM_THROW_IF(delta < size/2, OpenSim::Exception,
         "Cannot estimate memory usage due to invalid getRSS() evaluation."

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -261,9 +261,8 @@ size_t estimateMemoryChangeForCreator(T creator, const size_t nSamples = 100)
 // memory use estimators (e.g. estimateMemoryChangeForCreator and
 // estimateMemoryChangeForCommand). Do this at the beginning of your test 
 // involving checks for memory use.
-void validateMemoryUseEstimates()
+void validateMemoryUseEstimates(const size_t nSamples = 11)
 {
-    size_t nSamples = 5;
     // Approximate size of a small OpenSim model
     size_t size = 1000 * 1024; // 1K * 1KB = 1MB;
 

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -163,7 +163,7 @@ void testMemoryUsage(const string& modelFile)
     };
 
     size_t model_size = 
-        estimateMemoryChangeForCreator<Model>(creator, 10);
+        estimateMemoryChangeForCreator<Model>(creator, 5);
 
     OPENSIM_THROW_IF(model_size == 0, OpenSim::Exception,
         "Model size was estimated to be zero.");

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -50,8 +50,10 @@ int main()
     try {
         LoadOpenSimLibrary("osimActuators");
         testStates("arm26.osim");
-        testMemoryUsage("arm26.osim");
-        testMemoryUsage("PushUpToesOnGroundWithMuscles.osim");
+        if (isGetRSSValid()) {
+            testMemoryUsage("arm26.osim");
+            testMemoryUsage("PushUpToesOnGroundWithMuscles.osim");
+        }
     }
     catch (const Exception& e) {
         cout << "testInitState failed: ";
@@ -150,32 +152,34 @@ void testMemoryUsage(const string& modelFile)
 {
     using namespace SimTK;
 
-    if (isGetRSSValid) {
-        //=========================================================================
-        // Estimate the size of the model when loaded into memory
-        const size_t model_size = estimateMemoryChangeForModelLoading(modelFile, 10);
+    //=========================================================================
+    // Estimate the size of the model when loaded into memory
+    auto loader = [modelFile]() {
+        OpenSim::Model model(modelFile);
+        model.finalizeFromProperties();
+    };
+    size_t model_size = estimateMemoryChangeForCommand(loader, 10);
 
-        Model model(modelFile);
-        State state = model.initSystem();
+    Model model(modelFile);
+    State state = model.initSystem();
 
-        // also time how long initializing the state takes
-        clock_t startTime = clock();
+    // also time how long initializing the state takes
+    clock_t startTime = clock();
 
-        // determine the change in memory usage due to invoking model.initialiState
-        auto command = [&model]() mutable { model.initializeState(); };
-        const size_t leak = estimateMemoryChangeForCommand(command, MAX_N_TRIES);
+    // determine the change in memory usage due to invoking model.initialiState
+    auto command = [&model]() mutable { model.initializeState(); };
+    const size_t leak = estimateMemoryChangeForCommand(command, MAX_N_TRIES);
 
-        long double leak_percent = 100.0 * double(leak) / model_size;
+    long double leak_percent = 100.0 * double(leak) / model_size;
 
-        long double dT = (long double)(clock() - startTime) / CLOCKS_PER_SEC;
-        long double meanT = 1.0e3 * dT / MAX_N_TRIES; // in ms
+    long double dT = (long double)(clock() - startTime) / CLOCKS_PER_SEC;
+    long double meanT = 1.0e3 * dT / MAX_N_TRIES; // in ms
 
-        cout << "Approximate leak size: " << leak / 1024.0 << "KB or " <<
-            leak_percent << "% of model size." << endl;
-        cout << "Average initialization time: " << meanT << "ms" << endl;
+    cout << "Approximate leak size: " << leak / 1024.0 << "KB or " <<
+        leak_percent << "% of model size." << endl;
+    cout << "Average initialization time: " << meanT << "ms" << endl;
 
-        // If we are leaking more than 0.5% of the model's footprint that is significant
-        ASSERT((leak_percent) < 0.5, __FILE__, __LINE__,
-            "testMemoryUsage: state initialization leak > 0.5% of model memory footprint.");
-    }
+    // If we are leaking more than 0.5% of the model's footprint that is significant
+    ASSERT((leak_percent) < 0.5, __FILE__, __LINE__,
+        "testMemoryUsage: state initialization leak > 0.5% of model memory footprint.");
 }


### PR DESCRIPTION
This PR addresses #1263 (arising from the current failure in #1205) and intermittent failures in CI of `testInitStates.cpp`. The main issue is that a single call to `getCurrentRSS()` can be unreliable, but it is generally consistent over repeated calls (at least on Windows). 

Therefore, when evaluating the memory usage of statement it makes sense to make several samples and to use the samples to select the typically "expected" value. Here we use the median value to represent the typical memory usage as estimated from `getCurrentRSS()`. The utility method wraps the *command* in a loop and estimates the change in memory use due to executing the command. The utility is `estimateMemoryChangeForCommand(T command, const size_t nSamples)` and is located in `auxiliaryTestFunctions.h` so other tests (such as `testComponents`) can also use it and be simplified. 

`testInitState` was simplified to use `estimateMemoryChangeForCommand` instead of employing its own loops in hopes of addressing #1205.

A method was also added to check that getRSS is valid by computing the change in memory usage after explicitly allocating a block of known size. It is currently being used as a guard in `testInitStates` to decide whether memory usage should even be tested.  Currently, if it is invalid the test are skipped. I am looking for reviewer comments on whether something like this should stay or not. Leaving it may cause the the memory usage to never be tested on Mac or Linux.

Adapting `testComponents` (and any other tests) will be part of subsequent PRs.