### PR TITLE
Incorrect number format used in error message

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -152,11 +152,11 @@ void Coordinate::extendFinalizeFromProperties()
         double dv = get_default_value();
         SimTK_ERRCHK2_ALWAYS(dv > (get_range(0) - SimTK::SqrtEps), prefix.c_str(),
             "Default coordinate value is less than range minimum.\n" 
-            "Default value = %d  < min = %d.", dv,  get_range(0));
+            "Default value = %g  < min = %g.", dv,  get_range(0));
 
         SimTK_ERRCHK2_ALWAYS(dv < (get_range(1) + SimTK::SqrtEps), prefix.c_str(),
             "Default coordinate value is greater than range maximum.\n"
-            "Default value = %d > max = %d.", dv, get_range(1));    
+            "Default value = %g > max = %g.", dv, get_range(1));    
     }
 
     _lockedWarningGiven=false;


### PR DESCRIPTION
Using `%d` rather than `%g` produces a message like `max = -379567735` rather than `max = 1.571`.