### PR TITLE
Reset Component::_propertySubcomponents after copy.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2686,7 +2686,8 @@ private:
     SimTK::ResetOnCopy<SimTK::MeasureIndex> _simTKcomponentIndex;
 
     // list of subcomponents that are contained in this Component's properties
-    SimTK::Array_<SimTK::ReferencePtr<Component> >  _propertySubcomponents;
+    SimTK::ResetOnCopy<SimTK::Array_<SimTK::ReferencePtr<Component>>>
+        _propertySubcomponents;
     // Keep fixed list of data member Components upon construction
     SimTK::Array_<SimTK::ClonePtr<Component> > _memberSubcomponents;
     // Hold onto adopted components

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -782,7 +782,22 @@ void testMisc() {
     theWorld.print("Nested_" + modelFile);
 }
 
-
+// In order to access subcomponents in a copy, One must invoke
+// finalizeFromProperties() after copying. This test makes sure that you get an
+// exception if you did not call finalizeFromProperties() before calling a
+// method like getComponentList().
+void testExceptionsFinalizeFromPropertiesAfterCopy() {
+    TheWorld theWorld;
+    {
+        MultibodySystem system;
+        Foo* foo = new Foo();
+        theWorld.add(foo);
+    }
+    {
+        TheWorld copy = theWorld;
+        SimTK_TEST_MUST_THROW(copy.getComponentList());
+    }
+}
 
 void testListInputs() {
     MultibodySystem system;
@@ -1941,6 +1956,7 @@ int main() {
 
     SimTK_START_TEST("testComponentInterface");
         SimTK_SUBTEST(testMisc);
+        SimTK_SUBTEST(testExceptionsFinalizeFromPropertiesAfterCopy);
         SimTK_SUBTEST(testListInputs);
         SimTK_SUBTEST(testListSockets);
         SimTK_SUBTEST(testComponentPathNames);


### PR DESCRIPTION
In PR #1511 @aseth1 did a good job of throwing exceptions if the user had not called `finalizeFromProperties()` after a copy. However, I found a situation that fell through his checks. This PR addresses that situation.

The situation was that after copying, the member variable `Component::_propertySubcomponents`, of type `SimTK::Array_<SimTK::ReferencePtr<Component>>`, would have non-zero size but all the reference pointers inside it were null. Therefore, the check that [`!(nmsc + npsc + nasc)`](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Common/Component.cpp#L1595) returned was false even though we expected it to be true.

The fix was to reset the entire `SimTK::Array_` upon copy, so that it has no entries, thereby causing `!(nmsc + npsc + nasc)` to be true after copying, as expected.

I started this PR in my quest to fix test failures in Debug. Without this fix, `testContactGeometry` fails on Windows in Debug. I have verified locally that this PR fixes `testContactGeometry` on Windows in Debug. I have also added a test to make sure that an exception is thrown if `finalizeFromProperties()` is not invoked after copying a component that has a property subcomponent.