### PR TITLE
Actuator curves bindings fix

### DIFF
--- a/Bindings/OpenSimHeaders_actuators.h
+++ b/Bindings/OpenSimHeaders_actuators.h
@@ -9,17 +9,9 @@
 #include <OpenSim/Actuators/TorqueActuator.h>
 #include <OpenSim/Actuators/BodyActuator.h>
 #include <OpenSim/Actuators/PointToPointActuator.h>
-#include <OpenSim/Actuators/ActiveForceLengthCurve.h>
-#include <OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h>
-#include <OpenSim/Actuators/FiberCompressiveForceLengthCurve.h>
-#include <OpenSim/Actuators/FiberForceLengthCurve.h>
-#include <OpenSim/Actuators/ForceVelocityCurve.h>
-#include <OpenSim/Actuators/ForceVelocityInverseCurve.h>
 #include <OpenSim/Actuators/ClutchedPathSpring.h>
-#include <OpenSim/Actuators/TendonForceLengthCurve.h>
 #include <OpenSim/Actuators/SpringGeneralizedForce.h>
 #include <OpenSim/Actuators/RigidTendonMuscle.h>
 #include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>
-#include <OpenSim/Actuators/ClutchedPathSpring.h>
 
 #endif // OPENSIM_OPENSIM_HEADERS_ACTUATORS_H_

--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -145,5 +145,11 @@
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 #include <OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h>
 #include <OpenSim/Actuators/FiberCompressiveForceLengthCurve.h>
+#include <OpenSim/Actuators/ActiveForceLengthCurve.h>
+#include <OpenSim/Actuators/FiberForceLengthCurve.h>
+#include <OpenSim/Actuators/ForceVelocityCurve.h>
+#include <OpenSim/Actuators/ForceVelocityInverseCurve.h>
+#include <OpenSim/Actuators/TendonForceLengthCurve.h>
+
 #endif // OPENSIM_OPENSIM_HEADERS_SIMULATION_H_
 

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -18,7 +18,7 @@ class TestBasics(unittest.TestCase):
     def test_version(self):
         print(osim.__version__)
 
-    def test_Thelen2003Muscle_helper_classes(self):
+    def test_muscle_helper_classes(self):
         # This test exists because some classes that Thelen2003Muscle used were
         # not accessibly in the bindings.
         muscle = osim.Thelen2003Muscle()
@@ -28,6 +28,11 @@ class TestBasics(unittest.TestCase):
 
         adm = muscle.getActivationModel()
         adm.get_activation_time_constant()
+
+        muscle = osim.Millard2012EquilibriumMuscle()
+
+        tendonFL = osim.TendonForceLengthCurve()
+        muscle.setTendonForceLengthCurve(tendonFL)
 
     def test_SimTKArray(self):
         # Initally created to test the creation of a separate simbody module.

--- a/Bindings/actuators.i
+++ b/Bindings/actuators.i
@@ -8,12 +8,5 @@
 %include <OpenSim/Actuators/ClutchedPathSpring.h>
 %include <OpenSim/Actuators/SpringGeneralizedForce.h>
 %include <OpenSim/Actuators/RigidTendonMuscle.h>
-%include <OpenSim/Actuators/ActiveForceLengthCurve.h>
-%include <OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h>
-%include <OpenSim/Actuators/FiberCompressiveForceLengthCurve.h>
-%include <OpenSim/Actuators/FiberForceLengthCurve.h>
-%include <OpenSim/Actuators/ForceVelocityCurve.h>
-%include <OpenSim/Actuators/ForceVelocityInverseCurve.h>
-%include <OpenSim/Actuators/TendonForceLengthCurve.h>
 
 %include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -231,6 +231,13 @@
 %template(getJointList) OpenSim::Model::getComponentList<OpenSim::Joint>;
 
 %include <OpenSim/Actuators/osimActuatorsDLL.h>
+%include <OpenSim/Actuators/ActiveForceLengthCurve.h>
+%include <OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h>
+%include <OpenSim/Actuators/FiberCompressiveForceLengthCurve.h>
+%include <OpenSim/Actuators/FiberForceLengthCurve.h>
+%include <OpenSim/Actuators/ForceVelocityCurve.h>
+%include <OpenSim/Actuators/ForceVelocityInverseCurve.h>
+%include <OpenSim/Actuators/TendonForceLengthCurve.h>
 %include <OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h>
 %include <OpenSim/Actuators/MuscleFixedWidthPennationModel.h>
 %include <OpenSim/Actuators/Thelen2003Muscle.h>


### PR DESCRIPTION
Bindings update to fix #1541. Moved muscle curves from actuators to simulation in interface and header files. Added python test to check if Millard2012EquilibriumMuscle object can accept new TendonForceLengthCurve.