### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ sudo apt-add-repository --yes ppa:fenics-packages/fenics-exp
 sudo apt-get update
 sudo apt-get --yes install git cmake cmake-curses-gui clang-3.6 \
                            freeglut3-dev libxi-dev libxmu-dev \
-                           liblapack-dev swig3.0 python-dev \
+                           liblapack-dev swig3.1 python-dev \
                            openjdk-7-jdk
 sudo rm -f /usr/bin/cc /usr/bin/c++
 sudo ln -s /usr/bin/clang-3.6 /usr/bin/cc


### PR DESCRIPTION
Please change the swig version because I am getting this error when I run cmake under the heading "For the impatientUbuntu 14.04"

gautam@ubuntu:~/opensim_build$ sudo cmake ../opensim-core -DCMAKE_INSTALL_PREFIX="~/opensim_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSIM_DEPENDENCIES_DIR="~/opensim_dependencies_install" -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=ON -DWITH_BTK=ON
-- Could NOT find Matlab: Found unsuitable version "NOTFOUND", but required is at least "7.0" (found Matlab_INCLUDE_DIRS-NOTFOUND)
CMake Error at /usr/share/cmake-3.2/Modules/FindPackageHandleStandardArgs.cmake:138 (message):
  Could NOT find SWIG: Found unsuitable version "3.0.2", but required is at
  least "3.0.6" (found /usr/bin/swig3.0)
Call Stack (most recent call first):
  /usr/share/cmake-3.2/Modules/FindPackageHandleStandardArgs.cmake:372 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.2/Modules/FindSWIG.cmake:75 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  Bindings/CMakeLists.txt:2 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/gautam/opensim_build/CMakeFiles/CMakeOutput.log".