### PR TITLE
Split and shorten testCMCGait10dof18musc.

### DIFF
--- a/Applications/CMC/test/gait10dof18musc_Setup_CMC.xml
+++ b/Applications/CMC/test/gait10dof18musc_Setup_CMC.xml
@@ -8,13 +8,13 @@
 		<!--List of xml files used to construct an force set for the model.-->
 		<force_set_files> gait10dof_Reserve_Actuators.xml</force_set_files>
 		<!--Directory used for writing results.-->
-		<results_directory>gait10dof18musc_ResultsCMC</results_directory>
+        <results_directory />
 		<!--Output precision.  It is 8 by default.-->
 		<output_precision>8</output_precision>
 		<!--Initial time for the simulation.-->
 		<initial_time>0.6</initial_time>
 		<!--Final time for the simulation.-->
-		<final_time>1.1</final_time>
+		<final_time>0.9</final_time>
 		<!--Flag indicating whether or not to compute equilibrium values for states other than the coordinates or speeds.  For example, equilibrium muscle fiber lengths or muscle forces.-->
 		<solve_for_equilibrium_for_auxiliary_states>true</solve_for_equilibrium_for_auxiliary_states>
 		<!--Maximum number of integrator steps.-->

--- a/Applications/CMC/test/testCMCGait10dof18musc_Millard.cpp
+++ b/Applications/CMC/test/testCMCGait10dof18musc_Millard.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                           OpenSim:  testCMCGait10dof18musc.cpp             *
+ *                OpenSim:  testCMCGait10dof18musc_Millard.cpp                *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -36,12 +36,6 @@ int main() {
 
     SimTK::Array_<std::string> failures;
 
-    try { testGait10dof18musc(); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testGait10dof18musc_Thelen");
-    }
-
     // redo with the Millard2012EquilibriumMuscle 
     Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
 
@@ -63,16 +57,17 @@ int main() {
 
 void testGait10dof18musc() {
     cout<<"\n******************************************************************" << endl;
-    cout << "*                      testGait10dof18musc                       *" << endl;
+    cout << "*                   testGait10dof18musc_Millard                   *" << endl;
     cout << "******************************************************************\n" << endl;
     CMCTool cmc("gait10dof18musc_Setup_CMC.xml");
+    cmc.setResultsDir("gait10dof18musc_ResultsCMC_Millard");
     const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
 
     if (!cmc.run())
         OPENSIM_THROW(Exception, "testGait10dof18musc " + muscleType +
             " failed to complete.");
 
-    Storage results("gait10dof18musc_ResultsCMC/walk_subject_states.sto");
+    Storage results("gait10dof18musc_ResultsCMC_Millard/walk_subject_states.sto");
     Storage temp("gait10dof18musc_std_walk_subject_states.sto");
 
     Storage *standard = new Storage();

--- a/Applications/CMC/test/testCMCGait10dof18musc_Thelen.cpp
+++ b/Applications/CMC/test/testCMCGait10dof18musc_Thelen.cpp
@@ -1,0 +1,82 @@
+/* -------------------------------------------------------------------------- *
+ *                 OpenSim:  testCMCGait10dof18musc_Thelen.cpp                *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+// INCLUDE
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/AnalysisSet.h>
+#include <OpenSim/Tools/CMCTool.h>
+#include <OpenSim/Tools/ForwardTool.h>
+#include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+using namespace OpenSim;
+using namespace std;
+
+void testGait10dof18musc();
+
+int main() {
+
+    SimTK::Array_<std::string> failures;
+
+    try { testGait10dof18musc(); }
+    catch (const std::exception& e) {
+        cout << e.what() << endl;
+        failures.push_back("testGait10dof18musc_Thelen");
+    }
+
+    if (!failures.empty()) {
+        cout << "Done, with failure(s): " << failures << endl;
+        return 1;
+    }
+
+    cout << "Done" << endl;
+
+    return 0;
+}
+
+void testGait10dof18musc() {
+    cout<<"\n******************************************************************" << endl;
+    cout << "*                   testGait10dof18musc_Thelen                   *" << endl;
+    cout << "******************************************************************\n" << endl;
+    CMCTool cmc("gait10dof18musc_Setup_CMC.xml");
+    cmc.setResultsDir("gait10dof18musc_ResultsCMC_Thelen");
+    const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
+
+    if (!cmc.run())
+        OPENSIM_THROW(Exception, "testGait10dof18musc " + muscleType +
+            " failed to complete.");
+
+    Storage results("gait10dof18musc_ResultsCMC_Thelen/walk_subject_states.sto");
+    Storage temp("gait10dof18musc_std_walk_subject_states.sto");
+
+    Storage *standard = new Storage();
+    cmc.getModel().formStateStorage(temp, *standard);
+
+    int nstates = standard->getColumnLabels().size() - 1;
+
+    // angles and speeds within .6 degrees .6 degs/s; activations within 1%
+    std::vector<double> rms_tols(nstates, 0.01);
+
+    CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols,
+        __FILE__, __LINE__, "testGait10dof18musc "+ muscleType + " failed");
+
+    cout << "\ntestGait10dof18musc "+ muscleType +" passed\n" << endl;
+}


### PR DESCRIPTION
This PR duplicates the effort in #1191 ; oops. 

I split testCMCGait10dof18musc into two tests, one for each of the two muscle models. I also shortened the duration of the CMC run, but not so much that the tolerances need to change.

We should either merge this one or #1191, but not both. Also, if shortening CMC final time is controversial because of issues related to the tolerance, I would prefer to undo that change and merge only the split into two test cases.