### PR TITLE
[doxygen] Indicate that Millard2012AccelerationMuscle is "experimental"

### DIFF
--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.h
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.h
@@ -172,6 +172,11 @@ MuscleFirstOrderActivationDynamicModel.
 \li kg: kilograms
 \li s: seconds
 
+<B>Caution</B>
+
+The Millard2012AccelerationMuscle class is experimental and has not been
+extensively tested in all operational conditions.
+
 <B>Usage</B>
 
  Note that this object should be updated through the set methods provided. 


### PR DESCRIPTION
Added message to warn users that Millard2012AccelerationMuscle hasn't been fully tested:

![caution](https://cloud.githubusercontent.com/assets/4203505/18704404/a13883ce-7f9e-11e6-8997-95b69c20abbe.png)

Fixes #1185.