### PR TITLE
Disallow copy assignment & move assignment in Property | Add assign()

### DIFF
--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -196,6 +196,7 @@ public:
     @returns The index assigned to this value in the list. **/
     template <class T> int appendValue(const T& value);
 
+    /** Assign (copy) property *that* to this object. */
     virtual void assign(const AbstractProperty& that) = 0;
     /**@}**/
 

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -119,7 +119,7 @@ public:
         if (getComment() != other.getComment()) return false;
         if (getMinListSize() != other.getMinListSize()) return false;
         if (getMaxListSize() != other.getMaxListSize()) return false;
-     
+
         if (size() != other.size()) return false;
         // Note: we're delegating comparison of the "use default" flags
         // because only the new Property system copies them correctly, so
@@ -195,6 +195,8 @@ public:
     list isn't already of maximum size. 
     @returns The index assigned to this value in the list. **/
     template <class T> int appendValue(const T& value);
+
+    virtual void assign(const AbstractProperty& that) = 0;
     /**@}**/
 
     /** This method sets the "use default" flag for this property and the 
@@ -277,6 +279,10 @@ protected:
     AbstractProperty();
     AbstractProperty(const std::string& name, 
                      const std::string& comment);
+    AbstractProperty(const AbstractProperty&)            = default;
+    AbstractProperty(AbstractProperty&&)                 = default;
+    AbstractProperty& operator=(const AbstractProperty&) = default;
+    AbstractProperty& operator=(AbstractProperty&&)      = default;
 
     // This is the remainder of the interface that a concrete Property class
     // must implement, hidden from AbstractProperty users.

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -247,13 +247,9 @@ bool Object::operator==(const Object& other) const
     if (other.getNumProperties() != numProps)
         return false;
 
-    std::cout << "operator==()" << std::endl;
-    std::cout << getName() << std::endl;
     for (int px = 0; px < numProps; ++px) {
         const AbstractProperty& myProp    = getPropertyByIndex(px);
         const AbstractProperty& otherProp = other.getPropertyByIndex(px);
-        std::cout << myProp.getName() << " " << otherProp.getName()
-                  << std::endl;
 
         if (!myProp.equals(otherProp))
             return false;

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -247,9 +247,13 @@ bool Object::operator==(const Object& other) const
     if (other.getNumProperties() != numProps)
         return false;
 
+    std::cout << "operator==()" << std::endl;
+    std::cout << getName() << std::endl;
     for (int px = 0; px < numProps; ++px) {
         const AbstractProperty& myProp    = getPropertyByIndex(px);
         const AbstractProperty& otherProp = other.getPropertyByIndex(px);
+        std::cout << myProp.getName() << " " << otherProp.getName()
+                  << std::endl;
 
         if (!myProp.equals(otherProp))
             return false;

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -324,8 +324,6 @@ out all the values of any property:
 template <class T>
 class Property : public AbstractProperty {
 public:
-    // Default constructor, destructor, copy constructor, copy assignment 
-
     /** Provides type-specific methods used to implement generic functionality.
     This class must be specialized for any 
     type T that is used in a Property\<T> instantiation, unless T is an 
@@ -570,6 +568,12 @@ public:
     }
 
 protected:
+    Property() = default;
+    ~Property() = default;
+    Property(const Property&) = default;
+    Property(Property&&) = default;
+    Property& operator=(const Property&) = default;
+    Property& operator=(Property&&) = default;
     /** @cond **/ // Hide from Doxygen.
     // This is the interface that SimpleProperty and ObjectProperty must
     // implement.
@@ -712,6 +716,16 @@ public:
 
     SimpleProperty* clone() const override final 
     {   return new SimpleProperty(*this); }
