### PR TITLE
[doxygen] Add Python and Java/Matlab example code to Joints

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/BallJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/BallJoint.h
@@ -59,6 +59,17 @@ public:
         \code{.cpp}
         const auto& rx = myBallJoint.getCoordinate(BallJoint::Coord::Rotation1X);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rx = myBallJoint.getCoordinate(opensim.BallJoint.Coord_Rotation1X)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rx = myBallJoint.getCoordinate(BallJoint.Coord.Rotation1X);
+        \endcode
     */
     enum class Coord: unsigned {
         Rotation1X,

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
@@ -56,6 +56,17 @@ public:
         const auto& rx = myEllipsoidJoint.
                          getCoordinate(EllipsoidJoint::Coord::Rotation1X);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rx = myEllipsoidJoint.getCoordinate(opensim.EllipsoidJoint.Coord_Rotation1X)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rx = myEllipsoidJoint.getCoordinate(EllipsoidJoint.Coord.Rotation1X);
+        \endcode
     */
     enum class Coord: unsigned {
         Rotation1X,

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
@@ -57,6 +57,17 @@ public:
         \code{.cpp}
         const auto& rx = myFreeJoint.getCoordinate(FreeJoint::Coord::Rotation1X);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rx = myFreeJoint.getCoordinate(opensim.FreeJoint.Coord_Rotation1X)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rx = myFreeJoint.getCoordinate(FreeJoint.Coord.Rotation1X);
+        \endcode
     */
     enum class Coord: unsigned {
         Rotation1X,

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
@@ -52,6 +52,17 @@ public:
         const auto& rx = myGimbalJoint.
                          getCoordinate(GimbalJoint::Coord::Rotation1X);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rx = myGimbalJoint.getCoordinate(opensim.GimbalJoint.Coord_Rotation1X)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rx = myGimbalJoint.getCoordinate(GimbalJoint.Coord.Rotation1X);
+        \endcode
     */
     enum class Coord: unsigned {
         Rotation1X,

--- a/OpenSim/Simulation/SimbodyEngine/PinJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PinJoint.h
@@ -53,6 +53,17 @@ public:
         \code{.cpp}
         const auto& rz = myPinJoint.getCoordinate(PinJoint::Coord::RotationZ);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rz = myPinJoint.getCoordinate(opensim.PinJoint.Coord_RotationZ)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rz = myPinJoint.getCoordinate(PinJoint.Coord.RotationZ);
+        \endcode
     */
     enum class Coord: unsigned {
         RotationZ

--- a/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
@@ -52,6 +52,17 @@ public:
         const auto& rz = myPlanarJoint.
                          getCoordinate(PlanarJoint::Coord::RotationZ);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rz = myPlanarJoint.getCoordinate(opensim.PlanarJoint.Coord_RotationZ)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rz = myPlanarJoint.getCoordinate(PlanarJoint.Coord.RotationZ);
+        \endcode
     */
     enum class Coord: unsigned {
         RotationZ,

--- a/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
@@ -51,6 +51,17 @@ public:
         const auto& tx = mySliderJoint.
                          getCoordinate(SliderJoint::Coord::TranslationX);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        tx = mySliderJoint.getCoordinate(opensim.SliderJoint.Coord_TranslationX)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        tx = mySliderJoint.getCoordinate(SliderJoint.Coord.TranslationX);
+        \endcode
     */
     enum class Coord: unsigned {
         TranslationX

--- a/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
@@ -54,6 +54,17 @@ public:
         const auto& rx = myUniversalJoint.
                          getCoordinate(UniversalJoint::Coord::Rotation1X);
         \endcode
+
+        <b>Python example</b>
+        \code{.py}
+        import opensim
+        rx = myUniversalJoint.getCoordinate(opensim.UniversalJoint.Coord_Rotation1X)
+        \endcode
+
+        <b>Java/Matlab example</b>
+        \code{.java}
+        rx = myUniversalJoint.getCoordinate(UniversalJoint.Coord.Rotation1X);
+        \endcode
     */
     enum class Coord: unsigned {
         Rotation1X,

--- a/doc/doxygen-layout-user.xml
+++ b/doc/doxygen-layout-user.xml
@@ -77,10 +77,10 @@
       <typedefs title=""/>
       <functions title=""/>
       <properties title="OpenSim Property, Connector, Output, Input Documentation"/>
-      <!-- <enums title=""/>
+      <enums title=""/>
       
       
-      <related title=""/>
+      <!-- <related title=""/>
       <variables title=""/>
       <properties title=""/>
       <events title=""/> -->


### PR DESCRIPTION
Added usage examples for Python and Java/Matlab. Also note that the "enum" block wasn't being shown in user documentation, hence the change to doxygen-layout-user.xml. Here's the documentation for BallJoint:

![img1](https://cloud.githubusercontent.com/assets/4203505/18733388/6c7f968c-801f-11e6-9360-7722d148baab.png)

Fixes #1232. See #1272 for initial review and detailed explanation of design decisions.