### PR TITLE
Fix MATLAB tests on Windows (and with Xcode)

### DIFF
--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -8,6 +8,9 @@ set(matlab_output_dir "${CMAKE_BINARY_DIR}/Matlab")
 file(WRITE "${matlab_output_dir}/javaclasspath.txt"
     "${SWIG_JAVA_JAR_BUILD_OUTPUT_PATH}")
 if(MSVC OR XCODE) 
+    # TODO: should not write all configuration build dirs to the
+    # librarypath.txt file; this means that Debug libraries are available to
+    # the Release build, for example.
     set(_binary_dirs)
     foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
         set(_binary_dirs "${CMAKE_BINARY_DIR}/${cfg}\n${_binary_dirs}")
@@ -22,6 +25,9 @@ file(WRITE "${matlab_output_dir}/javalibrarypath.txt"
 macro(OpenSimAddMatlabTest TESTNAME MFILE)
     get_filename_component(_full_path_to_mfile "${MFILE}" ABSOLUTE)
     if(MSVC OR XCODE)
+        # Multi-generator configurations are handled differently.
+        # TODO Ideally, we would use a different WORKING_DIRECTORY for each
+        # config.
         foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
             matlab_add_unit_test(NAME Matlab_${TESTNAME}_${cfg}
                 UNITTEST_FILE "${_full_path_to_mfile}"
@@ -29,17 +35,18 @@ macro(OpenSimAddMatlabTest TESTNAME MFILE)
                 NO_UNITTEST_FRAMEWORK
                 )
             #UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
-	    if(WIN32)
-	        set_tests_properties(Matlab_${TESTNAME}_${cfg} PROPERTIES ENVIRONMENT
+        if(WIN32)
+            # Must set PATH so that osimJavaJNI can find osimCommon, etc.
+            set_tests_properties(Matlab_${TESTNAME}_${cfg} PROPERTIES ENVIRONMENT
                     "PATH=${CMAKE_BINARY_DIR}/${cfg}")
             endif()
-	endforeach()
+    endforeach()
     else()
         matlab_add_unit_test(NAME Matlab_${TESTNAME}
             UNITTEST_FILE "${_full_path_to_mfile}"
             NO_UNITTEST_FRAMEWORK
             )
-	    #TEST_ARGS CONFIGURATIONS Release RelWithDebInfo MinSizeRel
+        #TEST_ARGS CONFIGURATIONS Release RelWithDebInfo MinSizeRel
     endif()
 endmacro()
 

--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -21,18 +21,26 @@ file(WRITE "${matlab_output_dir}/javalibrarypath.txt"
 
 macro(OpenSimAddMatlabTest TESTNAME MFILE)
     get_filename_component(_full_path_to_mfile "${MFILE}" ABSOLUTE)
-    if(WIN32)
-        # On Windows, must set ADDITIONAL_PATH to find the opensim
-        # libraries.
-        set(_additional_path "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
+    if(MSVC OR XCODE)
+        foreach(cfg ${CMAKE_CONFIGURATION_TYPES})
+            matlab_add_unit_test(NAME Matlab_${TESTNAME}_${cfg}
+                UNITTEST_FILE "${_full_path_to_mfile}"
+                TEST_ARGS CONFIGURATIONS ${cfg}
+                NO_UNITTEST_FRAMEWORK
+                )
+            #UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
+	    if(WIN32)
+	        set_tests_properties(Matlab_${TESTNAME}_${cfg} PROPERTIES ENVIRONMENT
+                    "PATH=${CMAKE_BINARY_DIR}/${cfg}")
+            endif()
+	endforeach()
+    else()
+        matlab_add_unit_test(NAME Matlab_${TESTNAME}
+            UNITTEST_FILE "${_full_path_to_mfile}"
+            NO_UNITTEST_FRAMEWORK
+            )
+	    #TEST_ARGS CONFIGURATIONS Release RelWithDebInfo MinSizeRel
     endif()
-    matlab_add_unit_test(NAME Matlab_${TESTNAME}
-        UNITTEST_FILE "${_full_path_to_mfile}"
-        TEST_ARGS "CONFIGURATIONS Release RelWithDebInfo MinSizeRel"
-        ADDITIONAL_PATH "${_additional_path}"
-        NO_UNITTEST_FRAMEWORK
-        )
-    #UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
 endmacro()
 
 # Allow MSVC users to run only the Matlab tests directly from the MSVC GUI.

--- a/Bindings/Java/Matlab/tests/testAccessSubcomponents.m
+++ b/Bindings/Java/Matlab/tests/testAccessSubcomponents.m
@@ -7,9 +7,11 @@ model = Model('arm26.osim');
 % =====================
 muscle = model.getComponent('BICshort');
 assert(strcmp(muscle.getName(), 'BICshort'));
-Thelen2003Muscle.safeDownCast(muscle).get_max_isometric_force();
+thelenMuscle = Thelen2003Muscle.safeDownCast(muscle);
+thelenMuscle.get_max_isometric_force();
 muscle = model.updComponent('BICshort');
-Thelen2003Muscle.safeDownCast(muscle).set_max_isometric_force(100);
+updThelenMuscle = Thelen2003Muscle.safeDownCast(muscle)
+updThelenMuscle.set_max_isometric_force(100);
 
 % ComponentList
 % =============

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -50,7 +50,8 @@ for i = 0:(names.size() - 1)
 end
 
 % Access a specific concrete connectee.
-assert(Body.safeDownCast(joint.getConnectee('child_frame')).getMass() == 2);
+body = Body.safeDownCast(joint.getConnectee('child_frame'));
+assert(body.getMass() == 2);
 
 % Connect a connector.
 offset.updConnector('parent').connect(ground);
@@ -72,7 +73,8 @@ for i = 0:(names.size() - 1)
 end
 
 % Access the value of a concrete Output.
-OutputDouble.safeDownCast(coord.getOutput('speed')).getValue(state);
+concreteOutput = OutputDouble.safeDownCast(coord.getOutput('speed'));
+concreteOutput.getValue(state);
 
 % Channels
 % --------
@@ -117,7 +119,8 @@ end
 
 % Access the value of a concerete Input.
 % The value 1 comes from column 2 of the TableSource.
-assert(InputDouble.safeDownCast(rep.getInput('inputs')).getValue(state, 3)==1);
+concreteInput = InputDouble.safeDownCast(rep.getInput('inputs'));
+assert(concreteInput.getValue(state, 3)==1);
 % TODO Concrete channels are not wrapped yet.
 % TODO InputDouble.safeDownCast(comp.getInput(name)).getChannel(0).getValue(s);
 


### PR DESCRIPTION
This PR fixes the configuration of the MATLAB tests so they successfully run on Windows. I tested this locally.

Unfortunately, we cannot test this with continuous integration. So you'll have to trust me a little.