### PR TITLE
Macro-generated connectConnector_conn_name() functions

### DIFF
--- a/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
+++ b/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
@@ -52,12 +52,12 @@ reporter = TableReporterVec3();
 reporter.setName('reporter');
 reporter.set_report_time_interval(0.1);
 % Report the position of the origin of the body.
-reporter.updInput().connect(body.getOutput('position'));
+reporter.addToReport(body.getOutput('position'));
 % For comparison, we will also get the center of mass position from the
 % Model, and we can check that the two outputs are the same for our
 % one-body system. The (optional) second argument is an alias for the name
 % of the output; it is used as the column label in the table.
-reporter.updInput().connect(model.getOutput('com_position'), 'com_pos');
+reporter.addToReport(model.getOutput('com_position'), 'com_pos');
 % Display what input-output connections look like in XML (in .osim files).
 disp('Reporter input-output connections in XML:');
 disp(reporter.dump());

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -93,9 +93,9 @@ assert(strcmp(coord.getOutput('speed').getChannel('').getPathName(), ...
 % Only need the abstract types in order to connect.
 rep.updInput('inputs').connect(coord.getOutput('value'));
 % With alias:
-rep.updInput('inputs').connect(coord.getOutput('speed'), 'target');
+rep.updInput().connect(coord.getOutput('speed'), 'target');
 % These commands use the AbstractChannel.
-rep.updInput('inputs').connect(source.getOutput('column').getChannel('c1'));
+rep.addToReport(source.getOutput('column').getChannel('c1'));
 rep.updInput('inputs').connect(source.getOutput('column').getChannel('c2'), ...
                                'second_col');
 

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -93,7 +93,7 @@ assert(strcmp(coord.getOutput('speed').getChannel('').getPathName(), ...
 % Only need the abstract types in order to connect.
 rep.updInput('inputs').connect(coord.getOutput('value'));
 % With alias:
-rep.updInput().connect(coord.getOutput('speed'), 'target');
+rep.connectInput_inputs(coord.getOutput('speed'), 'target');
 % These commands use the AbstractChannel.
 rep.addToReport(source.getOutput('column').getChannel('c1'));
 rep.updInput('inputs').connect(source.getOutput('column').getChannel('c2'), ...

--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -53,7 +53,8 @@ end
 body = Body.safeDownCast(joint.getConnectee('child_frame'));
 assert(body.getMass() == 2);
 
-% Connect a connector.
+% Connect a connector. Try the different methods to ensure they all work.
+offset.connectConnector_parent(ground);
 offset.updConnector('parent').connect(ground);
 assert(strcmp(offset.getConnector('parent').getConnecteeName(), '../ground'));
 

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -30,8 +30,7 @@ class TestReporter {
         tableReporter.updInput("inputs").
                       connect(tableSource.getOutput("column").
                                           getChannel("col1"));
-        tableReporter.updInput().
-                      connect(tableSource.getOutput("column").
+        tableReporter.addToReport(tableSource.getOutput("column").
                                           getChannel("col2"));
 
         State state = model.initSystem();

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -30,7 +30,7 @@ class TestReporter {
         tableReporter.updInput("inputs").
                       connect(tableSource.getOutput("column").
                                           getChannel("col1"));
-        tableReporter.updInput("inputs").
+        tableReporter.updInput().
                       connect(tableSource.getOutput("column").
                                           getChannel("col2"));
 
@@ -115,8 +115,7 @@ class TestReporter {
         ConsoleReporter consoleReporter = new ConsoleReporter();
         consoleReporter.set_report_time_interval(timeInterval);
         consoleReporter.
-            updInput("inputs").
-            connect(model.getCoordinateSet().get(0).getOutput("value"),
+            addToReport(model.getCoordinateSet().get(0).getOutput("value"),
                     "pin1_angle");
         consoleReporter.
             updInput("inputs").
@@ -131,8 +130,7 @@ class TestReporter {
             connect(model.getCoordinateSet().get(0).getOutput("value"),
                     "q1");
         tableReporter.
-            updInput("inputs").
-            connect(model.getCoordinateSet().get(1).getOutput("value"),
+            addToReport(model.getCoordinateSet().get(1).getOutput("value"),
                     "q2");
         model.addComponent(tableReporter);
 

--- a/Bindings/Python/examples/build_simple_arm_model.py
+++ b/Bindings/Python/examples/build_simple_arm_model.py
@@ -119,9 +119,9 @@ arm.addController(brain)
 # We want to write our simulation results to the console.
 reporter = osim.ConsoleReporter()
 reporter.set_report_time_interval(1.0)
-reporter.updInput().connect(biceps.getOutput("fiber_force"))
+reporter.addToReport(biceps.getOutput("fiber_force"))
 elbow_coord = elbow.getCoordinate().getOutput("value")
-reporter.updInput().connect(elbow_coord, "elbow_angle")
+reporter.addToReport(elbow_coord, "elbow_angle")
 arm.addComponent(reporter)
 
 # ---------------------------------------------------------------------------

--- a/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
+++ b/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
@@ -53,12 +53,12 @@ def print_model():
     reporter.setName('reporter')
     reporter.set_report_time_interval(0.1)
     # Report the position of the origin of the body.
-    reporter.updInput().connect(body.getOutput('position'))
+    reporter.addToReport(body.getOutput('position'))
     # For comparison, we will also get the center of mass position from the
     # Model, and we can check that the two outputs are the same for our
     # one-body system. The (optional) second argument is an alias for the name
     # of the output; it is used as the column label in the table.
-    reporter.updInput().connect(model.getOutput('com_position'), 'com_pos')
+    reporter.addToReport(model.getOutput('com_position'), 'com_pos')
     # Display what input-output connections look like in XML (in .osim files).
     print("Reporter input-output connections in XML:\n" + reporter.dump())
     

--- a/Bindings/Python/tests/test_TableSourceReporter.py
+++ b/Bindings/Python/tests/test_TableSourceReporter.py
@@ -37,8 +37,8 @@ class TestTableSourceReporter(unittest.TestCase):
         m.addComponent(t_rep)
 
         # Connect.
-        c_rep.updInput("inputs").connect(source.getOutput("column").getChannel("col1"))
-        t_rep.updInput("inputs").connect(source.getOutput("column").getChannel("col2"))
+        c_rep.addToReport(source.getOutput("column").getChannel("col1"))
+        t_rep.addToReport(source.getOutput("column").getChannel("col2"))
 
         # Realize.
         s = m.initSystem()

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -84,11 +84,11 @@ class TestConnectors(unittest.TestCase):
         j1 = osim.PinJoint()
         j1.setName("j1")
         j1.updConnector("parent_frame").connect(model.getGround())
-        j1.updConnector("child_frame").connect(b1)
+        j1.connectConnector_child_frame(b1)
 
         j2 = osim.PinJoint()
         j2.setName("j2")
-        j2.updConnector("parent_frame").connect(b1)
+        j2.connectConnector_parent_frame(b1)
         j2.updConnector("child_frame").connect(b2)
 
         model.addBody(b1)

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -198,12 +198,14 @@ class TestInputsOutputs(unittest.TestCase):
         m.addComponent(rep)
 
         # Connect.
+        # There are multiple ways to perform the connection, especially
+        # for reporters.
         coord = j.get_coordinates(0)
         rep.updInput('inputs').connect(coord.getOutput('value'))
-        rep.updInput('inputs').connect(coord.getOutput('speed'), 'spd')
-        rep.updInput('inputs').connect(
+        rep.updInput().connect(coord.getOutput('speed'), 'spd')
+        rep.connectInput_inputs(
                 source.getOutput('column').getChannel('col1'))
-        rep.updInput('inputs').connect(
+        rep.addToReport(
                 source.getOutput('column').getChannel('col2'), 'second_col')
 
         s = m.initSystem()

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -202,7 +202,7 @@ class TestInputsOutputs(unittest.TestCase):
         # for reporters.
         coord = j.get_coordinates(0)
         rep.updInput('inputs').connect(coord.getOutput('value'))
-        rep.updInput().connect(coord.getOutput('speed'), 'spd')
+        rep.connectInput_inputs(coord.getOutput('speed'), 'spd')
         rep.connectInput_inputs(
                 source.getOutput('column').getChannel('col1'))
         rep.addToReport(

--- a/OpenSim/Actuators/BodyActuator.cpp
+++ b/OpenSim/Actuators/BodyActuator.cpp
@@ -93,7 +93,7 @@ const std::string& BodyActuator::getBodyName() const
 */
 void BodyActuator::setBody(const Body& body)
 {
-    updConnector<Body>("body").connect(body);
+    connectConnector_body(body);
 }
 
 /**

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -848,7 +848,9 @@ private:
     /** In an XML file, you can set this Connector's connectee name      */ \
     /** via the <b>\<connector_##cname##_connectee_name\></b> element.   */ \
     /** This connector was generated with the                            */ \
-    /** #OpenSim_DECLARE_CONNECTOR macro.                                */ \
+    /** #OpenSim_DECLARE_CONNECTOR macro;                                */ \
+    /** see AbstractConnector for more information.                      */ \
+    /** @connectormethods connectConnector_##cname##()                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -857,7 +859,14 @@ private:
                 "Path to a Component to satisfy the Connector '"            \
                 #cname "' of type " #T " (description: " comment ").")      \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Connector-related functions                                */ \
+    /** @{                                                               */ \
+    /** Connect the '##cname##' Connector to an object of type T##.      */ \
+    void connectConnector_##cname(const Object& object) {                   \
+        this->updConnector(#cname).connect(object);                         \
+    }                                                                       \
+    /** @}                                                               */
 
 // The following doxygen-like description does NOT actually appear in doxygen.
 /* Preferably, use the #OpenSim_DECLARE_CONNECTOR macro. Only use this macro
@@ -914,6 +923,8 @@ private:
     /** comment                                                          */ \
     /** In an XML file, you can set this Connector's connectee name      */ \
     /** via the <b>\<connector_##cname##_connectee_name\></b> element.   */ \
+    /** See AbstractConnector for more information.                      */ \
+    /** @connectormethods connectConnector_##cname##()                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -925,7 +936,14 @@ private:
     PropertyIndex constructConnector_##cname();                             \
     /* Remember the provided type so we can use it in the DEFINE macro.  */ \
     typedef T _connector_##cname##_type;                                    \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Connector-related functions                                */ \
+    /** @{                                                               */ \
+    /** Connect the '##cname##' Connector to an object of type T##.      */ \
+    void connectConnector_##cname(const Object& object) {                   \
+        this->updConnector(#cname).connect(object);                         \
+    }                                                                       \
+    /** @}                                                               */
 
 // The following doxygen-like description does NOT actually appear in doxygen.
 /* When specifying a Connector to a forward-declared type (using

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -986,14 +986,15 @@ PropertyIndex Class::constructConnector_##cname() {                         \
     /** @name Inputs                                                     */ \
     /** @{                                                               */ \
     /** comment                                                          */ \
-    /** This input is needed at stage istage.                            */ \
+    /** This input is needed at stage istage##.                          */ \
     /** In an XML file, you can set this Input's connectee name          */ \
     /** via the <b>\<input_##iname##_connectee_name\></b> element.       */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
-    /** See AbstractInput for more information.                          */ \
     /** This input was generated with the                                */ \
-    /** #OpenSim_DECLARE_INPUT macro.                                    */ \
+    /** #OpenSim_DECLARE_INPUT macro;                                    */ \
+    /** see AbstractInput for more information.                          */ \
+    /** @inputmethods connectInput_##iname##()                           */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1002,7 +1003,27 @@ PropertyIndex Class::constructConnector_##cname() {                         \
             "Path to an output (channel) to satisfy the one-value Input '"  \
             #iname "' of type " #T " (description: " comment ").",  istage) \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Input-related functions                                    */ \
+    /** @{                                                               */ \
+    /** Connect this Input to a single-valued (single-channel) Output.   */ \
+    /** The output must be of type T##.                                  */ \
+    /** This input is single-valued and thus cannot connect to a         */ \
+    /** list output.                                                     */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the output.                                */ \
+    void connectInput_##iname(const AbstractOutput& output,                 \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(output, alias);                            \
+    }                                                                       \
+    /** Connect this Input to an output channel of type T##.             */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the channel.                               */ \
+    void connectInput_##iname(const AbstractChannel& channel,               \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(channel, alias);                           \
+    }                                                                       \
+    /** @}                                                               */
 
 // TODO create new macros to handle custom copy constructors: with
 // constructInput_() methods, etc. NOTE: constructProperty_() must be called first
@@ -1026,14 +1047,15 @@ PropertyIndex Class::constructConnector_##cname() {                         \
     /** @{                                                               */ \
     /** comment                                                          */ \
     /** This input can connect to multiple outputs, all of which are     */ \
-    /** needed at stage istage.                                          */ \
+    /** needed at stage istage##.                                        */ \
     /** In an XML file, you can set this Input's connectee name          */ \
     /** via the <b>\<input_##iname##_connectee_names\></b> element.      */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
-    /** See AbstractInput for more information.                          */ \
     /** This input was generated with the                                */ \
-    /** #OpenSim_DECLARE_LIST_INPUT macro.                               */ \
+    /** #OpenSim_DECLARE_LIST_INPUT macro;                               */ \
+    /** see AbstractInput for more information.                          */ \
+    /** @inputmethods connectInput_##iname##()                           */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1043,7 +1065,28 @@ PropertyIndex Class::constructConnector_##cname() {                         \
             #iname "' of type " #T " (description: " comment "). "          \
             "To specify multiple paths, put spaces between them.", istage)  \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Input-related functions                                    */ \
+    /** @{                                                               */ \
+    /** Connect this Input to a single-valued or list Output.            */ \
+    /** The output must be of type T##.                                  */ \
+    /** If the output is a list output, this connects to all of the      */ \
+    /** channels of the output.                                          */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the output; the alias will be used for all */ \
+    /** channels of the output.                                          */ \
+    void connectInput_##iname(const AbstractOutput& output,                 \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(output, alias);                            \
+    }                                                                       \
+    /** Connect this Input to an output channel of type T##.             */ \
+    /** You can optionally provide an alias that will be used by this    */ \
+    /** component to refer to the channel.                               */ \
+    void connectInput_##iname(const AbstractChannel& channel,               \
+                              const std::string& alias = "") {              \
+        updInput(#iname).connect(channel, alias);                           \
+    }                                                                       \
+    /** @}                                                               */
 /// @}
 
 } // end of namespace OpenSim

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -113,18 +113,52 @@ public:
     OpenSim_DECLARE_LIST_INPUT(inputs, InputT, SimTK::Stage::Report,
         "Variable list of quantities to be reported.");
 
-    //=============================================================================
+    //==========================================================================
     // PUBLIC METHODS
-    //=============================================================================
+    //==========================================================================
 
     // Allow overloading of updInput
     using AbstractReporter::updInput;
 
+    /** Connect an output (single-valued or list) to this reporter. 
+    The output must be of type InputT.
+    If the output is a list output, this connects to all of the channels of the
+    output. You can optionally provide an alias that will be used by this
+    component to refer to the output; the alias will be used for all channels
+    of the output.                                          
+    @code
+    auto* reporter = new ConsoleReporter();
+    auto* src = new TableSource();
+    reporter->addToReport(src->getOutput("all_columns"));
+    @endcode
+    This method is equivalent to
+    connectInput_inputs(const AbstractOutput&, const std::string&). */
+    void addToReport(const AbstractOutput& output,
+                     const std::string& alias = "") {
+        connectInput_inputs(output, alias);
+    }
+
+    /** Connect an output channel to this reporter.
+    The output channel must be of type InputT.
+    You can optionally provide an alias that will be used by this component to
+    refer to the channel.
+    @code
+    auto* reporter = new ConsoleReporter();
+    auto* src = new TableSource();
+    reporter->addToReport(src->getOutput("column").getChannel("ankle"));
+    @endcode
+    This method is equivalent to
+    connectInput_inputs(const AbstractChannel&, const std::string&). */
+    void addToReport(const AbstractChannel& channel,
+                     const std::string& alias = "") {
+        connectInput_inputs(channel, alias);
+    }
+
     /** Convenience method that can be used in place of `updInput("inputs")`. 
     @code
     auto* reporter = new ConsoleReporter();
-    auto* src = new DataSource();
-    reporter->updInput().connect(src->getOutput("outputName"));
+    auto* src = new TableSource();
+    reporter->updInput().getLabel();
     @endcode
     */
     AbstractInput& updInput()

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -117,9 +117,6 @@ public:
     // PUBLIC METHODS
     //==========================================================================
 
-    // Allow overloading of updInput
-    using AbstractReporter::updInput;
-
     /** Connect an output (single-valued or list) to this reporter. 
     The output must be of type InputT.
     If the output is a list output, this connects to all of the channels of the
@@ -152,18 +149,6 @@ public:
     void addToReport(const AbstractChannel& channel,
                      const std::string& alias = "") {
         connectInput_inputs(channel, alias);
-    }
-
-    /** Convenience method that can be used in place of `updInput("inputs")`. 
-    @code
-    auto* reporter = new ConsoleReporter();
-    auto* src = new TableSource();
-    reporter->updInput().getLabel();
-    @endcode
-    */
-    AbstractInput& updInput()
-    {
-        return updInput("inputs");
     }
 
 protected:

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -480,7 +480,7 @@ void testMisc() {
     //Configure the connector to look for its dependency by this name
     //Will get resolved and connected automatically at Component connect
     bar.updConnector<Foo>("parentFoo").setConnecteeName(foo.getAbsolutePathName());
-    bar.updConnector<Foo>("childFoo").connect(foo);
+    bar.connectConnector_childFoo(foo);
         
     // add a subcomponent
     // connect internals
@@ -527,7 +527,7 @@ void testMisc() {
     SimTK_TEST(!theWorld.hasComponent<Foo>("Nonexistant"));
 
 
-    bar.updConnector<Foo>("childFoo").connect(foo2);
+    bar.connectConnector_childFoo(foo2);
     string connectorName = bar.updConnector<Foo>("childFoo").getName();
 
     // Bar should connect now
@@ -675,7 +675,7 @@ void testMisc() {
     bar2.updConnector<Foo>("parentFoo")
     .setConnecteeName(compFoo.getRelativePathName(bar2));
     
-    bar2.updConnector<Foo>("childFoo").connect(foo);
+    bar2.connectConnector_childFoo(foo);
     compFoo.upd_Foo1().updInput("input1")
         .connect(bar2.getOutput("PotentialEnergy"));
 
@@ -864,7 +864,7 @@ void testListConnectors() {
     
     // Ensure that calling connect() on bar's "parentFoo" doesn't increase
     // its number of connectees.
-    bar.updConnector<Foo>("parentFoo").connect(foo);
+    bar.connectConnector_parentFoo(foo);
     // TODO The "Already connected to 'foo'" is caught by `connect()`.
     SimTK_TEST(bar.getConnector<Foo>("parentFoo").getNumConnectees() == 1);
     
@@ -1001,9 +1001,8 @@ void testComponentPathNames()
     ASSERT(&foo1inA == foo1);
 
     // This bar2 that belongs to A and connects the two foo2s
-    bar2->updConnector<Foo>("parentFoo").connect(*foo2);
-    bar2->updConnector<Foo>("childFoo")
-        .connect(F->getComponent<Foo>("Foo2"));
+    bar2->connectConnector_parentFoo(*foo2);
+    bar2->connectConnector_childFoo(F->getComponent<Foo>("Foo2"));
 
     // auto& foo2inF = bar2->getComponent<Foo>("../../F/Foo2");
 
@@ -1012,7 +1011,7 @@ void testComponentPathNames()
     auto& fbar2 = F->updComponent<Bar>("Bar2");
     ASSERT(&fbar2 != bar2);
 
-    fbar2.updConnector<Foo>("parentFoo").connect(*foo1);
+    fbar2.connectConnector_parentFoo(*foo1);
     fbar2.updConnector<Foo>("childFoo")
         .setConnecteeName("../Foo1");
 
@@ -1031,8 +1030,8 @@ void testInputOutputConnections()
         foo1->setName("foo1");
         foo2->setName("foo2");
         bar->setName("bar");
-        bar->updConnector<Foo>("parentFoo").connect(*foo1);
-        bar->updConnector<Foo>("childFoo").connect(*foo2);
+        bar->connectConnector_parentFoo(*foo1);
+        bar->connectConnector_childFoo(*foo2);
         
         world.add(foo1);
         world.add(foo2);

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1023,50 +1023,50 @@ void testComponentPathNames()
 void testInputOutputConnections()
 {
     {
-    TheWorld world;
-    Foo* foo1 = new Foo();
-    Foo* foo2 = new Foo();
-    Bar* bar = new Bar();
+        TheWorld world;
+        Foo* foo1 = new Foo();
+        Foo* foo2 = new Foo();
+        Bar* bar = new Bar();
 
-    foo1->setName("foo1");
-    foo2->setName("foo2");
-    bar->setName("bar");
-    bar->updConnector<Foo>("parentFoo").connect(*foo1);
-    bar->updConnector<Foo>("childFoo").connect(*foo2);
-    
-    world.add(foo1);
-    world.add(foo2);
-    world.add(bar);
+        foo1->setName("foo1");
+        foo2->setName("foo2");
+        bar->setName("bar");
+        bar->updConnector<Foo>("parentFoo").connect(*foo1);
+        bar->updConnector<Foo>("childFoo").connect(*foo2);
+        
+        world.add(foo1);
+        world.add(foo2);
+        world.add(bar);
 
-    MultibodySystem mbs;
+        MultibodySystem mbs;
 
-    world.connect();
+        world.connect();
 
-    // do any other input/output connections
-    foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
+        // do any other input/output connections
+        foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
 
-    // Test various exceptions for inputs, outputs, connectors
-    ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
-    ASSERT_THROW(ConnectorNotFound, bar->updConnector<Foo>("parentFoo0"));
-    ASSERT_THROW(OutputNotFound, 
-        world.getComponent("./internalSub").getOutput("subState0"));
-    // Ensure that getOutput does not perform a "find"
-    ASSERT_THROW(OutputNotFound,
-        world.getOutput("./internalSub/subState"));
+        // Test various exceptions for inputs, outputs, connectors
+        ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
+        ASSERT_THROW(ConnectorNotFound, bar->updConnector<Foo>("parentFoo0"));
+        ASSERT_THROW(OutputNotFound, 
+            world.getComponent("./internalSub").getOutput("subState0"));
+        // Ensure that getOutput does not perform a "find"
+        ASSERT_THROW(OutputNotFound,
+            world.getOutput("./internalSub/subState"));
 
-    foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
+        foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
 
-    foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
-    foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
+        foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
+        foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
 
-    foo1->connectInput_activation(bar->getOutput("activation"));
-    foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
+        foo1->connectInput_activation(bar->getOutput("activation"));
+        foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    foo2->connectInput_activation(bar->getOutput("activation"));
-    foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
+        foo2->connectInput_activation(bar->getOutput("activation"));
+        foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    world.connect();
-    world.buildUpSystem(mbs);
+        world.connect();
+        world.buildUpSystem(mbs);
     }
     // Test exception message when asking for the value of an input that is
     // not wired up.

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -538,7 +538,7 @@ void testMisc() {
     ASSERT(foo2 == foo2found);
 
     // do any other input/output connections
-    foo.updInput("input1").connect(bar.getOutput("PotentialEnergy"));
+    foo.connectInput_input1(bar.getOutput("PotentialEnergy"));
     
     // check how this model serializes
     string modelFile("testComponentInterfaceModel.osim");
@@ -696,7 +696,7 @@ void testMisc() {
 
     auto* reporter = new TableReporterVector();
     reporter->set_report_time_interval(0.1);
-    reporter->updInput("inputs").connect(foo.getOutput("Qs"));
+    reporter->connectInput_inputs(foo.getOutput("Qs"));
     theWorld.add(reporter);
 
     MultibodySystem system3;
@@ -704,8 +704,8 @@ void testMisc() {
     theWorld.buildUpSystem(system3);
 
     // Connect our state variables.
-    foo.updInput("fiberLength").connect(bar.getOutput("fiberLength"));
-    foo.updInput("activation").connect(bar.getOutput("activation"));
+    foo.connectInput_fiberLength(bar.getOutput("fiberLength"));
+    foo.connectInput_activation(bar.getOutput("activation"));
     // Since hiddenStateVar is a hidden state variable, it has no
     // corresponding output.
     ASSERT_THROW( OpenSim::Exception,
@@ -808,10 +808,10 @@ void testListInputs() {
     theWorld.add(reporter);
 
     // wire up console reporter inputs to desired model outputs
-    reporter->updInput("inputs").connect(foo.getOutput("Output1"));
-    reporter->updInput("inputs").connect(bar.getOutput("PotentialEnergy"));
-    reporter->updInput("inputs").connect(bar.getOutput("fiberLength"));
-    reporter->updInput("inputs").connect(bar.getOutput("activation"));
+    reporter->connectInput_inputs(foo.getOutput("Output1"));
+    reporter->connectInput_inputs(bar.getOutput("PotentialEnergy"));
+    reporter->connectInput_inputs(bar.getOutput("fiberLength"));
+    reporter->connectInput_inputs(bar.getOutput("activation"));
 
     auto* tabReporter = new TableReporter();
     tabReporter->setName("TableReporterMixedOutputs");
@@ -819,10 +819,10 @@ void testListInputs() {
 
     // wire up table reporter inputs (using convenience method) to desired 
     // model outputs
-    tabReporter->updInput().connect(bar.getOutput("fiberLength"));
-    tabReporter->updInput().connect(bar.getOutput("activation"));
-    tabReporter->updInput().connect(foo.getOutput("Output1"));
-    tabReporter->updInput().connect(bar.getOutput("PotentialEnergy"));
+    tabReporter->addToReport(bar.getOutput("fiberLength"));
+    tabReporter->addToReport(bar.getOutput("activation"));
+    tabReporter->addToReport(foo.getOutput("Output1"));
+    tabReporter->addToReport(bar.getOutput("PotentialEnergy"));
 
     theWorld.connect();
     theWorld.buildUpSystem(system);
@@ -1042,7 +1042,7 @@ void testInputOutputConnections()
     world.connect();
 
     // do any other input/output connections
-    foo1->updInput("input1").connect(bar->getOutput("PotentialEnergy"));
+    foo1->connectInput_input1(bar->getOutput("PotentialEnergy"));
 
     // Test various exceptions for inputs, outputs, connectors
     ASSERT_THROW(InputNotFound, foo1->getInput("input0"));
@@ -1053,16 +1053,16 @@ void testInputOutputConnections()
     ASSERT_THROW(OutputNotFound,
         world.getOutput("./internalSub/subState"));
 
-    foo2->updInput("input1").connect(world.getComponent("./internalSub").getOutput("subState"));
+    foo2->connectInput_input1(world.getComponent("./internalSub").getOutput("subState"));
 
-    foo1->updInput("AnglesIn").connect(foo2->getOutput("Qs"));
-    foo2->updInput("AnglesIn").connect(foo1->getOutput("Qs"));
+    foo1->connectInput_AnglesIn(foo2->getOutput("Qs"));
+    foo2->connectInput_AnglesIn(foo1->getOutput("Qs"));
 
-    foo1->updInput("activation").connect(bar->getOutput("activation"));
-    foo1->updInput("fiberLength").connect(bar->getOutput("fiberLength"));
+    foo1->connectInput_activation(bar->getOutput("activation"));
+    foo1->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
-    foo2->updInput("activation").connect(bar->getOutput("activation"));
-    foo2->updInput("fiberLength").connect(bar->getOutput("fiberLength"));
+    foo2->connectInput_activation(bar->getOutput("activation"));
+    foo2->connectInput_fiberLength(bar->getOutput("fiberLength"));
 
     world.connect();
     world.buildUpSystem(mbs);
@@ -1476,7 +1476,7 @@ void testTableSource() {
     theWorld.add(tableSource);
     theWorld.add(tableReporter);
 
-    tableReporter->updInput("inputs").connect(tableSource->getOutput("column"));
+    tableReporter->addToReport(tableSource->getOutput("column"));
 
     theWorld.finalizeFromProperties();
 
@@ -1579,10 +1579,10 @@ void testListInputConnecteeSerialization() {
         // Connect, finalize, etc.
         const auto& output = source->getOutput("column");
         // See if we preserve the ordering of the channels.
-        reporter->updInput("inputs").connect(output.getChannel("a"));
-        reporter->updInput("inputs").connect(output.getChannel("c"));
+        reporter->addToReport(output.getChannel("a"));
+        reporter->addToReport(output.getChannel("c"));
         // We want to make sure aliases are preserved.
-        reporter->updInput("inputs").connect(output.getChannel("b"), "berry");
+        reporter->addToReport(output.getChannel("b"), "berry");
         world.finalizeFromProperties();
         world.connect();
         MultibodySystem system;
@@ -1665,9 +1665,9 @@ void testSingleValueInputConnecteeSerialization() {
         // Connect, finalize, etc.
         const auto& output = source->getOutput("column");
         // See if we preserve the ordering of the channels.
-        foo->updInput("input1").connect(output.getChannel("b"));
+        foo->connectInput_input1(output.getChannel("b"));
         // We want to make sure aliases are preserved.
-        foo->updInput("fiberLength").connect(output.getChannel("d"), "desert");
+        foo->connectInput_fiberLength(output.getChannel("d"), "desert");
         world.finalizeFromProperties();
         world.connect();
         MultibodySystem system;
@@ -1821,7 +1821,7 @@ void testAliasesAndLabels() {
     ASSERT_THROW(InputNotConnected, foo->getInput("input1").getLabel(0));
 
     // Non-list Input, no alias.
-    foo->updInput("input1").connect( bar->getOutput("Output1") );
+    foo->connectInput_input1( bar->getOutput("Output1") );
     SimTK_TEST(foo->getInput("input1").getAlias().empty());
     SimTK_TEST(foo->getInput("input1").getLabel() == "/world/bar|Output1");
 
@@ -1842,13 +1842,13 @@ void testAliasesAndLabels() {
     foo->updInput("input1").disconnect();
 
     // Non-list Input, with alias.
-    foo->updInput("input1").connect( bar->getOutput("Output1"), "baz" );
+    foo->connectInput_input1( bar->getOutput("Output1"), "baz" );
     SimTK_TEST(foo->getInput("input1").getAlias() == "baz");
     SimTK_TEST(foo->getInput("input1").getLabel() == "baz");
 
     // List Input, no aliases.
-    foo->updInput("listInput1").connect( bar->getOutput("Output1") );
-    foo->updInput("listInput1").connect( bar->getOutput("Output3") );
+    foo->connectInput_listInput1( bar->getOutput("Output1") );
+    foo->connectInput_listInput1( bar->getOutput("Output3") );
 
     ASSERT_THROW(OpenSim::Exception, foo->getInput("listInput1").getAlias());
     ASSERT_THROW(OpenSim::Exception, foo->getInput("listInput1").getLabel());
@@ -1862,8 +1862,8 @@ void testAliasesAndLabels() {
     foo->updInput("listInput1").disconnect();
 
     // List Input, with aliases.
-    foo->updInput("listInput1").connect( bar->getOutput("Output1"), "plugh" );
-    foo->updInput("listInput1").connect( bar->getOutput("Output3"), "thud" );
+    foo->connectInput_listInput1( bar->getOutput("Output1"), "plugh" );
+    foo->connectInput_listInput1( bar->getOutput("Output3"), "thud" );
 
     SimTK_TEST(foo->getInput("listInput1").getAlias(0) == "plugh");
     SimTK_TEST(foo->getInput("listInput1").getLabel(0) == "plugh");

--- a/OpenSim/Examples/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -85,7 +85,7 @@ Device* buildDevice() {
     //      frame will be connected in exampleHopperDevice.cpp.
     #pragma region Step2_TaskC_solution
 
-    anchorA->updConnector("child_frame").connect(*cuffA);
+    anchorA->connectConnector_child_frame(*cuffA);
 
     #pragma endregion
     
@@ -103,7 +103,7 @@ Device* buildDevice() {
 
     auto anchorB = new WeldJoint();
     anchorB->setName("anchorB");
-    anchorB->updConnector("child_frame").connect(*cuffB);
+    anchorB->connectConnector_child_frame(*cuffB);
     device->addComponent(anchorB);
 
     #pragma endregion
@@ -124,7 +124,7 @@ Device* buildDevice() {
     //TODO: Connect the controller's "actuator" Connector to pathActuator.
     #pragma region Step2_TaskC_solution
 
-    controller->updConnector("actuator").connect(*pathActuator);
+    controller->connectConnector_actuator(*pathActuator);
 
     #pragma endregion
 

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -155,11 +155,11 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
 
     // Loop through the desired device outputs and add them to the reporter.
     for (auto thisOutputName : deviceOutputs)
-        reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
+        reporter->addToReport(device.getOutput(thisOutputName));
 
     for (auto thisOutputName : deviceControllerOutputs)
-        reporter->updInput("inputs").
-        connect(device.getComponent("controller").getOutput(thisOutputName));
+        reporter->addToReport(
+                device.getComponent("controller").getOutput(thisOutputName));
 
     // Add the reporter to the model.
     model.addComponent(reporter);
@@ -331,8 +331,8 @@ void run(bool showVisualizer, bool simulateOnce)
         // Use the vastus muscle's activation as the control signal for the
         // device. The vastus string (at the top of this file) must
         // be filled in.
-        //kneeDevice->updComponent("controller").updInput("activation")
-        //    .connect(assistedHopper.getComponent(vastus).getOutput("activation"));
+        //kneeDevice->updComponent("controller").updInput("activation").connect(
+        //    assistedHopper.getComponent(vastus).getOutput("activation"));
 
         // List the device outputs we wish to display during the simulation.
         std::vector<std::string> kneeDeviceOutputs{ "tension", "height" };

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -156,19 +156,19 @@ void addConsoleReporterToHopper(Model& hopper)
     //      knee angle, and any other variables of interest.
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent(hopperHeightCoord).getOutput("value"), "height");
 
     #pragma endregion
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent("/Dennis/vastus").getOutput("activation"));
 
     #pragma endregion
     #pragma region Step1_TaskB_solution
 
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(
         hopper.getComponent("/Dennis/knee/kneeFlexion").getOutput("value"), "knee_angle");
 
     #pragma endregion
@@ -206,8 +206,8 @@ void addSignalGeneratorToDevice(Device& device)
     //      activation input.
     #pragma region Step2_TaskE_solution
 
-    device.updComponent("controller").updInput("activation")
-        .connect(signalGen->getOutput("signal"));
+    device.updComponent("controller").updInput("activation").connect(
+            signalGen->getOutput("signal"));
 
     #pragma endregion
 }
@@ -227,11 +227,11 @@ void addDeviceConsoleReporterToModel(Model& model, Device& device,
 
     // Loop through the desired device outputs and add them to the reporter.
     for (auto thisOutputName : deviceOutputs)
-        reporter->updInput("inputs").connect(device.getOutput(thisOutputName));
+        reporter->addToReport(device.getOutput(thisOutputName));
 
     for (auto thisOutputName : deviceControllerOutputs)
-        reporter->updInput("inputs").
-            connect(device.getComponent("controller").getOutput(thisOutputName));
+        reporter->addToReport(
+                device.getComponent("controller").getOutput(thisOutputName));
 
     // Add the reporter to the model.
     model.addComponent(reporter);
@@ -403,8 +403,8 @@ void run(bool showVisualizer, bool simulateOnce)
         // Use the vastus muscle's activation as the control signal for the
         // device. The vastus string (at the top of this file) must
         // be filled in.
-        kneeDevice->updComponent("controller").updInput("activation")
-            .connect(assistedHopper.getComponent(vastus).getOutput("activation"));
+        kneeDevice->updComponent("controller").updInput("activation").connect(
+                assistedHopper.getComponent(vastus).getOutput("activation"));
 
         // List the device outputs we wish to display during the simulation.
         std::vector<std::string> kneeDeviceOutputs{ "tension", "height" };

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -114,9 +114,9 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     #pragma region Step2_TaskD_solution
 
     const auto& frameA = model.getComponent<PhysicalFrame>(modelFrameAname);
-    anchorA.updConnector("parent_frame").connect(frameA);
+    anchorA.connectConnector_parent_frame(frameA);
     const auto& frameB = model.getComponent<PhysicalFrame>(modelFrameBname);
-    anchorB.updConnector("parent_frame").connect(frameB);
+    anchorB.connectConnector_parent_frame(frameB);
 
     #pragma endregion
 

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -94,7 +94,7 @@ void ConditionalPathPoint::constructProperties()
  */
 void ConditionalPathPoint::setCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("coordinate").connect(coordinate);
+    connectConnector_coordinate(coordinate);
 }
 
 bool ConditionalPathPoint::hasCoordinate() const

--- a/OpenSim/Simulation/Model/ContactGeometry.cpp
+++ b/OpenSim/Simulation/Model/ContactGeometry.cpp
@@ -101,7 +101,7 @@ const PhysicalFrame& ContactGeometry::getFrame() const
 
 void ContactGeometry::setFrame(const PhysicalFrame& frame)
 {
-    updConnector<PhysicalFrame>("frame").connect(frame);
+    connectConnector_frame(frame);
 }
 
 const PhysicalFrame& ContactGeometry::getBody() const

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -98,15 +98,15 @@ const Coordinate& MovingPathPoint::getZCoordinate() const
 
 void MovingPathPoint::setXCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("x_coordinate").connect(coordinate);
+    connectConnector_x_coordinate(coordinate);
 }
 void MovingPathPoint::setYCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("y_coordinate").connect(coordinate);
+    connectConnector_y_coordinate(coordinate);
 }
 void MovingPathPoint::setZCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("z_coordinate").connect(coordinate);
+    connectConnector_z_coordinate(coordinate);
 }
 
 void MovingPathPoint::extendConnectToModel(Model& model)

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -292,7 +292,7 @@ calcAccelerationInGround(const SimTK::State& state) const
 template <class C>
 void OffsetFrame<C>::setParentFrame(const C& parent)
 {
-    this->template updConnector<C>("parent").connect(parent);
+    this->connectConnector_parent(parent);
 }
 
 template <class C>

--- a/OpenSim/Simulation/Model/PointToPointSpring.cpp
+++ b/OpenSim/Simulation/Model/PointToPointSpring.cpp
@@ -91,12 +91,12 @@ void PointToPointSpring::constructProperties()
 
 void PointToPointSpring::setBody1(const PhysicalFrame& body)
 {
-    updConnector<PhysicalFrame>("body1").connect(body);
+    connectConnector_body1(body);
 }
 
 void PointToPointSpring::setBody2(const PhysicalFrame& body)
 {
-    updConnector<PhysicalFrame>("body2").connect(body);
+    connectConnector_body2(body);
 }
 
 const PhysicalFrame& PointToPointSpring::getBody1() const

--- a/OpenSim/Simulation/Model/PrescribedForce.cpp
+++ b/OpenSim/Simulation/Model/PrescribedForce.cpp
@@ -51,7 +51,7 @@ PrescribedForce::PrescribedForce(const std::string& name, const PhysicalFrame& f
     PrescribedForce()
 {
     setName(name);
-    updConnector<PhysicalFrame>("frame").connect(frame);
+    connectConnector_frame(frame);
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -98,7 +98,7 @@ const PhysicalFrame& Station::getParentFrame() const
  */
 void Station::setParentFrame(const OpenSim::PhysicalFrame& aFrame)
 {
-    updConnector<PhysicalFrame>("parent_frame").connect(aFrame);
+    connectConnector_parent_frame(aFrame);
 }
 
 SimTK::Vec3 Station::findLocationInFrame(const SimTK::State& s,

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -306,8 +306,8 @@ TwoFrameLinker<C, F>::TwoFrameLinker(const std::string &name,
     int ix2 = append_frames(frame2Offset);
     this->finalizeFromProperties();
 
-    this->template updConnector<F>("frame1").connect(get_frames(ix1));
-    this->template updConnector<F>("frame2").connect(get_frames(ix2));
+    this->connectConnector_frame1(get_frames(ix1));
+    this->connectConnector_frame2(get_frames(ix2));
 
     static_cast<PhysicalOffsetFrame&>(upd_frames(ix1)).setParentFrame(frame1);
     static_cast<PhysicalOffsetFrame&>(upd_frames(ix2)).setParentFrame(frame2);
@@ -333,8 +333,8 @@ TwoFrameLinker<C, F>::TwoFrameLinker(const std::string &name,
     int ix2 = append_frames(frame2Offset);
     this->finalizeFromProperties();
 
-    this->template updConnector<F>("frame1").connect(get_frames(ix1));
-    this->template updConnector<F>("frame2").connect(get_frames(ix2));
+    this->connectConnector_frame1(get_frames(ix1));
+    this->connectConnector_frame2(get_frames(ix2));
 }
 
 template <class C, class F>

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -70,8 +70,8 @@ Joint::Joint(const std::string &name, const PhysicalFrame& parent,
     setName(name);
     set_reverse(reverse);
 
-    updConnector<PhysicalFrame>("parent_frame").connect(parent);
-    updConnector<PhysicalFrame>("child_frame").connect(child);
+    connectConnector_parent_frame(parent);
+    connectConnector_child_frame(child);
 }
 
 /* Convenience Constructor*/
@@ -130,8 +130,8 @@ Joint::Joint(const std::string &name,
     static_cast<PhysicalOffsetFrame&>(upd_frames(pix)).setParentFrame(parent);
     static_cast<PhysicalOffsetFrame&>(upd_frames(cix)).setParentFrame(child);
 
-    updConnector<PhysicalFrame>("parent_frame").connect(upd_frames(pix));
-    updConnector<PhysicalFrame>("child_frame").connect(upd_frames(cix));
+    connectConnector_parent_frame(upd_frames(pix));
+    connectConnector_child_frame(upd_frames(cix));
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
@@ -158,7 +158,7 @@ void WeldConstraint::
         _internalOffset1.reset(new PhysicalOffsetFrame(frame1, in1));
         _internalOffset1->setName("internal_" + frame1.getName());
         updProperty_frames().adoptAndAppendValue(_internalOffset1.get());
-        updConnector<PhysicalFrame>("frame1").connect(*_internalOffset1);
+        connectConnector_frame1(*_internalOffset1);
     }
     else { // otherwise it is already "wired" up so just update
         _internalOffset1->setOffsetTransform(in1);
@@ -168,7 +168,7 @@ void WeldConstraint::
         _internalOffset2.reset(new PhysicalOffsetFrame(frame2, in2));
         _internalOffset2->setName("internal_" + frame2.getName());
         updProperty_frames().adoptAndAppendValue(_internalOffset2.get());
-        updConnector<PhysicalFrame>("frame2").connect(*_internalOffset2);
+        connectConnector_frame2(*_internalOffset2);
     }
     else {
         _internalOffset2->setOffsetTransform(in2);

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -437,8 +437,8 @@ generateMarkerDataFromModelAndStates(const Model& model,
     
     auto markers = m->getComponentList<Marker>();
     for (const auto& marker : markers) {
-        markerReporter->updInput().
-            connect(marker.getOutput("location"), marker.getName());
+        markerReporter->addToReport(
+                marker.getOutput("location"), marker.getName());
     }
 
     m->addComponent(markerReporter);

--- a/OpenSim/Simulation/Test/testNestedModelComponents.cpp
+++ b/OpenSim/Simulation/Test/testNestedModelComponents.cpp
@@ -81,11 +81,11 @@ void testPendulumModelWithNestedJoints()
     // Create WeldJoints to anchor cuff Bodies to the pendulum.
     auto* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
-    anchorA->updConnector("child_frame").connect(*cuffA);
+    anchorA->connectConnector_child_frame(*cuffA);
 
     auto* anchorB = new WeldJoint();
     anchorB->setName("anchorB");
-    anchorB->updConnector("child_frame").connect(*cuffB);
+    anchorB->connectConnector_child_frame(*cuffB);
 
     // add anchors to the Device
     device->addComponent(anchorA);
@@ -97,8 +97,8 @@ void testPendulumModelWithNestedJoints()
     // Connect the device to bodies of the pendulum
     const auto& rod1 = pendulum->getComponent<OpenSim::Body>("rod1");
     const auto& rod2 = pendulum->getComponent<OpenSim::Body>("rod2");
-    anchorA->updConnector("parent_frame").connect(rod1);
-    anchorB->updConnector("parent_frame").connect(rod2);
+    anchorA->connectConnector_parent_frame(rod1);
+    anchorB->connectConnector_parent_frame(rod2);
 
     State& s = pendulum->initSystem();
 }

--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -31,7 +31,7 @@ using namespace std;
 using namespace SimTK;
 using namespace OpenSim;
 
-void testConsoleReporerLabels() {
+void testConsoleReporterLabels() {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -46,10 +46,8 @@ void testConsoleReporerLabels() {
     // Create ConsoleReporter, and connect Outputs without and with alias.
     auto* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.);
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value") );
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value"), "height" );
+    reporter->addToReport(slider->getCoordinate().getOutput("value"));
+    reporter->addToReport(slider->getCoordinate().getOutput("value"), "height");
     model.addComponent(reporter);
 
     // Redirect cout to stringstream so ConsoleReporter output can be tested.
@@ -83,7 +81,7 @@ void testConsoleReporerLabels() {
     SimTK_TEST(idxHeading2 < idxHeading3);
 }
 
-void testTableReporerLabels() {
+void testTableReporterLabels() {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -99,10 +97,8 @@ void testTableReporerLabels() {
     // Create TableReporter, and connect Outputs without and with alias.
     auto* reporter = new TableReporter();
     reporter->set_report_time_interval(1.);
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value") );
-    reporter->updInput("inputs").connect(
-        slider->getCoordinate().getOutput("value"), "height" );
+    reporter->addToReport(slider->getCoordinate().getOutput("value"));
+    reporter->addToReport(slider->getCoordinate().getOutput("value"), "height");
     model.addComponent(reporter);
 
     // Simulate.
@@ -121,7 +117,7 @@ void testTableReporerLabels() {
 
 int main() {
     SimTK_START_TEST("testReporters");
-        SimTK_SUBTEST(testConsoleReporerLabels);
-        SimTK_SUBTEST(testTableReporerLabels);
+        SimTK_SUBTEST(testConsoleReporterLabels);
+        SimTK_SUBTEST(testTableReporterLabels);
     SimTK_END_TEST();
 };

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -87,8 +87,8 @@ int main() {
     // Add a console reporter to print the muscle fiber force and elbow angle.
     ConsoleReporter* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.0);
-    reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(biceps->getOutput("fiber_force"));
+    reporter->addToReport(
         elbow->getCoordinate(PinJoint::Coord::RotationZ).getOutput("value"),
         "elbow_angle");
     model.addComponent(reporter);

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ int main() {
     // Add a console reporter to print the muscle fiber force and elbow angle.
     ConsoleReporter* reporter = new ConsoleReporter();
     reporter->set_report_time_interval(1.0);
-    reporter->updInput("inputs").connect(biceps->getOutput("fiber_force"));
-    reporter->updInput("inputs").connect(
+    reporter->addToReport(biceps->getOutput("fiber_force"));
+    reporter->addToReport(
         elbow->getCoordinate(PinJoint::Coord::RotationZ).getOutput("value"),
         "elbow_angle");
     model.addComponent(reporter);

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -204,8 +204,9 @@ TAB_SIZE               = 4
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES                = "propmethods=\par Methods related to this property\n" \
-                         "inputmethods=\par Methods related to this input\n"
+ALIASES = "propmethods=\par Methods related to this property\n"               \
+          "inputmethods=\par Methods related to this input\n"                 \
+          "connectormethods=\par Methods related to this connector\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -204,7 +204,8 @@ TAB_SIZE               = 4
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES                = "propmethods=\par Methods related to this property\n"
+ALIASES                = "propmethods=\par Methods related to this property\n" \
+                         "inputmethods=\par Methods related to this input\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding


### PR DESCRIPTION
This PR is the counterpart to #1441 for connectors. The original plan was to rename connectors to sockets first before introducing the `connectSocket_*()` macro function. But we decided to switch the order of these changes, since having the macro-generated method in place for the alpha release is perhaps more important than having the rename to sockets for the alpha.