+
+    void assign(const AbstractProperty& that) override {
+        try {
+            *this = dynamic_cast<const SimpleProperty&>(that);
+        } catch(const std::bad_cast&) {
+            OPENSIM_THROW(InvalidArgument,
+                          "Unsupported type. Expected: " + this->getTypeName() +
+                          " | Received: " + that.getTypeName());
+        }
+    }
    
     std::string toString() const override final {
         std::stringstream out;
@@ -962,6 +976,16 @@ public:
 
     ObjectProperty* clone() const override final 
     {   return new ObjectProperty(*this); }
+
+    void assign(const AbstractProperty& that) override {
+        try {
+            *this = dynamic_cast<const ObjectProperty&>(that);
+        } catch(const std::bad_cast&) {
+            OPENSIM_THROW(InvalidArgument,
+                          "Unsupported type. Expected: " + this->getTypeName() +
+                          " | Received: " + that.getTypeName());
+        }
+    }
 
     // Implementation of these methods must be deferred until Object has been
     // declared; see Object.h.

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -324,13 +324,7 @@ out all the values of any property:
 template <class T>
 class Property : public AbstractProperty {
 public:
-    // Default constructor and destructor.
-    Property()                           = default;
-    ~Property()                          = default;
-    // Copy assignment and move assignment is not allowed as this is an
-    // abstract class. 
-    Property& operator=(const Property&) = delete;
-    Property& operator=(Property&&)      = delete;
+    // Default constructor, destructor, copy constructor, copy assignment 
 
     /** Provides type-specific methods used to implement generic functionality.
     This class must be specialized for any 
@@ -576,11 +570,6 @@ public:
     }
 
 protected:
-    // Copy constructor and move constructor only available to derived
-    // classes.
-    Property(const Property&) = default;
-    Property(Property&&)      = default;
-
     /** @cond **/ // Hide from Doxygen.
     // This is the interface that SimpleProperty and ObjectProperty must
     // implement.

--- a/OpenSim/Common/PropertyBool.cpp
+++ b/OpenSim/Common/PropertyBool.cpp
@@ -108,6 +108,15 @@ operator=(const PropertyBool &aProperty)
     return(*this);
 }
 
+void PropertyBool::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyBool&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyBool.h
+++ b/OpenSim/Common/PropertyBool.h
@@ -73,6 +73,8 @@ public:
 public:
     PropertyBool& operator=(const PropertyBool &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyBoolArray.cpp
+++ b/OpenSim/Common/PropertyBoolArray.cpp
@@ -121,6 +121,15 @@ operator=(const PropertyBoolArray &aProperty)
     return(*this);
 }
 
+void PropertyBoolArray::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyBoolArray&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyBoolArray.h
+++ b/OpenSim/Common/PropertyBoolArray.h
@@ -84,6 +84,8 @@ public:
 public:
     PropertyBoolArray& operator=(const PropertyBoolArray &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyDbl.cpp
+++ b/OpenSim/Common/PropertyDbl.cpp
@@ -110,6 +110,16 @@ operator=(const PropertyDbl &aProperty)
     return(*this);
 }
 
+void PropertyDbl::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyDbl&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
+
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyDbl.h
+++ b/OpenSim/Common/PropertyDbl.h
@@ -71,6 +71,7 @@ public:
     //--------------------------------------------------------------------------
 public:
     PropertyDbl& operator=(const PropertyDbl &aProperty);
+    void assign(const AbstractProperty& that) override;
 
     //--------------------------------------------------------------------------
     // GET AND SET

--- a/OpenSim/Common/PropertyDblArray.cpp
+++ b/OpenSim/Common/PropertyDblArray.cpp
@@ -124,6 +124,15 @@ operator=(const PropertyDblArray &aProperty)
     return(*this);
 }
 
+void PropertyDblArray::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyDblArray&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyDblArray.h
+++ b/OpenSim/Common/PropertyDblArray.h
@@ -86,6 +86,9 @@ public:
 #ifndef SWIG
     PropertyDblArray& operator=(const PropertyDblArray &aProperty);
 #endif
+
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyDblVec.h
+++ b/OpenSim/Common/PropertyDblVec.h
@@ -88,6 +88,16 @@ public:
         PropertyDblVec_* prop = new PropertyDblVec_<M>(*this);
         return prop;
     }
+    
+    void assign(const AbstractProperty& that) override {
+        try {
+            *this = dynamic_cast<const PropertyDblVec_&>(that);
+        } catch(const std::bad_cast&) {
+            OPENSIM_THROW(InvalidArgument,
+                          "Unsupported type. Expected: " + this->getTypeName() +
+                          " | Received: " + that.getTypeName());
+        }
+    }
 
 public:
 

--- a/OpenSim/Common/PropertyInt.cpp
+++ b/OpenSim/Common/PropertyInt.cpp
@@ -110,6 +110,15 @@ operator=(const PropertyInt &aProperty)
     return(*this);
 }
 
+void PropertyInt::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyInt&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyInt.h
+++ b/OpenSim/Common/PropertyInt.h
@@ -73,6 +73,8 @@ public:
 public:
     PropertyInt& operator=(const PropertyInt &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyIntArray.cpp
+++ b/OpenSim/Common/PropertyIntArray.cpp
@@ -122,6 +122,15 @@ operator=(const PropertyIntArray &aProperty)
     return(*this);
 }
 
