### PR TITLE
[travis] Temporarily, do not deploy to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,16 @@ matrix:
   include:
     - os: linux
       compiler: clang
-      env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=1 DEPLOY=yes
+      env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=1 DEPLOY=no # (TEMP bintray not working) yes
     - os: linux
       compiler: gcc
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=no
     - os: linux
       compiler: clang
-      env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3 DEPLOY=yes
+      env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3 DEPLOY=no # (TEMP bintray not working) yes
     - os: osx
       compiler: clang
-      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=yes
+      env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=no # (TEMP bintray not working) yes
       
 branches:
   except:


### PR DESCRIPTION
This PR causes Travis-CI to stop trying to deploy binaries to bintray. This should get rid of some intermittent failures on the master branch.
