### PR TITLE
GetCompilerVersion() handles Visual Studio 2017 (Visual C++ v1910).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -732,8 +732,8 @@ if( WIN32 )
         message(AUTHOR_WARNING "OpenSim::GetCompilerVersion() "
             "in OpenSim/version.h does not handle this newer version "
             "(v${MSVC_VERSION}) of Microsoft Visual C++. "
-			"Update OpenSim/version.h and the condition for this warning "
-			"in the root CMakeLists.txt.")
+            "Update OpenSim/version.h and the condition for this warning "
+            "in the root CMakeLists.txt.")
     endif()
     set(OPENSIM_COMPILER_INFO ${MSVC_VERSION})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,7 +731,9 @@ if( WIN32 )
     if (${MSVC_VERSION} GREATER 1910)
         message(AUTHOR_WARNING "OpenSim::GetCompilerVersion() "
             "in OpenSim/version.h does not handle this newer version "
-            "(v${MSVC_VERSION}) of Microsoft Visual C++.")
+            "(v${MSVC_VERSION}) of Microsoft Visual C++. "
+			"Update OpenSim/version.h and the condition for this warning "
+			"in the root CMakeLists.txt.")
     endif()
     set(OPENSIM_COMPILER_INFO ${MSVC_VERSION})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -728,6 +728,11 @@ set(OPENSIM_SYSTEM_INFO ${CMAKE_SYSTEM})
 set(OPENSIM_OS_NAME ${CMAKE_SYSTEM_NAME})
 
 if( WIN32 )
+    if (${MSVC_VERSION} GREATER 1910)
+        message(AUTHOR_WARNING "OpenSim::GetCompilerVersion() "
+            "in OpenSim/version.h does not handle this newer version "
+            "(v${MSVC_VERSION}) of Microsoft Visual C++.")
+    endif()
     set(OPENSIM_COMPILER_INFO ${MSVC_VERSION})
 else()
     set(OPENSIM_COMPILER_INFO ${CMAKE_CXX_COMPILER} )

--- a/OpenSim/version.h
+++ b/OpenSim/version.h
@@ -72,6 +72,9 @@ namespace OpenSim {
 
         if( 0 == os.compare("Windows")) {
             switch( atoi(GET_COMPILER_INFO) ) {
+            case 1910:
+                str = "Visual Studio 2017";
+                break;
             case 1900:
                 str = "Visual Studio 2015";
                 break;
@@ -82,20 +85,20 @@ namespace OpenSim {
                 str = "Visual Studio 2011";
                 break;
             case 1600:
-                    str = "Visual Studio 2010";
-                    break;
-                case 1500:
-                    str = "Visual Studio 2008";
-                    break;
-                case 1400:
-                    str = "Visual Studio 2005";
-                    break;
-                case 1310:
-                    str = "Visual Studio 2003";
-                    break;
-                case 1300:
-                    str = "Visual Studio 2002";
-                    break;
+                str = "Visual Studio 2010";
+                break;
+            case 1500:
+                str = "Visual Studio 2008";
+                break;
+            case 1400:
+                str = "Visual Studio 2005";
+                break;
+            case 1310:
+                str = "Visual Studio 2003";
+                break;
+            case 1300:
+                str = "Visual Studio 2002";
+                break;
             }
         } else if( 0 == os.compare("Darwin")) {
             str = "Mac OS X :";


### PR DESCRIPTION
This PR adds MSVC 2017 to the GetCompilerVersion() switch. This PR also causes CMake to generate a warning targeted to OpenSim's maintainers if GetCompilerVersion() doesn't handle a newer version of MSVC.