### PR TITLE
Fix Component counts in Model::print{Basic|Detailed}Info()

### DIFF
--- a/Applications/CMC/cmc.cpp
+++ b/Applications/CMC/cmc.cpp
@@ -129,7 +129,8 @@ int main(int argc,char **argv)
     cout<<"-----------------------------------------------------------------------\n";
     cout<<"Loaded library\n";
     cout<<"-----------------------------------------------------------------------\n";
-    model.printBasicInfo(cout);
+    model.finalizeFromProperties();
+    model.printBasicInfo();
     cout<<"-----------------------------------------------------------------------\n\n";
 
 

--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -145,7 +145,8 @@ int main(int argc,char **argv)
 
     // PRINT MODEL INFORMATION
     //Model& model = ik.getModel();
-    //model.printBasicInfo(cout);
+    //model.finalizeFromProperties();
+    //model.printBasicInfo();
 
     // start timing
     std::clock_t startTime = std::clock();

--- a/Applications/RRA/rra.cpp
+++ b/Applications/RRA/rra.cpp
@@ -126,7 +126,8 @@ int main(int argc,char **argv)
     cout<<"-----------------------------------------------------------------------\n";
     cout<<"Loaded library\n";
     cout<<"-----------------------------------------------------------------------\n";
-    model.printBasicInfo(cout);
+    model.finalizeFromProperties();
+    model.printBasicInfo();
     cout<<"-----------------------------------------------------------------------\n\n";
 
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -585,6 +585,20 @@ public:
         return ComponentList<T>(*this);
     }
 
