### PR TITLE
[WIP] CMake BUILD_TYPE/CONFIGURATION mismatch issue 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,22 @@ if(NOT Simbody_FOUND)
         SIMBODY_HOME to the installation directory of Simbody.")
 endif()
 
+# Check if Simbody targets were built using same BUILD_TYPE/CONFIGURATION as
+# current OpenSim build. If build/configuration types mismatch, stop the build.
+# ------------------------------------------------------------------------------
+get_property(Simbody_CONFIGURATION
+    TARGET   SimTKcommon
+    PROPERTY IMPORTED_CONFIGURATIONS)
+
+string(CONCAT MESSAGE
+    "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
+    "the current OpenSim BUILD_TYPE or CONFIGURATION.")
+
+add_custom_target(Simbody_CONFIG_check ALL
+    COMMAND "exit" "$<NOT:$<CONFIG:${Simbody_CONFIGURATION}>>"
+    COMMENT ${MESSAGE})
+  
+
 # Directories for Simbody headers and libraries for building.
 # -----------------------------------------------------------
 include_directories("${Simbody_INCLUDE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,14 @@ if(COMMAND cmake_policy)
     cmake_policy(SET CMP0005 NEW)
 endif(COMMAND cmake_policy)
 
+string(CONCAT DEP_BUILD_MSG
+  "\n-------------------------IMPORTANT----------------------------------\n"
+  "| Make sure that all OpenSim dependencies are built with the same   |\n"
+  "| CMAKE_BUILD_TYPE (Linux) or CONFIGURATION (Xcode/MSVC) as OpenSim |\n"
+  "| to avoid mysterious runtime errors.                               |\n"
+  "-------------------------IMPORTANT----------------------------------\n")
+message(${DEP_BUILD_MSG})
+
 # To create a folder hierarchy within Visual Studio.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,10 +567,19 @@ string(CONCAT MESSAGE
     "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
     "the current OpenSim BUILD_TYPE or CONFIGURATION.")
 
-add_custom_target(Simbody_CONFIG_check ALL
-    COMMAND "exit" "$<NOT:$<CONFIG:${Simbody_CONFIGURATION}>>"
-    COMMENT ${MESSAGE})
-  
+if(PLATFORM_NAME EQUAL Windows)
+    string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)  
+    add_custom_target(Simbody_CONFIG_check ALL
+        COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
+        COMMAND "if"
+              "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
+              "exit" "1"
+        COMMENT ${MESSAGE})
+elseif(PLATFORM_NAME EQUAL Mac OR PLATFORM_NAME EQUAL Linux)
+    add_custom_target(Simbody_CONFIG_check ALL
+        COMMAND "exit" "$<NOT:$<CONFIG:${Simbody_CONFIGURATION}>>"
+        COMMENT ${MESSAGE})
+endif()
 
 # Directories for Simbody headers and libraries for building.
 # -----------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ if(${PLATFORM_NAME} STREQUAL Windows)
         COMMAND "echo" "$<CONFIG>"
         COMMAND "echo" "asdf" "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%" "asdf"
         COMMAND "if"
-              "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>= %==\"%Simbody_CONFIG%\""
+              "\"%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%\"==\"%Simbody_CONFIG%\""
               "exit" "1"
         COMMENT ${MESSAGE})
 elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ string(CONCAT MESSAGE
     "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
     "the current OpenSim BUILD_TYPE or CONFIGURATION.")
 
-if(${PLATFORM_NAME} EQUAL Windows)
+if(${PLATFORM_NAME} STREQUAL Windows)
     string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)  
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
@@ -575,7 +575,7 @@ if(${PLATFORM_NAME} EQUAL Windows)
               "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
               "exit" "1"
         COMMENT ${MESSAGE})
