### PR TITLE
Remove unused Reporter Components doxygen page.

### DIFF
--- a/OpenSim/OpenSimDoxygenMain.h
+++ b/OpenSim/OpenSimDoxygenMain.h
@@ -28,7 +28,7 @@ Mainpage, the first page that a user sees when entering the Doxygen-
 generated API documentation. This is not actually included as part of the
 OpenSim source and it is not installed with OpenSim. **/
 
-/** @page reporters Reporter Components 
+/**  
  * @defgroup reporters Reporter Components
  * These components allow you to report the quantities calculated by your 
  * model in a unified way. You can wire the outputs of Component%s into one 


### PR DESCRIPTION
We already have a page for the group of Reporters. We don't need an additional
"page" for reporters. The page was empty anyway.
