### PR TITLE
[travis] Do not reinstall cmake on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,7 @@ before_install:
   # Stop build if comment contains [skip travis].
   - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
   
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew unlink cmake; fi
-  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then brew install cmake; fi
-  - cmake --version
+  - cmake --version # To help debug any cmake-related issues.
   
   ###########################################################################################################
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.


### PR DESCRIPTION
Travis has updated their default OSX image, which now has cmake 3.6.2. 
This is sufficiently new for us, so we no longer need to install a newer 
cmake on our own. Not only this, but their update was causing our Travis build script to fail (we unlinked the existing cmake but homebrew does not re-install cmake b/c the latest version is already installed).

https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/

This will hopefully resolve the build failures on @aymanhab's #1299 