### PR TITLE
Avoid compiling stale .java files when building newer commits.

### DIFF
--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -63,9 +63,25 @@ add_subdirectory(OpenSimJNI)
 # ---------------------
 find_package(Java 1.7 REQUIRED)
 
+# To avoid compiling stale .java files, delete any existing files and copy
+# over the new files from the module-specific directories (see
+# OpenSimJNI/CMakeLists.txt).
 add_custom_command(
     OUTPUT "${SWIG_JAVA_JAR_BUILD_OUTPUT_PATH}"
     DEPENDS ${SWIG_JAVA_ACTUATORS_CXX_FILE}
+    COMMAND ${CMAKE_COMMAND} -E remove ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}/*
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/simbody
+            ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/common
+            ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/simulation
+            ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenSimJNI/src/actuators-analysis-tools
+            ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
     COMMAND ${JAVA_COMPILE} 
             org/opensim/modeling/*.java 
             -source 1.6 -target 1.6

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -20,14 +20,20 @@ function(OpenSimGenerateJavaWrapper
         "${_swig_common_args}"
         )
 
+    # This directory will hold the SWIG-generated .java files, but SWIG won't
+    # create this directory for us.
+    execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory
+        ${CMAKE_CURRENT_BINARY_DIR}/src/${NAME})
     add_custom_command(
         # This target actually creates a lot more (all the produced .java files)
         # but we will just use these two files as a proxy for all of those.
         OUTPUT ${OUTPUT_CXX_FILE} ${OUTPUT_H_FILE}
+        # To avoid compiling stale .java files, delete any existing .java files.
+        COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/src/${NAME}/*
         COMMAND ${SWIG_EXECUTABLE}
             -v # verbose
             -o ${OUTPUT_CXX_FILE}
-            -outdir ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
+            -outdir ${CMAKE_CURRENT_BINARY_DIR}/src/${NAME}
             ${_swig_common_args}
         DEPENDS ${_${NAME}_dependencies}
         COMMENT "Generating Java bindings source code with SWIG: ${NAME}")


### PR DESCRIPTION
This fixes #1547. Java source files are deleted before they are regenerated,
avoiding the possibility of compiling stale java files from previous builds.