+void PropertyIntArray::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyIntArray&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyIntArray.h
+++ b/OpenSim/Common/PropertyIntArray.h
@@ -85,6 +85,8 @@ public:
 public:
     PropertyIntArray& operator=(const PropertyIntArray &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyObj.cpp
+++ b/OpenSim/Common/PropertyObj.cpp
@@ -121,6 +121,15 @@ operator=(const PropertyObj &aProperty)
     return(*this);
 }
 
+void PropertyObj::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyObj&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyObj.h
+++ b/OpenSim/Common/PropertyObj.h
@@ -86,6 +86,8 @@ public:
 public:
     PropertyObj& operator=(const PropertyObj &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyObjArray.h
+++ b/OpenSim/Common/PropertyObjArray.h
@@ -98,6 +98,16 @@ public:
         return (*this);
     }
 
+    void assign(const AbstractProperty& that) override {
+        try {
+            *this = dynamic_cast<const PropertyObjArray&>(that);
+        } catch(const std::bad_cast&) {
+            OPENSIM_THROW(InvalidArgument,
+                          "Unsupported type. Expected: " + this->getTypeName() +
+                          " | Received: " + that.getTypeName());
+        }
+    }
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/PropertyObjPtr.h
+++ b/OpenSim/Common/PropertyObjPtr.h
@@ -106,6 +106,16 @@ public:
         return *this;
     }
 
+    void assign(const AbstractProperty& that) override {
+        try {
+            *this = dynamic_cast<const PropertyObjPtr&>(that);
+        } catch(const std::bad_cast&) {
+            OPENSIM_THROW(InvalidArgument,
+                          "Unsupported type. Expected: " + this->getTypeName() +
+                          " | Received: " + that.getTypeName());
+        }
+    }
+
     bool operator==(const Property_Deprecated& aProperty) const override {
         bool equal = Property_Deprecated::operator==(aProperty);
         if (equal){ 

--- a/OpenSim/Common/PropertyStr.cpp
+++ b/OpenSim/Common/PropertyStr.cpp
@@ -87,6 +87,15 @@ PropertyStr* PropertyStr::clone() const
     return(property);
 }
 
+void PropertyStr::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyStr&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // OPERATORS

--- a/OpenSim/Common/PropertyStr.h
+++ b/OpenSim/Common/PropertyStr.h
@@ -74,6 +74,7 @@ public:
 #ifndef SWIG
     PropertyStr& operator=(const PropertyStr &aProperty);
 #endif
+    void assign(const AbstractProperty& that) override;
 
     //--------------------------------------------------------------------------
     // GET AND SET

--- a/OpenSim/Common/PropertyStrArray.cpp
+++ b/OpenSim/Common/PropertyStrArray.cpp
@@ -121,6 +121,15 @@ operator=(const PropertyStrArray &aProperty)
     return(*this);
 }
 
+void PropertyStrArray::assign(const AbstractProperty& that) {
+    try {
+        *this = dynamic_cast<const PropertyStrArray&>(that);
+    } catch(const std::bad_cast&) {
+        OPENSIM_THROW(InvalidArgument,
+                      "Unsupported type. Expected: " + this->getTypeName() +
+                      " | Received: " + that.getTypeName());
+    }
+}
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Common/PropertyStrArray.h
+++ b/OpenSim/Common/PropertyStrArray.h
@@ -84,6 +84,8 @@ public:
 public:
     PropertyStrArray& operator=(const PropertyStrArray &aProperty);
 
+    void assign(const AbstractProperty& that) override;
+
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------

--- a/OpenSim/Tools/Test/testModelCopy.cpp
+++ b/OpenSim/Tools/Test/testModelCopy.cpp
@@ -127,7 +127,8 @@ void testCopyModel(const string& fileName, const int nbod,
     modelCopy->finalizeFromProperties();
     // At this point properties should all match. assert that
     ASSERT(*model==*modelCopy);
-    ASSERT( model->getActuators().getSize() == modelCopy->getActuators().getSize() );
+    ASSERT(model->getActuators().getSize() ==
+           modelCopy->getActuators().getSize());
 
     //SimTK::State& defaultStateOfCopy = modelCopy->initSystem();
     // Compare state
@@ -138,7 +139,8 @@ void testCopyModel(const string& fileName, const int nbod,
     Model *cloneModel = modelCopy->clone();
     cloneModel->finalizeFromProperties();
     ASSERT(*model == *cloneModel);
-    ASSERT(model->getActuators().getSize() == cloneModel->getActuators().getSize());
+    ASSERT(model->getActuators().getSize() ==
+           cloneModel->getActuators().getSize());
 
     // Compare state again
     


### PR DESCRIPTION
Addressing #1488.

Because abstract class's copy assignment and move assignment operators cannot work polymorphically  through virtual function mechanism, disallow these operations. 
