### PR TITLE
Update col_label renaming for opensimTimeSeriesTableToMatlab

### DIFF
--- a/OpenSim/Sandbox/MatlabScripts/opensimTimeSeriesTableToMatlab.m
+++ b/OpenSim/Sandbox/MatlabScripts/opensimTimeSeriesTableToMatlab.m
@@ -26,13 +26,14 @@ for iCol = 0 : nCol -1
 
     col_label  = char(table.getColumnLabels.get(iCol));
 
-    if isempty(strfind(col_label, '/'))
-        eval(['[data.' col_label '] = rowdata;']);
-    else
-       temp = strfind(col_label, '/');
-       new_col_label = col_label(temp(end-1)+1:temp(end)-1);
-       eval(['[data.' new_col_label '] = rowdata;']);
+    if ~isempty(strfind(col_label, '/')) || ~isempty(strfind(col_label, '|'))
+        % Remove an initial slash.
+        col_label = regexprep(col_label, '^/', '');
+        % Replace all other slashes or vertical bars with an underscore.
+        col_label = strrep(col_label, '/', '_');
+        col_label = strrep(col_label, '|', '_');
     end
+    eval(['[data.' col_label '] = rowdata;']);
 
 
 end


### PR DESCRIPTION
I have updated the way that column labels get reformatted by @jimmyDunne's opensimTimeSeriesToMatlab.m script. Since the script was made, the format for output paths has changed to include a `|` character; this PR accounts for the `|` character. 

This PR also uses the full output path rather than only the leaf, since multiple columns could have the same leaf.

I forgot to skip the CI tests, but they are irrelevant for this PR (the sandbox is not tested).

I made these changes during the development of the TGCS exercise.

@jimmyDunne 
