### PR TITLE
Macro-generated connectConnector methods.

### DIFF
--- a/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
+++ b/Bindings/Java/Matlab/tests/testConnectorsInputsOutputs.m
@@ -53,7 +53,8 @@ end
 body = Body.safeDownCast(joint.getConnectee('child_frame'));
 assert(body.getMass() == 2);
 
-% Connect a connector.
+% Connect a connector. Try the different methods to ensure they all work.
+offset.connectConnector_parent(ground);
 offset.updConnector('parent').connect(ground);
 assert(strcmp(offset.getConnector('parent').getConnecteeName(), '../ground'));
 

--- a/Bindings/Python/tests/test_connectors_inputs_outputs.py
+++ b/Bindings/Python/tests/test_connectors_inputs_outputs.py
@@ -84,11 +84,11 @@ class TestConnectors(unittest.TestCase):
         j1 = osim.PinJoint()
         j1.setName("j1")
         j1.updConnector("parent_frame").connect(model.getGround())
-        j1.updConnector("child_frame").connect(b1)
+        j1.connectConnector_child_frame(b1)
 
         j2 = osim.PinJoint()
         j2.setName("j2")
-        j2.updConnector("parent_frame").connect(b1)
+        j2.connectConnector_parent_frame(b1)
         j2.updConnector("child_frame").connect(b2)
 
         model.addBody(b1)

--- a/OpenSim/Actuators/BodyActuator.cpp
+++ b/OpenSim/Actuators/BodyActuator.cpp
@@ -93,7 +93,7 @@ const std::string& BodyActuator::getBodyName() const
 */
 void BodyActuator::setBody(const Body& body)
 {
-    updConnector<Body>("body").connect(body);
+    connectConnector_body(body);
 }
 
 /**

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -848,7 +848,9 @@ private:
     /** In an XML file, you can set this Connector's connectee name      */ \
     /** via the <b>\<connector_##cname##_connectee_name\></b> element.   */ \
     /** This connector was generated with the                            */ \
-    /** #OpenSim_DECLARE_CONNECTOR macro.                                */ \
+    /** #OpenSim_DECLARE_CONNECTOR macro;                                */ \
+    /** see AbstractConnector for more information.                      */ \
+    /** @connectormethods connectConnector_##cname##()                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -857,7 +859,14 @@ private:
                 "Path to a Component to satisfy the Connector '"            \
                 #cname "' of type " #T " (description: " comment ").")      \
     };                                                                      \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Connector-related functions                                */ \
+    /** @{                                                               */ \
+    /** Connect the '##cname##' Connector to an object of type T##.      */ \
+    void connectConnector_##cname(const Object& object) {                   \
+        this->updConnector(#cname).connect(object);                         \
+    }                                                                       \
+    /** @}                                                               */
 
 // The following doxygen-like description does NOT actually appear in doxygen.
 /* Preferably, use the #OpenSim_DECLARE_CONNECTOR macro. Only use this macro
@@ -914,6 +923,8 @@ private:
     /** comment                                                          */ \
     /** In an XML file, you can set this Connector's connectee name      */ \
     /** via the <b>\<connector_##cname##_connectee_name\></b> element.   */ \
+    /** See AbstractConnector for more information.                      */ \
+    /** @connectormethods connectConnector_##cname##()                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -925,7 +936,14 @@ private:
     PropertyIndex constructConnector_##cname();                             \
     /* Remember the provided type so we can use it in the DEFINE macro.  */ \
     typedef T _connector_##cname##_type;                                    \
-    /** @endcond                                                         */
+    /** @endcond                                                         */ \
+    /** @name Connector-related functions                                */ \
+    /** @{                                                               */ \
+    /** Connect the '##cname##' Connector to an object of type T##.      */ \
+    void connectConnector_##cname(const Object& object) {                   \
+        this->updConnector(#cname).connect(object);                         \
+    }                                                                       \
+    /** @}                                                               */
 
 // The following doxygen-like description does NOT actually appear in doxygen.
 /* When specifying a Connector to a forward-declared type (using

--- a/OpenSim/Common/ComponentConnector.h
+++ b/OpenSim/Common/ComponentConnector.h
@@ -856,7 +856,7 @@ private:
     /** @cond                                                            */ \
     PropertyIndex PropertyIndex_connector_##cname##_connectee_name {        \
         this->template constructConnector<T>(#cname,                        \
-                "Path to a Component to satisfy the Connector '"            \
+                "Path to a Component that satisfies the Connector '"        \
                 #cname "' of type " #T " (description: " comment ").")      \
     };                                                                      \
     /** @endcond                                                         */ \
