### PR TITLE
Replace hardcoded map with OpenSim::Object_GetClassName<T>

### DIFF
--- a/Bindings/Python/tests/test_sockets_inputs_outputs.py
+++ b/Bindings/Python/tests/test_sockets_inputs_outputs.py
@@ -116,7 +116,7 @@ class TestInputsOutputs(unittest.TestCase):
         s = model.initSystem()
 
         out = model.getOutput("com_position")
-        self.assertEqual(out.getTypeName(), "SimTK::Vec<3,double,1>")
+        self.assertEqual(out.getTypeName(), "Vec3")
         print(out.getValueAsString(s))
 
         # Users should just call the method connected to this output, but

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1552,16 +1552,6 @@ void Component::printSubcomponentInfo() const {
 void Component::printOutputInfo(const bool includeDescendants) const {
     using ValueType = std::pair<std::string, SimTK::ClonePtr<AbstractOutput>>;
 
-    static const std::unordered_map<std::string, std::string>
-        typeAliases{{"SimTK::Vec<2,double,1>", "Vec2"},
-                    {"SimTK::Vec<3,double,1>", "Vec3"},
-                    {"SimTK::Vec<4,double,1>", "Vec4"},
-                    {"SimTK::Vec<5,double,1>", "Vec5"},
-                    {"SimTK::Vec<6,double,1>", "Vec6"},
-                    {"SimTK::Vec<2,SimTK::Vec<3,double,1>,1>", "SpatialVec"},
-                    {"SimTK::Transform_<double>", "Transform"},
-                    {"SimTK::Vector_<double>", "Vector"}};
-    
     // Do not display header for Components with no outputs.
     if (getNumOutputs() > 0) {
         const std::string msg = "Outputs from " + getAbsolutePathName() +
@@ -1569,34 +1559,15 @@ void Component::printOutputInfo(const bool includeDescendants) const {
         std::cout << msg << "\n" << std::string(msg.size(), '=') << std::endl;
 
         const auto& outputs = getOutputs();
-        unsigned maxlen{};
-        bool printingAlias{false};
-        for(const auto& output : outputs) {
-            const auto& name = output.second->getTypeName();
-            unsigned len = name.length();
-            if(typeAliases.find(name) != typeAliases.end()) {
-                len += typeAliases.at(name).length();
-                printingAlias = true;
-            }
-
-            maxlen = std::max(maxlen, len);
-        }
+        size_t maxlen{};
+        for(const auto& output : outputs)
+            maxlen = std::max(maxlen, output.second->getTypeName().length());
         maxlen += 2;
+        
         for(const auto& output : outputs) {
             const auto& name = output.second->getTypeName();
-            if(typeAliases.find(name) != typeAliases.end())
-                std::cout << std::string(maxlen -
-                                         name.length() -
-                                         typeAliases.at(name).length(), ' ');
-            else if(printingAlias)
-                std::cout << std::string(maxlen - name.length() + 3, ' ');
-            else
-                std::cout << std::string(maxlen - name.length(), ' ');
-            std::cout << "[" << name;
-            if(typeAliases.find(name) != typeAliases.end())
-                std::cout << " = " << typeAliases.at(name);
-            std::cout << "]  "
-                      << output.first << std::endl;
+            std::cout << std::string(maxlen - name.length(), ' ');
+            std::cout << "[" << name  << "]  " << output.first << std::endl;
         }
         std::cout << std::endl;
     }

--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -32,6 +32,7 @@
 
 // INCLUDES
 #include "Exception.h"
+#include "Object.h"
 
 #include <functional>
 #include <map>
@@ -287,8 +288,9 @@ public:
         return _result;
     }
     
-    std::string getTypeName() const override
-        { return SimTK::NiceTypeName<T>::namestr(); }
+    std::string getTypeName() const override {
+        return OpenSim::Object_GetClassName<T>::name();
+    }
 
     std::string getValueAsString(const SimTK::State& state) const override {
         if (isListOutput()) {

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1082,20 +1082,52 @@ OpenSim_OBJECT_ABSTRACT_DEFS(ConcreteClass);
 // getClassName() when it is available, otherwise a specialization.
 template <class T> struct Object_GetClassName 
 {   static const std::string& name() {return T::getClassName();} };
-template <> struct Object_GetClassName<double> 
-{   static const std::string name() {return "double";} };
-template <> struct Object_GetClassName<int> 
-{   static const std::string name() {return "int";} };
 template <> struct Object_GetClassName<bool> 
 {   static const std::string name() {return "bool";} };
+template <> struct Object_GetClassName<signed char> 
+{   static const std::string name() {return "char";} };
+template <> struct Object_GetClassName<unsigned char> 
+{   static const std::string name() {return "char";} };
+template <> struct Object_GetClassName<char> 
+{   static const std::string name() {return "char";} };
+template <> struct Object_GetClassName<short int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<unsigned short int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<unsigned int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<long int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<unsigned long int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<long long int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<unsigned long long int> 
+{   static const std::string name() {return "int";} };
+template <> struct Object_GetClassName<float> 
+{   static const std::string name() {return "float";} };
+template <> struct Object_GetClassName<double> 
+{   static const std::string name() {return "double";} };
+template <> struct Object_GetClassName<long double> 
+{   static const std::string name() {return "double";} };
 template <> struct Object_GetClassName<std::string> 
 {   static const std::string name() {return "string";} };
+template <> struct Object_GetClassName<SimTK::Vec2> 
+{   static const std::string name() {return "Vec2";} };
 template <> struct Object_GetClassName<SimTK::Vec3> 
 {   static const std::string name() {return "Vec3";} };
+template <> struct Object_GetClassName<SimTK::Vec6> 
+{   static const std::string name() {return "Vec6";} };
 template <> struct Object_GetClassName<SimTK::Vector_<SimTK::Real>>
 {   static const std::string name() {return "Vector"; } };
 template <> struct Object_GetClassName<SimTK::Vector_<SimTK::Vec3>>
 {   static const std::string name() {return "Vector_<Vec3>";} };
+template <> struct Object_GetClassName<SimTK::Vector_<SimTK::Vec6>>
+{   static const std::string name() {return "Vector_<Vec6>";} };
+template <> struct Object_GetClassName<SimTK::Vector_<SimTK::SpatialVec>>
+{   static const std::string name() {return "Vector_<SpatialVec>";} };
 template <> struct Object_GetClassName<SimTK::SpatialVec>
 {   static const std::string name() {return "SpatialVec";} };
 template <> struct Object_GetClassName<SimTK::Transform>


### PR DESCRIPTION
Addressing #1558.

This PR adds more specializations to `Object_GetClassname<T>` so it can be used more generally. Also removes use of hardcoded map in `Output<T>::getTypeName()` as it is not necessary anymore.