### PR TITLE
Fix testInitState for macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,11 +141,9 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then git log --format=%B --no-merges -n 1 | grep '\[ci valgrind\]'; export RUN_VALGRIND=$?; true; fi
   - if [ $RUN_VALGRIND = "0" ]; then export CTEST_FLAGS="-D ExperimentalMemCheck"; fi
   
-  ## Decide which tests to exclude.
+  ## Decide which tests to exclude, based on platform, configuration, etc.
   # Initialize environment variable.
   - export TESTS_TO_EXCLUDE="unmatched" # This is just for the regex.
-  ## On OSX, we know that testInitState fails; exclude it.
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
   ## If we are building in debug, there are some tests to ignore.
   - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMC|testOptimizationExample|testWrapping|testContactGeometry"; fi
   

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -310,7 +310,7 @@ size_t estimateMemoryChangeForCreator(T creator, const size_t nSamples = 100)
 
 // Determine if getRSS is providing reliable estimates of memory usage by
 // testing against an allocation of known size and verifying that the change
-// memory use is detected. Employ this method to validate the use of
+// in memory use is detected. Employ this method to validate the use of
 // memory use estimators (e.g. estimateMemoryChangeForCreator and
 // estimateMemoryChangeForCommand). Do this at the beginning of your test 
 // involving checks for memory use.

--- a/OpenSim/Auxiliary/auxiliaryTestFunctions.h
+++ b/OpenSim/Auxiliary/auxiliaryTestFunctions.h
@@ -314,7 +314,7 @@ size_t estimateMemoryChangeForCreator(T creator, const size_t nSamples = 100)
 // memory use estimators (e.g. estimateMemoryChangeForCreator and
 // estimateMemoryChangeForCommand). Do this at the beginning of your test 
 // involving checks for memory use.
-void validateMemoryUseEstimates(const size_t nSamples = 11)
+void validateMemoryUseEstimates(const size_t nSamples = 20)
 {
     // Approximate size of a small OpenSim model
     size_t size = 1000 * 1024; // 1K * 1KB = 1MB;

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -152,7 +152,7 @@ void testMemoryUsage(const string& modelFile)
 
     // Throw an exception if we cannot validate estimates
     // of memory with current instrumentation
-    validateMemoryUseEstimates(20);
+    validateMemoryUseEstimates();
 
     //=========================================================================
     // Estimate the size of the model when loaded into memory

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -152,7 +152,7 @@ void testMemoryUsage(const string& modelFile)
 
     // Throw an exception if we cannot validate estimates
     // of memory with current instrumentation
-    validateMemoryUseEstimates();
+    validateMemoryUseEstimates(20);
 
     //=========================================================================
     // Estimate the size of the model when loaded into memory


### PR DESCRIPTION
This PR fixes the failure of testInitState on macOS. This was done by increasing the number of samples used to validateMemoryUseEstimates.