### PR TITLE
Fix incorrect weighting assignments in MarkersReference

### DIFF
--- a/Applications/IK/test/testIK.cpp
+++ b/Applications/IK/test/testIK.cpp
@@ -84,7 +84,7 @@ void testMarkerWeightAssignments(const std::string& ikSetupFile)
 
     // assign different weightings so we can verify the assignments
     int nt = tasks.getSize();
-    for (int i{ 0 }; i < nt; ++i) {
+    for (int i=0; i < nt; ++i) {
         tasks[i].setWeight(double(i));
     }
 
@@ -95,13 +95,13 @@ void testMarkerWeightAssignments(const std::string& ikSetupFile)
     // perform the check
     checkMarkersReferenceConsistencyFromTool(ik);
 
-    // Now reverse the order and half the number of tasks
+    // Now reverse the order and reduce the number of tasks
     // so that marker and tasks lists are no longer the same
     IKTaskSet tasks2;
     tasks2.setName("half_markers");
 
-    for (int i{ nt / 2 }; i > -1 ; --i) {
-        tasks2.adoptAndAppend(tasks[2*i].clone());
+    for (int i = nt-1; i >= 0 ; i -= 2) {
+        tasks2.adoptAndAppend(tasks[i].clone());
     }
 
     cout << tasks2.dump(true) << endl;
@@ -127,8 +127,7 @@ void testMarkerWeightAssignments(const std::string& ikSetupFile)
     // and one more at the end
     tasks.adoptAndAppend(newMarker);
     tasks.setName("Added superfluous tasks");
-    cout << tasks.dump(true) << endl;
-    
+
     cout << tasks.dump(true) << endl;
     // update the tasks of the IK Tool
     ik.getIKTaskSet() = tasks;

--- a/Applications/IK/test/testIK.cpp
+++ b/Applications/IK/test/testIK.cpp
@@ -153,7 +153,7 @@ void checkMarkersReferenceConsistencyFromTool(InverseKinematicsTool& ik)
     SimTK::Array_<double> weights;
     markersReference.getWeights(state, weights);
 
-    for (auto i{ 0 }; i < names.size(); ++i) {
+    for (unsigned int i=0; i < names.size(); ++i) {
         std::cout << names[i] << ": " << weights[i];
         int ix = tasks.getIndex(names[i]);
         if (ix > -1) {

--- a/OpenSim/Simulation/MarkersReference.cpp
+++ b/OpenSim/Simulation/MarkersReference.cpp
@@ -191,7 +191,8 @@ MarkersReference::updateInternalWeights() const {
         // Associate user weights (as specified in the marker_weights property)
         // with the corresponding marker by order of marker names
         if (wix >= 0)
-            _weights[ix++] = get_marker_weights()[wix].getWeight();
+            _weights[ix] = get_marker_weights()[wix].getWeight();
+        ++ix;
     }
 }
 

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -101,18 +101,21 @@ int main()
 //=============================================================================
 void testMarkersReference()
 {
+    // column labels for marker data
     vector<std::string> labels{ "A", "B", "C", "D", "E", "F" };
+    // for testing construct a set of marker weights is a different order 
+    vector<int> order = { 3, 5, 1, 4, 0, 2 };
+
     size_t nc = labels.size();
     size_t nr = 5;
 
     TimeSeriesTable_<SimTK::Vec3> markerData;
     markerData.setColumnLabels(labels);
     for (size_t r{0}; r < nr; ++r) {
-    SimTK::RowVector_<SimTK::Vec3> row{ int(nc), SimTK::Vec3(0) };
-    markerData.appendRow(0.1*r, row);
+        SimTK::RowVector_<SimTK::Vec3> row{ int(nc), SimTK::Vec3(0) };
+        markerData.appendRow(0.1*r, row);
     }
 
-    vector<int> order = { 3, 5, 1, 4, 0, 2};
     Set<MarkerWeight> markerWeights;
     for (size_t m{0}; m < nc; ++m)
     markerWeights.adoptAndAppend(
@@ -157,7 +160,7 @@ void testMarkersReference()
     SimTK_ASSERT_ALWAYS(names.size() == weights.size(),
         "Number of markers does not match number of weights.");
 
-    for (unsigned int i{ 0 }; i < names.size(); ++i) {
+    for (unsigned int i=0; i < names.size(); ++i) {
         std::cout << names[i] << ": " << weights[i] << std::endl;
         SimTK_ASSERT_ALWAYS(weights[i] == double(i),
             "Mismatched weight to marker.");

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -134,7 +134,7 @@ void testMarkersReference()
     SimTK_ASSERT_ALWAYS(names.size() == weights.size(), 
         "Number of markers does not match number of weights.");
 
-    for (auto i{ 0 }; i < names.size(); ++i) {
+    for (unsigned int i{ 0 }; i < names.size(); ++i) {
         std::cout << names[i] << ": " << weights[i] << std::endl;
         SimTK_ASSERT_ALWAYS(weights[i] == double(i),
             "Mismatched weight to marker.");
@@ -157,7 +157,7 @@ void testMarkersReference()
     SimTK_ASSERT_ALWAYS(names.size() == weights.size(),
         "Number of markers does not match number of weights.");
 
-    for (auto i{ 0 }; i < names.size(); ++i) {
+    for (unsigned int i{ 0 }; i < names.size(); ++i) {
         std::cout << names[i] << ": " << weights[i] << std::endl;
         SimTK_ASSERT_ALWAYS(weights[i] == double(i),
             "Mismatched weight to marker.");

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -518,7 +518,7 @@ void InverseKinematicsTool::updateFromXMLNode(SimTK::Xml::Element& aNode, int ve
 }
 
 void InverseKinematicsTool::populateReferences(MarkersReference& markersReference,
-    SimTK::Array_<CoordinateReference>&coordinateReferences)
+    SimTK::Array_<CoordinateReference>&coordinateReferences) const
 {
     FunctionSet *coordFunctions = NULL;
     // Load the coordinate data

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -287,69 +287,9 @@ bool InverseKinematicsTool::run()
 
         //Convert old Tasks to references for assembly and tracking
         MarkersReference markersReference;
-        Set<MarkerWeight> markerWeights;
         SimTK::Array_<CoordinateReference> coordinateReferences;
-
-        FunctionSet *coordFunctions = NULL;
-        // Load the coordinate data
-        // bool haveCoordinateFile = false;
-        if(_coordinateFileName != "" && _coordinateFileName != "Unassigned"){
-            Storage coordinateValues(_coordinateFileName);
-            // Convert degrees to radian (TODO: this needs to have a check that the storage is, in fact, in degrees!)
-            _model->getSimbodyEngine().convertDegreesToRadians(coordinateValues);
-            // haveCoordinateFile = true;
-            coordFunctions = new GCVSplineSet(5,&coordinateValues);
-        }
-
-        // Loop through old "IKTaskSet" and assign weights to the coordinate and marker references
-        // For coordinates, create the functions for coordinate reference values
-        int index = 0;
-        for(int i=0; i < _ikTaskSet.getSize(); i++){
-            if (!_ikTaskSet[i].getApply()) continue;
-            if(IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&_ikTaskSet[i])){
-                CoordinateReference *coordRef = NULL;
-                if(coordTask->getValueType() == IKCoordinateTask::FromFile){
-                     if (!coordFunctions)
-                        throw Exception("InverseKinematicsTool: value for coordinate "+coordTask->getName()+" not found.");
-
-                     index = coordFunctions->getIndex(coordTask->getName(), index);
-                     if(index >= 0){
-                         coordRef = new CoordinateReference(coordTask->getName(),coordFunctions->get(index));
-                     }
-                }
-                else if((coordTask->getValueType() == IKCoordinateTask::ManualValue)){
-                        Constant reference(Constant(coordTask->getValue()));
-                        coordRef = new CoordinateReference(coordTask->getName(), reference);
-                }
-                else{ // assume it should be held at its default value
-                    double value = _model->getCoordinateSet().get(coordTask->getName()).getDefaultValue();
-                    Constant reference = Constant(value);
-                    coordRef = new CoordinateReference(coordTask->getName(), reference);
-                }
-
-                if(coordRef == NULL)
-                    throw Exception("InverseKinematicsTool: value for coordinate "+coordTask->getName()+" not found.");
-                else
-                    coordRef->setWeight(coordTask->getWeight());
-
-                coordinateReferences.push_back(*coordRef);
-            }
-            else if(IKMarkerTask *markerTask = dynamic_cast<IKMarkerTask *>(&_ikTaskSet[i])){
-                if(markerTask->getApply()){
-                    markerWeights.adoptAndAppend(
-                        new MarkerWeight(markerTask->getName(), markerTask->getWeight()));
-                }
-            }
-        }
-
-        // Set the default weight for markers
-        markersReference.setDefaultWeight(1.0);
-        // Set the weights for markers (markers in the model and the marker file
-        // but not assigned a weight in the markerWeightSet will use the default
-        // weight
-        markersReference.setMarkerWeightSet(markerWeights);
-        //Load the makers
-        markersReference.loadMarkersFile(_markerFileName);
+        // populate the references according to the setting of this Tool
+        populateReferences(markersReference, coordinateReferences);
 
         // Determine the start time, if the provided time range is not specified then use time from marker reference
         // also adjust the time range for the tool if the provided range exceeds that of the marker data
@@ -370,7 +310,7 @@ bool InverseKinematicsTool::run()
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.begin(s);
         // number of markers
-        int nm = markerWeights.getSize();
+        int nm = markersReference.getNumRefs();
         SimTK::Array_<double> squaredMarkerErrors(nm, 0.0);
         SimTK::Array_<Vec3> markerLocations(nm, Vec3(0));
         
@@ -576,3 +516,71 @@ void InverseKinematicsTool::updateFromXMLNode(SimTK::Xml::Element& aNode, int ve
     }
     Object::updateFromXMLNode(aNode, versionNumber);
 }
+
+void InverseKinematicsTool::populateReferences(MarkersReference& markersReference,
+    SimTK::Array_<CoordinateReference>&coordinateReferences)
+{
+    FunctionSet *coordFunctions = NULL;
+    // Load the coordinate data
+    // bool haveCoordinateFile = false;
+    if (_coordinateFileName != "" && _coordinateFileName != "Unassigned") {
+        Storage coordinateValues(_coordinateFileName);
+        // Convert degrees to radian (TODO: this needs to have a check that the storage is, in fact, in degrees!)
+        _model->getSimbodyEngine().convertDegreesToRadians(coordinateValues);
+        // haveCoordinateFile = true;
+        coordFunctions = new GCVSplineSet(5, &coordinateValues);
+    }
+
+    Set<MarkerWeight> markerWeights;
+    // Loop through old "IKTaskSet" and assign weights to the coordinate and marker references
+    // For coordinates, create the functions for coordinate reference values
+    int index = 0;
+    for (int i = 0; i < _ikTaskSet.getSize(); i++) {
+        if (!_ikTaskSet[i].getApply()) continue;
+        if (IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&_ikTaskSet[i])) {
+            CoordinateReference *coordRef = NULL;
+            if (coordTask->getValueType() == IKCoordinateTask::FromFile) {
+                if (!coordFunctions)
+                    throw Exception("InverseKinematicsTool: value for coordinate " + coordTask->getName() + " not found.");
+
+                index = coordFunctions->getIndex(coordTask->getName(), index);
+                if (index >= 0) {
+                    coordRef = new CoordinateReference(coordTask->getName(), coordFunctions->get(index));
+                }
+            }
+            else if ((coordTask->getValueType() == IKCoordinateTask::ManualValue)) {
+                Constant reference(Constant(coordTask->getValue()));
+                coordRef = new CoordinateReference(coordTask->getName(), reference);
+            }
+            else { // assume it should be held at its default value
+                double value = _model->getCoordinateSet().get(coordTask->getName()).getDefaultValue();
+                Constant reference = Constant(value);
+                coordRef = new CoordinateReference(coordTask->getName(), reference);
+            }
+
+            if (coordRef == NULL)
+                throw Exception("InverseKinematicsTool: value for coordinate " + coordTask->getName() + " not found.");
+            else
+                coordRef->setWeight(coordTask->getWeight());
+
+            coordinateReferences.push_back(*coordRef);
+        }
+        else if (IKMarkerTask *markerTask = dynamic_cast<IKMarkerTask *>(&_ikTaskSet[i])) {
+            if (markerTask->getApply()) {
+                markerWeights.adoptAndAppend(
+                    new MarkerWeight(markerTask->getName(), markerTask->getWeight()));
+            }
+        }
+    }
+
+    // Set the default weight for markers
+    markersReference.setDefaultWeight(1.0);
+    // Set the weights for markers (markers in the model and the marker file
+    // but not assigned a weight in the markerWeightSet will use the default
+    // weight
+    markersReference.setMarkerWeightSet(markerWeights);
+    //Load the makers
+    markersReference.loadMarkersFile(_markerFileName);
+}
+
+

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -39,6 +39,8 @@ namespace OpenSim {
 
 class Model;
 class IKTaskSet;
+class MarkersReference;
+class CoordinateReference;
 
 //=============================================================================
 //=============================================================================
@@ -164,6 +166,11 @@ public:
     //--------------------------------------------------------------------------
     bool run() override SWIG_DECLARE_EXCEPTION;
 
+    // For testing/debugging it is necessary to know exactly what are the
+    // MarkersReference (set of marker trajectories and their weights) and
+    // CoordinateReferences that are being used by the InverseKinematicsSolver.
+    void populateReferences(MarkersReference& markersReference,
+        SimTK::Array_<CoordinateReference>&coordinateReferences);
 
 //=============================================================================
 };  // END of class InverseKinematicsTool

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -166,11 +166,13 @@ public:
     //--------------------------------------------------------------------------
     bool run() override SWIG_DECLARE_EXCEPTION;
 
+    /** @cond **/ // hide from Doxygen
     // For testing/debugging it is necessary to know exactly what are the
     // MarkersReference (set of marker trajectories and their weights) and
     // CoordinateReferences that are being used by the InverseKinematicsSolver.
     void populateReferences(MarkersReference& markersReference,
         SimTK::Array_<CoordinateReference>&coordinateReferences) const;
+    /** @endcond **/
 
 //=============================================================================
 };  // END of class InverseKinematicsTool

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -170,7 +170,7 @@ public:
     // MarkersReference (set of marker trajectories and their weights) and
     // CoordinateReferences that are being used by the InverseKinematicsSolver.
     void populateReferences(MarkersReference& markersReference,
-        SimTK::Array_<CoordinateReference>&coordinateReferences);
+        SimTK::Array_<CoordinateReference>&coordinateReferences) const;
 
 //=============================================================================
 };  // END of class InverseKinematicsTool


### PR DESCRIPTION
This PR addresses issue #1443 where the weights associated with the `MarkersReference` consumed by the `InverseKinematicsSolver` are inconsistent with the weightings in the `IKTaskSet` associated with the `InverseKinematicsTool`.

The PR adds test cases in `testInverseKinematicsSolver` and `testIK` to reproduce the inconsistency. The inconsistency appeared when the number of tasks is less than the number of markers present in the data, in which case the index into the `MarkersReference` internal list of weights was not being incremented.

Additional conditions such as order and superfluous tasks (one without a corresponding marker) was also included.

The most significant change was the creation of `InverseKinematicsTool::populateReferences()` so that the `MarkersReference` generated by the Tool could be tested directly (opposed to adding `cout`s in a *debug* mode, for example).  