### PR TITLE
Use _WIN32 instead of WIN32 macro.

### DIFF
--- a/OpenSim/Actuators/osimActuatorsDLL.cpp
+++ b/OpenSim/Actuators/osimActuatorsDLL.cpp
@@ -52,7 +52,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Actuators/osimActuatorsDLL.h
+++ b/OpenSim/Actuators/osimActuatorsDLL.h
@@ -28,7 +28,7 @@
  */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMACTUATORS_API
 

--- a/OpenSim/Analyses/osimAnalysesDLL.cpp
+++ b/OpenSim/Analyses/osimAnalysesDLL.cpp
@@ -48,7 +48,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Analyses/osimAnalysesDLL.h
+++ b/OpenSim/Analyses/osimAnalysesDLL.h
@@ -24,7 +24,7 @@
  * -------------------------------------------------------------------------- */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMANALYSES_API
 

--- a/OpenSim/Common/DebugUtilities.cpp
+++ b/OpenSim/Common/DebugUtilities.cpp
@@ -56,7 +56,7 @@ void AddEnvironmentVariablesFromFile(const std::string &aFileName)
         if(line.find("export") != std::string::npos) {
             std::string env=line.substr(7);
             std::cout << "Setting environment '" << env << "'" << std::endl;
-#ifdef WIN32
+#ifdef _WIN32
             _putenv(env.c_str());
 #else
             putenv(const_cast<char*>(env.c_str()));

--- a/OpenSim/Common/DebugUtilities.h
+++ b/OpenSim/Common/DebugUtilities.h
@@ -24,7 +24,7 @@
 #include "osimCommonDLL.h"
 #include <string>
 
-#ifdef WIN32
+#ifdef _WIN32
 #define OPENSIM_NORETURN(declaration) __declspec(noreturn) declaration
 #else
 #define OPENSIM_NORETURN(declaration) declaration __attribute__ ((noreturn))

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -32,7 +32,7 @@
 #include "osimCommonDLL.h"
 #include <string>
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning(disable:4251) /*no DLL interface for type of member of exported class*/
 #pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
 #endif

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -107,7 +107,7 @@ FixSlashesInFilePath(const std::string &path)
 {
     std::string fixedPath = path;
     for(unsigned int i=0;i<fixedPath.length();i++) {
-#ifdef WIN32
+#ifdef _WIN32
         if(fixedPath[i] == '/') fixedPath[i] = '\\';
 #else
         if(fixedPath[i] == '\\') fixedPath[i] = '/';

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -27,7 +27,7 @@
  * Author: Frank C. Anderson 
  */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #pragma warning( disable : 4786 )
 #pragma warning( disable : 4660 )
@@ -47,7 +47,7 @@
 
 
 // EXPORT LINE FOR MICROSOFT VISUAL C++
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef SWIG
 template class OSIMCOMMON_API OpenSim::ArrayPtrs<OpenSim::Object>;
 #endif

--- a/OpenSim/Common/PropertyBoolArray.h
+++ b/OpenSim/Common/PropertyBoolArray.h
@@ -32,7 +32,7 @@
 #include <string>
 #include "Property_Deprecated.h"
 #include "Array.h"
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertyDblArray.h
+++ b/OpenSim/Common/PropertyDblArray.h
@@ -27,7 +27,7 @@
  * Author: Frank C. Anderson 
  */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertyDblVec.h
+++ b/OpenSim/Common/PropertyDblVec.h
@@ -23,7 +23,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertyGroup.h
+++ b/OpenSim/Common/PropertyGroup.h
@@ -23,7 +23,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertyIntArray.h
+++ b/OpenSim/Common/PropertyIntArray.h
@@ -33,7 +33,7 @@
 #include <string>
 #include "Property_Deprecated.h"
 #include "Array.h"
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertySet.h
+++ b/OpenSim/Common/PropertySet.h
@@ -26,7 +26,7 @@
 /* Note: This code was originally developed by Realistic Dynamics Inc. 
  * Author: Frank C. Anderson, Ajay Seth 
  */
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 
@@ -45,7 +45,7 @@
 #endif
 
 #ifndef SWIG
-#ifdef WIN32
+#ifdef _WIN32
 template class OSIMCOMMON_API OpenSim::ArrayPtrs<OpenSim::Property_Deprecated>;
 #endif
 #endif

--- a/OpenSim/Common/PropertyStrArray.h
+++ b/OpenSim/Common/PropertyStrArray.h
@@ -32,7 +32,7 @@
 #include <string>
 #include "Property_Deprecated.h"
 #include "Array.h"
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/PropertyTransform.h
+++ b/OpenSim/Common/PropertyTransform.h
@@ -22,7 +22,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )
 #endif
 

--- a/OpenSim/Common/Property_Deprecated.h
+++ b/OpenSim/Common/Property_Deprecated.h
@@ -76,7 +76,7 @@ template <class T> class Array;
     #define OSIMCOMMON_API
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4290 )   // VC++ non-ANSI Exception handling
 #pragma warning( disable : 4251 )   // VC2010 no-dll export of std::string
 

--- a/OpenSim/Common/XMLDocument.h
+++ b/OpenSim/Common/XMLDocument.h
@@ -49,7 +49,7 @@ namespace OpenSim {
  * @version 1.0
  * @author Ayman Habib, Frank C. Anderson, 
  */
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning( disable : 4251 )   // VC2010 no-dll export of std::string
 
 #endif

--- a/OpenSim/Common/osimCommonDLL.cpp
+++ b/OpenSim/Common/osimCommonDLL.cpp
@@ -46,7 +46,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Common/osimCommonDLL.h
+++ b/OpenSim/Common/osimCommonDLL.h
@@ -25,7 +25,7 @@
 
 // IMPORT AND EXPORT
 // UNIX
-#ifndef WIN32
+#ifndef _WIN32
     #define OSIMCOMMON_API
 
 // WINDOWS

--- a/OpenSim/Common/osimCommonTemplates.cpp
+++ b/OpenSim/Common/osimCommonTemplates.cpp
@@ -36,7 +36,7 @@
 
 
 using namespace OpenSim;
-#ifdef WIN32
+#ifdef _WIN32
 
 //template class OSIMCOMMON_API Array<bool>;
 //template class OSIMCOMMON_API Array<int>;
@@ -45,7 +45,7 @@ using namespace OpenSim;
 
 //template class OSIMCOMMON_API Set<Material>;
 
-#endif  // WIN32
+#endif  // _WIN32
 
 
 typedef Array<bool> ArrayBool;

--- a/OpenSim/Common/osimCommonTemplates.h
+++ b/OpenSim/Common/osimCommonTemplates.h
@@ -46,14 +46,14 @@
 #include "Set.h"
 
 
-#ifdef WIN32
+#ifdef _WIN32
 
 extern template class OSIMCOMMON_API Array<bool>;
 extern template class OSIMCOMMON_API Array<int>;
 extern template class OSIMCOMMON_API Array<double>;
 extern template class OSIMCOMMON_API Array<std::string>;
 
-#endif  // WIN32
+#endif  // _WIN32
 
 
 #endif  // __osimCommonTemplates_h__

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/osimPluginDLL.h
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/osimPluginDLL.h
@@ -23,7 +23,7 @@
  * -------------------------------------------------------------------------- */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMPLUGIN_API
 

--- a/OpenSim/Examples/SymbolicExpressionReporter/osimExpPluginDLL.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/osimExpPluginDLL.cpp
@@ -48,7 +48,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Examples/SymbolicExpressionReporter/osimExpPluginDLL.h
+++ b/OpenSim/Examples/SymbolicExpressionReporter/osimExpPluginDLL.h
@@ -24,7 +24,7 @@
  * -------------------------------------------------------------------------- */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMEXPPLUGIN_API
 

--- a/OpenSim/Simulation/osimSimulationDLL.cpp
+++ b/OpenSim/Simulation/osimSimulationDLL.cpp
@@ -53,7 +53,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Simulation/osimSimulationDLL.h
+++ b/OpenSim/Simulation/osimSimulationDLL.h
@@ -28,7 +28,7 @@
  */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMSIMULATION_API
 

--- a/OpenSim/Tools/osimToolsDLL.cpp
+++ b/OpenSim/Tools/osimToolsDLL.cpp
@@ -49,7 +49,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
-#if defined(WIN32)
+#if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
 //=============================================================================

--- a/OpenSim/Tools/osimToolsDLL.h
+++ b/OpenSim/Tools/osimToolsDLL.h
@@ -27,7 +27,7 @@
 #define osimToolsDLL_h__
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMTOOLS_API
 


### PR DESCRIPTION
I recently tried out Visual Studio 2017, which comes with an updated C++ compiler (VC++ v141). the only build error I got was that `WIN32` was not always defined when we expected it to be. However, we should not rely on `WIN32`; the correct macro to use is `_WIN32`.

References:

- https://msdn.microsoft.com/en-us/library/b0084kay.aspx
- http://stackoverflow.com/questions/662084/whats-the-difference-between-the-win32-and-win32-defines-in-c
