### PR TITLE
Use _WIN32 instead of WIN32 for osimSimmFileWriter.

### DIFF
--- a/OpenSim/Utilities/simmFileWriterDLL/osimSimmFileWriterDLL.h
+++ b/OpenSim/Utilities/simmFileWriterDLL/osimSimmFileWriterDLL.h
@@ -29,7 +29,7 @@
 */
 
 // UNIX PLATFORM
-#ifndef WIN32
+#ifndef _WIN32
 
 #define OSIMSIMMFILEWRITER_API
 


### PR DESCRIPTION
This is a followup to #1559.