### PR TITLE
[CMake] Update comment to help users building Matlab wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,9 +371,9 @@ if(WIN32 AND ${CMAKE_C_COMPILER} MATCHES "cl")
 
 endif()
 
-set(BUILD_JAVA_WRAPPING OFF CACHE BOOL "Build Java wrapping (needed if you're building the GUI and have SWIG and Java installed on your machine.)")
+set(BUILD_JAVA_WRAPPING OFF CACHE BOOL "Build Java wrapping (needed if you're building the GUI or the Matlab wrapping; requires that you have SWIG and Java installed on your machine.)")
 
-set(BUILD_PYTHON_WRAPPING OFF CACHE BOOL "Build Python wrapping (needed if you're building the Python wrapping and have SWIG and Python installed on your machine.)")
+set(BUILD_PYTHON_WRAPPING OFF CACHE BOOL "Build Python wrapping (needed if you're building the Python wrapping; requires that you have SWIG and Python installed on your machine.)")
 
 if(${BUILD_JAVA_WRAPPING})
     # If we can find a MATLAB installation, we'll try to run some MATLAB tests.


### PR DESCRIPTION
If building Python wrapping, it is clear that the `BUILD_PYTHON_WRAPPING` flag will need to be true, but there is no analogous `BUILD_MATLAB_WRAPPING` flag and the `BUILD_JAVA_WRAPPING` flag currently mentions only the GUI.