### PR TITLE
[readme] Add ZenHub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-OpenSim Core [![Travis][buildstatus_image_travis]][travisci] [![Appveyor][buildstatus_image_appveyor]][appveyorci]
+OpenSim Core
 ============
+ [![Travis][buildstatus_image_travis]][travisci] [![Appveyor][buildstatus_image_appveyor]][appveyorci] [![ZenHub][zenhub_image]][zenhub]
 
-**NOTE: This repository contains OpenSim 4.0 development and cannot be used to build OpenSim 3.x or earlier. For OpenSim 3.x, see [here](http://simtk-confluence.stanford.edu:8080/display/OpenSim/Building+OpenSim+from+Source).**
+**NOTE: This repository cannot be used to build OpenSim 3.x or earlier. For OpenSim 3.x, see [here](http://simtk-confluence.stanford.edu:8080/display/OpenSim/Building+OpenSim+from+Source).**
 
 OpenSim is software that lets users develop models of musculoskeletal
 structures and create dynamic simulations of movement, such as this one:
@@ -921,6 +922,9 @@ ctest -j8
 [travisci]: https://travis-ci.org/opensim-org/opensim-core
 [buildstatus_image_appveyor]: https://ci.appveyor.com/api/projects/status/i4wxnmx9jlk69kge/branch/master?svg=true
 [appveyorci]: https://ci.appveyor.com/project/opensim-org/opensim-core/branch/master
+[zenhub_image]: https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png
+[zenhub]: https://zenhub.com
+
 [running_gif]: doc/images/opensim_running.gif
 [simple_example_gif]: doc/images/opensim_double_pendulum_muscle.gif
 [java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html


### PR DESCRIPTION
This PR adds a ZenHub badge to our README. 

![image](https://cloud.githubusercontent.com/assets/846001/23819113/c922b42e-05b6-11e7-8402-9a208e9c0f04.png)

Unfortunately the badge is a low-res PNG. I tried using the SVG version but GitHub does not render SVG due to security vulnerabilities: http://stackoverflow.com/questions/13808020/include-an-svg-hosted-on-github-in-markdown.

I stopped the CI builds because they are unnecessary for this PR.