### PR TITLE
Fix segfault when realizing to Dynamics after createFromStatesStorage()

### DIFF
--- a/Bindings/Python/tests/test_states_trajectory.py
+++ b/Bindings/Python/tests/test_states_trajectory.py
@@ -78,6 +78,7 @@ class TestStatesTrajectory(unittest.TestCase):
         # wrapping works.
         model = osim.Model(os.path.join(test_dir,
             "gait10dof18musc_subject01.osim"))
+        model.initSystem()
         sto = osim.Storage(self.states_sto_fname)
         states = osim.StatesTrajectory.createFromStatesStorage(
                 model, sto)

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -76,6 +76,21 @@ class ScaleSet;
 //==============================================================================
 /// Model  Exceptions
 //==============================================================================
+class ModelHasNoSystem : public Exception {
+public:
+    ModelHasNoSystem(const std::string& file, size_t line,
+            const std::string& func,
+            const std::string& modelName) :
+                OpenSim::Exception(file, line, func) {
+        std::string msg = "You must first call initSystem() on your Model";
+        if (!modelName.empty()) {
+            msg += " '" + modelName + "'";
+        }
+        msg += ".";
+        addMessage(msg);
+    }
+};
+
 class PhysicalOffsetFramesFormLoop : public Exception {
 public:
     PhysicalOffsetFramesFormLoop(const std::string& file,

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -76,11 +76,11 @@ bool StatesTrajectory::isConsistent() const {
     // An empty or size-1 trajectory is necessarily consistent.
     if (getSize() <= 1) return true;
 
-    const auto& state0 = get(0);
+    const auto& state0 = operator[](0);
 
     for (unsigned itime = 1; itime < getSize(); ++itime) {
 
-        if (!state0.isConsistent(get(itime))) {
+        if (!state0.isConsistent(operator[](itime))) {
             return false;
         }
 
@@ -173,11 +173,10 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
     // This is what we'll return.
     StatesTrajectory states;
 
-    // Make a copy of the model so that we can get a corresponding state.
-    Model localModel(model);
-
+    OPENSIM_THROW_IF(!model.hasSystem(), ModelHasNoSystem, model.getName());
+    
     // We'll keep editing this state as we loop through time.
-    auto state = localModel.initSystem();
+    auto state = model.getWorkingState();
 
     // The labels of the columns in the storage file.
     const auto& stoLabels = sto.getColumnLabels();
@@ -203,7 +202,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
 
     // Check if states are missing from the Storage.
     // ---------------------------------------------
-    const auto& modelStateNames = localModel.getStateVariableNames();
+    const auto& modelStateNames = model.getStateVariableNames();
     std::vector<std::string> missingColumnNames;
     // Also, assemble the names of the states that we will actually set in the
     // trajectory, along with the corresponding state index.
@@ -219,7 +218,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
     }
     OPENSIM_THROW_IF(!allowMissingColumns && !missingColumnNames.empty(),
             MissingColumnsInStatesStorage, 
-            localModel.getName(), missingColumnNames);
+            model.getName(), missingColumnNames);
 
     // Check if the Storage has columns that are not states in the Model.
     // ------------------------------------------------------------------
@@ -235,7 +234,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
                     extraColumnNames.push_back(stoLabels[ic]);
                 }
             }
-            OPENSIM_THROW(ExtraColumnsInStatesStorage, localModel.getName(),
+            OPENSIM_THROW(ExtraColumnsInStatesStorage, model.getName(),
                     extraColumnNames);
         }
     }
@@ -261,12 +260,12 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
 
         // Put in NaNs for state variable values not in the Storage.
         for (const auto& stateName : missingColumnNames) {
-            localModel.setStateVariableValue(state, stateName, SimTK::NaN);
+            model.setStateVariableValue(state, stateName, SimTK::NaN);
         }
 
         // Fill up current State with the data for the current time.
         for (const auto& kv : statesToFillUp) {
-            localModel.setStateVariableValue(state,
+            model.setStateVariableValue(state,
                     kv.second, dependentValues[kv.first]);
         }
 

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -321,6 +321,22 @@ public:
     };
 #endif
 
