### PR TITLE
Get rid of some clang warnings related to ModelComponentSet::getModel().

### DIFF
--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -231,7 +231,7 @@ void ExternalLoads::transformPointsExpressedInGroundToAppliedBodies(const Storag
 
 ExternalForce* ExternalLoads::transformPointExpressedInGroundToAppliedBody(const ExternalForce &exForce, const Storage &kinematics, double startTime, double endTime)
 {
-    if(!&getModel() || !getModel().isValidSystem()) // no model and no system underneath, cannot proceed
+    if(!hasModel() || !getModel().isValidSystem()) // no model and no system underneath, cannot proceed
         throw Exception("ExternalLoads::transformPointExpressedInGroundToAppliedBody() requires a model with a valid system."); 
 
     if(!exForce._specifiesPoint){ // The external force does not apply a force to a point

--- a/OpenSim/Simulation/Model/ForceSet.cpp
+++ b/OpenSim/Simulation/Model/ForceSet.cpp
@@ -185,7 +185,7 @@ append(Force *aForce)
 {
     bool success = ModelComponentSet<Force>::adoptAndAppend(aForce);
 
-    if((success)&&(&updModel()!=NULL)) {
+    if (success && hasModel()) {
         updateActuators();
         updateMuscles();
     }
@@ -209,7 +209,7 @@ append(Force &aForce)
     bool success = ModelComponentSet<Force>::cloneAndAppend(aForce);
 
 
-    if ((success) && (&getModel() != NULL)) {
+    if (success && hasModel()) {
         updateActuators();
         updateMuscles();
     }

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -92,6 +92,8 @@ public:
     }
 
 #ifndef SWIG
+    /** Does this Set have a Model associated with it? */
+    bool hasModel() const { return _model; }
     /**
      * Get this Model this set is part of.
      */

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -93,7 +93,7 @@ public:
 
 #ifndef SWIG
     /** Does this Set have a Model associated with it? */
-    bool hasModel() const { return _model; }
+    bool hasModel() const { return _model.get(); }
     /**
      * Get this Model this set is part of.
      */


### PR DESCRIPTION
This PR gets rid of some warnings generated by clang when checking for a null model like `&getModel()`.

