### PR TITLE
opensim-cmd print-xml Properly serialize defaults.

### DIFF
--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -45,8 +45,8 @@ Description:
   
          scale  ik  id  rra  cmc  forward  analyze     (case-insensitive)
 
-  or the name of any registered OpenSim class (even from a plugin). Here are
-  descriptions of the Tools listed above:
+  or the name of any registered (concrete) OpenSim class (even from a plugin).
+  Here are descriptions of the Tools listed above:
   
          scale    Create a subject-specific model.
          ik       Inverse Kinematics
@@ -114,12 +114,15 @@ int print_xml(int argc, const char** argv) {
     const auto* obj = Object::getDefaultInstanceOfType(className);
 
     if (!obj) {
-        throw Exception("There is no tool or class named '" + className + "'.\n"
+        throw Exception("There is no tool or registered concrete class named '"
+                + className + "'.\n"
                 "Did you intend to load a plugin (with --library)?");
     }
 
     std::cout << "Printing '" << outputFile << "'." << std::endl;
+    Object::setSerializeAllDefaults(true);
     obj->print(outputFile);
+    Object::setSerializeAllDefaults(false);
 
     return EXIT_SUCCESS;
 }

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -341,11 +341,11 @@ void testPrintXML() {
     testCommand("print-xml x y z", EXIT_FAILURE,
             StartsWith("Unexpected argument: print-xml, x, y, z"));
     testCommand("print-xml bleepbloop", EXIT_FAILURE,
-            "There is no tool or class named 'bleepbloop'.\n"
-            "Did you intend to load a plugin (with --library)?\n");
+        "There is no tool or registered concrete class named 'bleepbloop'.\n"
+        "Did you intend to load a plugin (with --library)?\n");
     testCommand("print-xml bleepbloop y", EXIT_FAILURE,
-            "There is no tool or class named 'bleepbloop'.\n"
-            "Did you intend to load a plugin (with --library)?\n");
+        "There is no tool or registered concrete class named 'bleepbloop'.\n"
+        "Did you intend to load a plugin (with --library)?\n");
 
     // Successful input.
     // =================


### PR DESCRIPTION
This fixes a bug in `opensim-cmd print-xml` wherein the printed template xml file was essentially empty; the default values were not written out.