+    /** Thrown by createFromStatesStorage(). */
+    class ModelHasNoSystem : public Exception {
+    public:
+        ModelHasNoSystem(const std::string& file, size_t line,
+                const std::string& func,
+                const std::string& modelName) :
+                    OpenSim::Exception(file, line, func) {
+            std::string msg = "You must first call initSystem() on your Model";
+            if (!modelName.empty()) {
+                msg += " '" + modelName + "'";
+            }
+            msg += ".";
+            addMessage(msg);
+        }
+    };
+
     /** Thrown when trying to create a StatesTrajectory from a states Storage,
      * and the Storage does not contain a column for every continuous state
      * variable. */
@@ -414,6 +430,9 @@ public:
      * exactly reproduce results from the initial state trajectory; constraints
      * may not be satisfied, etc.
      *
+     * The states in the resulting trajectory will be realized to
+     * SimTK::Stage::Instance.
+     *
      * @note The naming convention for state variables changed in OpenSim v4.0;
      * `ankle_r/ankle_angle_r/speed` used to be `ankle_angle_r_u`,
      * `soleus_r/activation` used to be `soleus_r.activation`, etc. This
@@ -433,6 +452,8 @@ public:
      *      ignored.
      *
      * #### Usage
+     * You must have called Model::initSystem() on your model before calling
+     * this function.
      * Here is how you might use this function in python:
      * @code{.py}
      * import opensim
@@ -443,6 +464,9 @@ public:
      * print(states[0].getTime())
      * print(model.getStateVariableValue(states[0], "knee/flexion/value"))
      * @endcode
+     * 
+     * @throws ModelHasNoSystem Thrown if you have not yet called initSystem()
+     *      on the model.
      * 
      * @throws MissingColumnsInStatesStorage See the description of the
      *      `allowMissingColumns` argument.

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -321,22 +321,6 @@ public:
     };
 #endif
 
-    /** Thrown by createFromStatesStorage(). */
-    class ModelHasNoSystem : public Exception {
-    public:
-        ModelHasNoSystem(const std::string& file, size_t line,
-                const std::string& func,
-                const std::string& modelName) :
-                    OpenSim::Exception(file, line, func) {
-            std::string msg = "You must first call initSystem() on your Model";
-            if (!modelName.empty()) {
-                msg += " '" + modelName + "'";
-            }
-            msg += ".";
-            addMessage(msg);
-        }
-    };
-
     /** Thrown when trying to create a StatesTrajectory from a states Storage,
      * and the Storage does not contain a column for every continuous state
      * variable. */
@@ -432,9 +416,9 @@ public:
      *
      * The states in the resulting trajectory will be realized to
      * SimTK::Stage::Instance. You should not use the resulting trajectory with
-     * an instance of the model other than the you pass to this function; the
-     * state contains Instance-stage cache variables that point to force
-     * elements within the model.
+     * an instance of the model other than the one you passed to this function
+     * (the state contains Instance-stage cache variables that are pointers to
+     * objects in the model; e.g., force elements).
      *
      * @note The naming convention for state variables changed in OpenSim v4.0;
      * `ankle_r/ankle_angle_r/speed` used to be `ankle_angle_r_u`,

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -431,7 +431,10 @@ public:
      * may not be satisfied, etc.
      *
      * The states in the resulting trajectory will be realized to
-     * SimTK::Stage::Instance.
+     * SimTK::Stage::Instance. You should not use the resulting trajectory with
+     * an instance of the model other than the you pass to this function; the
+     * state contains Instance-stage cache variables that point to force
+     * elements within the model.
      *
      * @note The naming convention for state variables changed in OpenSim v4.0;
      * `ankle_r/ankle_angle_r/speed` used to be `ankle_angle_r_u`,

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2016 Stanford University and the Authors                     *
+ * Copyright (c) 2005-2016 Stanford University and the Authors                *
  * Author(s): Chris Dembia                                                    *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -36,6 +36,7 @@ using namespace SimTK;
 // TODO detailed exceptions when integrity checks fail.
 // TODO currently, one gets segfaults if state is not realized.
 // TODO accessing acceleration-level outputs.
+// TODO Improve performance of createFromStatesStorage(): it is very slow now.
 
 // Big to-do's:
 // TODO convert to data table (specify which columns).
