### PR TITLE
Add transpose to RowVector & Vector for Python/Java

### DIFF
--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -696,6 +696,7 @@ class TestTables {
 
     public static void test_vector_rowvector() {
         {
+        System.out.println("Test transpose RowVector to Vector.");
         RowVector rowVec = new RowVector(4);
         for(int i = 0; i < 4; ++i)
             rowVec.set(i, i);
@@ -703,12 +704,14 @@ class TestTables {
         assert colVec.size() == 4;
         for(int i = 0; i < 4; ++i)
             assert colVec.get(i) == i;
+        System.out.println("Test transpose Vector to RowVector.");
         RowVector rowVec_copy = colVec.transpose();
         assert rowVec_copy.size() == 4;
         for(int i = 0; i < 4; ++i)
             assert rowVec_copy.get(i) == i;
         }
         {
+        System.out.println("Test transpose RowVectorOfVec3 to VectorOfVec3.");
         StdVectorVec3 elems = new StdVectorVec3();
         for(int i = 0; i < 4; ++i)
             elems.add(new Vec3(i, i+1, i+2)); 
@@ -719,6 +722,7 @@ class TestTables {
             assert colVec.get(i).get(0) == i &&
                    colVec.get(i).get(1) == i+1 &&
                    colVec.get(i).get(2) == i+2;
+        System.out.println("Test transpose VectorOfVec3 to RowVectorOfVec3.");
         RowVectorOfVec3 rowVec_copy = colVec.transpose();
         assert rowVec_copy.size() == 4;
         for(int i = 0; i < 4; ++i)

--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -694,11 +694,46 @@ class TestTables {
         ikTool.run();
     }
 
+    public static void test_vector_rowvector() {
+        {
+        RowVector rowVec = new RowVector(4);
+        for(int i = 0; i < 4; ++i)
+            rowVec.set(i, i);
+        Vector colVec = rowVec.transpose();
+        assert colVec.size() == 4;
+        for(int i = 0; i < 4; ++i)
+            assert colVec.get(i) == i;
+        RowVector rowVec_copy = colVec.transpose();
+        assert rowVec_copy.size() == 4;
+        for(int i = 0; i < 4; ++i)
+            assert rowVec_copy.get(i) == i;
+        }
+        {
+        StdVectorVec3 elems = new StdVectorVec3();
+        for(int i = 0; i < 4; ++i)
+            elems.add(new Vec3(i, i+1, i+2)); 
+        RowVectorOfVec3 rowVec = new RowVectorOfVec3(elems);
+        VectorOfVec3 colVec = rowVec.transpose();
+        assert colVec.size() == 4;
+        for(int i = 0; i < 4; ++i)
+            assert colVec.get(i).get(0) == i &&
+                   colVec.get(i).get(1) == i+1 &&
+                   colVec.get(i).get(2) == i+2;
+        RowVectorOfVec3 rowVec_copy = colVec.transpose();
+        assert rowVec_copy.size() == 4;
+        for(int i = 0; i < 4; ++i)
+            assert rowVec_copy.get(i).get(0) == i &&
+                   rowVec_copy.get(i).get(1) == i+1 &&
+                   rowVec_copy.get(i).get(2) == i+2;
+        }
+    }
+
     public static void main(String[] args)  throws java.io.IOException {
         test_DataTable();
         test_DataTableVec3();
         test_TimeSeriesTable();
         test_TimeSeriesTableVec3();
         test_FlattenWithIK();
+        test_vector_rowvector();
     }
 }

--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -5,6 +5,35 @@ import os, unittest
 import opensim as osim
 
 class TestDataTable(unittest.TestCase):
+    def test_vector_rowvector(self):
+        print
+        print 'Test transpose RowVector to Vector.'
+        row = osim.RowVector([1, 2, 3, 4])
+        col = row.transpose()
+        assert (col[0] == row[0] and
+                col[1] == row[1] and
+                col[2] == row[2] and
+                col[3] == row[3])
+        print 'Test transpose Vector to RowVector.'
+        row_copy = col.transpose()
+        assert (row_copy[0] == row[0] and
+                row_copy[1] == row[1] and
+                row_copy[2] == row[2] and
+                row_copy[3] == row[3])
+        print 'Test transpose RowVectorOfVec3 to VectorOfVec3.'
+        row = osim.RowVectorOfVec3([osim.Vec3(1, 2, 3), 
+                                    osim.Vec3(4, 5, 6),
+                                    osim.Vec3(7, 8, 9)])
+        col = row.transpose()
+        assert (str(col[0]) == str(row[0]) and
+                str(col[1]) == str(row[1]) and
+                str(col[2]) == str(row[2]))
+        print 'Test transpose VectorOfVec3 to RowVectorOfVec3.'
+        row_copy = col.transpose()
+        assert (str(row_copy[0]) == str(row[0]) and
+                str(row_copy[1]) == str(row[1]) and
+                str(row_copy[2]) == str(row[2]))
+    
     def test_DataTable(self):
         print
         table = osim.DataTable()

--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -55,6 +55,10 @@ namespace SimTK {
          return new RowVector_<double>{static_cast<int>(row.size()),
                                        row.data()};
      }
+
+     Vector_<double> transpose() {
+         return $self->operator~();
+     }
  }
 %extend VectorBase<double> {
      double __getitem__(size_t i) {
@@ -75,6 +79,10 @@ namespace SimTK {
      Vector_(const std::vector<double>& row) {
          return new Vector_<double>{static_cast<int>(row.size()),
                                     row.data()};
+     }
+
+     RowVector_<double> transpose() {
+         return $self->operator~();
      }
  }
 %template(MatrixBaseDouble)    SimTK::MatrixBase<double>;
@@ -108,6 +116,13 @@ namespace SimTK {
          return new RowVector_<Vec3>{static_cast<int>(row.size()),
                                      row.data()};
      }
+
+     Vector_<Vec3> transpose() {
+         Vector_<Vec3> colVec{static_cast<int>($self->nelt())};
+         for(unsigned i = 0; i < colVec.nelt(); ++i)
+             colVec[i] = $self->operator[](i);
+         return colVec;
+     }
  }
 %extend VectorBase<Vec3> {
      Vec3 __getitem__(size_t i) {
@@ -128,6 +143,13 @@ namespace SimTK {
      Vector_(const std::vector<Vec3>& row) {
          return new Vector_<Vec3>{static_cast<int>(row.size()),
                                   row.data()};
+     }
+
+     RowVector_<Vec3> transpose() {
+         RowVector_<Vec3> rowVec{static_cast<int>($self->nelt())};
+         for(unsigned i = 0; i < rowVec.nelt(); ++i)
+             rowVec[i] = $self->operator[](i);
+         return rowVec;
      }
  }
 %template(MatrixBaseVec3)    SimTK::MatrixBase<Vec3>;


### PR DESCRIPTION
Addressing #849.

The solution in C++ is mentioned in the above issue. This PR addresses the problem for Python/Java by adding `transpose()` to `Vector`, `RowVector` and their `Vec3` variants.