### PR TITLE
Add space in exception message

### DIFF
--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -213,7 +213,7 @@ protected:
             OPENSIM_THROW(Exception,
                           "Attempting to update reporter with rows having "
                           "invalid timestamps. Hint: If running simulation in "
-                          "a loop, use clearTable() to clear table at the end"
+                          "a loop, use clearTable() to clear table at the end "
                           "of each loop.\n\n" + std::string{exception.what()});
         }
     }


### PR DESCRIPTION
This PR adds a space within an exception message. Accordingly, CI tests are not necessary.