### PR TITLE
Remove method Coordinate::setRange from Python binding as it can't be…

### DIFF
--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -18,6 +18,9 @@ using namespace OpenSim;
 using namespace SimTK;
 %}
 
+// Ignore method that is not callable from Python (uses double[] arg)
+%ignore OpenSim::Coordinate::setRange;
+
 
 %include "python_preliminaries.i"
 
@@ -212,3 +215,4 @@ SET_ADOPT_HELPER(Analysis);
         return $self->get(i);
     }
 };
+


### PR DESCRIPTION
… called from Python. This addresses issue #1368 one way by removing the method from Python bindings. A possible more general fix is to use a higher level datastructure (e.g. SimTK::Vector or OpenSim::Array) so the interface from Python is not different.