### PR TITLE
Restore tool tests when NOT BUILD_INDIVIDUAL_APPS

### DIFF
--- a/Applications/Analyze/CMakeLists.txt
+++ b/Applications/Analyze/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME analyze)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME analyze)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/CMC/CMakeLists.txt
+++ b/Applications/CMC/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME cmc)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME cmc)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -1,14 +1,13 @@
-if(OPENSIM_BUILD_INDIVIDUAL_APPS)
-    # Basically, don't install the old applications on Linux or OSX, where
-    # they conflict with system executables like "id".
-    add_subdirectory(Analyze)
-    add_subdirectory(Forward)
-    add_subdirectory(Scale)
-    add_subdirectory(IK)
-    add_subdirectory(ID)
-    add_subdirectory(CMC)
-    add_subdirectory(RRA)
-    add_subdirectory(versionUpdate)
-endif()
+# If NOT OPENSIM_BUILD_INDIVIDUAL_APPS, then we will not build the old
+# applications like "id". However, we still need to include those folders to
+# build the tests for the tools.
+add_subdirectory(Analyze)
+add_subdirectory(Forward)
+add_subdirectory(Scale)
+add_subdirectory(IK)
+add_subdirectory(ID)
+add_subdirectory(CMC)
+add_subdirectory(RRA)
+add_subdirectory(versionUpdate)
 
 add_subdirectory(opensim-cmd)

--- a/Applications/Forward/CMakeLists.txt
+++ b/Applications/Forward/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME forward)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME forward)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/ID/CMakeLists.txt
+++ b/Applications/ID/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME id)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME id)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/IK/CMakeLists.txt
+++ b/Applications/IK/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME ik)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME ik)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/RRA/CMakeLists.txt
+++ b/Applications/RRA/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME rra)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME rra)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/Applications/Scale/CMakeLists.txt
+++ b/Applications/Scale/CMakeLists.txt
@@ -1,4 +1,6 @@
-OpenSimAddApplication(NAME scale)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME scale)
+endif()
 
 if(BUILD_TESTING)
     subdirs(test)

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -197,6 +197,8 @@ function(OpenSimAddTests)
 
             add_executable(${TEST_NAME} ${test_program}
                 ${OSIMADDTESTS_SOURCES})
+            target_include_directories(${TEST_NAME}
+                PRIVATE ${OpenSim_SOURCE_DIR} ${OpenSim_SOURCE_DIR}/Vendors)
             target_link_libraries(${TEST_NAME} ${OSIMADDTESTS_LINKLIBS})
             add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
             set_target_properties(${TEST_NAME} PROPERTIES


### PR DESCRIPTION
I accidentally removed a bunch of tests on non-Windows platforms! Oops! This PR brings back those tests.

This fix is related to #1419 : The reason why testScale wasn't failing on Travis is because it wasn't being run!

Note: it is expected that the travis tests will fail (b/c of testScale).

Suggested reviewers: @aseth1 