### PR TITLE
[doxygen] Removed old doxygen comments and fixed typos

### DIFF
--- a/OpenSim/Simulation/InverseKinematicsSolver.h
+++ b/OpenSim/Simulation/InverseKinematicsSolver.h
@@ -38,12 +38,13 @@ class MarkersReference;
 /**
  * Solve for the coordinates (degrees of freedom) of the model that satisfy the
  * set of constraints imposed on the model and the set of desired coordinate
- * values.  The InverseKinematics provides the option to convert the problem to
- * an approximate one where the constraint violations are treated as penalties
- * to be minimized rather than strictly enforced. This can speed up the solution
- * and can be used to seed the constrained problem closer to the solution.
+ * values. The InverseKinematicsSolver provides the option to convert the
+ * problem to an approximate one where the constraint violations are treated as
+ * penalties to be minimized rather than strictly enforced. This can speed up
+ * the solution and can be used to seed the constrained problem closer to the
+ * solution.
  *
- * The InverseKinematics objective: 
+ * The InverseKinematicsSolver objective:
  * \f[
  *   min: J = sum(Wm_i*(m_i-md_i)^T*(m_i-md_i)) + sum(Wq_j*(q_j-qd_j)^2) +
  *            [Wc*sum(c_{err})^2]
@@ -52,7 +53,7 @@ class MarkersReference;
  * and qd_j are model and desired joint coordinates. Wm_i and Wq_j are the
  * marker and coordinate weightings, respectively, and Wc is the weighting on
  * constraint errors. When Wc == Infinity, the second term is not included,
- * but instead q is subject to the constraint equations: 
+ * but instead q is subject to the constraint equations:
  *      \f[ c_{err} = G(q)-Go = 0 \f]
  *
  * When the model (and the number of goals) is guaranteed not to change and
@@ -66,9 +67,9 @@ class MarkersReference;
  */
 class OSIMSIMULATION_API InverseKinematicsSolver: public AssemblySolver
 {
-//=============================================================================
+//==============================================================================
 // METHODS
-//=============================================================================
+//==============================================================================
 public:
     //--------------------------------------------------------------------------
     // CONSTRUCTION
@@ -92,23 +93,23 @@ public:
         to track a desired trajectory of coordinate values. */
     //virtual void track(SimTK::State &s);
 
-    /** Change the weighting of a marker to take effect when assemble() or
-        track() is called next, given the marker's name. */
+    /** Change the weighting of a marker, given the marker's name. Takes effect
+        when assemble() or track() is called next. */
     void updateMarkerWeight(const std::string &markerName, double value);
-    /** Change the weighting of a marker to take effect when assemble() or
-        track() is called next, given the marker's index. */
+    /** Change the weighting of a marker, given the marker's index. Takes effect
+        when assemble() or track() is called next. */
     void updateMarkerWeight(int markerIndex, double value);
-    /** Change the weighting of a marker to take effect when assemble() or
-        track() is called next. Update all marker weights, specified in the same
-        order as they appear in the MarkersReference that was passed in when the
+    /** Change the weighting of all markers. Takes effect when assemble() or
+        track() is called next. Marker weights are specified in the same order
+        as they appear in the MarkersReference that was passed in when the
         solver was constructed. */
     void updateMarkerWeights(const SimTK::Array_<double> &weights);
 
-    /** Compute and return a marker's spatial location in ground, given the
-        marker's name. */
+    /** Compute and return a marker's spatial location in the ground frame,
+        given the marker's name. */
     SimTK::Vec3 computeCurrentMarkerLocation(const std::string &markerName);
-    /** Compute and return a marker's spatial location in ground, given the
-        marker's index. */
+    /** Compute and return a marker's spatial location in the ground frame,
+        given the marker's index. */
     SimTK::Vec3 computeCurrentMarkerLocation(int markerIndex);
     /** Compute and return the spatial locations of all markers, expressed in
         the ground frame. */

--- a/OpenSim/Simulation/InverseKinematicsSolver.h
+++ b/OpenSim/Simulation/InverseKinematicsSolver.h
@@ -36,16 +36,16 @@ class MarkersReference;
 //=============================================================================
 //=============================================================================
 /**
- * Solve for the coordinates (degrees-of-freedom) of the model that satisfy the
- * set of constraints imposed on the model as well as set of desired coordinate
+ * Solve for the coordinates (degrees of freedom) of the model that satisfy the
+ * set of constraints imposed on the model and the set of desired coordinate
  * values.  The InverseKinematics provides the option to convert the problem to
  * an approximate one where the constraint violations are treated as penalties
- * to be minimized rather than strictly enforced. This can speedup the solution
- * time and can be used to seed the constrained problem closer to the solution.
+ * to be minimized rather than strictly enforced. This can speed up the solution
+ * and can be used to seed the constrained problem closer to the solution.
  *
  * The InverseKinematics objective: 
  * \f[
- *   min: J = sum(Wm_i*(m_i-md_i)^T*(m_i-md_i)) + sum(Wq_j*(q_j-qd_j)^2)) +
+ *   min: J = sum(Wm_i*(m_i-md_i)^T*(m_i-md_i)) + sum(Wq_j*(q_j-qd_j)^2) +
  *            [Wc*sum(c_{err})^2]
  * \f]
  * where m_i and md_i are the model and desired marker locations (Vec3); q_j
@@ -56,7 +56,7 @@ class MarkersReference;
  *      \f[ c_{err} = G(q)-Go = 0 \f]
  *
  * When the model (and the number of goals) is guaranteed not to change and
- * the initial state is close to the InverseKinematics solution (i.e. from the 
+ * the initial state is close to the InverseKinematics solution (e.g., from the 
  * initial assemble()), then track() is an efficient method for updating the
  * configuration to determine the small change in coordinate values, q.
  *
@@ -79,12 +79,12 @@ public:
                             SimTK::Array_<CoordinateReference> &coordinateReferences,
                             double constraintWeight = SimTK::Infinity);
     
-    /** Assemble a model configuration that meets the InverseKinematics conditions  
+    /* Assemble a model configuration that meets the InverseKinematics conditions  
         (desired values and constraints) starting from an initial state that  
         does not have to satisfy the constraints. */
     //virtual void assemble(SimTK::State &s);
 
-    /** Obtain a model configuration that meets the InverseKinematics conditions  
+    /* Obtain a model configuration that meets the InverseKinematics conditions  
         (desired values and constraints) given a state that satisfies or
         is close to satisfying the constraints. Note there can be no change
         in the number of constraints or desired coordinates. Desired
@@ -92,33 +92,51 @@ public:
         to track a desired trajectory of coordinate values. */
     //virtual void track(SimTK::State &s);
 
-    /** Change the weighting of a marker to take affect when assemble or track is called next. 
-        Update a marker's weight by name. */
+    /** Change the weighting of a marker to take effect when assemble() or
+        track() is called next, given the marker's name. */
     void updateMarkerWeight(const std::string &markerName, double value);
-    /** Update a marker's weight by its index. */
+    /** Change the weighting of a marker to take effect when assemble() or
+        track() is called next, given the marker's index. */
     void updateMarkerWeight(int markerIndex, double value);
-    /** Update all markers weights by order in the markersReference passed in to
-        construct the solver. */
+    /** Change the weighting of a marker to take effect when assemble() or
+        track() is called next. Update all marker weights, specified in the same
+        order as they appear in the MarkersReference that was passed in when the
+        solver was constructed. */
     void updateMarkerWeights(const SimTK::Array_<double> &weights);
 
-    /** Compute and return the spatial location of a marker in ground. */
+    /** Compute and return a marker's spatial location in ground, given the
+        marker's name. */
     SimTK::Vec3 computeCurrentMarkerLocation(const std::string &markerName);
+    /** Compute and return a marker's spatial location in ground, given the
+        marker's index. */
     SimTK::Vec3 computeCurrentMarkerLocation(int markerIndex);
-    /** Compute and return the spatial locations of all markers in ground. */
+    /** Compute and return the spatial locations of all markers, expressed in
+        the ground frame. */
     void computeCurrentMarkerLocations(SimTK::Array_<SimTK::Vec3> &markerLocations);
 
-    /** Compute and return the distance error between model marker and observation. */
+    /** Compute and return the distance error between a model marker and its
+        observation, given the marker's name. */
     double computeCurrentMarkerError(const std::string &markerName);
+    /** Compute and return the distance error between a model marker and its
+        observation, given the marker's index. */
     double computeCurrentMarkerError(int markerIndex);
-    /** Compute and return the distance errors between all model markers and their observations. */
+    /** Compute and return the distance errors between all model markers and
+        their observations. */
     void computeCurrentMarkerErrors(SimTK::Array_<double> &markerErrors);
 
-    /** Compute and return the squared-distance error between model marker and observation. 
-        This is cheaper than calling the error and squaring it, since distance from norm-2 */
+    /** Compute and return the squared-distance error between a model marker and
+        its observation, given the marker's name. This method is cheaper than
+        squaring the value returned by computeCurrentMarkerError(). */
     double computeCurrentSquaredMarkerError(const std::string &markerName);
+    /** Compute and return the squared-distance error between a model marker and
+        its observation, given the marker's index. This method is cheaper than
+        squaring the value returned by computeCurrentMarkerError(). */
     double computeCurrentSquaredMarkerError(int markerIndex);
-    /** Compute and return the distance errors between all model marker and observations. */
+    /** Compute and return the squared-distance errors between all model markers
+        and their observations. This method is cheaper than squaring the values
+        returned by computeCurrentMarkerErrors(). */
     void computeCurrentSquaredMarkerErrors(SimTK::Array_<double> &markerErrors);
+
     /** Marker locations and errors may be computed in an order that is different
         from tasks file or listed in the model. Return the corresponding marker
         name for an index in the list of marker locations/errors returned by the
@@ -129,10 +147,10 @@ protected:
     /** Internal method to convert the CoordinateReferences into goals of the 
         assembly solver. Subclasses can override to include other goals  
         such as point of interest matching (Marker tracking). This method is
-        automatically called by assemble. */
+        automatically called by assemble(). */
     void setupGoals(SimTK::State &s) override;
     /** Internal method to update the time, reference values and/or their 
-        weights that define the goals, based on the passed in state */
+        weights that define the goals, based on the provided state. */
     void updateGoals(const SimTK::State &s) override;
 
 private:


### PR DESCRIPTION
### Summary
Doxygen from commented-out methods was being added to the documentation for `updateMarkerWeight()` (see changes on L83 and L88). Also fixed typos and added comments to previously undocumented methods.

I have used `[ci skip]` to avoid further congestion on Travis. Because the doxygen won't be built on myosin, I've printed to a pdf. GitHub claims to support attaching pdfs to comments but it isn't working; instead, I've uploaded it [here](http://stanford.edu/~tkuchida/temp/InverseKinematicsSolver%20doxygen.pdf).

### Exclusions
Does not address the violation of the "minimally complete interface" rule.