### PR TITLE
Fix some CMC tests in Debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ before_install:
   ## On OSX, we know that testInitState fails; exclude it.
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
   ## If we are building in debug, there are some tests to ignore.
-  - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMC|testOptimizationExample|testWrapping|testContactGeometry"; fi
+  #- if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|putTestNameHere"; fi
   
   ## Set compiler flags.
   - export CXX_FLAGS="-Werror -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ before_install:
   ## On OSX, we know that testInitState fails; exclude it.
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testInitState"; fi
   ## If we are building in debug, there are some tests to ignore.
-  - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testCMCGait10dof18musc"; fi
+  - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testOptimizationExample|testCMCGait10dof18musc"; fi
   
   ## Set compiler flags.
   - export CXX_FLAGS="-Werror -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
@@ -21,8 +21,6 @@
 		<maximum_number_of_integrator_steps>20000</maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
-		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>0</minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
@@ -22,7 +22,7 @@
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
 		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
+		<minimum_integrator_step_size>       1e-8 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_CMC.xml
@@ -21,6 +21,8 @@
 		<maximum_number_of_integrator_steps>20000</maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
+		<!--Minimum integration step size.-->
+		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
@@ -21,6 +21,8 @@
 		<maximum_number_of_integrator_steps>30000</maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
+		<!--Minimum integration step size.-->
+		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
@@ -21,8 +21,6 @@
 		<maximum_number_of_integrator_steps>30000</maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
-		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>0</minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
+++ b/Applications/CMC/test/block_hanging_from_muscle_Setup_Forward.xml
@@ -22,7 +22,7 @@
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>1</maximum_integrator_step_size>
 		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
+		<minimum_integrator_step_size>       1e-8 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator step size is decreased.-->
 		<integrator_error_tolerance>1e-008</integrator_error_tolerance>
 		<!--Set of analyses to be run during the investigation.-->

--- a/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
+++ b/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
@@ -292,6 +292,8 @@
 		<maximum_number_of_integrator_steps> 30000 </maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>       0.10000000 </maximum_integrator_step_size>
+		<!--Minimum integration step size.-->
+		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator
 		    step size is decreased.-->
 		<integrator_error_tolerance>       0.00000100 </integrator_error_tolerance>

--- a/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
+++ b/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
@@ -293,7 +293,7 @@
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>       0.10000000 </maximum_integrator_step_size>
 		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>       1e-12 </minimum_integrator_step_size>
+		<minimum_integrator_step_size>       1e-8 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator
 		    step size is decreased.-->
 		<integrator_error_tolerance>       0.00000100 </integrator_error_tolerance>

--- a/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
+++ b/Applications/CMC/test/twoMusclesOnBlock_Setup_Forward.xml
@@ -292,8 +292,6 @@
 		<maximum_number_of_integrator_steps> 30000 </maximum_number_of_integrator_steps>
 		<!--Maximum integration step size.-->
 		<maximum_integrator_step_size>       0.10000000 </maximum_integrator_step_size>
-		<!--Minimum integration step size.-->
-		<minimum_integrator_step_size>       0.00000000 </minimum_integrator_step_size>
 		<!--Integrator error tolerance. When the error is greater, the integrator
 		    step size is decreased.-->
 		<integrator_error_tolerance>       0.00000100 </integrator_error_tolerance>


### PR DESCRIPTION
Two of the CMC tests were failing in debug because the minimum step size for the integrator was set to an invalid value of 0. This PR fixes those two tests.

There is still one more CMC test that is failing in debug mode due to timing out; I have left that as ignored for now.