### PR TITLE
Remove user-facing "reverse" property from Joint - part 2 of 2

### DIFF
--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -60,7 +60,8 @@ using namespace std;
 // 30511 for replacing Probe::isDisabled with Probe::enabled.
 // 30512 for removing Model::FrameSet and moving frames to components list
 // 30513 for removing internal (silent) clamping of Muscle controls (excitations)
-const int XMLDocument::LatestVersion = 30513;
+// 30514 for removing user-facing "reverse" property from Joint
+const int XMLDocument::LatestVersion = 30514;
 //=============================================================================
 // DESTRUCTOR AND CONSTRUCTOR(S)
 //=============================================================================

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -60,7 +60,7 @@ using namespace std;
 // 30511 for replacing Probe::isDisabled with Probe::enabled.
 // 30512 for removing Model::FrameSet and moving frames to components list
 // 30513 for removing internal (silent) clamping of Muscle controls (excitations)
-// 30514 for removing user-facing "reverse" property from Joint
+// 30514 for removing "reverse" property from Joint
 const int XMLDocument::LatestVersion = 30514;
 //=============================================================================
 // DESTRUCTOR AND CONSTRUCTOR(S)

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -660,30 +660,75 @@ void Joint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
         // found and its value is "true".
         if (documentVersion < 30514) {
             auto reverseElt = aNode.element_begin("reverse");
-            auto parentElt  = aNode.element_begin(
-                                  "socket_parent_frame_connectee_name");
-            auto childElt   = aNode.element_begin(
-                                  "socket_child_frame_connectee_name");
 
             if (reverseElt != aNode.element_end()) {
                 bool swapFrames = false;
                 reverseElt->getValue().tryConvertToBool(swapFrames);
 
-                if (swapFrames
-                    && parentElt != aNode.element_end()
-                    && childElt  != aNode.element_end())
-                {
+                if (swapFrames) {
                     std::string oldParentFrameName = "";
                     std::string oldChildFrameName  = "";
 
-                    parentElt->getValueAs<std::string>(oldParentFrameName);
-                    childElt->getValueAs<std::string>(oldChildFrameName);
+                    // Find names of parent and child frames. If more than one
+                    // "parent_frame" or "child_frame" element exists, keep the
+                    // first one. The "parent_frame" and "child_frame" elements
+                    // may be listed in either order.
+                    SimTK::Xml::element_iterator connectorsNode =
+                        aNode.element_begin("connectors");
+                    SimTK::Xml::element_iterator connectorElt = connectorsNode->
+                        element_begin("Connector_PhysicalFrame_");
+                    SimTK::Xml::element_iterator connecteeNameElt;
 
-                    parentElt->setValue(oldChildFrameName);
-                    childElt->setValue(oldParentFrameName);
+                    while (connectorElt != connectorsNode->element_end())
+                    {
+                        if (connectorElt->getRequiredAttributeValue("name") ==
+                            "parent_frame" && oldParentFrameName.empty())
+                        {
+                            connecteeNameElt = connectorElt->
+                                               element_begin("connectee_name");
+                            connecteeNameElt->getValueAs<std::string>(
+                                oldParentFrameName);
+                        }
+                        else if (connectorElt->getRequiredAttributeValue("name")
+                                 == "child_frame" && oldChildFrameName.empty())
+                        {
+                            connecteeNameElt = connectorElt->
+                                               element_begin("connectee_name");
+                            connecteeNameElt->getValueAs<std::string>(
+                                oldChildFrameName);
+                        }
+                        ++connectorElt;
+                    }
+
+                    // Swap parent and child frame names. If more than one
+                    // "parent_frame" or "child_frame" element exists, assign
+                    // the same value to all such elements.
+                    connectorsNode = aNode.element_begin("connectors");
+                    connectorElt = connectorsNode->element_begin(
+                                   "Connector_PhysicalFrame_");
+
+                    while (connectorElt != connectorsNode->element_end())
+                    {
+                        if (connectorElt->getRequiredAttributeValue("name") ==
+                            "parent_frame")
+                        {
+                            connecteeNameElt = connectorElt->
+                                               element_begin("connectee_name");
+                            connecteeNameElt->setValue(oldChildFrameName);
+                        }
+                        else if (connectorElt->getRequiredAttributeValue("name")
+                                 == "child_frame")
+                        {
+                            connecteeNameElt = connectorElt->
+                                               element_begin("connectee_name");
+                            connecteeNameElt->setValue(oldParentFrameName);
+                        }
+                        ++connectorElt;
+                    }
                 }
 
-                // Remove old "reverse" element.
+                // Remove "reverse" element regardless of its value (it is no
+                // longer a property of Joint).
                 aNode.eraseNode(reverseElt);
             }
         }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -203,8 +203,6 @@ public:
         derived class. */
     Coordinate& updCoordinate();
 
-    bool getIsReversed() const { return isReversed; }
-
     // Model building
     int numCoordinates() const { return getProperty_coordinates().size(); }
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/double_pendulum_testReverse.osim
+++ b/OpenSim/Simulation/SimbodyEngine/Test/double_pendulum_testReverse.osim
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSimDocument Version="20302">
+	<Model name="double_pendulum_testReverse">
+		<defaults/>
+		<credits> Ajay Seth </credits>
+		<publications> For testing change in 30514 (removing "reverse" property from Joint). PinJoint "pin2" has "reverse" set to "true". </publications>
+		<ForceSet name="">
+			<objects/>
+			<groups/>
+		</ForceSet>
+		<length_units> meters </length_units>
+		<force_units> N </force_units>
+		<!--Acceleration due to gravity.-->
+		<gravity>       0.00000000      -9.80665000       0.00000000 </gravity>
+		<!--Bodies in the model.-->
+		<BodySet name="">
+			<objects>
+				<Body name="ground">
+					<mass>       0.00000000 </mass>
+					<mass_center>       0.00000000       0.00000000       0.00000000 </mass_center>
+					<inertia_xx>       0.00000000 </inertia_xx>
+					<inertia_yy>       0.00000000 </inertia_yy>
+					<inertia_zz>       0.00000000 </inertia_zz>
+					<inertia_xy>       0.00000000 </inertia_xy>
+					<inertia_xz>       0.00000000 </inertia_xz>
+					<inertia_yz>       0.00000000 </inertia_yz>
+					<!--Joint that connects this body with the parent body.-->
+					<Joint/>
+					<VisibleObject name="">
+						<!--Set of geometry files and associated attributes, allow .vtp, .stl,
+						    .obj-->
+						<GeometrySet name="">
+							<objects/>
+							<groups/>
+						</GeometrySet>
+						<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
+						<scale_factors>       1.00000000       1.00000000       1.00000000 </scale_factors>
+						<!--transform relative to owner specified as 3 rotations (rad) followed by
+						    3 translations rX rY rZ tx ty tz-->
+						<transform>       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000 </transform>
+						<!--Whether to show a coordinate frame-->
+						<show_axes> true </show_axes>
+						<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded Can be overriden for
+						    individual geometries-->
+						<display_preference> 4 </display_preference>
+					</VisibleObject>
+					<WrapObjectSet name="">
+						<objects/>
+						<groups/>
+					</WrapObjectSet>
+				</Body>
+				<Body name="rod1">
+					<mass>       1.00000000 </mass>
+					<mass_center>       0.00000000       0.00000000       0.00000000 </mass_center>
+					<inertia_xx>       0.00000000 </inertia_xx>
+					<inertia_yy>       0.00000000 </inertia_yy>
+					<inertia_zz>       0.00000000 </inertia_zz>
+					<inertia_xy>       0.00000000 </inertia_xy>
+					<inertia_xz>       0.00000000 </inertia_xz>
+					<inertia_yz>       0.00000000 </inertia_yz>
+					<!--Joint that connects this body with the parent body.-->
+					<Joint>
+						<PinJoint name="pin1">
+							<parent_body> ground </parent_body>
+							<location_in_parent>       0.00000000       0.00000000       0.00000000 </location_in_parent>
+							<orientation_in_parent>       0.00000000       0.00000000       0.00000000 </orientation_in_parent>
+							<location>       0.00000000       0.50000000       0.00000000 </location>
+							<orientation>       0.00000000       0.00000000       0.00000000 </orientation>
+							<!--Generalized coordinates parameterizing this joint.-->
+							<CoordinateSet name="">
+								<objects>
+									<Coordinate name="q1">
+										<!--Cooridnate can describe rotational, translational, or coupled values.
+										    Defaults to rotational.-->
+										<motion_type> rotational </motion_type>
+										<default_value>      -0.78539816 </default_value>
+										<default_speed_value>       0.00000000 </default_speed_value>
+										<range>      -1.57079633       1.57079633 </range>
+										<clamped> false </clamped>
+										<locked> false </locked>
+										<prescribed_function/>
+									</Coordinate>
+								</objects>
+								<groups/>
+							</CoordinateSet>
+							<reverse> false </reverse>
+						</PinJoint>
+					</Joint>
+					<VisibleObject name="">
+						<!--Set of geometry files and associated attributes, allow .vtp, .stl,
+						    .obj-->
+						<GeometrySet name="">
+							<objects/>
+							<groups/>
+						</GeometrySet>
+						<!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
+						<scale_factors>       1.00000000       1.00000000       1.00000000 </scale_factors>
+						<!--transform relative to owner specified as 3 rotations (rad) followed by
+						    3 translations rX rY rZ tx ty tz-->
+						<transform>       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000 </transform>
+						<!--Whether to show a coordinate frame-->
+						<show_axes> true </show_axes>
+						<!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded Can be overriden for
+						    individual geometries-->
+						<display_preference> 4 </display_preference>
+					</VisibleObject>
+					<WrapObjectSet name="">
+						<objects/>
+						<groups/>
+					</WrapObjectSet>
+				</Body>
+        <Body name="rod2">
+          <mass>       1.00000000 </mass>
+          <mass_center>       0.00000000       0.00000000       0.00000000 </mass_center>
+          <inertia_xx>       0.00000000 </inertia_xx>
+          <inertia_yy>       0.00000000 </inertia_yy>
+          <inertia_zz>       0.00000000 </inertia_zz>
+          <inertia_xy>       0.00000000 </inertia_xy>
+          <inertia_xz>       0.00000000 </inertia_xz>
+          <inertia_yz>       0.00000000 </inertia_yz>
+          <!--Joint that connects this body with the parent body.-->
+          <Joint>
+            <PinJoint name="pin2">
+              <parent_body> rod1 </parent_body>
+              <location_in_parent>       0.00000000       0.00000000       0.00000000 </location_in_parent>
+              <orientation_in_parent>       0.00000000       0.00000000       0.00000000 </orientation_in_parent>
+              <location>       0.00000000       0.50000000       0.00000000 </location>
+              <orientation>       0.00000000       0.00000000       0.00000000 </orientation>
+              <!--Generalized coordinates parameterizing this joint.-->
+              <CoordinateSet name="">
+                <objects>
+                  <Coordinate name="q2">
+                    <!--Cooridnate can describe rotational, translational, or coupled values.
+										    Defaults to rotational.-->
+                    <motion_type> rotational </motion_type>
+                    <default_value>      -1.04719755 </default_value>
+                    <default_speed_value>       0.00000000 </default_speed_value>
+                    <range>      -1.57079633       1.57079633 </range>
+                    <clamped> false </clamped>
+                    <locked> false </locked>
+                    <prescribed_function/>
+                  </Coordinate>
+                </objects>
+                <groups/>
+              </CoordinateSet>
+              <reverse> true </reverse>
+            </PinJoint>
+          </Joint>
+          <VisibleObject name="">
+            <!--Set of geometry files and associated attributes, allow .vtp, .stl,
+						    .obj-->
+            <GeometrySet name="">
+              <objects/>
+              <groups/>
+            </GeometrySet>
+            <!--Three scale factors for display purposes: scaleX scaleY scaleZ-->
+            <scale_factors>       1.00000000       1.00000000       1.00000000 </scale_factors>
+            <!--transform relative to owner specified as 3 rotations (rad) followed by
+						    3 translations rX rY rZ tx ty tz-->
+            <transform>       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000       0.00000000 </transform>
+            <!--Whether to show a coordinate frame-->
+            <show_axes> true </show_axes>
+            <!--Display Pref. 0:Hide 1:Wire 3:Flat 4:Shaded Can be overriden for
+						    individual geometries-->
+            <display_preference> 4 </display_preference>
+          </VisibleObject>
+          <WrapObjectSet name="">
+            <objects/>
+            <groups/>
+          </WrapObjectSet>
+        </Body>
+      </objects>
+      <groups/>
+    </BodySet>
+    <!--Constraints in the model.-->
+    <ConstraintSet name="">
+      <objects/>
+      <groups/>
+    </ConstraintSet>
+    <!--Markers in the model.-->
+    <MarkerSet name="">
+      <objects/>
+      <groups/>
+    </MarkerSet>
+    <!--ContactGeometry objects in the model.-->
+    <ContactGeometrySet name="">
+      <objects/>
+      <groups/>
+    </ContactGeometrySet>
+    <!--Controller objects in the model.-->
+    <ControllerSet name="Controllers">
+      <objects/>
+      <groups/>
+    </ControllerSet>
+  </Model>
+</OpenSimDocument>

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2242,8 +2242,7 @@ void testUserJointReversal()
 
     // Open model.
     auto model = Model("double_pendulum_testReverse.osim");
-    //model.finalizeFromProperties();
-    model.initSystem();
+    model.finalizeConnections(model); //calls finalizeFromProperties internally
 
     // The topology is specified as follows:
     //     [ground] <- (pin1) <- [rod1] <- (pin2) <- [rod2]

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2125,10 +2125,6 @@ void testAutomaticJointReversal()
     //model.setUseVisualizer(true);
     SimTK::State& s = model.initSystem();
 
-    ASSERT(hip->getIsReversed() == true);
-    ASSERT(knee->getIsReversed() == true);
-    ASSERT(ankle->getIsReversed() == true);
-
     SimTK::Transform pelvisX = pelvis->getTransformInGround(s);
     cout << "Pelvis Transform (reverse): " << pelvisX << endl;
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2244,11 +2244,13 @@ void testUserJointReversal()
     auto model = Model("double_pendulum_testReverse.osim");
     model.finalizeConnections(model); //calls finalizeFromProperties internally
 
-    // The topology is specified as follows:
-    //     [ground] <- (pin1) <- [rod1] <- (pin2) <- [rod2]
-    // but the "reverse" element of "pin2" is "true" so, after deserialization,
-    // the topology should be the following:
-    //     [ground] <- (pin1) <- [rod1] -> (pin2) -> [rod2]
+    // In this model file:
+    // - pin1's parent is ground and child is rod1
+    // - pin2's parent is rod1 and child is rod2
+    // but the "reverse" element of pin2 is set to "true" so, after
+    // deserialization, the following should be true:
+    // - pin1's parent is ground and child is rod1
+    // - pin2's parent is rod2 and child is rod1 (parent and child are swapped)
     auto& pin1 = model.getComponent<Joint>("pin1");
     ASSERT(pin1.getParentFrame().findBaseFrame().getName() == "ground",
         __FILE__, __LINE__,


### PR DESCRIPTION
### Summary
Completes fix for #611 (see #1567 for part 1).

### Contents
- Added `Joint::updateFromXMLNode()` block that swaps parent and child frames in old model files where a Joint's "reverse" property has been set to "true".
- Added corresponding test to testJoints.
- Removed `Joint::getIsReversed()` method. Whether a Joint is reversed internally in the multibody tree (and even the fact that Joints _can_ be reversed) should be hidden from the user. This method was used only in testJoints and was not essential to the test.

### Note
testStaticOptimization will fail until #1576 has been merged.