### PR TITLE
Add moment arm test for a joint comprised of a plurality of bodies

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -70,7 +70,7 @@
 #include <OpenSim/Common/FunctionAdapter.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
-#include <simbody/internal/MobilizedBody_BuiltIns.h>
+#include <OpenSim/Simulation/Test/SimulationComponentsForTesting.h>
 
 using namespace OpenSim;
 using namespace std;
@@ -146,91 +146,6 @@ public:
     }
 }; // End of MultidimensionalFunction
 
-
-//=============================================================================
-// CompoundJoint necessary for testing equivalent body force calculations
-// for joints comprised by more than one mobilized body.
-//=============================================================================
-class CompoundJoint : public Joint {
-OpenSim_DECLARE_CONCRETE_OBJECT(CompoundJoint, Joint);
-
-public:
-    /** Indices of Coordinates. */
-    enum class Coord: unsigned {
-        Rotation1X,
-        Rotation2Y,
-        Rotation3Z
-    };
-
-private:
-    /** Specify the Coordinates of this CompoundJoint */
-    CoordinateIndex rx{ constructCoordinate(Coordinate::MotionType::Rotational,
-                                   static_cast<unsigned>(Coord::Rotation1X)) };
-    CoordinateIndex ry{ constructCoordinate(Coordinate::MotionType::Rotational,
-                                   static_cast<unsigned>(Coord::Rotation2Y)) };
-    CoordinateIndex rz{ constructCoordinate(Coordinate::MotionType::Rotational,
-                                   static_cast<unsigned>(Coord::Rotation3Z)) };
-
-public:
-    // CONSTRUCTION
-    using Joint::Joint;
-
-protected:
-    void extendAddToSystem(SimTK::MultibodySystem& system) const override
-    {
-        using namespace SimTK;
-
-        Super::extendAddToSystem(system);
-
-        // PARENT TRANSFORM
-        const SimTK::Transform& P_Po =
-            getParentFrame().findTransformInBaseFrame();
-        // CHILD TRANSFORM
-        const SimTK::Transform& B_Bo = getChildFrame().findTransformInBaseFrame();
-
-        int coordinateIndexForMobility = 0;
-
-        SimTK::Transform childTransform0(Rotation(), Vec3(0));
-
-        SimTK::Body::Massless massless;
-
-        // CREATE MOBILIZED BODY for body rotation about body Z
-        MobilizedBody simtkMasslessBody1 = createMobilizedBody<MobilizedBody::Pin>(
-            system.updMatterSubsystem().updMobilizedBody(getParentFrame().getMobilizedBodyIndex()),
-            P_Po,
-            massless,
-            childTransform0,
-            coordinateIndexForMobility);
-
-        // Find the joint frame with Z aligned to body X
-        Rotation rotToX(Pi/2, YAxis);
-        SimTK::Transform parentTransform1(rotToX, Vec3(0));
-        SimTK::Transform childTransform1(rotToX, Vec3(0));
-
-        // CREATE MOBILIZED BODY for body rotation about body X
-        MobilizedBody simtkMasslessBody2 = createMobilizedBody<MobilizedBody::Pin>(
-            simtkMasslessBody1,
-            parentTransform1,
-            massless,
-            childTransform1,
-            coordinateIndexForMobility);
-
-        // Now Find the joint frame with Z aligned to body Y
-        Rotation rotToY(-Pi/2, XAxis);
-        SimTK::Transform parentTransform2(rotToY, Vec3(0));
-        SimTK::Transform childTransform2(B_Bo.R()*rotToY, B_Bo.p());
-        
-        // CREATE MOBILIZED BODY for body rotation about body Y
-        MobilizedBody mobBod = createMobilizedBody<MobilizedBody::Pin>(
-            simtkMasslessBody2,
-            parentTransform2,
-            getChildInternalRigidBody(),
-            childTransform2,
-            coordinateIndexForMobility, &getChildFrame());
-    }
-//=============================================================================
-};  // END of class CompoundJoint
-//=============================================================================
 
 void testCustomVsUniversalPin();
 void testCustomJointVsFunctionBased();

