### PR TITLE
Expose Rotation multiply() in SWIG (wrapping)

### DIFF
--- a/Bindings/Java/Matlab/tests/testosimTableStruct.m
+++ b/Bindings/Java/Matlab/tests/testosimTableStruct.m
@@ -10,12 +10,16 @@ labels.add('marker1');labels.add('marker2');
 labels.add('marker3');labels.add('marker4');
 table.setColumnLabels(labels);
 
+R = Rotation(pi/3, Vec3(0.1, 0.2, 0.3));
+
 for i = 1 : 10
     elem = Vec3(randi(10,1),randi(10,1),randi(10,1));
     elems = StdVectorVec3();
     elems.add(elem); elems.add(elem); elems.add(elem); elems.add(elem);
     row = RowVectorOfVec3(elems);
-    table.appendRow(0.1,row);
+    
+    rotatedRow = R.multiply(row);    
+    table.appendRow(0.1,rotatedRow);
 end
 
 % Set the indpendentColumn (Time) values

--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -186,6 +186,10 @@ namespace SimTK {
     RowVector_<Vec3> multiply(const RowVector_<Vec3>& row) {
         return operator*(*$self, row);
     }
+
+    RowVector_<Vec3> multiply(const RowVectorView_<Vec3>& row) {
+        return operator*(*$self, row);
+    }
 }
 
 
@@ -225,8 +229,8 @@ namespace SimTK {
 typedef int MobilizedBodyIndex;
 
 namespace SimTK {
-%template(ArrayIndexUnsigned) ArrayIndexTraits<unsigned>; 
-%template(ArrayIndexInt) ArrayIndexTraits<int>; 
+%template(ArrayIndexUnsigned) ArrayIndexTraits<unsigned>;
+%template(ArrayIndexInt) ArrayIndexTraits<int>;
 }
 
 %include <SWIGSimTK/PolygonalMesh.h>

--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -172,12 +172,23 @@ namespace SimTK {
 %template(MatrixOfSpatialVec) Matrix_<SpatialVec>;
 }
 
-
 %include <SWIGSimTK/Rotation.h>
 namespace SimTK {
 %template(Rotation) SimTK::Rotation_<double>;
 %template(InverseRotation) SimTK::InverseRotation_<double>;
 }
+
+%extend SimTK::Rotation_<double> {
+    Vec3 multiply(const Vec3& v) {
+        return operator*(*$self, v);
+    }
+
+    RowVector_<Vec3> multiply(const RowVector_<Vec3>& row) {
+        return operator*(*$self, row);
+    }
+}
+
+
 // Transform
 %include <SWIGSimTK/Transform.h>
 namespace SimTK {

--- a/OpenSim/Sandbox/futureIKListOutputs.cpp
+++ b/OpenSim/Sandbox/futureIKListOutputs.cpp
@@ -398,9 +398,8 @@ void testFutureIKListOutputs() {
     modelMarkers->updInput("inputs").connect(ik->getOutput("model_marker_pos"));
     // Connect to all channels in the "coords" list output.
     solution->updInput("inputs").connect(ik->getOutput("coords"));
-    hjc->dumpConnections();
-    ik->dumpConnections();
-
+    hjc->printSocketInfo();
+    ik->printSocketInfo();
 
     model.printSubcomponentInfo();
 


### PR DESCRIPTION
Exposes C++ `operator*` as Rotation.multiply() via scripting and enables native rotation of a `Vec3` or a `RowVectorVec3` (rows of a `TimeSeriesTableVec3`).

Addresses issue raised in review of #1434. In addition to making it more convenient to use the SimTK::Rotation in MATLAB, it should improve the performance of converting large tables of Marker and Force data.

@jimmyDunne I added a one line test to see if the method was correctly exposed. Can you verify that it works for #1434?
