### PR TITLE
min_control should not be adjusted for "version 30513" files

### DIFF
--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -93,7 +93,7 @@ void Muscle::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
             }
             XMLDocument::renameChildNode(aNode, "pennation_angle", "pennation_angle_at_optimal");
         }
-        if (versionNumber <= 30513) {
+        if (versionNumber < 30513) {
             SimTK::Xml::element_iterator minControlElt =
                 aNode.element_begin("min_control");
             double minControl = 0;


### PR DESCRIPTION
See #1575. According to [the comments in Muscle.cpp at L102](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Simulation/Model/Muscle.cpp#L102), the `min_control` property is assumed to be incorrect if its value is 0 and the model version number is 30512 or less. This assumption is not made for more recent models, so the last `if` block in `Muscle::updateFromXMLNode()` should not be run on "version 30513" files.