### PR TITLE
Do not build versionUpdate if NOT OPENSIM_BUILD_INDIVIDUAL_APPS.

### DIFF
--- a/Applications/versionUpdate/CMakeLists.txt
+++ b/Applications/versionUpdate/CMakeLists.txt
@@ -1,1 +1,3 @@
-OpenSimAddApplication(NAME versionUpdate)
+if(OPENSIM_BUILD_INDIVIDUAL_APPS)
+    OpenSimAddApplication(NAME versionUpdate)
+endif()


### PR DESCRIPTION
On UNIX, we would like for *only* the new `opensim-cmd` command line tool to be installed. By accident, `versionUpdate` also gets installed. This PR fixes that.

Should be a quick review!

@klshrinidhi, would you be interested? Only one reviewer is necessary (from CONTRIBUTING.md: "Updates to ... CMake files must be reviewed by at least one member of the Dev Team before being merged.").