### PR TITLE
[doxygen] Remove "pre-4.0" in description of createFromStatesStorage

### DIFF
--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -404,9 +404,9 @@ public:
         }
     };
 
-    /// @name Create partial trajectory from pre-4.0 files
+    /// @name Create partial trajectory from a states Storage
     /// @{
-    /** Create a partial trajectory of States from a (pre-4.0) states Storage
+    /** Create a partial trajectory of States from a states Storage
      * object. The resulting StatesTrajectory will restore continuous state
      * variable values, but not discrete state variable values, modeling
      * option values, etc. Also, keep in mind that states Storage files usually


### PR DESCRIPTION
We had thought that 4.0 would contain an XML file format for state objects; we no longer think this will happen. So this PR removes the "pre-4.0" language with regard to states storage objects/files.