### PR TITLE
Allow making a standalone Python package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -222,6 +222,10 @@ script:
   - make -j8 install > /dev/null
 
   ## Test python wrapping.
+  # Since we use OPENSIM_COPY_SIMBODY=ON, ensure the Python bindings are not
+  # relying on the original Simbody libraries but rather the copied ones.
+  # This should make sure we have the correct RPATH for Simbody on macOS.
+  - rm -r ~/simbody
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/lib/python2.7/site-packages; fi
   # Run the python tests, verbosely.

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -106,8 +106,15 @@ set_source_files_properties(
         PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS}")
 
 if(${OPENSIM_USE_INSTALL_RPATH})
-    set_target_properties(osim${KIT} PROPERTIES
-        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+    # TODO @loader_path only makes sense on macOS, so we need to revisit for
+    # Linux (use $ORIGIN).
+
+    # The osim libraries that osimJavaJNI needs are in the same folder as
+    # osimJavaJNI. Adding @loader_rpath (the \ is to escape the @) to the
+    # run-path list will let osimJavaJNI find osimTools, etc.
+    # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
+    set_property(TARGET osim${KIT} APPEND PROPERTY
+        INSTALL_RPATH "\@loader_path/"
         )
 endif()
 

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -2,16 +2,6 @@
 # Find python.
 # ============
 
-# PythonInterp is supposed to come before PythonLibs.
-find_package(PythonInterp 2.7 REQUIRED)
-find_package(PythonLibs 2.7 REQUIRED)
-
-# We may need to update the python install dir to include the python version,
-# now that we know it. We replace the token "VERSION" with the actual python
-# version.
-string(REPLACE "VERSION" "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
-    OPENSIM_INSTALL_PYTHONDIR "${OPENSIM_INSTALL_PYTHONDIR}")
-
 # Location of the opensim python package in the build directory, for testing.
 if(MSVC OR XCODE)
     # Multi-configuration generators like MSVC and XCODE use one build tree for
@@ -159,11 +149,21 @@ macro(OpenSimAddPythonModule)
     endif()
     
     if(${OPENSIM_USE_INSTALL_RPATH})
+        # TODO @loader_path only makes sense on macOS, so we need to revisit
+        # for Linux (use $ORIGIN).
+        # We always set a relative RPATH but only use an absolute RPATH if the
+        # python package is not standalone, as the libraries are not copied
+        # into the python package.
+        # TODO consider using a relative path from the python package directory
+        # to the OpenSim library directory.
+        set(run_path_list "\@loader_path/")
+        if(NOT OPENSIM_PYTHON_STANDALONE)
+            list(APPEND run_path_list
+                    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+        endif()
         # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
-        # TODO test that NOT using APPEND causes BTK to not be found.
         set_property(TARGET ${_libname} APPEND PROPERTY
-            INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
-            )
+            INSTALL_RPATH "${run_path_list}")
     endif()
 
     # Copy files into the build tree python package.

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -159,6 +159,7 @@ macro(OpenSimAddPythonModule)
     endif()
     
     if(${OPENSIM_USE_INSTALL_RPATH})
+        # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
         set_target_properties(${_libname} PROPERTIES
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
             )

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -160,7 +160,8 @@ macro(OpenSimAddPythonModule)
     
     if(${OPENSIM_USE_INSTALL_RPATH})
         # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
-        set_target_properties(${_libname} PROPERTIES
+        # TODO test that NOT using APPEND causes BTK to not be found.
+        set_property(TARGET ${_libname} APPEND PROPERTY
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
             )
     endif()

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -15,7 +15,9 @@ setup(name='opensim',
       url='http://opensim.stanford.edu/',
       license='Apache 2.0',
       packages=['opensim'],
-      package_data={'opensim': ['_*.*']},
+      # The last 3 entries are for if OPENSIM_PYTHON_STANDALONE is ON.
+      # The asterisk after the extension is to handle version numbers on Linux.
+      package_data={'opensim': ['_*.*', '*.dylib', '*.dll', '*.so*']},
       include_package_data=True,
       classifiers=[
           'Intended Audience :: Science/Research',

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ from the internet, we turn this option OFF." ON)
 set(SIMBODY_HOME $ENV{SIMBODY_HOME} CACHE
     PATH "The location of the Simbody installation to use; you can change this. Set as empty to let CMake search for Simbody automatically.")
 
+# TODO rename to OPENSIM_COPY_DEPENDENCIES and handle BTK.
 option(OPENSIM_COPY_SIMBODY "Copy Simbody headers and libraries into the
 OpenSim installation. This way, you can treat OpenSim and Simbody as one
 package, and you only need to set environment variables (e.g., PATH,
@@ -96,7 +97,9 @@ LD_LIBRARY_PATH, DYLD_LIBRARY_PATH) for OpenSim.  On Windows, this also copies
 Simbody dll's and exe's into the OpenSim build directory, so that you don't
 need to set PATH to run OpenSim tests and examples; this is done via the
 SimbodyFiles project. If OFF, you likely must set those environment variables
-for both OpenSim and Simbody." ON)
+for both OpenSim and Simbody. To make a distributable installation on macOS, 
+this should be set to ON to avoid using absolute paths for RPATHs to Simbody
+libraries." ON)
 
 option(BUILD_API_ONLY "Build/install only headers, libraries,
 wrapping, tests; not applications (opensim, ik, rra, etc.)." OFF)
@@ -457,39 +460,40 @@ if(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
 endif()
 
 
-## On APPLE, use MACOSX_RPATH.
-## On Linux, this variable has no effect.
-set(OPENSIM_USE_INSTALL_RPATH FALSE)
+## RPATH 
+# If it is necesasry to not put RPATHS in the installed binaries, set
+# set CMAKE_SKIP_INSTALL_RPATH to OFF.
 if(APPLE)
-    option(OPENSIM_NO_LIBRARY_PATH_ENV_VAR
-        "If ON, you don't need to set 
-        DYLD_LIBRARY_PATH (on OSX) to make use of OpenSim's executables.
-        Instead, we bake the location of OpenSim's libraries into the
-        executables, so the executables already know where to find the
-        libraries. This uses the RPATH mechanism." ON)
-    if(${OPENSIM_NO_LIBRARY_PATH_ENV_VAR})
-        # CMake 2.8.12 introduced the ability to set RPATH for shared libraries on
-        # OSX. This helps executables find the libraries they depend on without
-        # having to set the DYLD_LIBRARY_PATH environment variable.
-        # The code below is all taken from the link below, and implements the
-        # scenario "Always use full RPATH".
-        # http://www.cmake.org/Wiki/CMake_RPATH_handling
-        # Note: the RPATH won't succeed if the libraries are moved; in this case,
-        # one will still need to set DYLD_LIBRARY_PATH (or alter the RPATH in the
-        # executables/libraries that depend on Simbody's libraries).
-        set(CMAKE_MACOSX_RPATH ON)
+    # CMake 2.8.12 introduced the ability to set RPATH for shared libraries
+    # on OSX. This helps executables find the libraries they depend on
+    # without having to set the DYLD_LIBRARY_PATH environment variable. 
+    # See http://www.cmake.org/Wiki/CMake_RPATH_handling and `man dydl`.
+    # We have attempted to make the RPATH work even if the
+    # installation is relocated (using relative paths), but you may need to
+    # use DYLD_LIBRARY_PATH (or alter the RPATH using install_name_tool) in
+    # these cases.
+    ## On Linux, this variable has no effect.
+    set(CMAKE_MACOSX_RPATH ON)
 
-        # Add the automatically determined parts of the RPATH
-        # which point to directories outside the build tree to the install RPATH.
+    if(NOT OPENSIM_COPY_SIMBODY)
+        # Add the automatically determined parts of the RPATH which point
+        # to directories outside the build tree to the install RPATH.
+        # If we are copying Simbody into OpenSim's installation, then
+        # there's no need to link to the libraries in Simbody's original
+        # installation. Furthermore, we may be distributing OpenSim to
+        # other computers that will not have our original Simbody
+        # installation, and so the RPATH would point to a nonexistant
+        # directory on others' computers.
+        # TODO handle copying BTK.
         set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif()
 
-        # The RPATH to be used when installing, but only if it's not a system
-        # directory.
-        list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
-            "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
-        if("${isSystemDir}" STREQUAL "-1")
-            set(OPENSIM_USE_INSTALL_RPATH TRUE)
-        endif()
+    # Set RPATH so that OpenSim can find its own libraries, but only if
+    # OpenSim is not installed into a system library directory.
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    if("${isSystemDir}" STREQUAL "-1")
+        set(OPENSIM_USE_INSTALL_RPATH TRUE)
     endif()
 endif()
 ## Add rpath to the binaries on Linux.
@@ -522,6 +526,7 @@ if(WITH_BTK)
     include(${BTK_USE_FILE})
     add_definitions(-DWITH_BTK)
     CopyDependencyDLLsForWin(BTK ${BTK_INSTALL_PREFIX})
+    # TODO this should be handled separately between macOS and Linux.
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${BTK_LIBRARY_DIRS}")
 endif()
 
@@ -605,6 +610,7 @@ include_directories("${Simbody_INCLUDE_DIR}")
 # Copy files over from the Simbody installation.
 # ----------------------------------------------
 if(${OPENSIM_COPY_SIMBODY})
+    # TODO copy BTK as well.
 
     # Install Simbody headers into OpenSim installation.
     install(DIRECTORY "${Simbody_INCLUDE_DIR}/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,20 @@ for both OpenSim and Simbody. To make a distributable installation on macOS,
 this should be set to ON to avoid using absolute paths for RPATHs to Simbody
 libraries." ON)
 
+option(OPENSIM_PYTHON_STANDALONE "Make the Python package standalone, meaning
+the OpenSim (and Simbody and BTK) shared libraries it depends on are copied
+into the package. If you are building OpenSim on the same machine on which you
+plan to use it, you can leave this OFF. If you are distributing OpenSim to
+other computers, you should turn this ON. If macOS, this option affects how
+RPATH is set for the SWIG-generated shared libraries. This variable has no
+effect if BUILD_PYTHON_WRAPPING is OFF." OFF)
+# There are many potential ways to distribute the python bindings; here's how
+# you might want to set the above option for different ways of distributing:
+#   simtk.org GUI distribution, macOS: ON (since no env. vars are set)
+#   simtk.org GUI distrubution, Windows: OFF (PATH is set)
+#   pypi: ON (there is no way to install the C++ libraries otherwise)
+#   debian, homebrew, conda: OFF (can have a separate C++ library package)
+
 option(BUILD_API_ONLY "Build/install only headers, libraries,
 wrapping, tests; not applications (opensim, ik, rra, etc.)." OFF)
 
@@ -431,6 +445,21 @@ if(${BUILD_JAVA_WRAPPING})
     endif()
 endif()
 
+if(${BUILD_PYTHON_WRAPPING})
+    # PythonInterp is supposed to come before PythonLibs.
+    find_package(PythonInterp 2.7 REQUIRED)
+    find_package(PythonLibs 2.7 REQUIRED)
+
+    # We update the python install dir to include the python version,
+    # now that we know it. We replace the token "VERSION" with the actual python
+    # version.
+    string(REPLACE "VERSION" "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
+        OPENSIM_INSTALL_PYTHONDIR "${OPENSIM_INSTALL_PYTHONDIR}")
+    # This must be done before adding the OpenSim libraries, since
+    # OPENSIM_INSTALL_PYTHONDIR is used in OpenSimAddLibrary (in
+    # OpenSimMacros.cmake).
+endif()
+
 if(WIN32)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
 endif()
@@ -526,6 +555,10 @@ if(WITH_BTK)
     include(${BTK_USE_FILE})
     add_definitions(-DWITH_BTK)
     CopyDependencyDLLsForWin(BTK ${BTK_INSTALL_PREFIX})
+    if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
+    OpenSimInstallDependencyLibraries(BTK "${BTK_INSTALL_PREFIX}"
+        "${BTK_LIBRARY_DIRS}" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
+    endif()
     # TODO this should be handled separately between macOS and Linux.
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${BTK_LIBRARY_DIRS}")
 endif()
@@ -623,12 +656,11 @@ if(${OPENSIM_COPY_SIMBODY})
     # is only needed for programmers goes in sdk/lib.
     # TODO use SimbodyConfig.cmake variables instead of these globs.
     if(WIN32)
-        file(GLOB SIMBODY_BIN_FILES
-            ${Simbody_BIN_DIR}/*.dll
-            ${Simbody_BIN_DIR}/*.exe)
-        file(GLOB SIMBODY_ARCHIVE_FILES
-            ${Simbody_LIB_DIR}/*.lib)
+        file(GLOB SIMBODY_BIN_FILES ${Simbody_BIN_DIR}/*.dll
+                                    ${Simbody_BIN_DIR}/*.exe)
+        file(GLOB SIMBODY_ARCHIVE_FILES ${Simbody_LIB_DIR}/*.lib)
     else()
+        # TODO simbody-visualizer executable probably isn't even there.
         file(GLOB SIMBODY_BIN_FILES
             ${Simbody_BIN_DIR}/simbody*) # executables only (e.g., visualizer).
         # If the LIB_DIR is some common place for libraries (e.g., /usr/lib/),
@@ -688,6 +720,10 @@ if(${OPENSIM_COPY_SIMBODY})
                 VERBATIM)
         endforeach()
     endif()
+endif()
+if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
+    OpenSimInstallDependencyLibraries(SimTK "${Simbody_BIN_DIR}"
+        "${Simbody_LIB_DIR}" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,7 @@ endif()
 
 
 ## RPATH 
-# If it is necesasry to not put RPATHS in the installed binaries, set
+# If it is necessary to not put RPATHS in the installed binaries, set
 # set CMAKE_SKIP_INSTALL_RPATH to OFF.
 if(APPLE)
     # CMake 2.8.12 introduced the ability to set RPATH for shared libraries

--- a/OpenSim/Utilities/simmFileWriterDLL/CMakeLists.txt
+++ b/OpenSim/Utilities/simmFileWriterDLL/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB INCLUDES *.h)
 OpenSimAddLibrary(
     KIT SimmFileWriter
     AUTHORS "Peter_Loan"
+    EXCLUDEFROMPYTHON
     LINKLIBS osimCommon osimSimulation osimActuators ${Simbody_LIBRARIES}
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -5,6 +5,7 @@ include(CMakeParseArguments)
 #   argument. Otherwise, omit.
 # LOWERINCLUDEDIRNAME: When installing the headers for this library, make the
 #   name of the library all lower-case (e.g., Lepton -> lepton).
+# EXCLUDEFROMPYTHON: Do not install this library into the python package.
 # KIT: Name of the library (e.g., Common).
 # AUTHORS: A string listing authors of the library.
 # LINKLIBS: List of libraries (targets) to link against.
@@ -33,7 +34,7 @@ function(OpenSimAddLibrary)
     # Parse arguments.
     # ----------------
     # http://www.cmake.org/cmake/help/v2.8.9/cmake.html#module:CMakeParseArguments
-    set(options VENDORLIB LOWERINCLUDEDIRNAME)
+    set(options VENDORLIB LOWERINCLUDEDIRNAME EXCLUDEFROMPYTHON)
     set(oneValueArgs KIT AUTHORS)
     set(multiValueArgs LINKLIBS INCLUDES SOURCES TESTDIRS INCLUDEDIRS)
     cmake_parse_arguments(
@@ -92,6 +93,16 @@ function(OpenSimAddLibrary)
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         ARCHIVE DESTINATION "${OPENSIM_INSTALL_ARCHIVEDIR}")
+    if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE
+            AND NOT OSIMADDLIB_EXCLUDEFROMPYTHON)
+        if (WIN32)
+            install(TARGETS ${OSIMADDLIB_LIBRARY_NAME}
+                RUNTIME DESTINATION "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
+        else()
+            install(TARGETS ${OSIMADDLIB_LIBRARY_NAME}
+                LIBRARY DESTINATION "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
+        endif()
+    endif()
 
     # Install headers.
     # ----------------
@@ -145,6 +156,8 @@ function(OpenSimAddLibrary)
         #    list(APPEND run_path_list
         #           "\@loader_path/${lib_dir_to_simbody_lib_dir}")
         #endif()
+        # It is possible that on UNIX (APPLE and Linux), we will install
+        # Simbody and BTK beside OpenSim, rather than in their own directories.
         # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
         set_property(TARGET ${OSIMADDLIB_LIBRARY_NAME} APPEND PROPERTY
             INSTALL_RPATH "${run_path_list}"
@@ -296,6 +309,38 @@ function(OpenSimAddApplication)
             )
     endif()
 
+endfunction()
+
+
+# Function to install shared libraries (any platform) from a dependency install
+# directory into the OpenSim installation. One use case is to install libraries
+# into the python package.
+# PREFIX: A common part of the library file names (e.g., 'SimTK' or 'BTK').
+#         This is to avoid copying unrelated files from a folder like /usr/lib.
+# DEP_LIBS_DIR_WIN: Directory to search for the dependency's library, on
+#         Windows.
+# DEP_LIBS_DIR_UNIX: Directory to search for the dependency's library, on
+#         UNIX (APPLE and Linux). Specify only the lib directory to avoid
+#         searching all of /usr/local (if the dependency is installed to a
+#         system location like this).
+# OSIM_DESTINATION: Destination of the libraries within OpenSim's installation.
+function(OpenSimInstallDependencyLibraries PREFIX DEP_LIBS_DIR_WIN
+        DEP_LIBS_DIR_UNIX OSIM_DESTINATION)
+    if(WIN32)
+        file(GLOB_RECURSE LIBS "${DEP_LIBS_DIR_WIN}/${PREFIX}*.dll")
+    else()
+        if(APPLE)
+            set(lib_ext "dylib")
+        else()
+            set(lib_ext "so*") # Trailing * for version #s.
+        endif()
+        file(GLOB_RECURSE LIBS "${DEP_LIBS_DIR_UNIX}/lib${PREFIX}*.${lib_ext}")
+    endif()
+    if(NOT LIBS)
+        message(FATAL_ERROR "Zero shared libraries found in directory "
+            "${DEP_INSTALL_DIR}.")
+    endif()
+    install(FILES ${LIBS} DESTINATION "${OSIM_DESTINATION}")
 endfunction()
 
 

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -87,11 +87,6 @@ function(OpenSimAddLibrary)
     # at the top level in OpenSim/bin/*.dll (Windows) or OpenSim/lib/*.so
     # (Linux) or OpemSim/lib/*.dylib (Mac). Windows .lib files, and Linux/Mac
     # .a static archives are only needed at link time so go in sdk/lib.
-    if(WIN32)
-        set(OSIMADDLIB_LIBRARY_DESTINATION sdk/lib)
-    else()
-        set(OSIMADDLIB_LIBRARY_DESTINATION lib)
-    endif()
     install(TARGETS ${OSIMADDLIB_LIBRARY_NAME}
         EXPORT OpenSimTargets
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -123,6 +118,38 @@ function(OpenSimAddLibrary)
             DESTINATION ${_INCLUDE_PREFIX}/${_INCLUDE_LIBNAME})
     endif()
 
+    # RPATH (so that libraries find library dependencies)
+    if(${OPENSIM_USE_INSTALL_RPATH})
+        # TODO @loader_path only makes sense on macOS, so we need to revisit
+        # for Linux (use $ORIGIN).
+
+        set(run_path_list "\@loader_path/")
+        # TODO if/when Simbody and BTK libraries are installed in their own
+        # directories (not beside OpenSim libraries), we will have to add the
+        # following (also for BTK; this commented code has not been tested):
+        #if(${OPENSIM_COPY_SIMBODY})
+        #    file(RELATIVE_PATH lib_dir_to_install_dir
+        #        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+        #        "${CMAKE_INSTALL_PREFIX}")
+        #    # The location of Simbody's libraries within the Simbody root.
+        #    file(RELATIVE_PATH simbody_root_dir_to_simbody_lib_dir
+        #         "${SIMBODY_ROOT_DIR}" "${SIMBODY_LIB_DIR}")
+        #        ) 
+        #    # The location of Simbody's libraries relative to OpenSim's
+        #    # installation root (OPENSIM_INSTALL_SIMBODYDIR does not exist).
+        #    file(install_dir_to_simbody_lib_dir
+        #       "${OPENSIM_INSTALL_SIMBODYDIR}${simbody_root_dir_to_simbody_lib_dir}"
+        #       )
+        #    set(lib_dir_to_simbody_lib_dir
+        #        "${lib_dir_to_install_dir}${install_dir_to_simbody_lib_dir}")
+        #    list(APPEND run_path_list
+        #           "\@loader_path/${lib_dir_to_simbody_lib_dir}")
+        #endif()
+        # Use APPEND to include the BTK RPATH, set in CMAKE_INSTALL_RPATH.
+        set_property(TARGET ${OSIMADDLIB_LIBRARY_NAME} APPEND PROPERTY
+            INSTALL_RPATH "${run_path_list}"
+            )
+    endif()
 
     # Testing.
     # --------
@@ -255,8 +282,8 @@ function(OpenSimAddApplication)
 
     # RPATH (so that the executable finds libraries without using env. vars).
     if(${OPENSIM_USE_INSTALL_RPATH})
-        # TODO @executable_path only makes sense on OSX, so if we use RPATH on
-        # Linux we'll have to revisit.
+        # TODO @executable_path only makes sense on macOS, so we need to revisit
+        # for Linux (use $ORIGIN).
 
         # bin_dir_to_install_dir is most likely "../"
         file(RELATIVE_PATH bin_dir_to_install_dir
@@ -264,7 +291,7 @@ function(OpenSimAddApplication)
             "${CMAKE_INSTALL_PREFIX}")
         set(bin_dir_to_lib_dir
             "${bin_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
-        set_target_properties(${OSIMADDAPP_NAME} PROPERTIES
+        set_property(TARGET ${OSIMADDAPP_NAME} APPEND PROPERTY
             INSTALL_RPATH "\@executable_path/${bin_dir_to_lib_dir}"
             )
     endif()


### PR DESCRIPTION
This PR should not be merged until after #1573 is merged, as the branch `python_standalone` is built on `macOS_RPATH_relative`.

As it is, our python package is not standalone: it depends on shared libraries in OpenSim's bin or lib directory. As we prepare for distributing the GUI, it will help users for the python package to be standalone: to contain all the libraries it needs. That is, someone could install the python package into their python installation and then delete OpenSim, and the python package would still work. 

This issue is biggest on macOS (on Windows, the python package can find the DLL dependencies via the OpenSim bin dir that we add to PATH; on Linux, a proper installation would put the shared libraries in /usr/lib or /usr/local/lib).

I created a CMake option `OPENSIM_PYTHON_STANDALONE`) to control whether or not we copy OpenSim, Simbody, and BTK libraries into the python package. By default, we do not (that is, we maintain the current behavior). It is expected that packagers (e.g., @aymanhab) will set the option as necessary. Different ways of distributing the python package may require different settings for this option; it's not exactly clear to me yet how this flag should be used for Homebrew, etc.

This PR also handles changes to the RPATH on macOS so that the OpenSim/Simbody/BTK libraries are found whether or not they are copied into the installation.

Unlike #1573, this PR handles BTK. That is, BTK libraries are copied into the python package if `WITH_BTK=ON`. However, the python libraries (e.g., `_simulation.so`) end up with an RPATH to the absolute path of the BTK libraries on the build machine. This should be modified in the future so that the python package we distribute with the GUI doesn't have an RPATH for an absolute path on @aymanhab's computer.