--- a/OpenSim/Simulation/Test/SimulationComponentsForTesting.h
+++ b/OpenSim/Simulation/Test/SimulationComponentsForTesting.h
@@ -1,0 +1,123 @@
+#ifndef OPENSIM_SIMULATION_COMPONENTS_FOR_TESTING_H_
+#define OPENSIM_SIMULATION_COMPONENTS_FOR_TESTING_H_
+
+/* -------------------------------------------------------------------------- *
+ *                OpenSim: SimulationComponentsForTesting.h                   *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Ajay Seth                                                       *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/** This file contains simulation-related Components that may be used by
+ * multiple tests in this directory and its subdirectories, and that exist only
+ * for use in tests. */
+
+#include <OpenSim/Simulation/osimSimulation.h>
+#include <simbody/internal/MobilizedBody_BuiltIns.h>
+
+using namespace OpenSim;
+using namespace std;
+
+//==============================================================================
+// CompoundJoint necessary for testing equivalent kinematics and body force
+// calculations for joints comprised of more than one mobilized body.
+//==============================================================================
+class CompoundJoint : public Joint {
+OpenSim_DECLARE_CONCRETE_OBJECT(CompoundJoint, Joint);
+
+public:
+    /** Indices of Coordinates. */
+    enum class Coord : unsigned {
+        Rotation1X,
+        Rotation2Y,
+        Rotation3Z
+    };
+
+private:
+    /** Specify the Coordinates of this CompoundJoint */
+    CoordinateIndex rx{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation1X)) };
+    CoordinateIndex ry{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation2Y)) };
+    CoordinateIndex rz{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation3Z)) };
+
+public:
+    // CONSTRUCTION
+    using Joint::Joint;
+
+protected:
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override
+    {
+        using namespace SimTK;
+
+        Super::extendAddToSystem(system);
+
+        // PARENT TRANSFORM
+        const SimTK::Transform& P_Po =
+            getParentFrame().findTransformInBaseFrame();
+        // CHILD TRANSFORM
+        const SimTK::Transform& B_Bo =
+            getChildFrame().findTransformInBaseFrame();
+
+        int coordinateIndexForMobility = 0;
+
+        SimTK::Transform childTransform0(Rotation(), Vec3(0));
+
+        SimTK::Body::Massless massless;
+
+        // CREATE MOBILIZED BODY for body rotation about body Z
+        MobilizedBody masslessBody1 = createMobilizedBody<MobilizedBody::Pin>(
+            system.updMatterSubsystem().updMobilizedBody(
+                getParentFrame().getMobilizedBodyIndex()),
+            P_Po,
+            massless,
+            childTransform0,
+            coordinateIndexForMobility);
+
+        // Find the joint frame with Z aligned to body X
+        Rotation rotToX(Pi/2, YAxis);
+        SimTK::Transform parentTransform1(rotToX, Vec3(0));
+        SimTK::Transform childTransform1(rotToX, Vec3(0));
+
+        // CREATE MOBILIZED BODY for body rotation about body X
+        MobilizedBody masslessBody2 = createMobilizedBody<MobilizedBody::Pin>(
+            masslessBody1,
+            parentTransform1,
+            massless,
+            childTransform1,
+            coordinateIndexForMobility);
+
+        // Now Find the joint frame with Z aligned to body Y
+        Rotation rotToY(-Pi/2, XAxis);
+        SimTK::Transform parentTransform2(rotToY, Vec3(0));
+        SimTK::Transform childTransform2(B_Bo.R()*rotToY, B_Bo.p());
+
+        // CREATE MOBILIZED BODY for body rotation about body Y
+        MobilizedBody mobBod = createMobilizedBody<MobilizedBody::Pin>(
+            masslessBody2,
+            parentTransform2,
+            getChildInternalRigidBody(),
+            childTransform2,
+            coordinateIndexForMobility, &getChildFrame());
+    }
+
+}; // end of CompoundJoint
+
+#endif // OPENSIM_SIMULATION_COMPONENTS_FOR_TESTING_H_

