### PR TITLE
[travis] Ignore specific warnings on osx too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ before_install:
   
   ## Set compiler flags.
   - export CXX_FLAGS="-Werror -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"
-  - # Use this to ignore warnings on only Linux: if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX_FLAGS="$CXX_FLAGS <add warnings here>"; fi;
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CXX_FLAGS="$CXX_FLAGS -Wno-inconsistent-missing-override"; fi;
 
   # Run superbuild to download, configure, build and install dependencies.
   - mkdir $OPENSIM_DEPENDENCIES_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,11 @@ before_install:
   - if $(git log -n1 --format="%B" | grep --quiet '\[skip travis\]'); then exit; fi 
   
   - cmake --version # To help debug any cmake-related issues.
+      
+  ## Avoid bug on OSX (https://github.com/travis-ci/travis-ci/issues/6307)
+  # This prevents the build from failing with:
+  # `/Users/travis/build.sh: line 109: shell_session_update: command not found`
+  - rvm get head
   
   ###########################################################################################################
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,8 +145,8 @@ before_install:
   - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMC|testOptimizationExample|testWrapping"; fi
   
   ## Set compiler flags.
-  - export CXX_FLAGS="-Werror"
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX_FLAGS="$CXX_FLAGS -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"; fi;
+  - export CXX_FLAGS="-Werror -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"
+  - # Use this to ignore warnings on only Linux: if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX_FLAGS="$CXX_FLAGS <add warnings here>"; fi;
 
   # Run superbuild to download, configure, build and install dependencies.
   - mkdir $OPENSIM_DEPENDENCIES_BUILD_DIR


### PR DESCRIPTION
We had been ignoring certain warnings on Linux. This PR causes us to ignore these warnings on OSX as well.

The intent of this PR is to fix the currently-failing OSX builds.