### PR TITLE
Macro-generated connectInput_name()

### DIFF
--- a/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
+++ b/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
@@ -52,12 +52,12 @@ reporter = TableReporterVec3();
 reporter.setName('reporter');
 reporter.set_report_time_interval(0.1);
 % Report the position of the origin of the body.
-reporter.updInput().connect(body.getOutput('position'));
+reporter.addToReport(body.getOutput('position'));
 % For comparison, we will also get the center of mass position from the
 % Model, and we can check that the two outputs are the same for our
 % one-body system. The (optional) second argument is an alias for the name
 % of the output; it is used as the column label in the table.
-reporter.updInput().connect(model.getOutput('com_position'), 'com_pos');
+reporter.addToReport(model.getOutput('com_position'), 'com_pos');
 % Display what input-output connections look like in XML (in .osim files).
 disp('Reporter input-output connections in XML:');
 disp(reporter.dump());

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -93,9 +93,9 @@ assert(strcmp(coord.getOutput('speed').getChannel('').getPathName(), ...
 % Only need the abstract types in order to connect.
 rep.updInput('inputs').connect(coord.getOutput('value'));
 % With alias:
-rep.updInput('inputs').connect(coord.getOutput('speed'), 'target');
+rep.updInput().connect(coord.getOutput('speed'), 'target');
 % These commands use the AbstractChannel.
-rep.updInput('inputs').connect(source.getOutput('column').getChannel('c1'));
+rep.addToReport(source.getOutput('column').getChannel('c1'));
 rep.updInput('inputs').connect(source.getOutput('column').getChannel('c2'), ...
                                'second_col');
 

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -93,7 +93,7 @@ assert(strcmp(coord.getOutput('speed').getChannel('').getPathName(), ...
 % Only need the abstract types in order to connect.
 rep.updInput('inputs').connect(coord.getOutput('value'));
 % With alias:
-rep.updInput().connect(coord.getOutput('speed'), 'target');
+rep.connectInput_inputs(coord.getOutput('speed'), 'target');
 % These commands use the AbstractChannel.
 rep.addToReport(source.getOutput('column').getChannel('c1'));
 rep.updInput('inputs').connect(source.getOutput('column').getChannel('c2'), ...

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -30,8 +30,7 @@ class TestReporter {
         tableReporter.updInput("inputs").
                       connect(tableSource.getOutput("column").
                                           getChannel("col1"));
-        tableReporter.updInput().
-                      connect(tableSource.getOutput("column").
+        tableReporter.addToReport(tableSource.getOutput("column").
                                           getChannel("col2"));
 
         State state = model.initSystem();

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -30,7 +30,7 @@ class TestReporter {
         tableReporter.updInput("inputs").
                       connect(tableSource.getOutput("column").
                                           getChannel("col1"));
-        tableReporter.updInput("inputs").
+        tableReporter.updInput().
                       connect(tableSource.getOutput("column").
                                           getChannel("col2"));
 
@@ -115,8 +115,7 @@ class TestReporter {
         ConsoleReporter consoleReporter = new ConsoleReporter();
         consoleReporter.set_report_time_interval(timeInterval);
         consoleReporter.
-            updInput("inputs").
-            connect(model.getCoordinateSet().get(0).getOutput("value"),
+            addToReport(model.getCoordinateSet().get(0).getOutput("value"),
                     "pin1_angle");
         consoleReporter.
             updInput("inputs").
@@ -131,8 +130,7 @@ class TestReporter {
             connect(model.getCoordinateSet().get(0).getOutput("value"),
                     "q1");
         tableReporter.
-            updInput("inputs").
-            connect(model.getCoordinateSet().get(1).getOutput("value"),
+            addToReport(model.getCoordinateSet().get(1).getOutput("value"),
                     "q2");
         model.addComponent(tableReporter);
 

--- a/Bindings/Python/examples/build_simple_arm_model.py
+++ b/Bindings/Python/examples/build_simple_arm_model.py
@@ -119,9 +119,9 @@ arm.addController(brain)
 # We want to write our simulation results to the console.
 reporter = osim.ConsoleReporter()
 reporter.set_report_time_interval(1.0)
-reporter.updInput().connect(biceps.getOutput("fiber_force"))
+reporter.addToReport(biceps.getOutput("fiber_force"))
 elbow_coord = elbow.getCoordinate().getOutput("value")
-reporter.updInput().connect(elbow_coord, "elbow_angle")
+reporter.addToReport(elbow_coord, "elbow_angle")
 arm.addComponent(reporter)
 
 # ---------------------------------------------------------------------------

--- a/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
+++ b/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
@@ -53,12 +53,12 @@ def print_model():
     reporter.setName('reporter')
     reporter.set_report_time_interval(0.1)
     # Report the position of the origin of the body.
-    reporter.updInput().connect(body.getOutput('position'))
+    reporter.addToReport(body.getOutput('position'))
     # For comparison, we will also get the center of mass position from the
     # Model, and we can check that the two outputs are the same for our
     # one-body system. The (optional) second argument is an alias for the name
     # of the output; it is used as the column label in the table.
-    reporter.updInput().connect(model.getOutput('com_position'), 'com_pos')
+    reporter.addToReport(model.getOutput('com_position'), 'com_pos')
     # Display what input-output connections look like in XML (in .osim files).
     print("Reporter input-output connections in XML:\n" + reporter.dump())
     

--- a/Bindings/Python/tests/test_TableSourceReporter.py
+++ b/Bindings/Python/tests/test_TableSourceReporter.py
@@ -37,8 +37,8 @@ class TestTableSourceReporter(unittest.TestCase):
         m.addComponent(t_rep)
 
         # Connect.
-        c_rep.updInput("inputs").connect(source.getOutput("column").getChannel("col1"))
-        t_rep.updInput("inputs").connect(source.getOutput("column").getChannel("col2"))
+        c_rep.addToReport(source.getOutput("column").getChannel("col1"))
+        t_rep.addToReport(source.getOutput("column").getChannel("col2"))
 
         # Realize.
         s = m.initSystem()

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -198,12 +198,14 @@ class TestInputsOutputs(unittest.TestCase):
         m.addComponent(rep)
 
         # Connect.
+        # There are multiple ways to perform the connection, especially
+        # for reporters.
         coord = j.get_coordinates(0)
         rep.updInput('inputs').connect(coord.getOutput('value'))
-        rep.updInput('inputs').connect(coord.getOutput('speed'), 'spd')
-        rep.updInput('inputs').connect(
+        rep.updInput().connect(coord.getOutput('speed'), 'spd')
+        rep.connectInput_inputs(
                 source.getOutput('column').getChannel('col1'))
-        rep.updInput('inputs').connect(
+        rep.addToReport(
                 source.getOutput('column').getChannel('col2'), 'second_col')
 
         s = m.initSystem()

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -202,7 +202,7 @@ class TestInputsOutputs(unittest.TestCase):
         # for reporters.
         coord = j.get_coordinates(0)
         rep.updInput('inputs').connect(coord.getOutput('value'))
-        rep.updInput().connect(coord.getOutput('speed'), 'spd')
+        rep.connectInput_inputs(coord.getOutput('speed'), 'spd')
         rep.connectInput_inputs(
                 source.getOutput('column').getChannel('col1'))
         rep.addToReport(

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -986,14 +986,15 @@ PropertyIndex Class::constructConnector_##cname() {                         \
     /** @name Inputs                                                     */ \
     /** @{                                                               */ \
     /** comment                                                          */ \
-    /** This input is needed at stage istage.                            */ \
+    /** This input is needed at stage istage##.                          */ \
     /** In an XML file, you can set this Input's connectee name          */ \
     /** via the <b>\<input_##iname##_connectee_name\></b> element.       */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
-    /** See AbstractInput for more information.                          */ \
     /** This input was generated with the                                */ \
-    /** #OpenSim_DECLARE_INPUT macro.                                    */ \
+    /** #OpenSim_DECLARE_INPUT macro;                                    */ \
+    /** see AbstractInput for more information.                          */ \
+    /** @inputmethods connectInput_##iname##()                           */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1002,7 +1003,27 @@ PropertyIndex Class::constructConnector_##cname() {                         \
             "Path to an output (channel) to satisfy the one-value Input '"  \
             #iname "' of type " #T " (description: " comment ").",  istage) \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Input-related functions                                    */ \
+    /** @{                                                               */ \
+    /** Connect this Input to a single-valued (single-channel) Output.   */ \
+    /** The output must be of type T##.                                  */ \
+    /** This input is single-valued and thus cannot connect to a         */ \
+    /** list output.                                                     */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the output.                                */ \
+    void connectInput_##iname(const AbstractOutput& output,                 \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(output, alias);                            \
+    }                                                                       \
+    /** Connect this Input to an output channel of type T##.             */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the channel.                               */ \
+    void connectInput_##iname(const AbstractChannel& channel,               \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(channel, alias);                           \
+    }                                                                       \
+    /** @}                                                               */
 
 // TODO create new macros to handle custom copy constructors: with
 // constructInput_() methods, etc. NOTE: constructProperty_() must be called first
@@ -1026,14 +1047,15 @@ PropertyIndex Class::constructConnector_##cname() {                         \
     /** @{                                                               */ \
     /** comment                                                          */ \
     /** This input can connect to multiple outputs, all of which are     */ \
-    /** needed at stage istage.                                          */ \
+    /** needed at stage istage##.                                        */ \
     /** In an XML file, you can set this Input's connectee name          */ \
     /** via the <b>\<input_##iname##_connectee_names\></b> element.      */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
-    /** See AbstractInput for more information.                          */ \
     /** This input was generated with the                                */ \
-    /** #OpenSim_DECLARE_LIST_INPUT macro.                               */ \
+    /** #OpenSim_DECLARE_LIST_INPUT macro;                               */ \
+    /** see AbstractInput for more information.                          */ \
+    /** @inputmethods connectInput_##iname##()                           */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1043,7 +1065,28 @@ PropertyIndex Class::constructConnector_##cname() {                         \
             #iname "' of type " #T " (description: " comment "). "          \
             "To specify multiple paths, put spaces between them.", istage)  \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Input-related functions                                    */ \
+    /** @{                                                               */ \
+    /** Connect this Input to a single-valued or list Output.            */ \
+    /** The output must be of type T##.                                  */ \
+    /** If the output is a list output, this connects to all of the      */ \
+    /** channels of the output.                                          */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the output; the alias will be used for all */ \
+    /** channels of the output.                                          */ \
+    void connectInput_##iname(const AbstractOutput& output,                 \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(output, alias);                            \
+    }                                                                       \
+    /** Connect this Input to an output channel of type T##.             */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the channel.                               */ \
+    void connectInput_##iname(const AbstractChannel& channel,               \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(channel, alias);                           \
+    }                                                                       \
+    /** @}                                                               */
 /// @}
 
 } // end of namespace OpenSim

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -113,18 +113,52 @@ public:
     OpenSim_DECLARE_LIST_INPUT(inputs, InputT, SimTK::Stage::Report,
         "Variable list of quantities to be reported.");
 
-    //=============================================================================
+    //==========================================================================
     // PUBLIC METHODS
-    //=============================================================================
+    //==========================================================================
 
     // Allow overloading of updInput
     using AbstractReporter::updInput;
 
+    /** Connect an output (single-valued or list) to this reporter. 
+    The output must be of type InputT.
+    If the output is a list output, this connects to all of the channels of the
+    output. You can optionally provide an alias that will be used by this
+    component to refer to the output; the alias will be used for all channels
+    of the output.                                          
+    @code
+    auto* reporter = new ConsoleReporter();
+    auto* src = new TableSource();
+    reporter->addToReport(src->getOutput("all_columns"));
+    @endcode
+    This method is equivalent to
+    connectInput_inputs(const AbstractOutput&, const std::string&). */
+    void addToReport(const AbstractOutput& output,
+                     const std::string& alias = "") {
+        connectInput_inputs(output, alias);
+    }
+
+    /** Connect an output channel to this reporter.
+    The output channel must be of type InputT.
+    You can optionally provide an alias that will be used by this component to
+    refer to the channel.
+    @code
+    auto* reporter = new ConsoleReporter();
+    auto* src = new TableSource();
+    reporter->addToReport(src->getOutput("column").getChannel("ankle"));
+    @endcode
+    This method is equivalent to
+    connectInput_inputs(const AbstractChannel&, const std::string&). */
+    void addToReport(const AbstractChannel& channel,
+                     const std::string& alias = "") {
+        connectInput_inputs(channel, alias);
+    }
+
     /** Convenience method that can be used in place of `updInput("inputs")`. 
     @code
     auto* reporter = new ConsoleReporter();
-    auto* src = new DataSource();
-    reporter->updInput().connect(src->getOutput("outputName"));
+    auto* src = new TableSource();
+    reporter->updInput().getLabel();
     @endcode
     */
     AbstractInput& updInput()

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -117,9 +117,6 @@ public:
     // PUBLIC METHODS
     //==========================================================================
 
-    // Allow overloading of updInput
-    using AbstractReporter::updInput;
-
     /** Connect an output (single-valued or list) to this reporter. 
     The output must be of type InputT.
     If the output is a list output, this connects to all of the channels of the
@@ -152,18 +149,6 @@ public:
     void addToReport(const AbstractChannel& channel,
                      const std::string& alias = "") {
         connectInput_inputs(channel, alias);
-    }
-
-    /** Convenience method that can be used in place of `updInput("inputs")`. 
-    @code
-    auto* reporter = new ConsoleReporter();
-    auto* src = new TableSource();
-    reporter->updInput().getLabel();
-    @endcode
-    */
-    AbstractInput& updInput()
-    {
-        return updInput("inputs");
     }
 
 protected:

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1023,50 +1023,50 @@ void testComponentPathNames()
 void testInputOutputConnections()
 {
     {
-    TheWorld world;
-    Foo* foo1 = new Foo();
-    Foo* foo2 = new Foo();
-    Bar* bar = new Bar();
+        TheWorld world;
+        Foo* foo1 = new Foo();
+        Foo* foo2 = new Foo();
+        Bar* bar = new Bar();
 
-    foo1->setName("foo1");
-    foo2->setName("foo2");
-    bar->setName("bar");
-    bar->updConnector<Foo>("parentFoo").connect(*foo1);
-    bar->updConnector<Foo>("childFoo").connect(*foo2);
-    
-    world.add(foo1);
-    world.add(foo2);
-    world.add(bar);
+        foo1->setName("foo1");
+        foo2->setName("foo2");
+        bar->setName("bar");
+        bar->updConnector<Foo>("parentFoo").connect(*foo1);
+        bar->updConnector<Foo>("childFoo").connect(*foo2);
+        
+        world.add(foo1);
+        world.add(foo2);
+        world.add(bar);
 
-    MultibodySystem mbs;
+        MultibodySystem mbs;
 
-    world.connect();
+        world.connect();
 
-    // do any other input/output connections
-    foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
+        // do any other input/output connections
+        foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
 
-    // Test various exceptions for inputs, outputs, connectors
-    ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
-    ASSERT_THROW(ConnectorNotFound, bar->updConnector<Foo>("parentFoo0"));
-    ASSERT_THROW(OutputNotFound, 
-        world.getComponent("./internalSub").getOutput("subState0"));
-    // Ensure that getOutput does not perform a "find"
-    ASSERT_THROW(OutputNotFound,
-        world.getOutput("./internalSub/subState"));
+        // Test various exceptions for inputs, outputs, connectors
+        ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
+        ASSERT_THROW(ConnectorNotFound, bar->updConnector<Foo>("parentFoo0"));
+        ASSERT_THROW(OutputNotFound, 
+            world.getComponent("./internalSub").getOutput("subState0"));
+        // Ensure that getOutput does not perform a "find"
+        ASSERT_THROW(OutputNotFound,
+            world.getOutput("./internalSub/subState"));
 
-    foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
+        foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
 
-    foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
-    foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
+        foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
+        foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
 
-    foo1->connectInput_activation(bar->getOutput("activation"));
-    foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
+        foo1->connectInput_activation(bar->getOutput("activation"));
+        foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    foo2->connectInput_activation(bar->getOutput("activation"));
-    foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
+        foo2->connectInput_activation(bar->getOutput("activation"));
+        foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    world.connect();
-    world.buildUpSystem(mbs);
+        world.connect();
+        world.buildUpSystem(mbs);
     }
     // Test exception message when asking for the value of an input that is
     // not wired up.

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -538,7 +538,7 @@ void testMisc() {
     ASSERT(foo2 == foo2found);
 
     // do any other input/output connections
-    foo.updInput("input1").connect(bar.getOutput("PotentialEnergy"));
+    foo.connectInput_input1(bar.getOutput("PotentialEnergy"));
     
     // check how this model serializes
     string modelFile("testComponentInterfaceModel.osim");
@@ -696,7 +696,7 @@ void testMisc() {
 
     auto* reporter = new TableReporterVector();
     reporter->set_report_time_interval(0.1);
-    reporter->updInput("inputs").connect(foo.getOutput("Qs"));
+    reporter->connectInput_inputs(foo.getOutput("Qs"));
     theWorld.add(reporter);
 
     MultibodySystem system3;
@@ -704,8 +704,8 @@ void testMisc() {
     theWorld.buildUpSystem(system3);
 
     // Connect our state variables.
-    foo.updInput("fiberLength").connect(bar.getOutput("fiberLength"));
-    foo.updInput("activation").connect(bar.getOutput("activation"));
+    foo.connectInput_fiberLength(bar.getOutput("fiberLength"));
+    foo.connectInput_activation(bar.getOutput("activation"));
     // Since hiddenStateVar is a hidden state variable, it has no
     // corresponding output.
     ASSERT_THROW( OpenSim::Exception,
@@ -808,10 +808,10 @@ void testListInputs() {
     theWorld.add(reporter);
 
     // wire up console reporter inputs to desired model outputs
-    reporter->updInput("inputs").connect(foo.getOutput("Output1"));
-    reporter->updInput("inputs").connect(bar.getOutput("PotentialEnergy"));
-    reporter->updInput("inputs").connect(bar.getOutput("fiberLength"));
-    reporter->updInput("inputs").connect(bar.getOutput("activation"));
+    reporter->connectInput_inputs(foo.getOutput("Output1"));
+    reporter->connectInput_inputs(bar.getOutput("PotentialEnergy"));
+    reporter->connectInput_inputs(bar.getOutput("fiberLength"));
+    reporter->connectInput_inputs(bar.getOutput("activation"));
 
     auto* tabReporter = new TableReporter();
     tabReporter->setName("TableReporterMixedOutputs");
@@ -819,10 +819,10 @@ void testListInputs() {
 
     // wire up table reporter inputs (using convenience method) to desired 
     // model outputs
-    tabReporter->updInput().connect(bar.getOutput("fiberLength"));
-    tabReporter->updInput().connect(bar.getOutput("activation"));
-    tabReporter->updInput().connect(foo.getOutput("Output1"));
-    tabReporter->updInput().connect(bar.getOutput("PotentialEnergy"));
+    tabReporter->addToReport(bar.getOutput("fiberLength"));
+    tabReporter->addToReport(bar.getOutput("activation"));
+    tabReporter->addToReport(foo.getOutput("Output1"));
+    tabReporter->addToReport(bar.getOutput("PotentialEnergy"));
 
     theWorld.connect();
     theWorld.buildUpSystem(system);
@@ -1042,7 +1042,7 @@ void testInputOutputConnections()
     world.connect();
 
     // do any other input/output connections
-    foo1->updInput("input1").connect(bar->getOutput("PotentialEnergy"));
+    foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
 
     // Test various exceptions for inputs, outputs, connectors
     ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
@@ -1053,16 +1053,16 @@ void testInputOutputConnections()
     ASSERT_THROW(OutputNotFound,
         world.getOutput("./internalSub/subState"));
 
-    foo2->updInput("input1").connect(world.getComponent("./internalSub").getOutput("subState"));
+    foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
 
-    foo1->updInput("AnglesIn").connect(foo2->getOutput("Qs"));
-    foo2->updInput("AnglesIn").connect(foo1->getOutput("Qs"));
+    foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
+    foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
 
-    foo1->updInput("activation").connect(bar->getOutput("activation"));
-    foo1->updInput("fiberLength").connect(bar->getOutput("fiberLength"));
+    foo1->connectInput_activation(bar->getOutput("activation"));
+    foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    foo2->updInput("activation").connect(bar->getOutput("activation"));
-    foo2->updInput("fiberLength").connect(bar->getOutput("fiberLength"));
+    foo2->connectInput_activation(bar->getOutput("activation"));
+    foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
     world.connect();
     world.buildUpSystem(mbs);
@@ -1476,7 +1476,7 @@ void testTableSource() {
     theWorld.add(tableSource);
     theWorld.add(tableReporter);
 
-    tableReporter->updInput("inputs").connect(tableSource->getOutput("column"));
+    tableReporter->addToReport(tableSource->getOutput("column"));
 
     theWorld.finalizeFromProperties();
 
@@ -1579,10 +1579,10 @@ void testListInputConnecteeSerialization() {
         // Connect, finalize, etc.
         const auto& output = source->getOutput("column");
         // See if we preserve the ordering of the channels.
-        reporter->updInput("inputs").connect(output.getChannel("a"));
-        reporter->updInput("inputs").connect(output.getChannel("c"));
+        reporter->addToReport(output.getChannel("a"));
+        reporter->addToReport(output.getChannel("c"));
         // We want to make sure aliases are preserved.
-        reporter->updInput("inputs").connect(output.getChannel("b"), "berry");
+        reporter->addToReport(output.getChannel("b"), "berry");
         world.finalizeFromProperties();
         world.connect();
         MultibodySystem system;
@@ -1665,9 +1665,9 @@ void testSingleValueInputConnecteeSerialization() {
         // Connect, finalize, etc.
         const auto& output = source->getOutput("column");
         // See if we preserve the ordering of the channels.
-        foo->updInput("input1").connect(output.getChannel("b"));
+        foo->connectInput_input1(output.getChannel("b"));
         // We want to make sure aliases are preserved.
-        foo->updInput("fiberLength").connect(output.getChannel("d"), "desert");
+        foo->connectInput_fiberLength(output.getChannel("d"), "desert");
         world.finalizeFromProperties();
         world.connect();
         MultibodySystem system;
@@ -1821,7 +1821,7 @@ void testAliasesAndLabels() {
     ASSERT_THROW(InputNotConnected, foo->getInput("input1").getLabel(0));
 
     // Non-list Input, no alias.
-    foo->updInput("input1").connect( bar->getOutput("Output1") );
+    foo->connectInput_input1( bar->getOutput("Output1") );
     SimTK_TEST(foo->getInput("input1").getAlias().empty());
     SimTK_TEST(foo->getInput("input1").getLabel() == "/world/bar|Output1");
 
@@ -1842,13 +1842,13 @@ void testAliasesAndLabels() {
     foo->updInput("input1").disconnect();
 
     // Non-list Input, with alias.
-    foo->updInput("input1").connect( bar->getOutput("Output1"), "baz" );
+    foo->connectInput_input1( bar->getOutput("Output1"), "baz" );
     SimTK_TEST(foo->getInput("input1").getAlias() == "baz");
     SimTK_TEST(foo->getInput("input1").getLabel() == "baz");
 
     // List Input, no aliases.
-    foo->updInput("listInput1").connect( bar->getOutput("Output1") );
-    foo->updInput("listInput1").connect( bar->getOutput("Output3") );
+    foo->connectInput_listInput1( bar->getOutput("Output1") );
+    foo->connectInput_listInput1( bar->getOutput("Output3") );
 
     ASSERT_THROW(OpenSim::Exception, foo->getInput("listInput1").getAlias());
     ASSERT_THROW(OpenSim::Exception, foo->getInput("listInput1").getLabel());
@@ -1862,8 +1862,8 @@ void testAliasesAndLabels() {
     foo->updInput("listInput1").disconnect();
 
     // List Input, with aliases.
-    foo->updInput("listInput1").connect( bar->getOutput("Output1"), "plugh" );
-    foo->updInput("listInput1").connect( bar->getOutput("Output3"), "thud" );
+    foo->connectInput_listInput1( bar->getOutput("Output1"), "plugh" );
+    foo->connectInput_listInput1( bar->getOutput("Output3"), "thud" );
 
     SimTK_TEST(foo->getInput("listInput1").getAlias(0) == "plugh");
     SimTK_TEST(foo->getInput("listInput1").getLabel(0) == "plugh");

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -155,11 +155,11 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
 
     // Loop through the desired device outputs and add them to the reporter.
     for (auto thisOutputName : deviceOutputs)
-        reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
+        reporter->addToReport(device.getOutput(thisOutputName));
 
     for (auto thisOutputName : deviceControllerOutputs)
-        reporter->updInput("inputs").
-        connect(device.getComponent("controller").getOutput(thisOutputName));
+        reporter->addToReport(
+                device.getComponent("controller").getOutput(thisOutputName));
 
     // Add the reporter to the model.
     model.addComponent(reporter);
@@ -331,8 +331,8 @@ void run(bool showVisualizer, bool simulateOnce)
         // Use the vastus muscle's activation as the control signal for the
         // device. The vastus string (at the top of this file) must
         // be filled in.
-        //kneeDevice->updComponent("controller").updInput("activation")
-        //    .connect(assistedHopper.getComponent(vastus).getOutput("activation"));
+        //kneeDevice->updComponent("controller").updInput("activation").connect(
+        //    assistedHopper.getComponent(vastus).getOutput("activation"));
 
         // List the device outputs we wish to display during the simulation.
         std::vector<std::string> kneeDeviceOutputs{ "tension", "height" };

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -156,19 +156,19 @@ void addConsoleReporterToHopper(Model& hopper)
     //      knee angle, and any other variables of interest.
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent(hopperHeightCoord).getOutput("value"), "height");
 
     #pragma endregion
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent("/Dennis/vastus").getOutput("activation"));
 
     #pragma endregion
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent("/Dennis/knee/kneeFlexion").getOutput("value"), "knee_angle");
 
     #pragma endregion
@@ -206,8 +206,8 @@ void addSignalGeneratorToDevice(Device& device)
     //      activation input.
     #pragma region Step2_TaskE_solution
 
-    device.updComponent("controller").updInput("activation")
-        .connect(signalGen->getOutput("signal"));
+    device.updComponent("controller").updInput("activation").connect(
+            signalGen->getOutput("signal"));
 
     #pragma endregion
 }
@@ -227,11 +227,11 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
 
     // Loop through the desired device outputs and add them to the reporter.
     for (auto thisOutputName : deviceOutputs)
-        reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
+        reporter->addToReport(device.getOutput(thisOutputName));
 
     for (auto thisOutputName : deviceControllerOutputs)
-        reporter->updInput("inputs").
-            connect(device.getComponent("controller").getOutput(thisOutputName));
+        reporter->addToReport(
+                device.getComponent("controller").getOutput(thisOutputName));
 
     // Add the reporter to the model.
     model.addComponent(reporter);
@@ -403,8 +403,8 @@ void run(bool showVisualizer, bool simulateOnce)
         // Use the vastus muscle's activation as the control signal for the
         // device. The vastus string (at the top of this file) must
         // be filled in.
-        kneeDevice->updComponent("controller").updInput("activation")
-            .connect(assistedHopper.getComponent(vastus).getOutput("activation"));
+        kneeDevice->updComponent("controller").updInput("activation").connect(
+                assistedHopper.getComponent(vastus).getOutput("activation"));
 
         // List the device outputs we wish to display during the simulation.
         std::vector<std::string> kneeDeviceOutputs{ "tension", "height" };

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -437,8 +437,8 @@ generateMarkerDataFromModelAndStates(const Model& model,
     
     auto markers = m->getComponentList<Marker>();
     for (const auto& marker : markers) {
-        markerReporter->updInput().
-            connect(marker.getOutput("location"), marker.getName());
+        markerReporter->addToReport(
+                marker.getOutput("location"), marker.getName());
     }
 
     m->addComponent(markerReporter);

--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -31,7 +31,7 @@ using namespace std;
 using namespace SimTK;
 using namespace OpenSim;
 
-void testConsoleReporerLabels() {
+void testConsoleReporterLabels() {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -46,10 +46,8 @@ void testConsoleReporerLabels() {
     // Create ConsoleReporter, and connect Outputs without and with alias.
     auto* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.);
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value") );
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value"), "height" );
+    reporter->addToReport(slider->getCoordinate().getOutput("value"));
+    reporter->addToReport(slider->getCoordinate().getOutput("value"), "height");
     model.addComponent(reporter);
 
     // Redirect cout to stringstream so ConsoleReporter output can be tested.
@@ -83,7 +81,7 @@ void testConsoleReporerLabels() {
     SimTK_TEST(idxHeading2 < idxHeading3);
 }
 
-void testTableReporerLabels() {
+void testTableReporterLabels() {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -99,10 +97,8 @@ void testTableReporerLabels() {
     // Create TableReporter, and connect Outputs without and with alias.
     auto* reporter = new TableReporter();
     reporter->set_report_time_interval(1.);
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value") );
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value"), "height" );
+    reporter->addToReport(slider->getCoordinate().getOutput("value"));
+    reporter->addToReport(slider->getCoordinate().getOutput("value"), "height");
     model.addComponent(reporter);
 
     // Simulate.
@@ -121,7 +117,7 @@ void testTableReporerLabels() {
 
 int main() {
     SimTK_START_TEST("testReporters");
-        SimTK_SUBTEST(testConsoleReporerLabels);
-        SimTK_SUBTEST(testTableReporerLabels);
+        SimTK_SUBTEST(testConsoleReporterLabels);
+        SimTK_SUBTEST(testTableReporterLabels);
     SimTK_END_TEST();
 };

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -87,8 +87,8 @@ int main() {
     // Add a console reporter to print the muscle fiber force and elbow angle.
     ConsoleReporter* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.0);
-    reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(biceps->getOutput("fiber_force"));
+    reporter->addToReport(
         elbow->getCoordinate(PinJoint::Coord::RotationZ).getOutput("value"),
         "elbow_angle");
     model.addComponent(reporter);

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ int main() {
     // Add a console reporter to print the muscle fiber force and elbow angle.
     ConsoleReporter* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.0);
-    reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(biceps->getOutput("fiber_force"));
+    reporter->addToReport(
         elbow->getCoordinate(PinJoint::Coord::RotationZ).getOutput("value"),
         "elbow_angle");
     model.addComponent(reporter);

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -204,7 +204,8 @@ TAB_SIZE               = 4
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES                = "propmethods=\par Methods related to this property\n"
+ALIASES                = "propmethods=\par Methods related to this property\n" \
+                         "inputmethods=\par Methods related to this input\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding


### PR DESCRIPTION
This PR implements steps 3 and 4 of [this devprop](https://github.com/opensim-org/opensim-core/blob/master/DevelopmentProposals/componentConnectInterface/componentConnectInterface.md). This PR does *not* create similar macros for sockets (e.g., `connectSocket_name()`); that will come after the connector->socket rename.

Most of the changes are just basically find/replace; the meat of the changes are in ComponentConnector.h. View the updated doxygen [here](http://myosin.sourceforge.net/1441); here are some snippets from the Reporter class:

![image](https://cloud.githubusercontent.com/assets/846001/21033455/362726e4-bd65-11e6-8b9e-9a2c33061a32.png)

![image](https://cloud.githubusercontent.com/assets/846001/21033463/44d4f9fa-bd65-11e6-9278-496e6683b5c1.png)

![image](https://cloud.githubusercontent.com/assets/846001/21033469/4d1dca10-bd65-11e6-8bc7-477022040497.png)


I worked on this PR as part of our effort to have an alpha release for Tuesday.

The main concern/question I have is that these new methods are only available on the concrete class; so for example, `model.getComponent("reporter").connectInput_inputs()` wouldn't work.