### PR TITLE
Instruct users to check Matlab's JVM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ On Windows using Visual Studio
       intermediate; good for TortoiseSVN users;
     * [GitHub for Windows](https://windows.github.com/), easiest.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
-    * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
+    * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
+        * Note: Older versions of Matlab may use an older version of JVM. Run
+                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
     * **python scripting** (optional):
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
@@ -448,7 +450,9 @@ ctest -j8
     * Xcode Command Line Tools gives you git on the command line.
     * [GitHub for Mac](https://mac.github.com), for a simple-to-use GUI.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
-    * **MATLAB scripting** (optional): [Java development kit][java] 1.7.
+    * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
+        * Note: Older versions of Matlab may use an older version of JVM. Run
+                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
     * **python scripting** (optional):
         * Mac OSX comes with python, but you could also use:
         * [`brew install python`](http://brew.sh),
@@ -646,6 +650,8 @@ specific Ubuntu versions under 'For the impatient' below.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6; must get from SWIG website.
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7;
       `openjdk-6-jdk` or `openjdk-7-jdk`.
+        * Note: Older versions of Matlab may use an older version of JVM. Run
+                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
     * **python scripting** (optional): `python-dev`.
 
 For example, you could get the required dependencies (except Simbody) via:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ include source code for the OpenSim GUI.
 Simple example
 --------------
 Let's simulate a simple arm whose elbow is actuated by a muscle, using 
-the C++ interface (You can find a python version of this example at 
+the C++ interface (You can find a Python version of this example at 
 `Bindings/Python/examples/build_simple_arm_model.py`):
 
 ```cpp
@@ -195,9 +195,9 @@ On Windows using Visual Studio
     * [GitHub for Windows](https://windows.github.com/), easiest.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
-        * Note: Older versions of Matlab may use an older version of JVM. Run
-                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
-    * **python scripting** (optional):
+        * Note: Older versions of MATLAB may use an older version of JVM. Run
+                'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
+    * **Python scripting** (optional):
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
     * The choice between 32-bit/64-bit must be the same between Java, Python,
@@ -451,10 +451,10 @@ ctest -j8
     * [GitHub for Mac](https://mac.github.com), for a simple-to-use GUI.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
-        * Note: Older versions of Matlab may use an older version of JVM. Run
-                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
-    * **python scripting** (optional):
-        * Mac OSX comes with python, but you could also use:
+        * Note: Older versions of MATLAB may use an older version of JVM. Run
+                'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
+    * **Python scripting** (optional):
+        * Mac OSX comes with Python, but you could also use:
         * [`brew install python`](http://brew.sh),
         * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
@@ -553,8 +553,8 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above. CMake sets `PYTHON_*` variables to tell you the
-      Python it will use for building the wrappers. (If you installed python
-      with homebrew, [CMake will not find the homebrew python libraries on its
+      Python it will use for building the wrappers. (If you installed Python
+      with Homebrew, [CMake will not find the Homebrew Python libraries on its
       own](https://github.com/Homebrew/homebrew/issues/25118); you must set the
       CMake variable `PYTHON_LIBRARIES` manually. Use `'$(python-config
       --prefix)/lib/libpython2.7.dylib'` in bash to get the correct value.)
@@ -650,9 +650,9 @@ specific Ubuntu versions under 'For the impatient' below.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6; must get from SWIG website.
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7;
       `openjdk-6-jdk` or `openjdk-7-jdk`.
-        * Note: Older versions of Matlab may use an older version of JVM. Run
-                'ver' in Matlab to check Matlab's JVM version (must be >= 1.7).
-    * **python scripting** (optional): `python-dev`.
+        * Note: Older versions of MATLAB may use an older version of JVM. Run
+                'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
+    * **Python scripting** (optional): `python-dev`.
 
 For example, you could get the required dependencies (except Simbody) via:
 


### PR DESCRIPTION
Matlab's JVM version must be at least 1.7 (to agree with the version required by CMake). It's possible to build against an older version of JDK and modify the CMake file (or, alternatively, to update Matlab's JVM). I don't think it's necessary to explain all that in the README, but I do think it would be helpful to let users know about this issue.