### PR TITLE
Improve access to LoadOpenSimLibrary() in bindings.

### DIFF
--- a/Bindings/Java/swig/java_actuators.i
+++ b/Bindings/Java/swig/java_actuators.i
@@ -1,5 +1,5 @@
-%module(directors="1") opensimModel
-%module opensimModel
+%module(directors="1") opensimActuatorsAnalysesTools
+%module opensimActuatorsAnalysesTools
 
 #pragma SWIG nowarn=822,451,503,516,325,401
 

--- a/Bindings/Java/swig/java_common.i
+++ b/Bindings/Java/swig/java_common.i
@@ -1,5 +1,5 @@
-%module(directors="1") opensimModelCommon
-%module opensimModelCommon
+%module(directors="1") opensimCommon
+%module opensimCommon
 
 #pragma SWIG nowarn=822,451,503,516,325,401
 

--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -1,5 +1,5 @@
-%module(directors="1") opensimModelSimulation
-%module opensimModelSimulation
+%module(directors="1") opensimSimulation
+%module opensimSimulation
 
 #pragma SWIG nowarn=822,451,503,516,325,401
 
@@ -175,7 +175,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %extend OpenSim::Model {
     static void LoadOpenSimLibrary(std::string libraryName){
-        LoadOpenSimLibrary(libraryName);
+        LoadOpenSimLibrary(libraryName, true);
     }
     
     void setDefaultControls(SimTK::Vector& newControls) {

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -60,6 +60,11 @@
 %template(ArrayConstObjPtr) OpenSim::Array<const OpenSim::Object*>;
 %template(ArrayPtrsConstObj) OpenSim::ArrayPtrs<const OpenSim::Object>;
 
+namespace OpenSim {
+    %ignore LoadOpenSimLibraries;
+}
+%include <OpenSim/Common/LoadOpenSimLibrary.h>
+
 // Used in Component::generateDecorations.
 %include <OpenSim/Common/ModelDisplayHints.h>
 

--- a/OpenSim/Common/LoadOpenSimLibrary.cpp
+++ b/OpenSim/Common/LoadOpenSimLibrary.cpp
@@ -146,8 +146,7 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
 OSIMCOMMON_API void
 OpenSim::LoadOpenSimLibrary(const std::string &aLibraryName)
 {
-    OPENSIM_PORTABLE_HINSTANCE library = LoadOpenSimLibrary(aLibraryName.c_str(), false);
-    if(!library) { cout<<"ERROR- library "<<aLibraryName<<" could not be loaded.\n\n"; }
+    OPENSIM_PORTABLE_HINSTANCE library = LoadOpenSimLibrary(aLibraryName, true);
 }
 
 OSIMCOMMON_API bool

--- a/OpenSim/Common/LoadOpenSimLibrary.h
+++ b/OpenSim/Common/LoadOpenSimLibrary.h
@@ -42,16 +42,46 @@ namespace OpenSim
 
 /** Load an OpenSim (plugin) library, using a path to a library (relative or
  * absolute) but *without* the file extension (.dll, .so, .dylib). This method
- * will prefer a debug variant of the library if OpenSim was built in debug. */
+ * will prefer a debug variant of the library if OpenSim was built in debug.
+ *
+ * In MATLAB/Python, we suggest you use LoadOpenSimLibraryExact instead of this
+ * function. If you insist on using this variant, see the examples below.
+ *
+ * To load a plugin in MATLAB, use the following:
+ * @code
+ * import org.opensim.modeling.*;
+ * opensimCommon.LoadOpenSimLibrary('<path>/osimMyPlugin');
+ * @endcode
+ * Do NOT use MATLAB's `loadlibrary()`.
+ *
+ * To load a plugin in Python, use the following:
+ * @code{.py}
+ * import opensim
+ * opensim.LoadOpenSimLibrary('<path>/osimMyPlugin')
+ * @endcode  */
 OSIMCOMMON_API OPENSIM_PORTABLE_HMODULE WINAPI LoadOpenSimLibrary(
         const std::string &lpLibFileName, bool verbose);
-/** Uses LoadOpenSimLibrary(const std::string&, bool) without verbosity. */
+/** Uses LoadOpenSimLibrary(const std::string&, bool), with verbosity. */
 OSIMCOMMON_API void LoadOpenSimLibrary(const std::string &aLibraryName);
 /** Load an OpenSim (plugin) library using the exact path specified. Therefore,
  * you must supply an exact path to the library (either relative or absolute),
  * including the file extension (.dll, .so, .dylib). The only change that may
  * be made to the path is to convert forward slashes to backslashes on Windows
  * (and vice versa on UNIX).
+ *
+ * To load a plugin in MATLAB, use the following:
+ * @code
+ * import org.opensim.modeling.*;
+ * opensimCommon.LoadOpenSimLibraryExact('<path>/osimMyPlugin.dll');
+ * @endcode
+ * Do NOT use MATLAB's `loadlibrary()`.
+ *
+ * To load a plugin in Python, use the following:
+ * @code{.py}
+ * import opensim
+ * opensim.LoadOpenSimLibraryExact('<path>/osimMyPlugin.dll')
+ * @endcode
+ * 
  * @returns true if the library was successfully loaded; false otherwise. */
 OSIMCOMMON_API bool LoadOpenSimLibraryExact(const std::string &exactPath,
                                             bool verbose = true);

--- a/OpenSim/Common/LoadOpenSimLibrary.h
+++ b/OpenSim/Common/LoadOpenSimLibrary.h
@@ -81,6 +81,11 @@ OSIMCOMMON_API void LoadOpenSimLibrary(const std::string &aLibraryName);
  * import opensim
  * opensim.LoadOpenSimLibraryExact('<path>/osimMyPlugin.dll')
  * @endcode
+ *
+ * @note If your (plugin) library depends on other libraries, make sure they
+ * are available as well (e.g., by setting the appropriate values for
+ * environment variables like `PATH` (Windows), `LD_LIBRARY_PATH` (Linux), and
+ * `DYLD_LIBRARY_PATH` (macOS)).
  * 
  * @returns true if the library was successfully loaded; false otherwise. */
 OSIMCOMMON_API bool LoadOpenSimLibraryExact(const std::string &exactPath,


### PR DESCRIPTION
This PR improves the ability to load OpenSim plugin libraries in MATLAB, and introduces this ability in Python.

There are two functions for loading libraries: `LoadOpenSimLibrary` which does not take the library extension, and `LoadOpenSimLibraryExact` which does take the library extension. Both are available in the bindings:

MATLAB:
```
import org.opensim.modeling.*;
opensimCommon.LoadOpenSimLibrary('osimCommon');
opensimCommon.LoadOpenSimLibraryExact('osimCommon.dll');
```

Python:
```
import opensim
opensim.LoadOpenSimLibrary('osimCommon')
opensim.LoadOpenSimLibraryExact('osimCommon.dll')
```

I made sure that an error message is generated if the plugin library is not loaded. I also added doxygen documentation describing how to use these functions in the bindings.

I changed the default behavior of `LoadOpenSimLibrary()` to be verbose.

I also renamed the Java modules to not contain 'Model' in their names (e.g., `opensimModelCommon` -> `opensimCommon`). I hope this is okay, but if not, I can undo this change. I feel that these new names are clearer for MATLAB users (e.g., there is no Model in the Common library), even though the names are more similar to those used in the GUI codebase and could cause confusion there.

Fixes #669.

@aymanhab 