### PR TITLE
Allow constructing WrapObjects in bindings.

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -205,7 +205,14 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
   }
 %}
 
-
+%javamethodmodifiers OpenSim::PhysicalFrame::addWrapObject "private";
+%rename OpenSim::PhysicalFrame::addWrapObject private_addWrapObject;
+%typemap(javacode) OpenSim::PhysicalFrame %{
+  public void addWrapObject(WrapObject wrapObject) {
+      wrapObject.markAdopted();
+      private_addWrapObject(wrapObject);
+  }
+%}
 
 %import "java_common.i"
 

--- a/Bindings/Java/tests/TestModelBuilding.java
+++ b/Bindings/Java/tests/TestModelBuilding.java
@@ -55,6 +55,20 @@ class TestModelBuilding {
         arm.updCoordinateSet().get(1).setValue(state, 0.5*3.14);
         arm.equilibrateMuscles(state);
 
+        // WrapObjects.
+        WrapSphere sphere = new WrapSphere();
+        arm.getGround().addWrapObject(sphere);
+
+        WrapCylinder cylinder = new WrapCylinder();
+        cylinder.set_radius(0.5);
+        arm.getGround().addWrapObject(cylinder);
+
+        WrapTorus torus = new WrapTorus();
+        arm.getGround().addWrapObject(torus);
+
+        WrapEllipsoid ellipsoid = new WrapEllipsoid();
+        arm.getGround().addWrapObject(ellipsoid);
+
         System.out.println("Test finished!");
     }
     catch (IOException ex){

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -80,6 +80,10 @@ MODEL_ADOPT_HELPER(Controller);
     geom._markAdopted()
 %}
 
+%pythonappend OpenSim::PhysicalFrame::addWrapObject %{
+    wrapObject._markAdopted()
+%}
+
 // PrescribedController::prescribeControlForActuator takes ownership of
 // the passed-in function.
 // There are two overloads of this function; we append to both of them.

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -71,3 +71,22 @@ class TestBasics(unittest.TestCase):
         manager.setInitialTime(0)
         manager.setFinalTime(0.00001)
         manager.integrate(state)
+
+    def test_WrapObject(self):
+        # Make sure the WrapObjects are accessible.
+        model = osim.Model()
+
+        sphere = osim.WrapSphere()
+        model.getGround().addWrapObject(sphere)
+
+        cylinder = osim.WrapCylinder()
+        cylinder.set_radius(0.5)
+        model.getGround().addWrapObject(cylinder)
+
+        torus = osim.WrapTorus()
+        model.getGround().addWrapObject(torus)
+
+        ellipsoid = osim.WrapEllipsoid()
+        model.getGround().addWrapObject(ellipsoid)
+
+        

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -20,7 +20,8 @@
 %include <OpenSim/Simulation/MomentArmSolver.h>
 
 %include <OpenSim/Simulation/Model/Frame.h>
-// Following three lines hacked in out of order to work around WrapObjects use in PhysicalFrame
+// Following three lines hacked in out of order to work around WrapObjects use
+// in PhysicalFrame
 %include <OpenSim/Simulation/Wrap/WrapObject.h>
 %template(SetWrapObject) OpenSim::Set<OpenSim::WrapObject>;
 %include <OpenSim/Simulation/Wrap/WrapObjectSet.h>
@@ -136,7 +137,7 @@
 %template(ModelComponentSetMarkers) OpenSim::ModelComponentSet<OpenSim::Marker>;
 %include <OpenSim/Simulation/Model/MarkerSet.h>
 
-//%include <OpenSim/Simulation/Wrap/WrapObject.h>
+// WrapObject is included up above.
 %include <OpenSim/Simulation/Wrap/WrapSphere.h>
 %include <OpenSim/Simulation/Wrap/WrapCylinder.h>
 %include <OpenSim/Simulation/Wrap/WrapTorus.h>

--- a/OpenSim/Simulation/Wrap/WrapCylinder.h
+++ b/OpenSim/Simulation/Wrap/WrapCylinder.h
@@ -60,15 +60,16 @@ public:
     std::string getDimensionsString() const override;
     void scale(const SimTK::Vec3& aScaleFactors) override;
 
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
+    // WrapTorus uses WrapCylinder::wrapLine.
+    friend class WrapTorus;
+
     /// Implement generateDecorations to draw geometry in visualizer
     void generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
 
-protected:
     void extendFinalizeFromProperties() override;
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapCylinderObst.h
+++ b/OpenSim/Simulation/Wrap/WrapCylinderObst.h
@@ -95,11 +95,9 @@ public:
     std::string getDimensionsString() const override;
     void scale(const SimTK::Vec3& aScaleFactors) override { }
     void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
-protected:
     void setupProperties();
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.h
+++ b/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.h
@@ -120,11 +120,9 @@ public:
     std::string getDimensionsString() const override;
     void scale(const SimTK::Vec3& aScaleFactors) override { }
     virtual void connectToModelAndBody(Model& aModel, OpenSim::Body& aBody);
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
-protected:
     void setupProperties();
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapEllipsoid.h
+++ b/OpenSim/Simulation/Wrap/WrapEllipsoid.h
@@ -81,15 +81,13 @@ public:
 
     void scale(const SimTK::Vec3& aScaleFactors) override;
     void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
     /// Implement generateDecorations to draw geometry in visualizer
     void generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
 
-protected:
     void setupProperties();
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapObject.h
+++ b/OpenSim/Simulation/Wrap/WrapObject.h
@@ -131,6 +131,7 @@ public:
                          const PathWrap& aPathWrap,
                          WrapResult& aWrapResult) const;
 
+protected:
     virtual int wrapLine(const SimTK::State& state,
                          SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
                          const PathWrap& aPathWrap,
@@ -138,7 +139,6 @@ public:
 
     virtual void updateGeometry() {};
 
-protected:
    /** Determine the appropriate values of _quadrant, _wrapAxis, and _wrapSign,
      * based on the name of the quadrant. finalizeFromProperties() should be
      * called whenever the quadrant property changes. */

--- a/OpenSim/Simulation/Wrap/WrapSphere.h
+++ b/OpenSim/Simulation/Wrap/WrapSphere.h
@@ -73,14 +73,12 @@ public:
 
     void scale(const SimTK::Vec3& aScaleFactors) override;
     void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
     /// Implement generateDecorations to draw geometry in visualizer
     void generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
-protected:
     void setupProperties();
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapSphereObst.h
+++ b/OpenSim/Simulation/Wrap/WrapSphereObst.h
@@ -78,11 +78,9 @@ public:
     std::string getDimensionsString() const override;
     void scale(const SimTK::Vec3& aScaleFactors) override { }
     void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
-protected:
     void setupProperties();
 
 private:

--- a/OpenSim/Simulation/Wrap/WrapTorus.h
+++ b/OpenSim/Simulation/Wrap/WrapTorus.h
@@ -82,14 +82,12 @@ public:
 
     void scale(const SimTK::Vec3& aScaleFactors) override;
     void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
-#ifndef SWIG
+protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
-#endif
     /// Implement generateDecorations to draw geometry in visualizer
     void generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
-protected:
     void setupProperties();
 
 private:


### PR DESCRIPTION
This PR fixes #1457 and thus allows users to construct WrapObjects in MATLAB/Python.

I worked on this as part of the project of converting the hopper device example to MATLAB.