### PR TITLE
Fix MATLAB example code for accessing coordinates from joints

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/BallJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/BallJoint.h
@@ -66,15 +66,20 @@ public:
         rx = myBallJoint.getCoordinate(opensim.BallJoint.Coord_Rotation1X)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rx = myBallJoint.getCoordinate(BallJoint.Coord.Rotation1X);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rx = myBallJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y,
-        Rotation3Z
+        Rotation1X = 0u, ///< 0
+        Rotation2Y = 1u, ///< 1
+        Rotation3Z = 2u  ///< 2
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
@@ -63,15 +63,20 @@ public:
         rx = myEllipsoidJoint.getCoordinate(opensim.EllipsoidJoint.Coord_Rotation1X)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rx = myEllipsoidJoint.getCoordinate(EllipsoidJoint.Coord.Rotation1X);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rx = myEllipsoidJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y,
-        Rotation3Z
+        Rotation1X = 0u, ///< 0
+        Rotation2Y = 1u, ///< 1
+        Rotation3Z = 2u  ///< 2
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/FreeJoint.h
@@ -64,18 +64,23 @@ public:
         rx = myFreeJoint.getCoordinate(opensim.FreeJoint.Coord_Rotation1X)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rx = myFreeJoint.getCoordinate(FreeJoint.Coord.Rotation1X);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rx = myFreeJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y,
-        Rotation3Z,
-        TranslationX,
-        TranslationY,
-        TranslationZ
+        Rotation1X   = 0u, ///< 0
+        Rotation2Y   = 1u, ///< 1
+        Rotation3Z   = 2u, ///< 2
+        TranslationX = 3u, ///< 3
+        TranslationY = 4u, ///< 4
+        TranslationZ = 5u  ///< 5
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
@@ -59,15 +59,20 @@ public:
         rx = myGimbalJoint.getCoordinate(opensim.GimbalJoint.Coord_Rotation1X)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rx = myGimbalJoint.getCoordinate(GimbalJoint.Coord.Rotation1X);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rx = myGimbalJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y,
-        Rotation3Z
+        Rotation1X = 0u, ///< 0
+        Rotation2Y = 1u, ///< 1
+        Rotation3Z = 2u  ///< 2
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -217,8 +217,9 @@ const Coordinate& Joint::getCoordinate() const {
                      JointHasNoCoordinates);
     OPENSIM_THROW_IF(numCoordinates() > 1,
                      InvalidCall,
-                     "Joint has more than one coordinate. Use the getCoordinate "
-                     "method defined in the concrete class instead.");
+                     "Joint has more than one coordinate. Use get_coordinates() "
+                     "or the getCoordinate() method defined in the concrete "
+                     "class instead.");
 
     return get_coordinates(0);
 }
@@ -228,8 +229,9 @@ Coordinate& Joint::updCoordinate() {
                      JointHasNoCoordinates);
     OPENSIM_THROW_IF(numCoordinates() > 1,
                      InvalidCall,
-                     "Joint has more than one coordinate. Use the updCoordinate "
-                     "method defined in the concrete class instead.");
+                     "Joint has more than one coordinate. Use upd_coordinates() "
+                     "or the updCoordinate() method defined in the concrete "
+                     "class instead.");
 
     return upd_coordinates(0);
 }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -226,14 +226,15 @@ public:
 
     /** Convenience method to get a const reference to the Coordinate associated
         with a single-degree-of-freedom Joint. If the Joint has more than one
-        Coordinate, you must provide the appropriate argument to the
-        getCoordinate() method defined in the derived class. */
+        Coordinate, you must use get_coordinates() or provide the appropriate
+        argument to the getCoordinate() method defined in the derived class. */
     const Coordinate& getCoordinate() const;
 
     /** Convenience method to get a writable reference to the Coordinate
         associated with a single-degree-of-freedom Joint. If the Joint has more
-        than one Coordinate, you must provide the appropriate argument to the
-        updCoordinate() method defined in the derived class. */
+        than one Coordinate, you must use upd_coordinates() or provide the
+        appropriate argument to the updCoordinate() method defined in the
+        derived class. */
     Coordinate& updCoordinate();
 
     bool getReverse() const { return get_reverse(); }

--- a/OpenSim/Simulation/SimbodyEngine/PinJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PinJoint.h
@@ -60,13 +60,18 @@ public:
         rz = myPinJoint.getCoordinate(opensim.PinJoint.Coord_RotationZ)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rz = myPinJoint.getCoordinate(PinJoint.Coord.RotationZ);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rz = myPinJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        RotationZ
+        RotationZ = 0u ///< 0
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/PlanarJoint.h
@@ -59,15 +59,20 @@ public:
         rz = myPlanarJoint.getCoordinate(opensim.PlanarJoint.Coord_RotationZ)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rz = myPlanarJoint.getCoordinate(PlanarJoint.Coord.RotationZ);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rz = myPlanarJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        RotationZ,
-        TranslationX,
-        TranslationY
+        RotationZ    = 0u, ///< 0
+        TranslationX = 1u, ///< 1
+        TranslationY = 2u  ///< 2
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/SliderJoint.h
@@ -58,13 +58,18 @@ public:
         tx = mySliderJoint.getCoordinate(opensim.SliderJoint.Coord_TranslationX)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         tx = mySliderJoint.getCoordinate(SliderJoint.Coord.TranslationX);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        tx = mySliderJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        TranslationX
+        TranslationX = 0u ///< 0
     };
 
 private:

--- a/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/UniversalJoint.h
@@ -61,14 +61,19 @@ public:
         rx = myUniversalJoint.getCoordinate(opensim.UniversalJoint.Coord_Rotation1X)
         \endcode
 
-        <b>Java/Matlab example</b>
+        <b>Java example</b>
         \code{.java}
         rx = myUniversalJoint.getCoordinate(UniversalJoint.Coord.Rotation1X);
         \endcode
+
+        <b>MATLAB example</b>
+        \code{.m}
+        rx = myUniversalJoint.get_coordinates(0);
+        \endcode
     */
     enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y
+        Rotation1X = 0u, ///< 0
+        Rotation2Y = 1u  ///< 1
     };
 
 private:


### PR DESCRIPTION
Coordinate enums are available in Java but not in MATLAB. Fixes #1232.

[Example of updated doxygen on myosin](http://myosin.sourceforge.net/1493/classOpenSim_1_1BallJoint.html#aeafdd72ac449bc072bd0760404c37e3b)