### PR TITLE
Fixes Hopper example: wrapping of device over patella

### DIFF
--- a/OpenSim/Examples/ExampleHopperDevice/README.md
+++ b/OpenSim/Examples/ExampleHopperDevice/README.md
@@ -2,7 +2,7 @@ Example: *Hopper Device*
 ========================
 
 This example demonstrates some of the new features of the OpenSim 4.0 API.
-The Component architecture allows us to join sub-assemblies to form larger Models, with information flowing between Components via Inputs, Outputs, and Connectors.
+The Component architecture allows us to join sub-assemblies to form larger Models, with information flowing between Components via Inputs, Outputs, and Sockets.
 For more information, please refer to the [OpenSim doxygen](http://doxygen.opensim.community/) for the Component class.
 
 This interactive example consists of three steps:

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -97,10 +97,10 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
 
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
-    if (model.hasComponent<WrapCylinder>("thigh/patella")) {
+    const std::string patellaPath("thigh/patellaFrame/patella");
+    if (model.hasComponent<WrapCylinder>(patellaPath)) {
         auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
-        auto& frame = model.updComponent<PhysicalFrame>("thigh");
-        auto& wrapObject = frame.upd_WrapObjectSet().get("patella");
+        auto& wrapObject = model.updComponent<WrapCylinder>(patellaPath);
         cable.updGeometryPath().addPathWrap(wrapObject);
     }
 }

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -90,10 +90,8 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     //      modelFrameBname), then connect them to the parent frames of each
     //      anchor. (2 lines of code for each anchor.)
 
-    // Add the device to the model. We need to add the device using
-    // addModelComponent() rather than addComponent() because of a bug in
-    // Model::initSystem().
-    model.addModelComponent(&device);
+    // Add the device to the model.
+    model.addComponent(&device);
 
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -123,14 +123,14 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
     // Add the device to the model. We need to add the device using
     // addModelComponent() rather than addComponent() because of a bug in
     // Model::initSystem().
-    model.addModelComponent(&device);
+    model.addComponent(&device);
 
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
-    if (model.hasComponent<WrapCylinder>("thigh/patella")) {
+    const std::string patellaPath("thigh/patellaFrame/patella");
+    if (model.hasComponent<WrapCylinder>(patellaPath)) {
         auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
-        auto& frame = model.updComponent<PhysicalFrame>("thigh");
-        auto& wrapObject = frame.upd_WrapObjectSet().get("patella");
+        auto& wrapObject = model.updComponent<WrapCylinder>(patellaPath);
         cable.updGeometryPath().addPathWrap(wrapObject);
     }
 }

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -120,9 +120,7 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
 
     #pragma endregion
 
-    // Add the device to the model. We need to add the device using
-    // addModelComponent() rather than addComponent() because of a bug in
-    // Model::initSystem().
+    // Add the device to the model.
     model.addComponent(&device);
 
     // Configure the device to wrap over the patella (if one exists; there is no

--- a/OpenSim/Examples/ExampleHopperDevice/helperMethods.h
+++ b/OpenSim/Examples/ExampleHopperDevice/helperMethods.h
@@ -172,9 +172,8 @@ inline void simulate(Model& model,
     // Configure the visualizer.
     if (model.getUseVisualizer()) {
         SimTK::Visualizer& viz = model.updVisualizer().updSimbodyVisualizer();
-        // We use the input silo to get key presses. OpenSim::ModelVisualizer
-        // adds two InputListeners; the second is InputSilo.
-        silo = dynamic_cast<SimTK::Visualizer::InputSilo*>(&viz.updInputListener(1));
+        // We use the input silo to get key presses.
+        silo = &model.updVisualizer().updInputSilo();
 
         SimTK::DecorativeText help("Press any key to start a new simulation; "
                                    "ESC to quit.");

--- a/OpenSim/Examples/ExampleHopperDevice/helperMethods.h
+++ b/OpenSim/Examples/ExampleHopperDevice/helperMethods.h
@@ -34,7 +34,7 @@ namespace OpenSim {
 
 
 //------------------------------------------------------------------------------
-// Display the class name and basolute path name for each of the given 
+// Display the class name and absolute path name for each of the given
 // Component's descendants (children, grandchildren, etc.).
 //
 // Examples:
@@ -128,8 +128,8 @@ inline void showSubcomponentInfo(const Component& comp)
     // Step through compList again to print.
     for (const C& thisComp : compList) {
         const std::string thisClass = thisComp.getConcreteClassName();
-        for (unsigned i=0u; i < maxlen-thisClass.length(); ++i) { cout << " "; }
-        cout << "[" << thisClass << "]  " << thisComp.getAbsolutePathName() << endl;
+        cout << std::string(maxlen-thisClass.length(), ' ') << "[" << thisClass
+             << "]  " << thisComp.getAbsolutePathName() << endl;
     }
     cout << endl;
 }
@@ -141,9 +141,7 @@ inline void showAllOutputs(const Component& comp, bool includeDescendants)
     // Do not display header for Components with no outputs.
     if (comp.getNumOutputs() > 0) {
         const std::string msg = "Outputs from " + comp.getAbsolutePathName();
-        cout << msg << endl;
-        for (unsigned i=0u; i<msg.size(); ++i) { cout << "="; }
-        cout << endl;
+        cout << msg << "\n" << std::string(msg.size(), '=') << endl;
 
         std::vector<std::string> outputNames = comp.getOutputNames();
         for (auto thisName : outputNames) { cout << "  " << thisName << endl; }
@@ -194,7 +192,7 @@ inline void simulate(Model& model,
             unsigned key, modifiers;
             silo->waitForKeyHit(key, modifiers);
             if (key == SimTK::Visualizer::InputListener::KeyEsc) { break; }
-        } else if(!simulateOnce) {
+        } else if (!simulateOnce) {
             std::cout << "Press <Enter> to begin simulating, or 'q' followed "
                       << "by <Enter> to quit . . . " << std::endl;
             if (std::cin.get() == 'q') { break; }
@@ -222,7 +220,7 @@ inline Model buildTestbed(bool showVisualizer)
     // Create a new OpenSim model.
     auto testbed = Model();
     testbed.setName("testbed");
-    if(showVisualizer)
+    if (showVisualizer)
         testbed.setUseVisualizer(true);
     testbed.setGravity(Vec3(0));
 


### PR DESCRIPTION
This PR fixes an issue that Tom pointed out in #1494. The path to the patella has changed. 

This PR also cleans up a few other things. I tested locally on my Mac and all 3 parts of the example ran fine.

Fixes #1494