+    /**
+     * Uses getComponentList<T>() to count the number of underlying
+     * subcomponents of the specified type.
+     *
+     * @tparam T A subclass of Component (e.g., Body, Muscle).
+     */
+    template <typename T = Component>
+    unsigned countNumComponents() const {
+        unsigned count = 0u;
+        for (const auto& comp : getComponentList<T>())
+            ++count;
+        return count;
+    }
+
     /** Class that permits iterating over components/subcomponents (but does
      * not actually contain the components themselves). */
     template <typename T>

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1471,80 +1471,78 @@ bool Model::scale(SimTK::State& s, const ScaleSet& aScaleSet, double aFinalMass,
 //=============================================================================
 // PRINT
 //=============================================================================
-//_____________________________________________________________________________
-/**
- * Print some basic information about the model.
- *
- * @param aOStream Output stream.
- */
-void Model::printBasicInfo(std::ostream &aOStream) const
+void Model::printBasicInfo(std::ostream& aOStream) const
 {
-    aOStream<<"               MODEL: "<<getName()<<std::endl;
-    aOStream<<"         coordinates: "<<getCoordinateSet().getSize()<<std::endl;
-    aOStream<<"              forces: "<<getForceSet().getSize()<<std::endl;
-    aOStream<<"           actuators: "<<getActuators().getSize()<<std::endl;
-    aOStream<<"             muscles: "<<getMuscles().getSize()<<std::endl;
-    aOStream<<"            analyses: "<<getNumAnalyses()<<std::endl;
-    aOStream<<"              probes: "<<getProbeSet().getSize()<<std::endl;
-    aOStream<<"              bodies: "<<getBodySet().getSize()<<std::endl;
-    aOStream<<"              joints: "<<((OpenSim::Model*)this)->getJointSet().getSize()<<std::endl;
-    aOStream<<"         constraints: "<<getConstraintSet().getSize()<<std::endl;
-    aOStream<<"             markers: "<<getMarkerSet().getSize()<<std::endl;
-    aOStream<<"         controllers: "<<getControllerSet().getSize()<<std::endl;
-    aOStream<<"  contact geometries: "<< getContactGeometrySet().getSize() << std::endl;
-    aOStream<<"misc modelcomponents: "<< getMiscModelComponentSet().getSize() << std::endl;
+    OPENSIM_THROW_IF_FRMOBJ(!isObjectUpToDateWithProperties(), Exception,
+        "Model::finalizeFromProperties() must be called first.");
 
+    aOStream
+        << "\n               MODEL: " << getName()
+        << "\n         coordinates: " << countNumComponents<Coordinate>()
+        << "\n              forces: " << countNumComponents<Force>()
+        << "\n           actuators: " << countNumComponents<Actuator>()
+        << "\n             muscles: " << countNumComponents<Muscle>()
+        << "\n            analyses: " << getNumAnalyses()
+        << "\n              probes: " << countNumComponents<Probe>()
+        << "\n              bodies: " << countNumComponents<Body>()
+        << "\n              joints: " << countNumComponents<Joint>()
+        << "\n         constraints: " << countNumComponents<Constraint>()
+        << "\n             markers: " << countNumComponents<Marker>()
+        << "\n         controllers: " << countNumComponents<Controller>()
+        << "\n  contact geometries: " << countNumComponents<ContactGeometry>()
+        << "\nmisc modelcomponents: " << getMiscModelComponentSet().getSize()
+        << std::endl;
 }
-//_____________________________________________________________________________
-/**
- * Print detailed information about the model.
- *
- * @param aOStream Output stream.
- */
-void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) const
-{
-    //int i;
 
+void Model::printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) const
+{
     aOStream << "MODEL: " << getName() << std::endl;
 
-    aOStream << std::endl;
-    aOStream << "numStates = " << s.getNY() << std::endl;
-    aOStream << "numCoordinates = " << getNumCoordinates() << std::endl;
-    aOStream << "numSpeeds = " << getNumSpeeds() << std::endl;
-    aOStream << "numActuators = " << getActuators().getSize() << std::endl;
-    aOStream << "numBodies = " << getNumBodies() << std::endl;
-    aOStream << "numConstraints = " << getConstraintSet().getSize() << std::endl;
-    aOStream << "numProbes = " << getProbeSet().getSize() << std::endl;
+    aOStream
+        << "\nnumStates = "      << s.getNY()
+        << "\nnumCoordinates = " << countNumComponents<Coordinate>()
+        << "\nnumSpeeds = "      << countNumComponents<Coordinate>()
+        << "\nnumActuators = "   << countNumComponents<Actuator>()
+        << "\nnumBodies = "      << countNumComponents<Body>()
+        << "\nnumConstraints = " << countNumComponents<Constraint>()
+        << "\nnumProbes = "      << countNumComponents<Probe>()
+        << std::endl;
 
     aOStream << "\nANALYSES (total: " << getNumAnalyses() << ")" << std::endl;
-    for (int i = 0; i < _analysisSet.getSize(); i++)
-        aOStream << "analysis[" << i << "] = " << _analysisSet.get(i).getName() << std::endl;
+    for (int i = 0; i < _analysisSet.getSize(); ++i)
+        aOStream << "analysis[" << i << "] = " << _analysisSet.get(i).getName()
+                 << std::endl;
 
-    aOStream << "\nBODIES (total: " << getNumBodies() << ")" << std::endl;
-    const BodySet& bodySet = getBodySet();
-    for(int i=0; i < bodySet.getSize(); i++) {
-        const OpenSim::Body& body = bodySet.get(i);
-        aOStream << "body[" + std::to_string(i) + "] = " + body.getName() + ". ";
-        aOStream << "mass: " << body.get_mass() << std::endl;
-        const SimTK::Inertia& inertia = body.getInertia();
-        aOStream << "              moments of inertia:  " << inertia.getMoments()
+    aOStream << "\nBODIES (total: " << countNumComponents<Body>() << ")"
+             << std::endl;
+    unsigned bodyNum = 0u;
+    for (const auto& body : getComponentList<Body>()) {
+        const auto inertia = body.getInertia();
+        aOStream << "body[" << bodyNum << "] = " << body.getName() << ". "
+            << "mass: " << body.get_mass()
+            << "\n              moments of inertia:  " << inertia.getMoments()
+            << "\n              products of inertia: " << inertia.getProducts()
             << std::endl;
-        aOStream << "              products of inertia: " << inertia.getProducts()
-            << std::endl;
+        ++bodyNum;
     }
 
-    aOStream << "\nJOINTS (total: " << getNumJoints() << ")" << std::endl;
-    const JointSet& jointSet = getJointSet();
-    for (int i = 0; i < jointSet.getSize(); i++) {
-        const OpenSim::Joint& joint = get_JointSet().get(i);
-        aOStream << "joint[" << i << "] = " << joint.getName() << ".";
-        aOStream << " parent: " << joint.getParentFrame().getName() <<
-            ", child: " << joint.getChildFrame().getName() << std::endl;
+    aOStream << "\nJOINTS (total: " << countNumComponents<Joint>() << ")"
+             << std::endl;
+    unsigned jointNum = 0u;
+    for (const auto& joint : getComponentList<Joint>()) {
+        aOStream << "joint[" << jointNum << "] = " << joint.getName() << "."
+                 << " parent: " << joint.getParentFrame().getName()
+                 << ", child: " << joint.getChildFrame().getName() << std::endl;
+        ++jointNum;
     }
 
-    aOStream << "\nACTUATORS (total: " << getActuators().getSize() << ")" << std::endl;
-    for (int i = 0; i < getActuators().getSize(); i++) {
-         aOStream << "actuator[" << i << "] = " << getActuators().get(i).getName() << std::endl;
+    aOStream << "\nACTUATORS (total: " << countNumComponents<Actuator>() << ")"
+             << std::endl;
+    unsigned actuatorNum = 0u;
+    for (const auto& actuator : getComponentList<Actuator>()) {
+        aOStream << "actuator[" << actuatorNum << "] = " << actuator.getName()
+                 << std::endl;
+        ++actuatorNum;
     }
 
     /*
@@ -1569,11 +1567,12 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) con
 
     n = getNP();
     aOStream<<"\nCONTACTS ("<<n<<")" << std::endl;
+    */
 
-*/
     Array<string> stateNames = getStateVariableNames();
-    aOStream<<"\nSTATES (total: "<<stateNames.getSize()<<")"<<std::endl;
-    for(int i=0;i<stateNames.getSize();i++) aOStream<<"y["<<i<<"] = "<<stateNames[i]<<std::endl;
+    aOStream << "\nSTATES (total: " << stateNames.getSize() << ")" << std::endl;
+    for (int i = 0; i < stateNames.getSize(); ++i)
+        aOStream << "y[" << i << "] = " << stateNames[i] << std::endl;
 }
 
 //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -925,17 +925,18 @@ public:
     /**
      * Print some basic information about the model.
      *
-     * @param aOStream Output stream (e.g., std::cout).
+     * @param aOStream Output stream.
      */
-    void printBasicInfo(std::ostream& aOStream) const;
+    void printBasicInfo(std::ostream& aOStream = std::cout) const;
 
     /**
      * Print detailed information about the model.
      *
      * @param s        the system State.
-     * @param aOStream Output stream (e.g., std::cout).
+     * @param aOStream Output stream.
      */
-    void printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) const;
+    void printDetailedInfo(const SimTK::State& s,
+                           std::ostream& aOStream = std::cout) const;
 
     /**
      * Model relinquishes ownership of all components such as: Bodies, Constraints, Forces, 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -925,17 +925,17 @@ public:
     /**
      * Print some basic information about the model.
      *
-     * @param aOStream Output stream.
+     * @param aOStream Output stream (e.g., std::cout).
      */
-    void printBasicInfo(std::ostream &aOStream) const;
+    void printBasicInfo(std::ostream& aOStream) const;
 
     /**
      * Print detailed information about the model.
      *
-     * @param s   the system State.
-     * @param aOStream Output stream.
+     * @param s        the system State.
+     * @param aOStream Output stream (e.g., std::cout).
      */
-    void printDetailedInfo(const SimTK::State& s, std::ostream &aOStream) const;
+    void printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) const;
 
     /**
      * Model relinquishes ownership of all components such as: Bodies, Constraints, Forces, 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2038,7 +2038,8 @@ void testAddedFreeJointForBodyWithoutJoint()
     model.initSystem();
 
     ASSERT_EQUAL(6, model.getNumCoordinates(), 0);
-    model.printBasicInfo(cout);
+    model.finalizeFromProperties();
+    model.printBasicInfo();
 }
 
 void testAutomaticJointReversal()

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -1029,7 +1029,8 @@ void testProbesUsingMillardMuscleSimulation()
     model.addAnalysis(muscleAnalysis);
 
     // Print the model.
-    printf("\n"); model.printBasicInfo(cout); printf("\n");
+    model.finalizeFromProperties();
+    printf("\n"); model.printBasicInfo(); printf("\n");
     const std::string baseFilename = "testMuscleMetabolicsProbes";
     if (OUTPUT_FILES) {
         const std::string fname = baseFilename + "Model.osim";
@@ -1312,7 +1313,8 @@ void testProbesUsingMillardMuscleSimulation()
     model.addAnalysis(probeReporter2);
 
     // Print the model.
-    printf("\n"); model.printBasicInfo(cout); printf("\n");
+    model.finalizeFromProperties();
+    printf("\n"); model.printBasicInfo(); printf("\n");
     if (OUTPUT_FILES) {
         const std::string fname = baseFilename + "Model2.osim";
         model.print(fname);

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -488,7 +488,8 @@ void simulateMuscle(
     MuscleAnalysis* muscleReporter = new MuscleAnalysis(&model);
     model.addAnalysis(muscleReporter);
     model.print("testProbesModel.osim");
-    model.printBasicInfo(cout);
+    model.finalizeFromProperties();
+    model.printBasicInfo();
 
 
 

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -415,6 +415,9 @@ void simulateModelWithMusclesNoViz(const string &modelFile, double finalTime, do
     osimModel.addController(&actuatorController);
     osimModel.disownAllComponents(); // because PrescribedController is on stack
 
+    osimModel.finalizeFromProperties();
+    osimModel.printBasicInfo();
+
     // Initialize the system and get the state representing the state system
     SimTK::State& si = osimModel.initSystem();
 
@@ -424,11 +427,7 @@ void simulateModelWithMusclesNoViz(const string &modelFile, double finalTime, do
     }
     osimModel.equilibrateMuscles(si);
 
-    osimModel.finalizeFromProperties();
-    osimModel.printBasicInfo();
-
     simulate(osimModel, si, initialTime, finalTime);
-
 
 }// end of simulateModelWithMusclesNoViz()
 

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -424,7 +424,8 @@ void simulateModelWithMusclesNoViz(const string &modelFile, double finalTime, do
     }
     osimModel.equilibrateMuscles(si);
 
-    osimModel.printBasicInfo(cout);
+    osimModel.finalizeFromProperties();
+    osimModel.printBasicInfo();
 
     simulate(osimModel, si, initialTime, finalTime);
 
@@ -846,7 +847,8 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
 }// end of simulateModelWithCables()
 
 void simulate(Model& osimModel, State& si, double initialTime, double finalTime) {
-    //  osimModel.printBasicInfo(cout);
+    // osimModel.finalizeFromProperties();
+    // osimModel.printBasicInfo();
 
     // Dump model back out; no automated test provided here though.
     // osimModel.print(osimModel.getName() + "_out.osim");

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -245,7 +245,9 @@ bool InverseDynamicsTool::run()
         }
         else
             modelFromFile = false;
-        _model->printBasicInfo(cout);
+
+        _model->finalizeFromProperties();
+        _model->printBasicInfo();
 
         cout<<"Running tool " << getName() <<".\n"<<endl;
 

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -262,8 +262,8 @@ bool InverseKinematicsTool::run()
         else
             modelFromFile = false;
 
-        _model->printBasicInfo(cout);
-
+        _model->finalizeFromProperties();
+        _model->printBasicInfo();
 
         // Do the maneuver to change then restore working directory 
         // so that the parsing code behaves properly if called from a different directory.


### PR DESCRIPTION
Fixes #1551.

Sample output from `Model::printBasicInfo()`
<pre>
               MODEL: gait10dof18musc.osim
         coordinates: 10
              forces: 18
           actuators: 18
             muscles: 18
            analyses: 0
              probes: 0
              bodies: 12
              joints: 12
         constraints: 0
             markers: 0
         controllers: 0
  contact geometries: 0
misc modelcomponents: 0
</pre>

Sample output from `Model::printDetailedInfo()`
<pre>
MODEL: gait10dof18musc.osim

numStates = 56
numCoordinates = 10
numSpeeds = 10
numActuators = 18
numBodies = 12
numConstraints = 0
numProbes = 0

ANALYSES (total: 0)

BODIES (total: 12)
body[0] = pelvis. mass: 11.777
              moments of inertia:  ~[0.1028,0.0871,0.0579]
              products of inertia: ~[0,0,0]
body[1] = femur_r. mass: 9.3014
              moments of inertia:  ~[0.1339,0.0351,0.1412]
              products of inertia: ~[0,0,0]
body[2] = tibia_r. mass: 3.7075
              moments of inertia:  ~[0.0504,0.0051,0.0511]
              products of inertia: ~[0,0,0]
body[3] = talus_r. mass: 0.1
              moments of inertia:  ~[0.001,0.001,0.001]
              products of inertia: ~[0,0,0]
body[4] = calcn_r. mass: 1.25
              moments of inertia:  ~[0.0014,0.0039,0.0041]
              products of inertia: ~[0,0,0]
body[5] = toes_r. mass: 0.2166
              moments of inertia:  ~[0.0001,0.0002,0.0001]
              products of inertia: ~[0,0,0]
body[6] = femur_l. mass: 9.3014
              moments of inertia:  ~[0.1339,0.0351,0.1412]
              products of inertia: ~[0,0,0]
body[7] = tibia_l. mass: 3.7075
              moments of inertia:  ~[0.0504,0.0051,0.0511]
              products of inertia: ~[0,0,0]
body[8] = talus_l. mass: 0.1
              moments of inertia:  ~[0.001,0.001,0.001]
              products of inertia: ~[0,0,0]
body[9] = calcn_l. mass: 1.25
              moments of inertia:  ~[0.0014,0.0039,0.0041]
              products of inertia: ~[0,0,0]
body[10] = toes_l. mass: 0.2166
              moments of inertia:  ~[0.0001,0.0002,0.0001]
              products of inertia: ~[0,0,0]
body[11] = torso. mass: 34.2366
              moments of inertia:  ~[1.4745,0.7555,1.4314]
              products of inertia: ~[0,0,0]

JOINTS (total: 12)
joint[0] = ground_pelvis. parent: ground, child: pelvis
joint[1] = hip_r. parent: pelvis_offset, child: femur_r
joint[2] = knee_r. parent: femur_r, child: tibia_r
joint[3] = ankle_r. parent: tibia_r_offset, child: talus_r
joint[4] = subtalar_r. parent: talus_r_offset, child: calcn_r
joint[5] = mtp_r. parent: calcn_r_offset, child: toes_r
joint[6] = hip_l. parent: pelvis_offset, child: femur_l
joint[7] = knee_l. parent: femur_l, child: tibia_l
joint[8] = ankle_l. parent: tibia_l_offset, child: talus_l
joint[9] = subtalar_l. parent: talus_l_offset, child: calcn_l
joint[10] = mtp_l. parent: calcn_l_offset, child: toes_l
joint[11] = back. parent: pelvis_offset, child: torso

ACTUATORS (total: 18)
actuator[0] = hamstrings_r
actuator[1] = bifemsh_r
actuator[2] = glut_max_r
actuator[3] = iliopsoas_r
actuator[4] = rect_fem_r
actuator[5] = vasti_r
actuator[6] = gastroc_r
actuator[7] = soleus_r
actuator[8] = tib_ant_r
actuator[9] = hamstrings_l
actuator[10] = bifemsh_l
actuator[11] = glut_max_l
actuator[12] = iliopsoas_l
actuator[13] = rect_fem_l
actuator[14] = vasti_l
actuator[15] = gastroc_l
actuator[16] = soleus_l
actuator[17] = tib_ant_l

STATES (total: 56)
y[0] = ground_pelvis/pelvis_tilt/value
y[1] = ground_pelvis/pelvis_tilt/speed
y[2] = ground_pelvis/pelvis_tx/value
y[3] = ground_pelvis/pelvis_tx/speed
y[4] = ground_pelvis/pelvis_ty/value
y[5] = ground_pelvis/pelvis_ty/speed
y[6] = hip_r/hip_flexion_r/value
y[7] = hip_r/hip_flexion_r/speed
y[8] = knee_r/knee_angle_r/value
y[9] = knee_r/knee_angle_r/speed
y[10] = ankle_r/ankle_angle_r/value
y[11] = ankle_r/ankle_angle_r/speed
y[12] = hip_l/hip_flexion_l/value
y[13] = hip_l/hip_flexion_l/speed
y[14] = knee_l/knee_angle_l/value
y[15] = knee_l/knee_angle_l/speed
y[16] = ankle_l/ankle_angle_l/value
y[17] = ankle_l/ankle_angle_l/speed
y[18] = back/lumbar_extension/value
y[19] = back/lumbar_extension/speed
y[20] = hamstrings_r/activation
y[21] = hamstrings_r/fiber_length
y[22] = bifemsh_r/activation
y[23] = bifemsh_r/fiber_length
y[24] = glut_max_r/activation
y[25] = glut_max_r/fiber_length
y[26] = iliopsoas_r/activation
y[27] = iliopsoas_r/fiber_length
y[28] = rect_fem_r/activation
y[29] = rect_fem_r/fiber_length
y[30] = vasti_r/activation
y[31] = vasti_r/fiber_length
y[32] = gastroc_r/activation
y[33] = gastroc_r/fiber_length
y[34] = soleus_r/activation
y[35] = soleus_r/fiber_length
y[36] = tib_ant_r/activation
y[37] = tib_ant_r/fiber_length
y[38] = hamstrings_l/activation
y[39] = hamstrings_l/fiber_length
y[40] = bifemsh_l/activation
y[41] = bifemsh_l/fiber_length
y[42] = glut_max_l/activation
y[43] = glut_max_l/fiber_length
y[44] = iliopsoas_l/activation
y[45] = iliopsoas_l/fiber_length
y[46] = rect_fem_l/activation
y[47] = rect_fem_l/fiber_length
y[48] = vasti_l/activation
y[49] = vasti_l/fiber_length
y[50] = gastroc_l/activation
y[51] = gastroc_l/fiber_length
y[52] = soleus_l/activation
y[53] = soleus_l/fiber_length
y[54] = tib_ant_l/activation
y[55] = tib_ant_l/fiber_length
</pre>