--- a/OpenSim/Simulation/Test/testMomentArms.cpp
+++ b/OpenSim/Simulation/Test/testMomentArms.cpp
@@ -92,8 +92,9 @@ protected:
         SimTK::Body::Massless massless;
 
         // CREATE MOBILIZED BODY for body rotation about body Z
-        MobilizedBody simtkMasslessBody1 = createMobilizedBody<MobilizedBody::Pin>(
-            system.updMatterSubsystem().updMobilizedBody(getParentFrame().getMobilizedBodyIndex()),
+        MobilizedBody masslessBody1 = createMobilizedBody<MobilizedBody::Pin>(
+            system.updMatterSubsystem().updMobilizedBody(
+                getParentFrame().getMobilizedBodyIndex()),
             P_Po,
             massless,
             childTransform0,
@@ -105,8 +106,8 @@ protected:
         SimTK::Transform childTransform1(rotToX, Vec3(0));
 
         // CREATE MOBILIZED BODY for body rotation about body X
-        MobilizedBody simtkMasslessBody2 = createMobilizedBody<MobilizedBody::Pin>(
-            simtkMasslessBody1,
+        MobilizedBody masslessBody2 = createMobilizedBody<MobilizedBody::Pin>(
+            masslessBody1,
             parentTransform1,
             massless,
             childTransform1,
@@ -119,7 +120,7 @@ protected:
 
         // CREATE MOBILIZED BODY for body rotation about body Y
         MobilizedBody mobBod = createMobilizedBody<MobilizedBody::Pin>(
-            simtkMasslessBody2,
+            masslessBody2,
             parentTransform2,
             getChildInternalRigidBody(),
             childTransform2,

--- a/OpenSim/Simulation/Test/testMomentArms.cpp
+++ b/OpenSim/Simulation/Test/testMomentArms.cpp
@@ -35,13 +35,102 @@
 //
 //=============================================================================
 #include <OpenSim/Simulation/osimSimulation.h>
+#include <OpenSim/Actuators/Thelen2003Muscle.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Common/LoadOpenSimLibrary.h>
+#include <simbody/internal/MobilizedBody_BuiltIns.h>
 
 using namespace OpenSim;
 using namespace std;
 
-//=============================================================================
+//==============================================================================
+// CompoundJoint necessary for testing equivalent body force calculations for
+// joints comprised of more than one mobilized body.
+//==============================================================================
+class CompoundJoint : public Joint {
+OpenSim_DECLARE_CONCRETE_OBJECT(CompoundJoint, Joint);
+
+public:
+    /** Indices of Coordinates. */
+    enum class Coord : unsigned {
+        Rotation1X,
+        Rotation2Y,
+        Rotation3Z
+    };
+
+private:
+    /** Specify the Coordinates of this CompoundJoint */
+    CoordinateIndex rx{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation1X)) };
+    CoordinateIndex ry{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation2Y)) };
+    CoordinateIndex rz{ constructCoordinate(Coordinate::MotionType::Rotational,
+                                   static_cast<unsigned>(Coord::Rotation3Z)) };
+
+public:
+    // CONSTRUCTION
+    using Joint::Joint;
+
+protected:
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override
+    {
+        using namespace SimTK;
+
+        Super::extendAddToSystem(system);
+
+        // PARENT TRANSFORM
+        const SimTK::Transform& P_Po =
+            getParentFrame().findTransformInBaseFrame();
+        // CHILD TRANSFORM
+        const SimTK::Transform& B_Bo =
+            getChildFrame().findTransformInBaseFrame();
+
+        int coordinateIndexForMobility = 0;
+
+        SimTK::Transform childTransform0(Rotation(), Vec3(0));
+
+        SimTK::Body::Massless massless;
+
+        // CREATE MOBILIZED BODY for body rotation about body Z
+        MobilizedBody simtkMasslessBody1 = createMobilizedBody<MobilizedBody::Pin>(
+            system.updMatterSubsystem().updMobilizedBody(getParentFrame().getMobilizedBodyIndex()),
+            P_Po,
+            massless,
+            childTransform0,
+            coordinateIndexForMobility);
+
+        // Find the joint frame with Z aligned to body X
+        Rotation rotToX(Pi/2, YAxis);
+        SimTK::Transform parentTransform1(rotToX, Vec3(0));
+        SimTK::Transform childTransform1(rotToX, Vec3(0));
+
+        // CREATE MOBILIZED BODY for body rotation about body X
+        MobilizedBody simtkMasslessBody2 = createMobilizedBody<MobilizedBody::Pin>(
+            simtkMasslessBody1,
+            parentTransform1,
+            massless,
+            childTransform1,
+            coordinateIndexForMobility);
+
+        // Now Find the joint frame with Z aligned to body Y
+        Rotation rotToY(-Pi/2, XAxis);
+        SimTK::Transform parentTransform2(rotToY, Vec3(0));
+        SimTK::Transform childTransform2(B_Bo.R()*rotToY, B_Bo.p());
+
+        // CREATE MOBILIZED BODY for body rotation about body Y
+        MobilizedBody mobBod = createMobilizedBody<MobilizedBody::Pin>(
+            simtkMasslessBody2,
+            parentTransform2,
+            getChildInternalRigidBody(),
+            childTransform2,
+            coordinateIndexForMobility, &getChildFrame());
+    }
+//==============================================================================
+};  // END of class CompoundJoint
+//==============================================================================
+
+
+//==============================================================================
 // Common Parameters for the simulations are just global.
 const static double integ_accuracy = 1.0e-3;
 
@@ -51,12 +140,18 @@ void testMomentArmDefinitionForModel(const string &filename,
                                      SimTK::Vec2 rom = SimTK::Vec2(-SimTK::Pi/2,0),
                                      double mass = -1.0, string errorMessage = "");
 
+void testMomentArmsAcrossCompoundJoint();
+
 int main()
 {
     clock_t startTime = clock();
     LoadOpenSimLibrary("osimActuators");
+    Object::registerType(CompoundJoint());
 
     try {
+
+        testMomentArmsAcrossCompoundJoint();
+        cout << "Joint composed of more than one mobilized body: PASSED\n" << endl;
 
         testMomentArmDefinitionForModel("BothLegs22.osim", "r_knee_angle", "VASINT", 
             SimTK::Vec2(-2*SimTK::Pi/3, SimTK::Pi/18), 0.0, 
@@ -128,6 +223,33 @@ int main()
     cout << "Moment-arm test time: " << 1.0e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms" << endl;
 
     return 0;
+}
+
+void testMomentArmsAcrossCompoundJoint()
+{
+    Model model;
+
+    Body* leg = new Body("leg", 10., SimTK::Vec3(0,1,0), SimTK::Inertia(1,1,1));
+    model.addComponent(leg);
+
+    CompoundJoint* hip = new CompoundJoint("hip",
+        model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
+        *leg, SimTK::Vec3(0, 0.5, 0), SimTK::Vec3(0));
+    model.addComponent(hip);
+
+    Thelen2003Muscle* musc = new Thelen2003Muscle("muscle", 10., 0.1, 0.2, 0.);
+    musc->addNewPathPoint("p1", model.updGround(), SimTK::Vec3(0.05, 0, 0));
+    musc->addNewPathPoint("p2", *leg, SimTK::Vec3(0.05, 0.25, 0.01));
+    model.addForce(musc);
+
+    SimTK::State& s = model.initSystem();
+
+    const Coordinate& c = model.getCoordinateSet()[0];
+
+    model.print("testMomentArmsAcrossCompoundJoint.osim");
+    testMomentArmDefinitionForModel("testMomentArmsAcrossCompoundJoint.osim",
+        c.getName(), "muscle", SimTK::Vec2(-2 * SimTK::Pi / 3, SimTK::Pi / 18),
+        0.0, "testMomentArmsAcrossCompoundJoint: FAILED");
 }
 
 //==========================================================================================================


### PR DESCRIPTION
Addresses #578. Uses the same CompoundJoint as [testJoints.cpp](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp#L154). I can move the class to a common location if a suitable one exists. The only candidate I'm aware of is [auxiliaryTestFunctions.h](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Auxiliary/auxiliaryTestFunctions.h), but it doesn't seem desirable to add `#include` overhead there for Joint.