### PR TITLE
Speedup initSystem by delay loading mesh files

### DIFF
--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -176,6 +176,14 @@ int main()
     assert(context->getLocked(dr_elbow_flexNew));
     ASSERT_EQUAL(0.5, context->getValue(dr_elbow_flexNew), 0.000001);
 
+    // Exercise Editing workflow
+    OpenSim::Body& bdy = model->updBodySet().get("r_humerus");
+    AbstractProperty& massProp = bdy.updPropertyByName("mass");
+    double oldValue = PropertyHelper::getValueDouble(massProp);
+    double v = oldValue + 1.0;
+    context->cacheModelAndState();
+    PropertyHelper::setValueDouble(v, massProp);
+    context->restoreStateFromCachedModel();
     return status;
   } catch (const std::exception& e) {
       cout << "Exception: " << e.what() << endl;

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -177,6 +177,7 @@ int main()
     ASSERT_EQUAL(0.5, context->getValue(dr_elbow_flexNew), 0.000001);
 
     // Exercise Editing workflow
+    // These are the same calls done from GUI code base through Property edits
     OpenSim::Body& bdy = model->updBodySet().get("r_humerus");
     AbstractProperty& massProp = bdy.updPropertyByName("mass");
     double oldValue = PropertyHelper::getValueDouble(massProp);

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -274,7 +274,7 @@ void Mesh::extendFinalizeFromProperties() {
         try {
             std::ifstream objFile;
             objFile.open(attempts.back().c_str());
-            pmesh.loadFile(attempts.back().c_str());
+            //pmesh.loadFile(attempts.back().c_str());
             // objFile closes when destructed
 
         }

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -280,7 +280,7 @@ void Mesh::extendFinalizeFromProperties() {
 
         }
         catch (const std::exception& e) {
-            std::cout << "Visualizer couldn't read "
+            std::cout << "Visualizer couldn't open "
                 << attempts.back() << " because:\n"
                 << e.what() << "\n";
             return;

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -274,8 +274,9 @@ void Mesh::extendFinalizeFromProperties() {
         try {
             std::ifstream objFile;
             objFile.open(attempts.back().c_str());
-            //pmesh.loadFile(attempts.back().c_str());
             // objFile closes when destructed
+            // if the file can be opened but had bad contents e.g. binary vtp 
+            // it will be handled downstream 
 
         }
         catch (const std::exception& e) {


### PR DESCRIPTION
Avoid actual loading of mesh file in Mesh::extendFinalizeFromProperties and rely on lazy loading as implemented in DecorativeMeshFile