### PR TITLE
Add ability to add search paths in ModelVisualizer

### DIFF
--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -206,7 +206,7 @@ findGeometryFile(const Model& aModel,
 // Initialize the static variable.
 SimTK::Array_<std::string> ModelVisualizer::dirsToSearch{};
 
-void ModelVisualizer::addDirToSearchGeometryFile(const std::string& dir) {
+void ModelVisualizer::addDirToGeometrySearchPaths(const std::string& dir) {
     // Make sure to add trailing path-separator if one is not present.
     if(dir.back() == Pathname::getPathSeparator().back())
         dirsToSearch.push_back(dir);

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -139,6 +139,8 @@ void ModelVisualizer::show(const SimTK::State& state) const {
 
 // See if we can find the given file. The rules are
 //  - if it is an absolute pathname, we only get one shot, else:
+//  - search the user added paths in dirToSearch in reverse chronological order
+//    i.e. latest path added is searched first.
 //  - define "modelDir" to be the absolute pathname of the 
 //      directory from which we read in the .osim model, if we did,
 //      otherwise modelDir="." (current directory).

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -202,9 +202,9 @@ findGeometryFile(const Model& aModel,
 }
 
 // Initialize the static variable.
-std::vector<std::string> ModelVisualizer::dirsToSearch{};
+SimTK::Array_<std::string> ModelVisualizer::dirsToSearch{};
 
-void ModelVisualizer::addDirToSearch(const std::string& dir) {
+void ModelVisualizer::addDirToSearchGeometryFile(const std::string& dir) {
     // Make sure to add trailing path-separator if one is not present.
     if(dir.back() == Pathname::getPathSeparator().back())
         dirsToSearch.push_back(dir);

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -139,13 +139,13 @@ void ModelVisualizer::show(const SimTK::State& state) const {
 
 // See if we can find the given file. The rules are
 //  - if it is an absolute pathname, we only get one shot, else:
-//  - search the user added paths in dirToSearch in reverse chronological order
-//    i.e. latest path added is searched first.
 //  - define "modelDir" to be the absolute pathname of the 
 //      directory from which we read in the .osim model, if we did,
 //      otherwise modelDir="." (current directory).
 //  - look for the geometry file in modelDir
 //  - look for the geometry file in modelDir/Geometry
+//  - search the user added paths in dirToSearch in reverse chronological order
+//    i.e. latest path added is searched first.
 //  - look for the geometry file in installDir/Geometry
 bool ModelVisualizer::
 findGeometryFile(const Model& aModel, 
@@ -163,13 +163,6 @@ findGeometryFile(const Model& aModel,
         attempts.push_back(geoFile);
         foundIt = Pathname::fileExists(attempts.back());
     } else {
-        for(auto dir = dirsToSearch.crbegin();
-            dir != dirsToSearch.crend();
-            ++dir) {
-            attempts.push_back(*dir + geoFile);
-            if(Pathname::fileExists(attempts.back()))
-                return true;
-        }
         const string geoDir = "Geometry" + Pathname::getPathSeparator();
         string modelDir;
         if (aModel.getInputFileName() == "Unassigned") 
@@ -190,6 +183,18 @@ findGeometryFile(const Model& aModel,
         if (!foundIt) {
             attempts.push_back(modelDir + geoDir + geoFile); 
             foundIt = Pathname::fileExists(attempts.back());
+        }
+
+        if (!foundIt) {
+            for(auto dir = dirsToSearch.crbegin();
+                dir != dirsToSearch.crend();
+                ++dir) {
+                attempts.push_back(*dir + geoFile);
+                if(Pathname::fileExists(attempts.back())) {
+                    foundIt = true;
+                    break;
+                }
+            }
         }
 
         if (!foundIt) {

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -160,7 +160,14 @@ findGeometryFile(const Model& aModel,
     if (geoFileIsAbsolute) {
         attempts.push_back(geoFile);
         foundIt = Pathname::fileExists(attempts.back());
-    } else {  
+    } else {
+        for(auto dir = dirsToSearch.crbegin();
+            dir != dirsToSearch.crend();
+            ++dir) {
+            attempts.push_back(*dir + geoFile);
+            if(Pathname::fileExists(attempts.back()))
+                return true;
+        }
         const string geoDir = "Geometry" + Pathname::getPathSeparator();
         string modelDir;
         if (aModel.getInputFileName() == "Unassigned") 
@@ -192,6 +199,17 @@ findGeometryFile(const Model& aModel,
     }
 
     return foundIt;
+}
+
+// Initialize the static variable.
+std::vector<std::string> ModelVisualizer::dirsToSearch{};
+
+void ModelVisualizer::addDirToSearch(const std::string& dir) {
+    // Make sure to add trailing path-separator if one is not present.
+    if(dir.back() == Pathname::getPathSeparator().back())
+        dirsToSearch.push_back(dir);
+    else
+        dirsToSearch.push_back(dir + "/");
 }
 
 // Call this on a newly-constructed ModelVisualizer (typically from the Model's

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -209,7 +209,7 @@ void ModelVisualizer::addDirToSearchGeometryFile(const std::string& dir) {
     if(dir.back() == Pathname::getPathSeparator().back())
         dirsToSearch.push_back(dir);
     else
-        dirsToSearch.push_back(dir + "/");
+        dirsToSearch.push_back(dir + Pathname::getPathSeparator());
 }
 
 // Call this on a newly-constructed ModelVisualizer (typically from the Model's

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -182,7 +182,7 @@ public:
     The search rule is as follows:
       - If \a geoFile is an absolute pathname no search is done.
       - Otherwise, try the search paths added through 
-        addDirToSearchGeometryFile(). The paths are searched in 
+        addDirToGeometrySearchPaths(). The paths are searched in 
         reverse-chronological order -- the latest path added is searched first.
       - Otherwise, define modelDir as the directory from which the current
         Model file was read in, if any, otherwise the current directory.
@@ -202,7 +202,7 @@ public:
     /** Add a directory to the search path to be used by the function
     findGeometryFile. The added paths are searched in the 
     reverse-chronological order -- the latest path added is searched first. */
-    static void addDirToSearchGeometryFile(const std::string& dir);
+    static void addDirToGeometrySearchPaths(const std::string& dir);
     /**@}**/
 
 

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -201,7 +201,7 @@ public:
     /** Add a directory to the search path to be used by the function
     findGeometryFile. The added paths are searched in the 
     reverse-chronological order -- the latest path added is searched first. */
-    static void addDirToSearch(const std::string& dir);
+    static void addDirToSearchGeometryFile(const std::string& dir);
     /**@}**/
 
 
@@ -237,7 +237,7 @@ private:
     SimTK::Visualizer::InputSilo*   _silo;
 
     // List of directories to search.
-    static std::vector<std::string> dirsToSearch;
+    static SimTK::Array_<std::string> dirsToSearch;
 };
 
 

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -175,7 +175,8 @@ public:
     @param[out]     attempts
         On return, this is a list of the absolute path names that were tried.
         If \a geoFile was found, attempts.back() (the last entry) is the
-        absolute path name of \a geoFile.
+        absolute path name of \a geoFile. The last entry of this array will be
+        the path that succeeded in finding the geometry file.
     @returns \c true if \a geoFile was located and is readable.
         
     The search rule is as follows:

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -181,12 +181,12 @@ public:
         
     The search rule is as follows:
       - If \a geoFile is an absolute pathname no search is done.
-      - Otherwise, try the search paths added through 
-        addDirToGeometrySearchPaths(). The paths are searched in 
-        reverse-chronological order -- the latest path added is searched first.
       - Otherwise, define modelDir as the directory from which the current
         Model file was read in, if any, otherwise the current directory.
       - Try modelDir/geoFile, then modelDir/Geometry/geoFile.
+      - Otherwise, try the search paths added through 
+        addDirToGeometrySearchPaths(). The paths are searched in 
+        reverse-chronological order -- the latest path added is searched first.
       - Finally, try installDir/geoFile where installDir is taken from
         the OPENSIM_HOME environment variable if it exists, otherwise
         a default installation directory. 

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -199,7 +199,7 @@ public:
                             SimTK::Array_<std::string>& attempts);
 
     /** Add a directory to the search path to be used by the function
-    findGeometryPath. The added paths are searched in the 
+    findGeometryFile. The added paths are searched in the 
     reverse-chronological order -- the latest path added is searched first. */
     static void addDirToSearch(const std::string& dir);
     /**@}**/

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -180,6 +180,9 @@ public:
         
     The search rule is as follows:
       - If \a geoFile is an absolute pathname no search is done.
+      - Otherwise, try the search paths added through addDirToSearch. The paths
+        are searched in reverse-chronological order -- the latest path added is
+        searched first.
       - Otherwise, define modelDir as the directory from which the current
         Model file was read in, if any, otherwise the current directory.
       - Try modelDir/geoFile, then modelDir/Geometry/geoFile.
@@ -194,6 +197,11 @@ public:
                             const std::string&          geoFile,
                             bool&                       isAbsolute,
                             SimTK::Array_<std::string>& attempts);
+
+    /** Add a directory to the search path to be used by the function
+    findGeometryPath. The added paths are searched in the 
+    reverse-chronological order -- the latest path added is searched first. */
+    static void addDirToSearch(const std::string& dir);
     /**@}**/
 
 
@@ -227,6 +235,9 @@ private:
     // This is just a reference -- it is owned by the Simbody Visualizer so 
     // don't delete it!
     SimTK::Visualizer::InputSilo*   _silo;
+
+    // List of directories to search.
+    static std::vector<std::string> dirsToSearch;
 };
 
 

--- a/OpenSim/Simulation/Model/ModelVisualizer.h
+++ b/OpenSim/Simulation/Model/ModelVisualizer.h
@@ -181,9 +181,9 @@ public:
         
     The search rule is as follows:
       - If \a geoFile is an absolute pathname no search is done.
-      - Otherwise, try the search paths added through addDirToSearch. The paths
-        are searched in reverse-chronological order -- the latest path added is
-        searched first.
+      - Otherwise, try the search paths added through 
+        addDirToSearchGeometryFile(). The paths are searched in 
+        reverse-chronological order -- the latest path added is searched first.
       - Otherwise, define modelDir as the directory from which the current
         Model file was read in, if any, otherwise the current directory.
       - Try modelDir/geoFile, then modelDir/Geometry/geoFile.


### PR DESCRIPTION
Addressing #1498.

As per conversation with @aymanhab, this PR does not remove `OPENSIM_HOME`. This PR adds logic to search user added paths before falling back to previous behavior.