### PR TITLE
fix getComponentName() bug

### DIFF
--- a/OpenSim/Common/ComponentPath.cpp
+++ b/OpenSim/Common/ComponentPath.cpp
@@ -69,5 +69,10 @@ std::string ComponentPath::getSubcomponentNameAtLevel(size_t index) const
 
 std::string ComponentPath::getComponentName() const
 {
+    if (getNumPathLevels() == 0) {
+        std::string emptyStr{};
+        return emptyStr;
+    }
+
     return getSubcomponentNameAtLevel(getNumPathLevels() - 1);
 }

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -163,6 +163,9 @@ void testComponentPath() {
     for (size_t ind = 0; ind < levels.size(); ++ind) {
         ASSERT(numberedAbsPath.getSubcomponentNameAtLevel(ind) == levels[ind]);
     }
+    // Test getComponentName()
+    ASSERT(numberedAbsPath.getComponentName() == levels[levels.size()-1]);
+    ASSERT(emptyPath.getComponentName() == ""); // empty ComponentPath should return empty string
 
     // Do the same as above but with a relative path instead
     ComponentPath numberedRelPath(levels, false);


### PR DESCRIPTION
Addresses #1307. When getComponentName() is called on a ComponentPath without any names, it now returns an empty string rather than crashing.