### PR TITLE
Wrap SimTK::Visualizer and InputSilo for scripting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_install:
   ## Avoid bug on OSX (https://github.com/travis-ci/travis-ci/issues/6307)
   # This prevents the build from failing with:
   # `/Users/travis/build.sh: line 109: shell_session_update: command not found`
-  - rvm get head
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
   
   ###########################################################################################################
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.

--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -232,3 +232,34 @@ namespace SimTK {
 // Used for StatesTrajectory iterating.
 %template(StdVectorState) std::vector<SimTK::State>;
 %include <SWIGSimTK/SimbodyMatterSubsystem.h>
+
+%rename(SimTKVisualizer) SimTK::Visualizer;
+%include <simbody/internal/Visualizer.h>
+
+// Wrap SimTK::Visualizer and InputSilo to put geometry in Visualizer and
+// obtain keyboard input.
+// Nested classes are inaccessible from MATLAB.
+%feature("flatnested") SimTK::Visualizer::InputListener;
+%feature("flatnested") SimTK::Visualizer::InputSilo;
+%rename(SimTKVisualizerInputListener) SimTK::Visualizer::InputListener;
+%rename(SimTKVisualizerInputSilo) SimTK::Visualizer::InputSilo;
+%include <simbody/internal/Visualizer_InputListener.h>
+// The following is necessary because the BackgroundType enum cannot be used
+// from MATLAB.
+namespace SimTK {
+%extend Visualizer {
+    const Visualizer& setBackgroundTypeByInt(int index) {
+        if (index == 1) $self->setBackgroundType(SimTK::Visualizer::GroundAndSky);
+        else if (index == 2) $self->setBackgroundType(SimTK::Visualizer::SolidColor);
+        return *($self);
+    }
+}
+%extend Visualizer::InputSilo {
+    unsigned waitForKeyHitKeyOnly() {
+        unsigned key = 0;
+        unsigned modifier = 0;
+        $self->waitForKeyHit(key, modifier);
+        return key;
+    }
+}
+}


### PR DESCRIPTION
This PR addresses #1502: making `SimTK::Visualizer` and `SimTK::Visualizer::InputSilo` available in MATLAB. With these classes wrapped, it is possible to add DecorativeText to the Visualizer view, and to ask the InputSilo for key presses. There are no tests in this PR, but I have tested this on the tgcs2017 branch, and it works very nicely.

I had to create two functions in the swig interface file to work around the unavailability of enums in MATLAB, and the inability for SWIG to properly wrap functions that take `unsigned*` as an argument (I could have used swig typemaps instead, but I don't really know how to use them, and I thought this solution would be fine).