### PR TITLE
[appveyor] Cache swig to reduce sporadic failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,11 +60,20 @@ init:
 nuget:
   account_feed: true
 
+cache:
+  ## Cache swig, which we install via AppVeyor.
+  # The syntax here is <dir-to-cache> -> <invalidated-when-this-file-changes>
+  # If the appveyor.yml script is changed, then the cache is invalidated.
+  # https://www.appveyor.com/docs/build-cache/
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml # swig.exe
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml # supporting swig Lib files.
+
 install:
   - cmake --version
 
   ## Use Chocolatey to install SWIG.
-  - choco install swig --version 3.0.6 --yes > $null
+  # Only install swig if it isn't present (as a result of AppVeyor's caching).
+  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --version 3.0.6 --yes --limit-output #> $null
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"
@@ -112,11 +121,11 @@ test_script:
   - "%PYTHON_DIR%\\Scripts\\nosetests -v" #--exclude=%PYTHON_TESTS_TO_EXCLUDE%"
 
 after_test:
+  - cd %APPVEYOR_BUILD_FOLDER%
   - ## On master branch, create NuGet package for OpenSim.
   - # Detect if we are on the master branch.
   - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   - # Create and upload NuGet package.
-  - IF DEFINED DISTR cd %APPVEYOR_BUILD_FOLDER%
   - IF DEFINED DISTR nuget pack .opensim-core.nuspec -Properties "packageIdSuffix=%NUGET_PACKAGE_ID_SUFFIX%" -BasePath %OPENSIM_INSTALL_DIR%
   - IF DEFINED DISTR appveyor PushArtifact opensim-core%NUGET_PACKAGE_ID_SUFFIX%.0.0.0.nupkg
 


### PR DESCRIPTION
This is an attempt to reduce sporadic failures on Appveyor from being unable to download
swig from sourceforge. I am using Appveyor's caching mechanism to cache the download of swig.

I cancelled the travis tests.