### PR TITLE
[Step 2] Improved interface for connecting Components

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -211,7 +211,7 @@ void Component::componentsFinalizeFromProperties() const
 }
 
 // Base class implementation of non virtual connect method.
-void Component::connect(Component &root)
+void Component::finalizeConnections(Component &root)
 {
     if (!isObjectUpToDateWithProperties()){
         // if edits occur between construction and connect() this is
@@ -278,27 +278,27 @@ void Component::componentsConnect(Component& root)
 {
     // enable the subcomponents the opportunity to connect themselves
     for (unsigned int i = 0; i<_memberSubcomponents.size(); ++i) {
-        _memberSubcomponents[i].upd()->connect(root);
+        _memberSubcomponents[i].upd()->finalizeConnections(root);
     }
     for(unsigned int i=0; i<_propertySubcomponents.size(); ++i){
-        _propertySubcomponents[i].get()->connect(root);
+        _propertySubcomponents[i].get()->finalizeConnections(root);
     }
     for (unsigned int i = 0; i<_adoptedSubcomponents.size(); ++i) {
-        _adoptedSubcomponents[i].upd()->connect(root);
+        _adoptedSubcomponents[i].upd()->finalizeConnections(root);
     }
 }
 
-void Component::disconnect()
+void Component::clearConnections()
 {
     // First give the subcomponents the opportunity to disconnect themselves
     for (unsigned int i = 0; i<_memberSubcomponents.size(); i++) {
-        _memberSubcomponents[i]->disconnect();
+        _memberSubcomponents[i]->clearConnections();
     }
     for (unsigned int i = 0; i<_propertySubcomponents.size(); i++){
-        _propertySubcomponents[i]->disconnect();
+        _propertySubcomponents[i]->clearConnections();
     }
     for (unsigned int i = 0; i<_adoptedSubcomponents.size(); i++) {
-        _adoptedSubcomponents[i]->disconnect();
+        _adoptedSubcomponents[i]->clearConnections();
     }
 
     //Now cycle through and disconnect all connectors for this component

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -210,7 +210,7 @@ void Component::componentsFinalizeFromProperties() const
     }
 }
 
-// Base class implementation of non virtual connect method.
+// Base class implementation of non-virtual finalizeConnections method.
 void Component::finalizeConnections(Component &root)
 {
     if (!isObjectUpToDateWithProperties()){

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -387,11 +387,11 @@ public:
 
     /** Connect this Component to its aggregate component, which is the root
         of a tree of components.*/
-    void connect(Component& root);
+    void finalizeConnections(Component& root);
 
-    /** Disconnect this Component from its aggregate component. Empties all
-        component's connectors and sets them as disconnected.*/
-    void disconnect();
+    /** Disconnect/clear this Component from its aggregate component. Empties 
+        all component's connectors and sets them as disconnected.*/
+    void clearConnections();
 
     /** Have the Component add itself to the underlying computational System */
     void addToSystem(SimTK::MultibodySystem& system) const;

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -76,7 +76,7 @@ public:
 
     // Top level connection method for this all encompassing component, TheWorld
     void connect() {
-        Super::connect(*this);
+        Super::finalizeConnections(*this);
     }
     void buildUpSystem(MultibodySystem& system) { 
         connect();
@@ -1115,7 +1115,8 @@ void testInputOutputConnections()
         system.realize(s, Stage::Model);
         // The following will work, now that the connection is satisfied.
         b->getInput<double>("in1").getValue(s, 0);
-        b->disconnect(); // Disconnect to get the "not connected"exception.
+        // Disconnect to get the "not connected"exception.
+        b->clearConnections(); 
         SimTK_TEST_MUST_THROW_EXC(b->getInput<double>("in1").getValue(s, 0),
                 InputNotConnected);
     }

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -605,7 +605,7 @@ void Model::createMultibodyTree()
         // Currently we need to take a first pass at connecting the joints
         // in order to ask the joint for the frames that they attach to and
         // to determine their underlying base (physical) frames.
-        joint->connect(*this);
+        joint->finalizeConnections(*this);
 
         // hack to make sure underlying Frame is also connected so it can 
         // traverse to the base frame and get its name. This allows the
@@ -614,8 +614,10 @@ void Model::createMultibodyTree()
         // TODO: try to create the multibody tree later when components
         // can already be expected to be connected then traverse those
         // relationships to create the multibody tree. -aseth
-        const_cast<PhysicalFrame&>(joint->getParentFrame()).connect(*this);
-        const_cast<PhysicalFrame&>(joint->getChildFrame()).connect(*this);
+        const_cast<PhysicalFrame&>(joint->getParentFrame()).
+            finalizeConnections(*this);
+        const_cast<PhysicalFrame&>(joint->getChildFrame()).
+            finalizeConnections(*this);
 
         // Use joints to define the underlying multibody tree
         _multibodyTree.addJoint(name,
@@ -783,7 +785,7 @@ void Model::extendConnectToModel(Model &model)
         // PhysicalOffsetFrame can be listed in any order and may be attached
         // to any other PhysicalOffsetFrame, so we need to find their parent(s)
         // in the tree and add them first.
-        pof.connect(*this);
+        pof.finalizeConnections(*this);
         const PhysicalOffsetFrame* parentPof =
             dynamic_cast<const PhysicalOffsetFrame*>(&pof.getParentFrame());
         std::vector<const PhysicalOffsetFrame*> parentPofs;
@@ -952,7 +954,7 @@ void Model::addProbe(OpenSim::Probe *probe)
  */
 void Model::removeProbe(OpenSim::Probe *aProbe)
 {
-    disconnect();
+    clearConnections();
     updProbeSet().remove(aProbe);
     finalizeFromProperties();
 }
@@ -993,7 +995,7 @@ void Model::setup()
     // automatically marks properties that are Components as subcomponents
     finalizeFromProperties();
     //now connect the Model and all its subcomponents all up
-    connect(*this);
+    finalizeConnections(*this);
 }
 
 //_____________________________________________________________________________
@@ -1004,7 +1006,7 @@ void Model::setup()
  */
 void Model::cleanup()
 {
-    disconnect();
+    clearConnections();
     upd_ForceSet().setSize(0);
 }
 

--- a/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.cpp
+++ b/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.cpp
@@ -615,7 +615,7 @@ void Umberger2010MuscleMetabolicsProbe::
             << muscleName << "' specified. No metabolic muscles removed." << endl;
         return;
     }
-    disconnect();
+    clearConnections();
     upd_Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameterSet().remove(k);
 }
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1440,11 +1440,11 @@ void testPinJoint()
     // use the same coordinate name
     knee3.upd_coordinates(0).setName("knee_q");
 
-    knee3.connect(*osimModel);
+    knee3.finalizeConnections(*osimModel);
     knee3.dumpConnections();
     knee3.dumpSubcomponents();
 
-    knee.connect(*osimModel);
+    knee.finalizeConnections(*osimModel);
     knee.dumpConnections();
     knee.dumpSubcomponents();
 


### PR DESCRIPTION
Implementing step 2 of #1219.
Rename: 
* Component::connect to Component::finalizeConnections.
* Component::disconnect to Component::clearConnections.

@tkuchida @aseth1 