-elseif(${PLATFORM_NAME} EQUAL Mac OR ${PLATFORM_NAME} EQUAL Linux)
+elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "exit" "$<NOT:$<CONFIG:${Simbody_CONFIGURATION}>>"
         COMMENT ${MESSAGE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ if(${PLATFORM_NAME} STREQUAL Windows)
         COMMAND "echo" "$<CONFIG>"
         COMMAND "echo" "asdf" "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%" "asdf"
         COMMAND "if"
-              "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
+              "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>= %==\"%Simbody_CONFIG%\""
               "exit" "1"
         COMMENT ${MESSAGE})
 elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,8 @@ get_property(Simbody_CONFIGURATION
     TARGET   SimTKcommon
     PROPERTY IMPORTED_CONFIGURATIONS)
 
+message(${Simbody_CONFIGURATION})
+
 string(CONCAT MESSAGE
     "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
     "the current OpenSim BUILD_TYPE or CONFIGURATION.")
@@ -571,6 +573,8 @@ if(${PLATFORM_NAME} STREQUAL Windows)
     string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)  
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
+        COMMAND "echo" "%Simbody_CONFIG%"
+        COMMAND "echo" "$<CONFIG>"
         COMMAND "if"
               "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
               "exit" "1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ string(CONCAT MESSAGE
     "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
     "the current OpenSim BUILD_TYPE or CONFIGURATION.")
 
-if(PLATFORM_NAME EQUAL Windows)
+if(${PLATFORM_NAME} EQUAL Windows)
     string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)  
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
@@ -575,7 +575,7 @@ if(PLATFORM_NAME EQUAL Windows)
               "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
               "exit" "1"
         COMMENT ${MESSAGE})
-elseif(PLATFORM_NAME EQUAL Mac OR PLATFORM_NAME EQUAL Linux)
+elseif(${PLATFORM_NAME} EQUAL Mac OR ${PLATFORM_NAME} EQUAL Linux)
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "exit" "$<NOT:$<CONFIG:${Simbody_CONFIGURATION}>>"
         COMMENT ${MESSAGE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,7 @@ if(${PLATFORM_NAME} STREQUAL Windows)
         COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
         COMMAND "echo" "%Simbody_CONFIG%"
         COMMAND "echo" "$<CONFIG>"
+        COMMAND "echo" "asdf" "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%" "asdf"
         COMMAND "if"
               "%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%==\"%Simbody_CONFIG%\""
               "exit" "1"

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -19,4 +19,4 @@ OpenSimAddLibrary(
     TESTDIRS "Test"
     )
 
-    
+add_dependencies(osimCommon Simbody_CONFIG_check)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ and prints the following information to the console:
 Building from the source code
 -----------------------------
 
+**NOTE -- In all platforms (Windows, OSX, Linux), it is advised to build all OpenSim Dependencies (Simbody, BTK etc) with same *CMAKE_BUILD_TYPE* (Linux) / *CONFIGURATION* (MSVC/Xcode) as OpenSim. For example, if OpenSim is to be built with *CMAKE_BUILD_TYPE/CONFIGURATION* as *Debug*, Simbody, BTK and all other OpenSim dependencies also should be built with *CMAKE_BUILD_TYPE/CONFIGURATION* as *Debug*. Failing to do so *may* result in mysterious runtime errors like 'segfault' in standard c++ library implementation.**
+
 We support a few ways of building OpenSim:
 
 1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient-windows). 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ build_script:
   # Hack to avoid error MSB3191: Unable to create directory "C:\projects\opensim_build\Release\"
   # which may result from parallel jobs trying to create this directory.
   - cmake --build . --target SimbodyFiles --config Release
-  - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet #/p:TreatWarningsAsErrors="true"
+  - cmake --build . --config Release #/p:TreatWarningsAsErrors="true"
   
 test_script:
   ## Run tests.


### PR DESCRIPTION
Addressing #1276.

Windows testing was done in #1475. Appveyor builds show that the solution successfully stops the build when a mismatch in CONFIG is found between Simbody and OpenSim.
Linux testing was done locally.