@@ -181,14 +182,13 @@ void testFromStatesStorageGivesCorrectStates() {
 
     Storage sto(statesStoFname);
 
-    // It's important that we have not yet initialized the model, 
-    // since `createFromStatesStorage()` should be able to work with such a
-    // model.
-    auto states = StatesTrajectory::createFromStatesStorage(model, sto);
+    // This will fail because we have not yet called initSystem() on the model.
+    SimTK_TEST_MUST_THROW_EXC(
+            StatesTrajectory::createFromStatesStorage(model, sto),
+            OpenSim::StatesTrajectory::ModelHasNoSystem);
 
-    // However, we eventually *do* need to call initSystem() to make use of the
-    // trajectory with the model.
     model.initSystem();
+    auto states = StatesTrajectory::createFromStatesStorage(model, sto);
 
     // Test that the states are correct, and also that the iterator works.
     // -------------------------------------------------------------------
@@ -255,9 +255,18 @@ void testFromStatesStorageGivesCorrectStates() {
 
         SimTK_TEST(!model.calcMassCenterVelocity(state).isNaN());
 
-        // TODO acceleration-level stuff gives segfault.
-        // TODO model.getMultibodySystem().realize(state, SimTK::Stage::Acceleration);
-        // TODO SimTK_TEST(!model.calcMassCenterAcceleration(state).isNaN());
+        // Make sure that we can realize to Dynamics without an issue.
+        // There used to be a bug (GitHub Issue #1455) wherein Instance-stage
+        // cache variables contain raw pointers to SimTK::Force objects,
+        // therefore one cannot use such a state with different instances
+        // of the same model.
+        model.getMultibodySystem().realize(state, SimTK::Stage::Dynamics);
+        SimTK_TEST(!SimTK::isNaN(
+                    model.getMuscles().get(0).getActiveFiberForce(state)));
+
+        // Similarly, make sure we can do an acceleration-level calculation.
+        model.getMultibodySystem().realize(state, SimTK::Stage::Acceleration);
+        SimTK_TEST(!model.calcMassCenterAcceleration(state).isNaN());
 
         itime++;
     }
@@ -301,7 +310,6 @@ void testFromStatesStorageInconsistentModel(const std::string &stoFilepath) {
     // ------------------------------------
     {
         Model model("gait2354_simbody.osim");
-        // Needed for getting state variable names.
         model.initSystem();
 
         const auto stateNames = model.getStateVariableNames();
@@ -366,6 +374,9 @@ void testFromStatesStorageInconsistentModel(const std::string &stoFilepath) {
         model.updForceSet().remove(30);
 
         // Test that an exception is thrown.
+        // Must call initSystem() here; otherwise the _propertySubcomponents
+        // would be stale and would still include the forces we removed above.
+        model.initSystem();
         SimTK_TEST_MUST_THROW_EXC(
                 StatesTrajectory::createFromStatesStorage(model, sto),
                 StatesTrajectory::ExtraColumnsInStatesStorage
@@ -391,6 +402,7 @@ void testFromStatesStorageInconsistentModel(const std::string &stoFilepath) {
 void testFromStatesStorageUniqueColumnLabels() {
 
     Model model("gait2354_simbody.osim");
+    model.initSystem();
     Storage sto(statesStoFname);
     
     // Edit column labels so that they are not unique.
@@ -430,6 +442,7 @@ void testFromStatesStoragePre40CorrectStates() {
     Storage sto(pre40StoFname);
     // So the test doesn't take so long.
     sto.resampleLinear(0.01);
+    model.initSystem();
     auto states = StatesTrajectory::createFromStatesStorage(model, sto);
 
     model.initSystem();

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -183,7 +183,7 @@ void testFromStatesStorageGivesCorrectStates() {
     // This will fail because we have not yet called initSystem() on the model.
     SimTK_TEST_MUST_THROW_EXC(
             StatesTrajectory::createFromStatesStorage(model, sto),
-            OpenSim::StatesTrajectory::ModelHasNoSystem);
+            OpenSim::ModelHasNoSystem);
 
     model.initSystem();
     auto states = StatesTrajectory::createFromStatesStorage(model, sto);


### PR DESCRIPTION
This PR fixes #1455.

This PR does the first of the two proposed fixes: requires the user to call `initSystem()` before invoking `createFromStatesStorage()`.

I had explored including the second change of invalidating the Instance-stage cache from the states in the trajectory. However, I ultimately decided against including this change. The reason is that I want users to be able to invoke `statesTraj.isConsistent()` immediately after `createFromStatesStorage()`, and `isConsistent()` requires the states to be realized to the Instance stage (for things like `getNQErr()`).