### PR TITLE
Fix visualization failure for disabled muscles

### DIFF
--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -119,6 +119,10 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 {        
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
+    
+    // Ensure that the state has been realized to Stage::Dynamics to give
+    // clients of this path a chance to calculate meaningful color information.
+    getModel().realizeDynamics(state);
 
     const Array<PathPoint*>& pathPoints = getCurrentPath(state);
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -184,7 +184,7 @@ void GeometryPath::constructProperties()
 
     constructProperty_PathWrapSet(PathWrapSet());
     
-    Vec3 defaultColor = SimTK::White;
+    Vec3 defaultColor = SimTK::Gray;
     constructProperty_default_color(defaultColor);
 }
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -119,14 +119,8 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 {        
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
-    // Ensure that the state has been realized to Stage::Dynamics to give
-    // clients of this path a chance to calculate meaningful color information.
-    // TODO: this should be removed. Generate decorations is reporting it should 
-    // not force computations.
-    this->getModel().getMultibodySystem().realize(state, SimTK::Stage::Dynamics);
 
-    const Array<PathPoint*>& pathPoints =
-        getCacheVariableValue<Array<PathPoint*> >(state, "current_path");
+    const Array<PathPoint*>& pathPoints = getCurrentPath(state);
 
     const PathPoint* lastPoint = pathPoints[0];
     MobilizedBodyIndex mbix(0);

--- a/OpenSim/Tools/Test/testVisualization.cpp
+++ b/OpenSim/Tools/Test/testVisualization.cpp
@@ -195,14 +195,16 @@ void testVisModel(Model& model, const std::string standard_filename)
     cout << fromFile << endl;
     cout << "Length:" << fromModel.length() << "vs." << fromFile.length() << std::endl;
     int same = fromFile.compare(fromModel);
-    ASSERT(same == 0, __FILE__, __LINE__, 
-        "Visualization primitives from model do not match standard from file `"
-        + standard_filename + "'.");
+
     if (visualDebug) {
         char c;
         std::cout << "press Enter (or Return) to continue" << std::endl;
         std::cin >> c;
     }
+
+    ASSERT(same == 0, __FILE__, __LINE__, 
+        "Visualization primitives from model do not match standard from file `"
+        + standard_filename + "'.");
 }
 
 Model createModel4AppearanceTest()


### PR DESCRIPTION
Fixes #1111.

Since we are renaming `Force::isDisabled` to `Force::appliesForce`  it now implies that the Muscle is still present but simply that it does not apply forces to the system.

The fix then is to allow the muscle (`GeometryPath`) to draw itself regardless if it is applying force or not. This could be helpful for visually debugging muscle path issues without bringing a simulation to a halt.

The related bug was due to the `GeometryPath::generateDecorations()` accessing the *current_path*
cache variable directly, when it was invalid and required to be recomputed. This has been corrected.

Should be a quick review.
