### PR TITLE
Add Component::printSubcomponentInfo()

### DIFF
--- a/Bindings/Java/tests/TestIterators.java
+++ b/Bindings/Java/tests/TestIterators.java
@@ -5,7 +5,7 @@ class TestIterators {
     Model model = new Model();
 
     // Iterate through 
-    model.dumpSubcomponents();
+    model.printSubcomponentInfo();
     ComponentsList componentsList = model.getComponentsList();
     ComponentIterator compIter = componentsList.begin();
     int countComponents = 0;

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1507,47 +1507,6 @@ void Component::dumpConnections() const {
 void Component::printSubcomponentInfo() const {
     printSubcomponentInfo<Component>();
 }
-    
-template<typename C>
-void Component::printSubcomponentInfo() const {
-    std::string className = SimTK::NiceTypeName<C>::namestr();
-    const std::size_t colonPos = className.rfind(":");
-    if (colonPos != std::string::npos)
-        className = className.substr(colonPos+1, className.length()-colonPos);
-
-    std::cout << "Class name and absolute path name for descendants of '"
-              << getName() << "' that are of type " << className << ":\n"
-              << std::endl;
-
-    ComponentList<const C> compList = getComponentList<C>();
-
-    // Step through compList once to find the longest concrete class name.
-    unsigned maxlen = 0;
-    for (const C& thisComp : compList) {
-        auto len = thisComp.getConcreteClassName().length();
-        maxlen = std::max(maxlen, static_cast<unsigned>(len));
-    }
-    maxlen += 4; //padding
-
-    std::cout << std::setw(maxlen + 2) << "[" + getConcreteClassName() + "]"
-              << "  " << getAbsolutePathName() << std::endl;
-    auto prevPath = getAbsolutePathName();
-    // Step through compList again to print.
-    for (const C& thisComp : compList) {
-        const std::string thisClass = thisComp.getConcreteClassName();
-        std::cout << std::string(maxlen-thisClass.length(), ' ') << "["
-                  << thisClass << "]  ";
-        auto path = thisComp.getAbsolutePathName();
-        auto res = std::mismatch(prevPath.begin(), prevPath.end(),
-                                 path.begin());
-        while(*res.second != '/')
-            --res.second;
-        std::cout << std::setw(std::count(path.begin(), res.second, '/') * 4)
-                  << " " << path.substr(res.second - path.begin()) << std::endl;
-        prevPath = path;
-    }
-    std::cout << std::endl;
-}
 
 void Component::initComponentTreeTraversal(const Component &root) const {
     // Going down the tree, node is followed by all its

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1464,26 +1464,6 @@ void Component::AddedStateVariable::
 }
 
 
-void Component::dumpSubcomponents(int depth) const
-{
-    std::string tabs;
-    for (int t = 0; t < depth; ++t) {
-        tabs += "\t";
-    }
-
-    std::cout << tabs << getConcreteClassName();
-    std::cout << " '" << getName() << "'" << std::endl;
-    for (size_t i = 0; i < _memberSubcomponents.size(); ++i) {
-        _memberSubcomponents[int(i)]->dumpSubcomponents(depth + 1);
-    }
-    for (size_t i = 0; i < _propertySubcomponents.size(); ++i) {
-        _propertySubcomponents[int(i)]->dumpSubcomponents(depth + 1);
-    }
-    for (size_t i = 0; i < _adoptedSubcomponents.size(); ++i) {
-        _adoptedSubcomponents[int(i)]->dumpSubcomponents(depth + 1);
-    }
-}
-
 void Component::dumpConnections() const {
     std::cout << "Sockets for " << getConcreteClassName() << " '"
               << getName() << "':";
@@ -1524,6 +1504,50 @@ void Component::dumpConnections() const {
     }
 }
 
+void Component::printSubcomponentInfo() const {
+    printSubcomponentInfo<Component>();
+}
+    
+template<typename C>
+void Component::printSubcomponentInfo() const {
+    std::string className = SimTK::NiceTypeName<C>::namestr();
+    const std::size_t colonPos = className.rfind(":");
+    if (colonPos != std::string::npos)
+        className = className.substr(colonPos+1, className.length()-colonPos);
+
+    std::cout << "Class name and absolute path name for descendants of '"
+              << getName() << "' that are of type " << className << ":\n"
+              << std::endl;
+
+    ComponentList<const C> compList = getComponentList<C>();
+
+    // Step through compList once to find the longest concrete class name.
+    unsigned maxlen = 0;
+    for (const C& thisComp : compList) {
+        auto len = thisComp.getConcreteClassName().length();
+        maxlen = std::max(maxlen, static_cast<unsigned>(len));
+    }
+    maxlen += 4; //padding
+
+    std::cout << std::setw(maxlen + 2) << "[" + getConcreteClassName() + "]"
+              << "  " << getAbsolutePathName() << std::endl;
+    auto prevPath = getAbsolutePathName();
+    // Step through compList again to print.
+    for (const C& thisComp : compList) {
+        const std::string thisClass = thisComp.getConcreteClassName();
+        std::cout << std::string(maxlen-thisClass.length(), ' ') << "["
+                  << thisClass << "]  ";
+        auto path = thisComp.getAbsolutePathName();
+        auto res = std::mismatch(prevPath.begin(), prevPath.end(),
+                                 path.begin());
+        while(*res.second != '/')
+            --res.second;
+        std::cout << std::setw(res.second - path.begin()) << " "
+                  << path.substr(res.second - path.begin()) << std::endl;
+        prevPath = path;
+    }
+    std::cout << std::endl;
+}
 
 void Component::initComponentTreeTraversal(const Component &root) const {
     // Going down the tree, node is followed by all its

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1542,8 +1542,8 @@ void Component::printSubcomponentInfo() const {
                                  path.begin());
         while(*res.second != '/')
             --res.second;
-        std::cout << std::setw(res.second - path.begin()) << " "
-                  << path.substr(res.second - path.begin()) << std::endl;
+        std::cout << std::setw(std::count(path.begin(), res.second, '/') * 4)
+                  << " " << path.substr(res.second - path.begin()) << std::endl;
         prevPath = path;
     }
     std::cout << std::endl;

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1434,10 +1434,11 @@ public:
     // End of Model Component State Accessors.
     //@} 
 
-    /** @name Print debugging information to the console */
+    /** @name Print information about this component and subcomponents to the 
+     console                                                                  */
     /// @{
-    /** Debugging method to list all subcomponents by name and recurse
-        into these components to list their subcomponents, and so on. */
+    /** List all subcomponents by name and recurse into these components to 
+    list their subcomponents, and so on.                                      */
     void printSubcomponentInfo() const;
     
     /** List all the Sockets and Inputs and whether or not they are
@@ -1445,7 +1446,48 @@ public:
     void dumpConnections() const;
 
     template<typename C>
-    void printSubcomponentInfo() const;
+    void printSubcomponentInfo() const {
+        std::string className = SimTK::NiceTypeName<C>::namestr();
+        const std::size_t colonPos = className.rfind(":");
+        if (colonPos != std::string::npos)
+            className = className.substr(colonPos+1,
+                                         className.length()-colonPos);
+
+        std::cout << "Class name and absolute path name for descendants of '"
+                  << getName() << "' that are of type " << className << ":\n"
+                  << std::endl;
+
+        ComponentList<const C> compList = getComponentList<C>();
+
+        // Step through compList once to find the longest concrete class name.
+        unsigned maxlen = 0;
+        for (const C& thisComp : compList) {
+            auto len = thisComp.getConcreteClassName().length();
+            maxlen = std::max(maxlen, static_cast<unsigned>(len));
+        }
+        maxlen += 4; //padding
+
+        std::cout << std::string(maxlen-getConcreteClassName().length(), ' ')
+                  << "[" + getConcreteClassName() + "]"
+                  << "  " << getAbsolutePathName() << std::endl;
+        auto prevPath = getAbsolutePathName();
+        // Step through compList again to print.
+        for (const C& thisComp : compList) {
+            const std::string thisClass = thisComp.getConcreteClassName();
+            std::cout << std::string(maxlen-thisClass.length(), ' ') << "["
+                      << thisClass << "]  ";
+            auto path = thisComp.getAbsolutePathName();
+            auto res = std::mismatch(prevPath.begin(), prevPath.end(),
+                                     path.begin());
+            while(*res.second != '/')
+                --res.second;
+            std::cout << std::string(std::count(path.begin(),
+                                                res.second, '/') * 4, ' ')
+                      << path.substr(res.second - path.begin()) << std::endl;
+            prevPath = path;
+        }
+        std::cout << std::endl;
+    }
     /// @}
 
 protected:

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1434,14 +1434,18 @@ public:
     // End of Model Component State Accessors.
     //@} 
 
-    /** @name Dump debugging information to the console */
+    /** @name Print debugging information to the console */
     /// @{
     /** Debugging method to list all subcomponents by name and recurse
         into these components to list their subcomponents, and so on. */
-    void dumpSubcomponents(int depth=0) const;
+    void printSubcomponentInfo() const;
+    
     /** List all the Sockets and Inputs and whether or not they are
      * connected. */
     void dumpConnections() const;
+
+    template<typename C>
+    void printSubcomponentInfo() const;
     /// @}
 
 protected:

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -690,7 +690,8 @@ void testMisc() {
                   world3.add(&bar2));
 
     cout << "Connecting theWorld:" << endl;
-    theWorld.dumpSubcomponents();
+    //theWorld.dumpSubcomponents();
+    theWorld.printSubcomponentInfo();
     theWorld.finalizeFromProperties();
     theWorld.connect();
 
@@ -753,7 +754,7 @@ void testMisc() {
     ASSERT_EQUAL(3.5, foo.getInputValue<double>(s, "fiberLength"), 1e-10);
     ASSERT_EQUAL(1.5, foo.getInputValue<double>(s, "activation"), 1e-10);
 
-    theWorld.dumpSubcomponents();
+    theWorld.printSubcomponentInfo();
 
     std::cout << "Iterate over all Components in the world." << std::endl;
     for (auto& component : theWorld.getComponentList<Component>()) {
@@ -943,7 +944,7 @@ void testComponentPathNames()
     A->add(D);
     D->add(E);
 
-    top.dumpSubcomponents();
+    top.printSubcomponentInfo();
 
     std::string absPathC = C->getAbsolutePathName();
     ASSERT(absPathC == "/Top/A/B/C");
@@ -983,7 +984,7 @@ void testComponentPathNames()
     F->setName("F");
     top.add(F);
 
-    top.dumpSubcomponents();
+    top.printSubcomponentInfo();
 
     std::string fFoo1AbsPath = 
         F->getComponent<Foo>("Foo1").getAbsolutePathName();
@@ -1015,7 +1016,7 @@ void testComponentPathNames()
     fbar2.updSocket<Foo>("childFoo")
         .setConnecteeName("../Foo1");
 
-    top.dumpSubcomponents();
+    top.printSubcomponentInfo();
     top.connect();
 }
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1441,11 +1441,11 @@ void testPinJoint()
 
     knee3.finalizeConnections(*osimModel);
     knee3.dumpConnections();
-    knee3.dumpSubcomponents();
+    knee3.printSubcomponentInfo();
 
     knee.finalizeConnections(*osimModel);
     knee.dumpConnections();
-    knee.dumpSubcomponents();
+    knee.printSubcomponentInfo();
 
     // once connected the two ways of constructing the knee joint should
     // yield identical definitions
@@ -2261,7 +2261,7 @@ void testAutomaticJointReversal()
     auto relPathOff2 = cground.getRelativePathName(off2);
 
     //modelConstrained.setUseVisualizer(true);
-    modelConstrained.dumpSubcomponents();
+    modelConstrained.printSubcomponentInfo();
     SimTK::State& sc = modelConstrained.initSystem();
 
     SimTK::Transform pelvisXc = cpelvis.getTransformInGround(sc);

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -128,7 +128,7 @@ void testNestedComponentListConsistency() {
 void testComponentListConst() {
 
     Model model(modelFilename);
-    model.dumpSubcomponents();
+    model.printSubcomponentInfo();
 
     ComponentList<const Component> componentsList = model.getComponentList();
     std::cout << "list begin: " << componentsList.begin()->getName() << std::endl;


### PR DESCRIPTION
Addressing part of #1503.

Following is an example output:
```
 Class name and absolute path name for descendants of 'World' that are of type Component:
 
        [TheWorld]  /World
             [Sub]        /internalSub
             [Foo]        /Foo
             [Bar]        /Bar
             [Foo]        /Foo2
        [TheWorld]        /InternalWorld
             [Sub]                      /internalSub
             [Foo]                      /Foo
             [Bar]                      /Bar
             [Foo]                      /Foo2
        [TheWorld]        /World3
             [Sub]               /internalSub
             [Foo]               /Foo
             [Bar]               /Bar
             [Foo]               /Foo2
     [CompoundFoo]               /BigFoo
             [Foo]                      /Foo1
             [Foo]                      /Foo2
             [Bar]               /bar2
```