### PR TITLE
Handle order of PhysicalOffsetFrame

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -269,6 +269,7 @@ void Component::connect(Component &root)
     // adding subcomponents to the System
     extendConnect(root);
 
+    // Allow subcomponents to form their connections
     componentsConnect(root);
 
     // Forming connections changes the Connector which is a property

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -775,11 +775,13 @@ void Model::extendConnectToModel(Model &model)
     // PhysicalOffsetFrames require that their parent frame (a PhysicalFrame)
     // be added to the System first. So for each PhysicalOffsetFrame locate its
     // parent and verify its presence in the _orderedList otherwise add it first.
-    auto poFrames = getComponentList<PhysicalOffsetFrame>();
-    for (const auto& pof : poFrames) {
-        // Ground and Body type PhysicalFrames are handled by the Multibody graph
-        // PhysicalOffsetFrame can be listed in any order and be attched
+    auto poFrames = updComponentList<PhysicalOffsetFrame>();
+    for (auto& pof : poFrames) {
+        // Ground and Body type PhysicalFrames are included in the Multibody graph
+        // PhysicalOffsetFrame can be listed in any order and may be attached
         // to any other PhysicalOffsetFrame, so we need to find their parent(s)
+        // in the tree and add them first.
+        pof.connectToModel(*this);
         const PhysicalOffsetFrame* parentPof =
             dynamic_cast<const PhysicalOffsetFrame*>(&pof.getParentFrame());
         std::vector<const PhysicalOffsetFrame*> parentPofs;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -788,8 +788,8 @@ void Model::extendConnectToModel(Model &model)
         while (parentPof) {
             const auto found =
                 std::find(parentPofs.begin(), parentPofs.end(), parentPof);
-            OPENSIM_THROW_IF_FRMOBJ(found != parentPofs.end(), Exception,
-                "PhysicalOffsetFrames are not permitted to form loops.");
+            OPENSIM_THROW_IF_FRMOBJ(found != parentPofs.end(),
+                PhysicalOffsetFramesFormLoop, (*found)->getName());
             parentPofs.push_back(parentPof);
             // Given a chain of offsets, the most proximal must have Ground or 
             // Body as its parent. When that happens we can stop.

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -786,7 +786,13 @@ void Model::extendConnectToModel(Model &model)
             dynamic_cast<const PhysicalOffsetFrame*>(&pof.getParentFrame());
         std::vector<const PhysicalOffsetFrame*> parentPofs;
         while (parentPof) {
+            const auto found =
+                std::find(parentPofs.begin(), parentPofs.end(), parentPof);
+            OPENSIM_THROW_IF_FRMOBJ(found != parentPofs.end(), Exception,
+                "PhysicalOffsetFrames are not permitted to form loops.");
             parentPofs.push_back(parentPof);
+            // Given a chain of offsets, the most proximal must have Ground or 
+            // Body as its parent. When that happens we can stop.
             parentPof =
                 dynamic_cast<const PhysicalOffsetFrame*>(&parentPof->getParentFrame());
         }

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -781,7 +781,7 @@ void Model::extendConnectToModel(Model &model)
         // PhysicalOffsetFrame can be listed in any order and may be attached
         // to any other PhysicalOffsetFrame, so we need to find their parent(s)
         // in the tree and add them first.
-        pof.connectToModel(*this);
+        pof.connect(*this);
         const PhysicalOffsetFrame* parentPof =
             dynamic_cast<const PhysicalOffsetFrame*>(&pof.getParentFrame());
         std::vector<const PhysicalOffsetFrame*> parentPofs;

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -73,6 +73,23 @@ class ScaleSet;
     #endif
 #endif
 
+//==============================================================================
+/// Model  Exceptions
+//==============================================================================
+class PhysicalOffsetFramesFormLoop : public Exception {
+public:
+    PhysicalOffsetFramesFormLoop(const std::string& file,
+        size_t line,
+        const std::string& func,
+        const Object& obj,
+        const std::string& frameName) :
+        Exception(file, line, func, obj) {
+        std::string msg =
+            "PhysicalOffsetFrames are not permitted to form loops.\n'" + 
+            frameName + "' already part of a branch of PhysicalOffsetFrames.";
+        addMessage(msg);
+    }
+};
 
 //==============================================================================
 //                                  MODEL

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -384,8 +384,17 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
         "testPhysicalOffsetFrameOnPhysicalOffsetFrame(): "
         "incorrect MobilizedBodyIndex");
 
-    // Now test that we cannot get stuck in a loop of PhysicalOffsetFrames
-    // so create one deliberately.
+    // Verify that a direct loop throws an exception
+    // Re-wire the PhysicalOffsetFrames to form a loop
+    offsetFrameProximal->setParentFrame(*offsetFrameDistal);
+    offsetFrameDistal->setParentFrame(*offsetFrameProximal);
+
+    // Check that loop causes an exception to be thrown and that
+    // connecting does not run endlessly.
+    ASSERT_THROW(PhysicalOffsetFramesFormLoop, pendulum.initSystem());
+
+    // Now test that we do not get stuck in a loop of PhysicalOffsetFrames
+    // for more than two frames
     PhysicalOffsetFrame* offsetFrameMiddle = new PhysicalOffsetFrame();
     offsetFrameMiddle->setName("offsetFrameMiddle");
     offsetFrameMiddle->setOffsetTransform(X_RO);
@@ -398,7 +407,7 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
 
     // Check that loop causes an exception to be thrown and that
     // connecting does not run endlessly.
-    ASSERT_THROW(Exception, pendulum.initSystem());
+    ASSERT_THROW(PhysicalOffsetFramesFormLoop, pendulum.initSystem());
 }
 
 void testFilterByFrameType()

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -63,7 +63,7 @@ public:
 int main()
 {
     SimTK::Array_<std::string> failures;
-/*
+
     try { testBody(); }
     catch (const std::exception& e){
         cout << e.what() <<endl; failures.push_back("testBody");
@@ -86,7 +86,7 @@ int main()
         cout << e.what() << endl;
         failures.push_back("testPhysicalOffsetFrameOnPhysicalOffsetFrame");
     }
-*/
+
     try { testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder(); }
     catch (const std::exception& e) {
         cout << e.what() << endl;

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -343,6 +343,11 @@ void testPhysicalOffsetFrameOnBodySerialize()
 
 void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
 {
+    // The order of the offset frames in the Model's "components" property list
+    // is specified to be the reverse of the order of the offset frames in the
+    // Multibody tree. This test ensures that the calls to addToSystem() for 
+    // PhysicalOffsetFrames occur in the order of the Multibody tree instead of
+    // the order in Model's property list, which can be arbitrary.
     Model pendulum("double_pendulum.osim");
 
     SimTK::Transform X_RO;
@@ -354,6 +359,8 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
     PhysicalOffsetFrame* offsetFrameDistal = new PhysicalOffsetFrame();
     offsetFrameDistal->setName("offsetFrameDistal");
     offsetFrameDistal->setOffsetTransform(X_RO);
+    // add Distal offset first so it appears before Proximal in the Model's
+    // property list.
     pendulum.addComponent(offsetFrameDistal);
 
     PhysicalOffsetFrame* offsetFrameProximal = new PhysicalOffsetFrame();
@@ -377,7 +384,6 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
                 offsetFrameDistal->getMobilizedBodyIndex(), __FILE__, __LINE__,
         "testPhysicalOffsetFrameOnPhysicalOffsetFrame(): "
         "incorrect MobilizedBodyIndex");
-
 }
 
 void testFilterByFrameType()


### PR DESCRIPTION
Addresses #1255.

Only two significant changes:
 1. Introduced a test case in `testFrames` to produce a failure when `PhysicalOffsetFrame`s are added to the `Model` in an order that does not correspond to the Multibody topology.
 2. `Model::extendConnectToModel` now traverses its `PhysicalOffsetFrame` sub-components so that its parent `PhysicalFrame`s are queued up first to establish proximal to distal order. 

Should be a short review.