### PR TITLE
Require Model::finalizeFromProperties() to be called explicitly 

### DIFF
--- a/Applications/Analyze/test/testInducedAccelerations.cpp
+++ b/Applications/Analyze/test/testInducedAccelerations.cpp
@@ -80,7 +80,8 @@ void testDoublePendulumWithSolver()
     int nt = statesStore.getTimeColumn(time);
     statesStore.getDataForIdentifier("q", states);
 
-    Model pendulum("double_pendulum.osim", true);
+    Model pendulum("double_pendulum.osim");
+    pendulum.finalizeFromProperties();
     
     PrescribedController* controller=
         new PrescribedController();

--- a/Bindings/Java/tests/TestBasics.java
+++ b/Bindings/Java/tests/TestBasics.java
@@ -3,6 +3,7 @@ import org.opensim.modeling.*;
 class TestBasics {
     public static void testBasics() {
         Model m = new Model();
+        m.finalizeFromProperties();
         m.print("empty_model.osim");
         Frame gnd = m.getGround();
         FrameList frames = m.getFrameList();

--- a/Bindings/Java/tests/TestEditProperties.java
+++ b/Bindings/Java/tests/TestEditProperties.java
@@ -7,7 +7,6 @@ class TestEditProperties {
   public static void main(String[] args) {
     try {
         Model model = new Model("gait10dof18musc_subject01.osim");
-        model.finalizeFromProperties();
         OpenSimContext context=null;
         long t1  = System.currentTimeMillis();
         try {

--- a/Bindings/Java/tests/TestEditProperties.java
+++ b/Bindings/Java/tests/TestEditProperties.java
@@ -7,6 +7,7 @@ class TestEditProperties {
   public static void main(String[] args) {
     try {
         Model model = new Model("gait10dof18musc_subject01.osim");
+        model.finalizeFromProperties();
         OpenSimContext context=null;
         long t1  = System.currentTimeMillis();
         try {

--- a/Bindings/Java/tests/TestIterators.java
+++ b/Bindings/Java/tests/TestIterators.java
@@ -3,6 +3,7 @@ import org.opensim.modeling.*;
 class TestIterators {
   public static void main(String[] args) {
     Model model = new Model();
+    model.finalizeFromProperties();
 
     // Iterate through 
     model.dumpSubcomponents();

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -110,6 +110,7 @@ class TestReporter {
         
         String modelFileName = "double_pendulum_markers.osim";
         Model model = new Model(modelFileName);
+        model.finalizeFromProperties();
 
         ConsoleReporter consoleReporter = new ConsoleReporter();
         consoleReporter.set_report_time_interval(timeInterval);

--- a/Bindings/Python/tests/test_access_subcomponents.py
+++ b/Bindings/Python/tests/test_access_subcomponents.py
@@ -13,6 +13,8 @@ osim.Model.setDebugLevel(0)
 class TestAccessSubcomponents(unittest.TestCase):
     def test_individual_components(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
+		model.finalizeFromProperties()
+		
         muscle = model.getComponent('BICshort')
         assert muscle.getName() == 'BICshort'
         # No downcasting necessary!
@@ -22,6 +24,7 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_list(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
+		model.finalizeFromProperties()
 
         num_components = 0
         for comp in model.getComponentsList():
@@ -77,6 +80,7 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_filter(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
+		model.finalizeFromProperties()
 
         comps = model.getMuscleList()
         comps.setFilter(osim.ComponentFilterAbsolutePathNameContainsString('BIC'))

--- a/Bindings/Python/tests/test_access_subcomponents.py
+++ b/Bindings/Python/tests/test_access_subcomponents.py
@@ -13,8 +13,8 @@ osim.Model.setDebugLevel(0)
 class TestAccessSubcomponents(unittest.TestCase):
     def test_individual_components(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-		model.finalizeFromProperties()
-		
+        model.finalizeFromProperties()
+        
         muscle = model.getComponent('BICshort')
         assert muscle.getName() == 'BICshort'
         # No downcasting necessary!
@@ -24,7 +24,7 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_list(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-		model.finalizeFromProperties()
+        model.finalizeFromProperties()
 
         num_components = 0
         for comp in model.getComponentsList():
@@ -80,7 +80,7 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_filter(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-		model.finalizeFromProperties()
+        model.finalizeFromProperties()
 
         comps = model.getMuscleList()
         comps.setFilter(osim.ComponentFilterAbsolutePathNameContainsString('BIC'))

--- a/Bindings/Python/tests/test_component_interface.py
+++ b/Bindings/Python/tests/test_component_interface.py
@@ -13,6 +13,7 @@ class TestComponentInterface(unittest.TestCase):
     def test_printComponentsMatching(self):
         model = osim.Model(os.path.join(test_dir,
             "gait10dof18musc_subject01.osim"))
+        model.finalizeFromProperties();
         num_matches = model.printComponentsMatching("_r")
         self.assertEquals(num_matches, 98)
     def test_attachGeometry_memory_management(self):

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -438,6 +438,7 @@ void testClutchedPathSpring()
     //Test deserialization
     delete model;
     model = new Model("ClutchedPathSpringModel.osim");
+    model->finalizeFromProperties();
 
     // Create the force reporter
     ForceReporter* reporter = new ForceReporter(model);

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -901,6 +901,7 @@ void testThelen2003Muscle()
         // Print model and read back in.
         myModel.print(filename);
         Model myModel2(filename);
+        myModel2.finalizeFromProperties();
 
         const Thelen2003Muscle& myMcl2 = dynamic_cast<const Thelen2003Muscle&>(
             myModel2.getMuscles().get("myMuscle") );

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -131,12 +131,15 @@ void Component::addComponent(Component* subcomponent)
     while (root->hasParent()) {
         root = &(root->getParent());
     }
-
-    auto components = root->getComponentList<Component>();
-    for (auto& c : components) {
-        if (subcomponent == &c) {
-            OPENSIM_THROW( ComponentAlreadyPartOfOwnershipTree,
-                subcomponent->getName(), getName());
+    // if the root has no immediate subcomponents do not bother
+    // checking if the subcomponent is in the ownership tree
+    if ((root->getNumImmediateSubcomponents() > 0)) {
+        auto components = root->getComponentList<Component>();
+        for (auto& c : components) {
+            if (subcomponent == &c) {
+                OPENSIM_THROW(ComponentAlreadyPartOfOwnershipTree,
+                    subcomponent->getName(), getName());
+            }
         }
     }
 
@@ -1526,19 +1529,34 @@ void Component::dumpConnections() const {
 
 
 void Component::initComponentTreeTraversal(const Component &root) const {
-    // Going down the tree, node is followed by all its
-    // children in order, last child's successor is the parent's successor.
+    // Going down the tree, this node is followed by all its children.
+    // The last child's successor (next) is the parent's successor.
 
     const size_t nmsc = _memberSubcomponents.size();
     const size_t npsc = _propertySubcomponents.size();
     const size_t nasc = _adoptedSubcomponents.size();
 
-    // If this component has no parent and has no subcomponents
-    // this is an orphan component and likely failed to call 
-    // finalizeFromProperties on the root OR made and orphaned
-    // clone of the Component.
-    if (!(this->hasParent()) && !(nmsc + npsc + nasc) ){
+    // If this isn't the root component and it has no parent, then
+    // this is an orphan component and we likely failed to call 
+    // finalizeFromProperties on the root OR this is a clone that
+    // has not been added to the root (in which case would have a parent).
+    if ((this != &root) && !this->hasParent() ) {
         OPENSIM_THROW(ComponentIsAnOrphan, getName(), getConcreteClassName());
+    }
+
+    if ((this == &root) && !(nmsc + npsc + nasc)) {
+        ComponentIsRootWithNoSubcomponents ex(__FILE__, __LINE__, __func__,
+            getName(), getConcreteClassName());
+        if (getConcreteClassName() == "Model") {
+            // If we have a Model that is has no subcomponents we know this is 
+            // an issue of not calling finalizeFromProperties on the Model
+            throw ex;
+        }
+        else// Albeit strange for a Component to be root and have no subcomponents
+            // it is possible, and testComponents creates and interrogates
+            // components before they are added to a Model and many of these
+            // may have no subcomponents. So, just issue a warning in this case.
+            std::cout << "WARNING: " << ex.what() << std::endl;
     }
 
     const Component* last = nullptr;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1536,27 +1536,20 @@ void Component::initComponentTreeTraversal(const Component &root) const {
     const size_t npsc = _propertySubcomponents.size();
     const size_t nasc = _adoptedSubcomponents.size();
 
-    // If this isn't the root component and it has no parent, then
-    // this is an orphan component and we likely failed to call 
-    // finalizeFromProperties on the root OR this is a clone that
-    // has not been added to the root (in which case would have a parent).
-    if ((this != &root) && !this->hasParent() ) {
-        OPENSIM_THROW(ComponentIsAnOrphan, getName(), getConcreteClassName());
-    }
-
-    if ((this == &root) && !(nmsc + npsc + nasc)) {
-        ComponentIsRootWithNoSubcomponents ex(__FILE__, __LINE__, __func__,
-            getName(), getConcreteClassName());
-        if (getConcreteClassName() == "Model") {
-            // If we have a Model that is has no subcomponents we know this is 
-            // an issue of not calling finalizeFromProperties on the Model
-            throw ex;
+    if (!hasParent()) {
+        // If this isn't the root component and it has no parent, then
+        // this is an orphan component and we likely failed to call 
+        // finalizeFromProperties() on the root OR this is a clone that
+        // has not been added to the root (in which case would have a parent).
+        if (this != &root) {
+            OPENSIM_THROW(ComponentIsAnOrphan, getName(),
+                getConcreteClassName());
         }
-        else// Albeit strange for a Component to be root and have no subcomponents
-            // it is possible, and testComponents creates and interrogates
-            // components before they are added to a Model and many of these
-            // may have no subcomponents. So, just issue a warning in this case.
-            std::cout << "WARNING: " << ex.what() << std::endl;
+        // if the root (have no parent) and have no components
+        else if (!(nmsc + npsc + nasc)) {
+            OPENSIM_THROW(ComponentIsRootWithNoSubcomponents,
+                getName(), getConcreteClassName());
+        }
     }
 
     const Component* last = nullptr;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1529,9 +1529,9 @@ void Component::initComponentTreeTraversal(const Component &root) const {
     // Going down the tree, node is followed by all its
     // children in order, last child's successor is the parent's successor.
 
-    size_t nmsc = _memberSubcomponents.size();
-    size_t npsc = _propertySubcomponents.size();
-    size_t nasc = _adoptedSubcomponents.size();
+    const size_t nmsc = _memberSubcomponents.size();
+    const size_t npsc = _propertySubcomponents.size();
+    const size_t nasc = _adoptedSubcomponents.size();
 
     // If this component has no parent and has no subcomponents
     // this is an orphan component and likely failed to call 
@@ -1586,16 +1586,15 @@ void Component::initComponentTreeTraversal(const Component &root) const {
     }
 
     // recurse to handle children of subcomponents
-    for (unsigned int i = 0; i < _memberSubcomponents.size(); i++) {
+    for (unsigned int i = 0; i < nmsc; ++i) {
         _memberSubcomponents[i]->initComponentTreeTraversal(root);
     }
-    for (unsigned int i = 0; i < _propertySubcomponents.size(); i++) {
+    for (unsigned int i = 0; i < npsc; ++i) {
         _propertySubcomponents[i]->initComponentTreeTraversal(root);
     }
-    for (unsigned int i = 0; i < _adoptedSubcomponents.size(); i++) {
+    for (unsigned int i = 0; i < nasc; ++i) {
         _adoptedSubcomponents[i]->initComponentTreeTraversal(root);
     }
 }
-
 
 } // end of namespace OpenSim

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -93,6 +93,24 @@ public:
     }
 };
 
+
+class ComponentIsAnOrphan : public Exception {
+public:
+    ComponentIsAnOrphan(const std::string& file,
+        size_t line,
+        const std::string& func,
+        const std::string& thisName,
+        const std::string& componentConcreteClassName) :
+        Exception(file, line, func) {
+        std::string msg = "Component '" + thisName + "' of type " +
+            componentConcreteClassName + " has no parent or subcomponents.\n" +
+            "Verify that finalizeFromProperties() has been invoked on the " + 
+            "root Component or that this Component is not a clone, which has " +
+            "not been added to its parent.";
+        addMessage(msg);
+    }
+};
+
 class ComponentAlreadyPartOfOwnershipTree : public Exception {
 public:
     ComponentAlreadyPartOfOwnershipTree(const std::string& file,
@@ -2856,9 +2874,9 @@ void Input<T>::connect(const AbstractOutput& output,
     for (const auto& chan : outT->getChannels()) {
     
         // Record the number of pre-existing satisfied connections...
-        const int numPreexistingSatisfiedConnections(_connectees.size());
+        const size_t numPreexistingSatisfiedConnections(_connectees.size());
         // ...which happens to be the index of this new connectee.
-        const int idxThisConnectee = numPreexistingSatisfiedConnections;
+        const size_t idxThisConnectee = numPreexistingSatisfiedConnections;
         _connectees.push_back(
             SimTK::ReferencePtr<const Channel>(&chan.second) );
 
@@ -2878,7 +2896,7 @@ void Input<T>::connect(const AbstractOutput& output,
         // serialized
         int numDesiredConnections = getNumConnectees();
         if (idxThisConnectee < numDesiredConnections)
-            setConnecteeName(pathStr, idxThisConnectee);
+            setConnecteeName(pathStr, unsigned int(idxThisConnectee));
         else
             appendConnecteeName(pathStr);
 
@@ -2906,9 +2924,9 @@ void Input<T>::connect(const AbstractChannel& channel,
     }
     
     // Record the number of pre-existing satisfied connections...
-    const int numPreexistingSatisfiedConnections(_connectees.size());
+    const size_t numPreexistingSatisfiedConnections(_connectees.size());
     // ...which happens to be the index of this new connectee.
-    const int idxThisConnectee = numPreexistingSatisfiedConnections;
+    const size_t idxThisConnectee{ numPreexistingSatisfiedConnections };
     _connectees.push_back(SimTK::ReferencePtr<const Channel>(chanT));
     
     // Update the connectee name as
@@ -2926,7 +2944,7 @@ void Input<T>::connect(const AbstractChannel& channel,
     // Set the connectee name so the connection can be serialized.
     int numDesiredConnections = getNumConnectees();
     if (idxThisConnectee < numDesiredConnections) // satisifed <= desired
-        setConnecteeName(pathStr, idxThisConnectee);
+        setConnecteeName(pathStr, unsigned int(idxThisConnectee));
     else
         appendConnecteeName(pathStr);
     

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -105,7 +105,7 @@ public:
             componentConcreteClassName + " has no parent and is not the root.\n" +
             "Verify that finalizeFromProperties() has been invoked on the " + 
             "root Component or that this Component is not a clone, which has " +
-            "not been added to its parent.";
+            "not been added to its parent Component.";
         addMessage(msg);
     }
 };
@@ -2154,7 +2154,7 @@ public:
     const Component& getParent() const;
 
     /** Check if this Component has a parent assigned or not.
-        A component may not have a parent assigned if it:
+        A component may not have a parent Component assigned if it:
         1) is the root component, or 2) has not been added to its parent. */
     bool hasParent() const;
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -120,8 +120,9 @@ public:
         Exception(file, line, func) {
         std::string msg = "Component '" + thisName + "' of type " +
             componentConcreteClassName + " is the root but has no " + 
-            "subcomponents.\n" +
-            "Verify that finalizeFromProperties() was called on this Component.";
+            "subcomponents listed.\n" +
+            "Verify that finalizeFromProperties() was called on this "
+            "Component to identify its subcomponents.";
         addMessage(msg);
     }
 };

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2916,7 +2916,7 @@ void Input<T>::connect(const AbstractOutput& output,
         // serialized
         int numDesiredConnections = getNumConnectees();
         if (idxThisConnectee < numDesiredConnections)
-            setConnecteeName(pathStr, unsigned int(idxThisConnectee));
+            setConnecteeName(pathStr, unsigned(idxThisConnectee));
         else
             appendConnecteeName(pathStr);
 
@@ -2965,7 +2965,7 @@ void Input<T>::connect(const AbstractChannel& channel,
     int numDesiredConnections = getNumConnectees();
 
     if (idxThisConnectee < numDesiredConnections) // satisifed <= desired
-        setConnecteeName(pathStr, unsigned int(idxThisConnectee));
+        setConnecteeName(pathStr, unsigned(idxThisConnectee));
     else
         appendConnecteeName(pathStr);
     

--- a/OpenSim/Sandbox/TaskSpace/futureTaskSpace.cpp
+++ b/OpenSim/Sandbox/TaskSpace/futureTaskSpace.cpp
@@ -89,6 +89,7 @@ void switchMuscles(Model& model, State& state, bool appliesForce)
 void testTaskSpace()
 {
     Model model("futureTaskSpace.osim");
+    model.finalizeFromProperties();
 
     std::string indexBodyName = "hand_r";
     Vec3 indexOffset(0.05, -0.14, 0.011);

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -393,6 +393,7 @@ loadModel(const string &aToolSetupFileName, ForceSet *rOriginalForceSet )
 
         try {
             model = new Model(_modelFile);
+            model->finalizeFromProperties();
             if (rOriginalForceSet!=NULL)
                 *rOriginalForceSet = model->getForceSet();
         } catch(...) { // Properly restore current directory if an exception is thrown

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -85,13 +85,12 @@ Model::Model() : ModelComponent(),
 {
     constructProperties();
     setNull();
-    finalizeFromProperties();
 }
 //_____________________________________________________________________________
 /**
  * Constructor from an XML file
  */
-Model::Model(const string &aFileName, const bool finalize) :
+Model::Model(const string &aFileName) :
     ModelComponent(aFileName, false),
     _fileName("Unassigned"),
     _analysisSet(AnalysisSet()),
@@ -103,10 +102,6 @@ Model::Model(const string &aFileName, const bool finalize) :
     constructProperties();
     setNull();
     updateFromXMLDocument();
-
-    if (finalize) {
-        finalizeFromProperties();
-    }
 
     _fileName = aFileName;
     cout << "Loaded model " << getName() << " from file " << getInputFileName() << endl;

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -231,7 +231,7 @@ public:
     @param finalize  whether to extendFinalizeFromProperties to create a valid OpenSim Model or not on exit, 
                      defaults to true. If set to false only deserialization is performed.
     **/
-    explicit Model(const std::string& filename, bool finalize=true) SWIG_DECLARE_EXCEPTION;
+    explicit Model(const std::string& filename) SWIG_DECLARE_EXCEPTION;
 
     /**
      * Perform some set up functions that happen after the

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -230,7 +230,8 @@ public:
     the file. In order to evaluate the validity of the properties (e.g. Inertia
     tensors, availability of a Mesh files, and to traverse the tree of the
     Model's subcomponents, one must invoke Model::finalizeFromProperties(), 
-    first.
+    first. Model::initSystem() invokes finalizeFromProperties() on its way to
+    creating the System and initializing the State.
 
     @param filename     Name of a file containing an OpenSim model in XML
                         format; suffix is typically ".osim". 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -228,8 +228,8 @@ public:
     NOTE: The Model is read in (deserialized) from the model file, which means
     the properties of the Model and its components are filled in from values in
     the file. In order to evaluate the validity of the properties (e.g. Inertia
-    tensors, availability of a Mesh files, and to traverse the tree of the
-    Model's subcomponents, one must invoke Model::finalizeFromProperties(), 
+    tensors, availability of Mesh files, and to traverse the tree of the
+    Model's subcomponents) one must invoke Model::finalizeFromProperties() 
     first. Model::initSystem() invokes finalizeFromProperties() on its way to
     creating the System and initializing the State.
 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -220,16 +220,20 @@ public:
     //--------------------------------------------------------------------------
 public:
 
-    /** Default constructor creates a %Model containing only the ground Body
+    /** Default constructor creates a %Model containing only the Ground frame
     and a set of default properties. */
     Model();
 
     /** Constructor from an OpenSim XML model file. 
+    NOTE: The Model is read in (deserialized) from the model file, which means
+    the properties of the Model and its components are filled in from values in
+    the file. In order to evaluate the validity of the properties (e.g. Inertia
+    tensors, availability of a Mesh files, and to traverse the tree of the
+    Model's subcomponents, one must invoke Model::finalizeFromProperties(), 
+    first.
+
     @param filename     Name of a file containing an OpenSim model in XML
                         format; suffix is typically ".osim". 
-                        
-    @param finalize  whether to extendFinalizeFromProperties to create a valid OpenSim Model or not on exit, 
-                     defaults to true. If set to false only deserialization is performed.
     **/
     explicit Model(const std::string& filename) SWIG_DECLARE_EXCEPTION;
 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -228,8 +228,8 @@ public:
     NOTE: The Model is read in (deserialized) from the model file, which means
     the properties of the Model and its components are filled in from values in
     the file. In order to evaluate the validity of the properties (e.g. Inertia
-    tensors, availability of Mesh files, and to traverse the tree of the
-    Model's subcomponents) one must invoke Model::finalizeFromProperties() 
+    tensors, availability of Mesh files, ...) and to identify properties as
+    subcomponents of the Model, one must invoke Model::finalizeFromProperties() 
     first. Model::initSystem() invokes finalizeFromProperties() on its way to
     creating the System and initializing the State.
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -1011,6 +1011,8 @@ void testRollingOnSurfaceConstraint()
     arrowGeom.setColor(Vec3(1, 0, 0));
     ground.attachGeometry(arrowGeom.clone());
 
+    osimModel->finalizeFromProperties();
+
     //OpenSim rod
     auto osim_rod = new OpenSim::Body("rod", mass, comInRod, inertiaAboutCom);
     OpenSim::PhysicalOffsetFrame* cylFrame = new PhysicalOffsetFrame(*osim_rod, Transform(comInRod));

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2013,7 +2013,8 @@ void testEquivalentBodyForceFromGeneralizedForce()
     // Actuators that will fail to register and the model will not load.
     LoadOpenSimLibrary("osimActuators");
 
-    Model gaitModel("testJointConstraints.osim", true);
+    Model gaitModel("testJointConstraints.osim");
+    gaitModel.finalizeFromProperties();
     gaitModel.print("testJointConstraints.osim_30503.osim");
 
     testEquivalentBodyForceForGenForces(gaitModel);

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -618,7 +618,8 @@ void testBushingForce()
 
     osimModel.print("BushingForceModel.osim");
 
-    Model previousVersionModel("BushingForceModel_30000.osim", true);
+    Model previousVersionModel("BushingForceModel_30000.osim");
+    previousVersionModel.finalizeFromProperties();
     previousVersionModel.print("BushingForceModel_30000_in_Latest.osim");
 
     const BushingForce& bushingForceFromPrevious =
@@ -1247,6 +1248,7 @@ void testCoordinateLimitForce()
 
     // Check serialization and deserialization
     Model loadedModel{"CoordinateLimitForceTest.osim"};
+    loadedModel.finalizeFromProperties();
 
     ASSERT(loadedModel == *osimModel,
         "Deserialized CoordinateLimitForceTest failed to be equivalent to original.");

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -172,6 +172,8 @@ void testPhysicalOffsetFrameOnBody()
 
     cout << "\nRunning testOffsetFrameOnBody" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
+    pendulum->finalizeFromProperties();
+
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
 
     // The offset transform on the rod body
@@ -246,6 +248,8 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrame()
 
     cout << "\nRunning testPhysicalOffsetFrameOnPhysicalOffsetFrame" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
+    pendulum->finalizeFromProperties();
+
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
     
     SimTK::Transform X_RO;
@@ -314,6 +318,8 @@ void testPhysicalOffsetFrameOnBodySerialize()
 
     cout << "\nRunning testPhysicalOffsetFrameOnBodySerialize" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
+    pendulum->finalizeFromProperties();
+
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
 
     SimTK::Transform X_RO;
@@ -358,6 +364,7 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
     // PhysicalOffsetFrames occur in the order of the Multibody tree instead of
     // the order in Model's property list, which can be arbitrary.
     Model pendulum("double_pendulum.osim");
+    pendulum.finalizeFromProperties();
 
     SimTK::Transform X_RO;
     X_RO.setP(SimTK::Vec3(0.1, 0.2, 0.3));
@@ -423,6 +430,7 @@ void testFilterByFrameType()
     cout << "\nRunning testFilterByFrameType" << endl;
     // Previous model with a PhysicalOffsetFrame attached to rod1
     Model* pendulumWFrame = new Model("double_pendulum_extraFrame.osim");
+    pendulumWFrame->finalizeFromProperties();
 
     // Create an ordinary (non-physical) OffsetFrame attached to rod2
     const OpenSim::Body& rod2 = pendulumWFrame->getBodySet().get("rod2");

--- a/OpenSim/Simulation/Test/testNestedModelComponents.cpp
+++ b/OpenSim/Simulation/Test/testNestedModelComponents.cpp
@@ -64,6 +64,7 @@ void testPendulumModelWithNestedJoints()
 
     // Load the pendulum model
     Model* pendulum = new Model("double_pendulum.osim");
+    pendulum->finalizeFromProperties();
     
     // Create a new empty device;
     C* device = new C();

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -55,6 +55,7 @@ Real getStorageEntry(const Storage& sto,
 
 void testPopulateTrajectoryAndStatesTrajectoryReporter() {
     Model model("gait2354_simbody.osim");
+    model.finalizeFromProperties();
 
     // To assist with creating interesting (non-zero) coordinate values:
     model.updCoordinateSet().get("pelvis_ty").setDefaultLocked(true);

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -142,6 +142,7 @@ void testFrontBack() {
 void createStateStorageFile() {
 
     Model model("gait2354_simbody.osim");
+    model.finalizeFromProperties();
 
     // To assist with creating interesting (non-zero) coordinate values:
     model.updCoordinateSet().get("pelvis_ty").setDefaultLocked(true);

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -426,7 +426,7 @@ void testComponent(const Component& instanceToTest)
     }
 }
 
-void testComponentEquivalence(const Component* a, const Component* b) 
+void testComponentEquivalence(const Component* a, const Component* b, bool recurse = true)
 {
     const string& className = a->getConcreteClassName();
 
@@ -437,7 +437,7 @@ void testComponentEquivalence(const Component* a, const Component* b)
     int ns_a = a->getNumSockets();
     int ns_b = b->getNumSockets();
     cout << className << " getNumSockets: " << ns_a << endl;
-    ASSERT(ns_a==ns_b, __FILE__, __LINE__, 
+    ASSERT(ns_a == ns_b, __FILE__, __LINE__,
         className + "components differ in number of sockets.");
 
     int nin_a = a->getNumInputs();
@@ -449,21 +449,32 @@ void testComponentEquivalence(const Component* a, const Component* b)
     int nout_a = a->getNumOutputs();
     int nout_b = b->getNumOutputs();
     cout << className << " getNumOutputs: " << nout_a << endl;
-    ASSERT(nout_a == nout_b, __FILE__, __LINE__, 
+    ASSERT(nout_a == nout_b, __FILE__, __LINE__,
         className + " components differ in number of outputs.");
 
-    auto aSubsList = a->getComponentList<Component>();
-    auto bSubsList = b->getComponentList<Component>();
-    auto iter_a = aSubsList.begin();
-    auto iter_b = bSubsList.begin();
+    if (recurse) {
+        try {
+            auto aSubsList = a->getComponentList<Component>();
+            auto bSubsList = b->getComponentList<Component>();
+            auto iter_a = aSubsList.begin();
+            auto iter_b = bSubsList.begin();
 
-    //Subcomponents must be equivalent too!
-    while (iter_a != aSubsList.end() && iter_b != aSubsList.end()) {
-        const Component& asub = *iter_a;
-        const Component& bsub = *iter_b;
-        testComponentEquivalence(&asub, &bsub);
-        ++iter_a;
-        ++iter_b;
+            //Subcomponents must be equivalent too!
+            while (iter_a != aSubsList.end() && iter_b != aSubsList.end()) {
+                const Component& asub = *iter_a;
+                const Component& bsub = *iter_b;
+                testComponentEquivalence(&asub, &bsub, false);
+                ++iter_a;
+                ++iter_b;
+            }
+        }
+        // only trap the ComponentIsRootWithNoSubcomponents
+        catch (const ComponentIsRootWithNoSubcomponents& ex) {
+            // Just print the exception message but allow the test to continue.
+            // The test is blind to whether Components should have any 
+            // subcomponents as part of its generic processing.
+            cout << ex.what() << endl;
+        }
     }
 }
 

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -515,6 +515,9 @@ void testSerialization(Component* instance)
 
     Component* deserializedComp = dynamic_cast<Component *>(deserializedInstance);
 
+    instance->finalizeFromProperties();
+    deserializedComp->finalizeFromProperties();
+
     testComponentEquivalence(instance, deserializedComp);
     delete deserializedInstance;
 }

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -495,6 +495,8 @@ void testComponentListNonConstWithNonConstIterator() {
 // Ensure that we can compare const_iterator and (non-const) iterator.
 void testComponentListComparisonOperators() {
     Model model(modelFilename);
+    model.finalizeFromProperties();
+
     ComponentList<Body> list = model.updComponentList<Body>();
     ComponentList<Body>::const_iterator constIt = list.cbegin();
     ComponentList<Body>::iterator mutIt = list.begin();

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -128,6 +128,7 @@ void testNestedComponentListConsistency() {
 void testComponentListConst() {
 
     Model model(modelFilename);
+    model.finalizeFromProperties();
     model.dumpSubcomponents();
 
     ComponentList<const Component> componentsList = model.getComponentList();
@@ -260,6 +261,7 @@ void testComponentListConst() {
 // components.
 void testComponentListNonConstWithConstIterator() {
     Model model(modelFilename);
+    model.finalizeFromProperties();
 
     // Making this a const ComponentList causes us to use the const
     // begin()/end() methods, which return const_iterators, and thus avoids
@@ -392,6 +394,7 @@ void testComponentListNonConstWithConstIterator() {
 // allow modifying the elements of the list.
 void testComponentListNonConstWithNonConstIterator() {
     Model model(modelFilename);
+    model.finalizeFromProperties();
 
     ComponentList<Component> componentsList = model.updComponentList();
     int numComponents = 0;

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -129,7 +129,8 @@ void testComponentListConst() {
 
     Model model(modelFilename);
 
-    ASSERT_THROW(OpenSim::ComponentIsAnOrphan, model.getComponentList());
+    ASSERT_THROW( ComponentIsRootWithNoSubcomponents,
+                    model.getComponentList());
 
     model.finalizeFromProperties();
     model.dumpSubcomponents();

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -128,71 +128,77 @@ void testNestedComponentListConsistency() {
 void testComponentListConst() {
 
     Model model(modelFilename);
+
+    ASSERT_THROW(OpenSim::ComponentIsAnOrphan, model.getComponentList());
+
     model.finalizeFromProperties();
     model.dumpSubcomponents();
 
     ComponentList<const Component> componentsList = model.getComponentList();
-    std::cout << "list begin: " << componentsList.begin()->getName() << std::endl;
+    cout << "list begin: " << componentsList.begin()->getName() << endl;
     int numComponents = 0;
-    for (ComponentList<const Component>::const_iterator it = componentsList.begin();
-            it != componentsList.end();
-            ++it) {
-        std::cout << "Iterator is at: " << it->getAbsolutePathName() << " <" << it->getConcreteClassName() << ">" << std::endl;
+    for (ComponentList<const Component>::const_iterator 
+            it = componentsList.begin(); it != componentsList.end();  ++it) {
+        cout << "Iterator is at: " << it->getAbsolutePathName() << 
+            " <" << it->getConcreteClassName() << ">" << endl;
         numComponents++;
         // it->setName("this line should not compile; using const_iterator.");
     }
     
-    ComponentList<const OpenSim::Body> bodiesList = model.getComponentList<OpenSim::Body>();
+    ComponentList<const OpenSim::Body> bodiesList = 
+        model.getComponentList<OpenSim::Body>();
+
     int numBodies = 0;
-    std::cout << "Bodies list begin: " << bodiesList.begin()->getName() << std::endl;
-    for (ComponentList<OpenSim::Body>::const_iterator it = bodiesList.begin();
-            it != bodiesList.end();
-            ++it) {
-        std::cout << "Iterator is at Body: " << it->getName() << std::endl;
+    cout << "Bodies list begin: " << bodiesList.begin()->getName() << endl;
+    for (ComponentList<OpenSim::Body>::const_iterator 
+            it = bodiesList.begin(); it != bodiesList.end(); ++it) {
+        cout << "Iterator is at Body: " << it->getName() << endl;
         numBodies++;
     }
     // Now we try the post increment variant of the iterator
-    std::cout << "Bodies list begin, using post increment: " << bodiesList.begin()->getName() << std::endl;
+    cout << "Bodies list begin, using post increment: " 
+        << bodiesList.begin()->getName() << endl;
     int numBodiesPost = 0;
-    for (ComponentList<OpenSim::Body>::const_iterator itPost = bodiesList.begin();
-            itPost != bodiesList.end();
-            itPost++) {
-        std::cout << "Iterator is at Body: " << itPost->getName() << std::endl;
+    for (ComponentList<OpenSim::Body>::const_iterator 
+            itPost = bodiesList.begin(); itPost != bodiesList.end(); itPost++) {
+        cout << "Iterator is at Body: " << itPost->getName() << endl;
         numBodiesPost++;
     }
 
     int numMuscles = 0;
-    std::cout << "Using range-for loop over Muscles: " << std::endl;
+    cout << "Using range-for loop over Muscles: " << endl;
     ComponentList<const Muscle> musclesList = model.getComponentList<Muscle>();
     for (const Muscle& muscle : musclesList) {
-        std::cout << "Iterator is at muscle: " << muscle.getName() << std::endl;
+        cout << "Iterator is at muscle: " << muscle.getName() << endl;
         numMuscles++;
     }
     
     int numGeomPaths = 0;
-    ComponentList<const GeometryPath> geomPathList = model.getComponentList<GeometryPath>();
+    ComponentList<const GeometryPath> geomPathList =
+        model.getComponentList<GeometryPath>();
     for (const GeometryPath& gpath : geomPathList) {
         (void)gpath; // Suppress unused variable warning.
         numGeomPaths++;
     }
     const OpenSim::Joint& shoulderJnt = model.getJointSet().get(0);
-    // cycle through components under shoulderJnt should return the Joint itself and the Coordinate
+    // cycle through components under shoulderJnt should return the Joint 
+    // and the Coordinate
     int numJntComponents = 0;
-    ComponentList<const Component> jComponentsList = shoulderJnt.getComponentList();
-    std::cout << "Components/subComponents under Shoulder Joint:" << std::endl;
-    for (ComponentList<Component>::const_iterator it = jComponentsList.begin();
-            it != jComponentsList.end();
-            ++it) {
-        std::cout << "Iterator is at: " << it->getConcreteClassName() << " " << it->getAbsolutePathName() << std::endl;
+    ComponentList<const Component> jComponentsList = 
+        shoulderJnt.getComponentList();
+    cout << "Components/subComponents under Shoulder Joint:" << endl;
+    for (ComponentList<Component>::const_iterator
+            it = jComponentsList.begin(); it != jComponentsList.end(); ++it) {
+        cout << "Iterator is at: " << it->getConcreteClassName() << " "
+            << it->getAbsolutePathName() << endl;
         numJntComponents++;
     }
-    cout << "Num all components = " << numComponents << std::endl;
-    cout << "Num bodies = " << numBodies << std::endl;
-    cout << "Num Muscles = " << numMuscles << std::endl;
-    cout << "Num GeometryPath components = " << numGeomPaths << std::endl;
-    // Components = Model+3Body+3Marker+2(Joint+Coordinate)+6(Muscle+GeometryPath)
-    // Should test against 1+#Bodies+#Markers+#Joints+#Constraints+#Coordinates+#Forces+#ForcesWithPath+..
-    // Would that account for internal (split-bodies etc.?)
+    cout << "Num all components = " << numComponents << endl;
+    cout << "Num bodies = " << numBodies << endl;
+    cout << "Num Muscles = " << numMuscles << endl;
+    cout << "Num GeometryPath components = " << numGeomPaths << endl;
+    // Components = Model + 3Body + 3Marker + 2(Joint+Coordinate) 
+    //              + 6(Muscle+GeometryPath)
 
     // To test states we must have added the components to the system
     // which is done when the model creates and initializes the system
@@ -200,10 +206,10 @@ void testComponentListConst() {
 
     unsigned numJoints{}, numCoords{};
     for(const auto& joint : model.getComponentList<Joint>()) {
-        std::cout << "Joint: " << joint.getAbsolutePathName() << std::endl;
+        cout << "Joint: " << joint.getAbsolutePathName() << endl;
         ++numJoints;
         for(const auto& coord : joint.getComponentList<Coordinate>()) {
-            std::cout << "Coord: " << coord.getAbsolutePathName() << std::endl;
+            cout << "Coord: " << coord.getAbsolutePathName() << endl;
             ++numCoords;
         }
     }
@@ -211,26 +217,33 @@ void testComponentListConst() {
     ASSERT(numCoords == 2);
 
     int numJointsWithStateVariables = 0;
-    ComponentList<const Joint> jointsWithStates = model.getComponentList<Joint>();
+    ComponentList<const Joint> jointsWithStates = 
+        model.getComponentList<Joint>();
     ComponentWithStateVariables myFilter;
     jointsWithStates.setFilter(myFilter); 
     for (const Joint& comp : jointsWithStates) {
-        cout << comp.getConcreteClassName() << ":" << comp.getAbsolutePathName() << endl;
+        cout << comp.getConcreteClassName() << ":" 
+            << comp.getAbsolutePathName() << endl;
         numJointsWithStateVariables++;
     }
+
     int numModelComponentsWithStateVariables = 0;
-    ComponentList<const ModelComponent> comps = model.getComponentList<ModelComponent>();
+    ComponentList<const ModelComponent> comps = 
+        model.getComponentList<ModelComponent>();
     comps.setFilter(myFilter);
     for (const ModelComponent& comp : comps) {
-        cout << comp.getConcreteClassName() << ":" << comp.getAbsolutePathName() << endl;
+        cout << comp.getConcreteClassName() << ":" 
+            << comp.getAbsolutePathName() << endl;
         numModelComponentsWithStateVariables++;
     }
+
     //Now test a std::iterator method
     ComponentList<const Frame> allFrames = model.getComponentList<Frame>();
     ComponentList<Frame>::const_iterator skipIter = allFrames.begin();
     int countSkipFrames = 0;
     while (skipIter != allFrames.end()){
-        cout << skipIter->getConcreteClassName() << ":" << skipIter->getAbsolutePathName() << endl;
+        cout << skipIter->getConcreteClassName() << ":" 
+            << skipIter->getAbsolutePathName() << endl;
         std::advance(skipIter, 2);
         countSkipFrames++;
     }

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -221,6 +221,7 @@ void testPrescribedControllerOnBlock(bool enabled)
     
     osimModel.print("blockWithPrescribedController.osim");
     Model modelfileFromFile("blockWithPrescribedController.osim");
+    modelfileFromFile.finalizeFromProperties();
 
     // Verify that serialization and then deserialization is correct
     ASSERT(osimModel == modelfileFromFile);

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -97,8 +97,7 @@ int main()
         //Serialize all the components
         testModel.print("allComponents.osim");
 
-        // The finalize flag is for testing purposes ONLY. This way we
-        // can ignore invalid properties and focus the test on serialization.
+        // Now, deserilaize the Model from file 
         Model deserializedModel("allComponents.osim");
 
         try {

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -99,7 +99,7 @@ int main()
 
         // The finalize flag is for testing purposes ONLY. This way we
         // can ignore invalid properties and focus the test on serialization.
-        Model deserializedModel("allComponents.osim", false);
+        Model deserializedModel("allComponents.osim");
 
         try {
             deserializedModel.finalizeFromProperties();


### PR DESCRIPTION
Removes implicit call to `finalizeFromProperties()` within `Model` constructors and requires the call to be explicit (related to issues #606, #1010, #1130). Also adds exceptions for orphaned (accidental cloning) and empty root components (when forgetting to call `finalizeFromProperties()` on  a model).