### PR TITLE
In bindings, use takeKeyHit() instead of waitForKeyHit(). Update Simbody commit

### DIFF
--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -246,6 +246,11 @@ namespace SimTK {
 %include <simbody/internal/Visualizer_InputListener.h>
 // The following is necessary because the BackgroundType enum cannot be used
 // from MATLAB.
+// The new version of takeKeyHit() allows returning the value rather than using
+// an output variable as an argument, which is difficult to manage with SWIG.
+// The alternative `waitForKeyHit()` is not ideal for MATLAB, as MATLAB is not
+// able to interrupt native functions, and `waitForKeyHit()` will hang if the
+// simbody-visualizer is killed.
 namespace SimTK {
 %extend Visualizer {
     const Visualizer& setBackgroundTypeByInt(int index) {
@@ -255,10 +260,10 @@ namespace SimTK {
     }
 }
 %extend Visualizer::InputSilo {
-    unsigned waitForKeyHitKeyOnly() {
+    unsigned takeKeyHitKeyOnly() {
         unsigned key = 0;
         unsigned modifier = 0;
-        $self->waitForKeyHit(key, modifier);
+        $self->takeKeyHit(key, modifier);
         return key;
     }
 }

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -147,9 +147,10 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        ea7d94640b084d9feaa55e140c76e696f242a06a 
+              TAG        9e761bbb372e5da90ae478d2a5d3a4952ad94b27 
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
+                     
 
 AddDependency(NAME       docopt
               URL        https://github.com/docopt/docopt.cpp.git


### PR DESCRIPTION
This PR follows up on #1506. Initially, I had wrapped SimTK's `waitForKeyHit()` for use in MATLAB. However, if I killed the simbody-visualizer before hitting any keys, then MATLAB would hang forever at `waitForKeyHit()`, and Ctrl+C would not interrupt the function call; the only way to recover was to kill MATLAB.

So, it is necessary to wrap `takeKeyHit()` instead. By not wrapping `waitForKeyHit()` we help other users avoid the same issues I ran into.

This PR also updates the commit for the Simbody dependency to include a bug fix wherein the visualizer would cause MATLAB to crash (https://github.com/simbody/simbody/pull/548).

@aymanhab 