@@ -968,7 +968,7 @@ PropertyIndex Class::constructConnector_##cname() {                         \
     using T = _connector_##cname##_type;                                    \
     std::string typeStr = T::getClassName();                                \
     return this->template constructConnector<T>(#cname,                     \
-        "Path to a Component to satisfy the Connector '"                    \
+        "Path to a Component that satisfies the Connector '"                \
         #cname "' of type " + typeStr + ".");                               \
 }
 /// @}

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -480,7 +480,7 @@ void testMisc() {
     //Configure the connector to look for its dependency by this name
     //Will get resolved and connected automatically at Component connect
     bar.updConnector<Foo>("parentFoo").setConnecteeName(foo.getAbsolutePathName());
-    bar.updConnector<Foo>("childFoo").connect(foo);
+    bar.connectConnector_childFoo(foo);
         
     // add a subcomponent
     // connect internals
@@ -527,7 +527,7 @@ void testMisc() {
     SimTK_TEST(!theWorld.hasComponent<Foo>("Nonexistant"));
 
 
-    bar.updConnector<Foo>("childFoo").connect(foo2);
+    bar.connectConnector_childFoo(foo2);
     string connectorName = bar.updConnector<Foo>("childFoo").getName();
 
     // Bar should connect now
@@ -675,7 +675,7 @@ void testMisc() {
     bar2.updConnector<Foo>("parentFoo")
     .setConnecteeName(compFoo.getRelativePathName(bar2));
     
-    bar2.updConnector<Foo>("childFoo").connect(foo);
+    bar2.connectConnector_childFoo(foo);
     compFoo.upd_Foo1().updInput("input1")
         .connect(bar2.getOutput("PotentialEnergy"));
 
@@ -864,7 +864,7 @@ void testListConnectors() {
     
     // Ensure that calling connect() on bar's "parentFoo" doesn't increase
     // its number of connectees.
-    bar.updConnector<Foo>("parentFoo").connect(foo);
+    bar.connectConnector_parentFoo(foo);
     // TODO The "Already connected to 'foo'" is caught by `connect()`.
     SimTK_TEST(bar.getConnector<Foo>("parentFoo").getNumConnectees() == 1);
     
@@ -1001,9 +1001,8 @@ void testComponentPathNames()
     ASSERT(&foo1inA == foo1);
 
     // This bar2 that belongs to A and connects the two foo2s
-    bar2->updConnector<Foo>("parentFoo").connect(*foo2);
-    bar2->updConnector<Foo>("childFoo")
-        .connect(F->getComponent<Foo>("Foo2"));
+    bar2->connectConnector_parentFoo(*foo2);
+    bar2->connectConnector_childFoo(F->getComponent<Foo>("Foo2"));
 
     // auto& foo2inF = bar2->getComponent<Foo>("../../F/Foo2");
 
@@ -1012,7 +1011,7 @@ void testComponentPathNames()
     auto& fbar2 = F->updComponent<Bar>("Bar2");
     ASSERT(&fbar2 != bar2);
 
-    fbar2.updConnector<Foo>("parentFoo").connect(*foo1);
+    fbar2.connectConnector_parentFoo(*foo1);
     fbar2.updConnector<Foo>("childFoo")
         .setConnecteeName("../Foo1");
 
@@ -1031,8 +1030,8 @@ void testInputOutputConnections()
         foo1->setName("foo1");
         foo2->setName("foo2");
         bar->setName("bar");
-        bar->updConnector<Foo>("parentFoo").connect(*foo1);
-        bar->updConnector<Foo>("childFoo").connect(*foo2);
+        bar->connectConnector_parentFoo(*foo1);
+        bar->connectConnector_childFoo(*foo2);
         
         world.add(foo1);
         world.add(foo2);

--- a/OpenSim/Examples/ExampleHopperDevice/buildDeviceModel_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/buildDeviceModel_answers.cpp
@@ -85,7 +85,7 @@ Device* buildDevice() {
     //      frame will be connected in exampleHopperDevice.cpp.
     #pragma region Step2_TaskC_solution
 
-    anchorA->updConnector("child_frame").connect(*cuffA);
+    anchorA->connectConnector_child_frame(*cuffA);
 
     #pragma endregion
     
@@ -103,7 +103,7 @@ Device* buildDevice() {
 
     auto anchorB = new WeldJoint();
     anchorB->setName("anchorB");
-    anchorB->updConnector("child_frame").connect(*cuffB);
+    anchorB->connectConnector_child_frame(*cuffB);
     device->addComponent(anchorB);
 
     #pragma endregion
@@ -124,7 +124,7 @@ Device* buildDevice() {
     //TODO: Connect the controller's "actuator" Connector to pathActuator.
     #pragma region Step2_TaskC_solution
 
-    controller->updConnector("actuator").connect(*pathActuator);
+    controller->connectConnector_actuator(*pathActuator);
 
     #pragma endregion
 

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -114,9 +114,9 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     #pragma region Step2_TaskD_solution
 
     const auto& frameA = model.getComponent<PhysicalFrame>(modelFrameAname);
-    anchorA.updConnector("parent_frame").connect(frameA);
+    anchorA.connectConnector_parent_frame(frameA);
     const auto& frameB = model.getComponent<PhysicalFrame>(modelFrameBname);
-    anchorB.updConnector("parent_frame").connect(frameB);
+    anchorB.connectConnector_parent_frame(frameB);
 
     #pragma endregion
 

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -94,7 +94,7 @@ void ConditionalPathPoint::constructProperties()
  */
 void ConditionalPathPoint::setCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("coordinate").connect(coordinate);
+    connectConnector_coordinate(coordinate);
 }
 
 bool ConditionalPathPoint::hasCoordinate() const

--- a/OpenSim/Simulation/Model/ContactGeometry.cpp
+++ b/OpenSim/Simulation/Model/ContactGeometry.cpp
@@ -101,7 +101,7 @@ const PhysicalFrame& ContactGeometry::getFrame() const
 
 void ContactGeometry::setFrame(const PhysicalFrame& frame)
 {
-    updConnector<PhysicalFrame>("frame").connect(frame);
+    connectConnector_frame(frame);
 }
 
 const PhysicalFrame& ContactGeometry::getBody() const

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -98,15 +98,15 @@ const Coordinate& MovingPathPoint::getZCoordinate() const
 
 void MovingPathPoint::setXCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("x_coordinate").connect(coordinate);
+    connectConnector_x_coordinate(coordinate);
 }
 void MovingPathPoint::setYCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("y_coordinate").connect(coordinate);
+    connectConnector_y_coordinate(coordinate);
 }
 void MovingPathPoint::setZCoordinate(const Coordinate& coordinate)
 {
-    updConnector<Coordinate>("z_coordinate").connect(coordinate);
+    connectConnector_z_coordinate(coordinate);
 }
 
 void MovingPathPoint::extendConnectToModel(Model& model)

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -292,7 +292,7 @@ calcAccelerationInGround(const SimTK::State& state) const
 template <class C>
 void OffsetFrame<C>::setParentFrame(const C& parent)
 {
-    this->template updConnector<C>("parent").connect(parent);
+    this->connectConnector_parent(parent);
 }
 
 template <class C>

--- a/OpenSim/Simulation/Model/PointToPointSpring.cpp
+++ b/OpenSim/Simulation/Model/PointToPointSpring.cpp
@@ -91,12 +91,12 @@ void PointToPointSpring::constructProperties()
 
 void PointToPointSpring::setBody1(const PhysicalFrame& body)
 {
-    updConnector<PhysicalFrame>("body1").connect(body);
+    connectConnector_body1(body);
 }
 
 void PointToPointSpring::setBody2(const PhysicalFrame& body)
 {
-    updConnector<PhysicalFrame>("body2").connect(body);
+    connectConnector_body2(body);
 }
 
 const PhysicalFrame& PointToPointSpring::getBody1() const

--- a/OpenSim/Simulation/Model/PrescribedForce.cpp
+++ b/OpenSim/Simulation/Model/PrescribedForce.cpp
@@ -51,7 +51,7 @@ PrescribedForce::PrescribedForce(const std::string& name, const PhysicalFrame& f
     PrescribedForce()
 {
     setName(name);
-    updConnector<PhysicalFrame>("frame").connect(frame);
+    connectConnector_frame(frame);
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -98,7 +98,7 @@ const PhysicalFrame& Station::getParentFrame() const
  */
 void Station::setParentFrame(const OpenSim::PhysicalFrame& aFrame)
 {
-    updConnector<PhysicalFrame>("parent_frame").connect(aFrame);
+    connectConnector_parent_frame(aFrame);
 }
 
 SimTK::Vec3 Station::findLocationInFrame(const SimTK::State& s,

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -306,8 +306,8 @@ TwoFrameLinker<C, F>::TwoFrameLinker(const std::string &name,
     int ix2 = append_frames(frame2Offset);
     this->finalizeFromProperties();
 
-    this->template updConnector<F>("frame1").connect(get_frames(ix1));
-    this->template updConnector<F>("frame2").connect(get_frames(ix2));
+    this->connectConnector_frame1(get_frames(ix1));
+    this->connectConnector_frame2(get_frames(ix2));
 
     static_cast<PhysicalOffsetFrame&>(upd_frames(ix1)).setParentFrame(frame1);
     static_cast<PhysicalOffsetFrame&>(upd_frames(ix2)).setParentFrame(frame2);
@@ -333,8 +333,8 @@ TwoFrameLinker<C, F>::TwoFrameLinker(const std::string &name,
     int ix2 = append_frames(frame2Offset);
     this->finalizeFromProperties();
 
-    this->template updConnector<F>("frame1").connect(get_frames(ix1));
-    this->template updConnector<F>("frame2").connect(get_frames(ix2));
+    this->connectConnector_frame1(get_frames(ix1));
+    this->connectConnector_frame2(get_frames(ix2));
 }
 
 template <class C, class F>

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -70,8 +70,8 @@ Joint::Joint(const std::string &name, const PhysicalFrame& parent,
     setName(name);
     set_reverse(reverse);
 
-    updConnector<PhysicalFrame>("parent_frame").connect(parent);
-    updConnector<PhysicalFrame>("child_frame").connect(child);
+    connectConnector_parent_frame(parent);
+    connectConnector_child_frame(child);
 }
 
 /* Convenience Constructor*/
@@ -130,8 +130,8 @@ Joint::Joint(const std::string &name,
     static_cast<PhysicalOffsetFrame&>(upd_frames(pix)).setParentFrame(parent);
     static_cast<PhysicalOffsetFrame&>(upd_frames(cix)).setParentFrame(child);
 
-    updConnector<PhysicalFrame>("parent_frame").connect(upd_frames(pix));
-    updConnector<PhysicalFrame>("child_frame").connect(upd_frames(cix));
+    connectConnector_parent_frame(upd_frames(pix));
+    connectConnector_child_frame(upd_frames(cix));
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/WeldConstraint.cpp
@@ -158,7 +158,7 @@ void WeldConstraint::
         _internalOffset1.reset(new PhysicalOffsetFrame(frame1, in1));
         _internalOffset1->setName("internal_" + frame1.getName());
         updProperty_frames().adoptAndAppendValue(_internalOffset1.get());
-        updConnector<PhysicalFrame>("frame1").connect(*_internalOffset1);
+        connectConnector_frame1(*_internalOffset1);
     }
     else { // otherwise it is already "wired" up so just update
         _internalOffset1->setOffsetTransform(in1);
@@ -168,7 +168,7 @@ void WeldConstraint::
         _internalOffset2.reset(new PhysicalOffsetFrame(frame2, in2));
         _internalOffset2->setName("internal_" + frame2.getName());
         updProperty_frames().adoptAndAppendValue(_internalOffset2.get());
-        updConnector<PhysicalFrame>("frame2").connect(*_internalOffset2);
+        connectConnector_frame2(*_internalOffset2);
     }
     else {
         _internalOffset2->setOffsetTransform(in2);

--- a/OpenSim/Simulation/Test/testNestedModelComponents.cpp
+++ b/OpenSim/Simulation/Test/testNestedModelComponents.cpp
@@ -81,11 +81,11 @@ void testPendulumModelWithNestedJoints()
     // Create WeldJoints to anchor cuff Bodies to the pendulum.
     auto* anchorA = new WeldJoint();
     anchorA->setName("anchorA");
-    anchorA->updConnector("child_frame").connect(*cuffA);
+    anchorA->connectConnector_child_frame(*cuffA);
 
     auto* anchorB = new WeldJoint();
     anchorB->setName("anchorB");
-    anchorB->updConnector("child_frame").connect(*cuffB);
+    anchorB->connectConnector_child_frame(*cuffB);
 
     // add anchors to the Device
     device->addComponent(anchorA);
@@ -97,8 +97,8 @@ void testPendulumModelWithNestedJoints()
     // Connect the device to bodies of the pendulum
     const auto& rod1 = pendulum->getComponent<OpenSim::Body>("rod1");
     const auto& rod2 = pendulum->getComponent<OpenSim::Body>("rod2");
-    anchorA->updConnector("parent_frame").connect(rod1);
-    anchorB->updConnector("parent_frame").connect(rod2);
+    anchorA->connectConnector_parent_frame(rod1);
+    anchorB->connectConnector_parent_frame(rod2);
 
     State& s = pendulum->initSystem();
 }

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -204,8 +204,9 @@ TAB_SIZE               = 4
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES                = "propmethods=\par Methods related to this property\n" \
-                         "inputmethods=\par Methods related to this input\n"
+ALIASES = "propmethods=\par Methods related to this property\n"               \
+          "inputmethods=\par Methods related to this input\n"                 \
+          "connectormethods=\par Methods related to this connector\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding


### PR DESCRIPTION
This PR is the counterpart to #1441 for connectors. The original plan was to rename connectors to sockets first before introducing the `connectSocket_*()` macro function. But we decided to switch the order of these changes, since having the macro-generated method in place for the alpha release is perhaps more important than having the rename to sockets for the alpha.

This is my second attempt at creating this PR, as #1446 shows an outdated diff (from before #1441 was merged).