### PR TITLE
Remove PathPoint from Station derived hierachy

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -240,7 +240,9 @@ bool OpenSimContext::replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, Ab
 }
 
 void OpenSimContext::setLocation(PathPoint& mp, int i, double d) {
-    mp.setLocationCoord(*_configState, i, d);
+    SimTK::Vec3 loc = mp.getLocation(*_configState);
+    loc[i] = d;
+    mp.setLocation(loc);
     _configState->invalidateAll(SimTK::Stage::Position);
     _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
 }

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -120,7 +120,7 @@ double OpenSimContext::getMuscleLength(Muscle& m) {
   return m.getLength(*_configState);
 }
 
-const Array<PathPoint*>& OpenSimContext::getCurrentPath(Muscle& m) {
+const Array<AbstractPathPoint*>& OpenSimContext::getCurrentPath(Muscle& m) {
   return m.getGeometryPath().getCurrentPath(*_configState);
 }
 
@@ -174,10 +174,13 @@ void OpenSimContext::setZCoordinate(MovingPathPoint& mmp, Coordinate&  newCoord)
     return;
 }
 
-void OpenSimContext::setBody(PathPoint& pathPoint, PhysicalFrame&  newBody) {
-   pathPoint.changeBodyPreserveLocation(*_configState, newBody);
-   this->recreateSystemAfterSystemExists();
-   realizeVelocity();
+void OpenSimContext::setBody(AbstractPathPoint& pathPoint, PhysicalFrame&  newBody) {
+    PathPoint* spp = dynamic_cast<PathPoint*>(&pathPoint);
+    if (spp) {
+        spp->changeBodyPreserveLocation(*_configState, newBody);
+        this->recreateSystemAfterSystemExists();
+        realizeVelocity();
+    }
 }
 
 
@@ -220,7 +223,7 @@ void OpenSimContext::setRangeMax(ConditionalPathPoint&  via, double d) {
     return;
 }
 
-bool OpenSimContext::replacePathPoint(GeometryPath& p, PathPoint& mp, PathPoint& newPoint) {
+bool OpenSimContext::replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, AbstractPathPoint& newPoint) {
    bool ret= p.replacePathPoint(*_configState, &mp, &newPoint );
    recreateSystemAfterSystemExists();
    realizeVelocity();
@@ -228,11 +231,13 @@ bool OpenSimContext::replacePathPoint(GeometryPath& p, PathPoint& mp, PathPoint&
    return ret;
 }
 
-void OpenSimContext::setLocation(PathPoint& mp, int i, double d) {
-    mp.setLocation(*_configState, i, d);
-  _configState->invalidateAll(SimTK::Stage::Position);
-  _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-    return;
+void OpenSimContext::setLocation(AbstractPathPoint& mp, int i, double d) {
+    PathPoint* spp = dynamic_cast<PathPoint*>(&mp);
+    if (spp) {
+        spp->setLocationCoord(*_configState, i, d);
+        _configState->invalidateAll(SimTK::Stage::Position);
+        _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
+    }
 }
 
 void OpenSimContext::setEndPoint(PathWrap& mw, int newEndPt) {
@@ -257,7 +262,7 @@ bool OpenSimContext::deletePathPoint(GeometryPath& p, int menuChoice) {
   return ret;
 }
 
-bool OpenSimContext::isActivePathPoint(PathPoint& mp) {
+bool OpenSimContext::isActivePathPoint(AbstractPathPoint& mp) {
   return mp.isActive(*_configState);
 };
 

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -239,13 +239,10 @@ bool OpenSimContext::replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, Ab
    return ret;
 }
 
-void OpenSimContext::setLocation(AbstractPathPoint& mp, int i, double d) {
-    PathPoint* spp = dynamic_cast<PathPoint*>(&mp);
-    if (spp) {
-        spp->setLocationCoord(*_configState, i, d);
-        _configState->invalidateAll(SimTK::Stage::Position);
-        _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
-    }
+void OpenSimContext::setLocation(PathPoint& mp, int i, double d) {
+    mp.setLocationCoord(*_configState, i, d);
+    _configState->invalidateAll(SimTK::Stage::Position);
+    _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
 }
 
 void OpenSimContext::setEndPoint(PathWrap& mw, int newEndPt) {

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -174,10 +174,18 @@ void OpenSimContext::setZCoordinate(MovingPathPoint& mmp, Coordinate&  newCoord)
     return;
 }
 
-void OpenSimContext::setBody(AbstractPathPoint& pathPoint, PhysicalFrame&  newBody) {
+void OpenSimContext::setBody(AbstractPathPoint& pathPoint, PhysicalFrame&  newBody)
+{
     PathPoint* spp = dynamic_cast<PathPoint*>(&pathPoint);
     if (spp) {
         spp->changeBodyPreserveLocation(*_configState, newBody);
+        this->recreateSystemAfterSystemExists();
+        realizeVelocity();
+        return;
+    }
+    MovingPathPoint* mpp = dynamic_cast<MovingPathPoint*>(&pathPoint);
+    if (mpp) {
+        mpp->setParentFrame(newBody);
         this->recreateSystemAfterSystemExists();
         realizeVelocity();
     }

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -45,7 +45,7 @@ class Model;
 class MovingPathPoint;
 class Muscle;
 class GeometryPath;
-class PathPoint;
+class AbstractPathPoint;
 class PathWrap;
 class ConditionalPathPoint;
 class WrapObject;
@@ -136,7 +136,7 @@ public:
     // Muscles
     double getActivation(Muscle& act);
     double getMuscleLength(Muscle& act);
-    const Array<PathPoint*>& getCurrentPath(Muscle& act);
+    const Array<AbstractPathPoint*>& getCurrentPath(Muscle& act);
     void copyMuscle(Muscle& from, Muscle& to);
     void replacePropertyFunction(OpenSim::Object& obj, OpenSim::Function* aOldFunction, OpenSim::Function* aNewFunction);
 
@@ -147,16 +147,16 @@ public:
     void setXCoordinate(MovingPathPoint& mmp, Coordinate& newCoord);
     void setYCoordinate(MovingPathPoint& mmp, Coordinate& newCoord);
     void setZCoordinate(MovingPathPoint& mmp, Coordinate& newCoord);
-    void setBody(PathPoint& pathPoint, PhysicalFrame& newBody);
+    void setBody(AbstractPathPoint& pathPoint, PhysicalFrame& newBody);
     void setCoordinate(ConditionalPathPoint& via, Coordinate& newCoord);
     void setRangeMin(ConditionalPathPoint& via, double d);
     void setRangeMax(ConditionalPathPoint& via, double d);
-    bool replacePathPoint(GeometryPath& p, PathPoint& mp, PathPoint& newPoint);
-    void setLocation(PathPoint& mp, int i, double d);
+    bool replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, AbstractPathPoint& newPoint);
+    void setLocation(AbstractPathPoint& mp, int i, double d);
     void setEndPoint(PathWrap& mw, int newEndPt);
     void addPathPoint(GeometryPath& p, int menuChoice, PhysicalFrame& body);
     bool deletePathPoint(GeometryPath& p, int menuChoice);
-    bool isActivePathPoint(PathPoint& mp) ; 
+    bool isActivePathPoint(AbstractPathPoint& mp) ; 
     // Muscle Wrapping
     void setStartPoint(PathWrap& mw, int newStartPt);
     void addPathWrap(GeometryPath& p, WrapObject& awo);

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -152,7 +152,7 @@ public:
     void setRangeMin(ConditionalPathPoint& via, double d);
     void setRangeMax(ConditionalPathPoint& via, double d);
     bool replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, AbstractPathPoint& newPoint);
-    void setLocation(AbstractPathPoint& mp, int i, double d);
+    void setLocation(PathPoint& mp, int i, double d);
     void setEndPoint(PathWrap& mw, int newEndPt);
     void addPathPoint(GeometryPath& p, int menuChoice, PhysicalFrame& body);
     bool deletePathPoint(GeometryPath& p, int menuChoice);

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -122,11 +122,11 @@ int main()
     bool after = PropertyHelper::getValueBool(dProp);
     SimTK_ASSERT_ALWAYS(!after, "Property has wrong value!!");
     dTRIlong->updGeometryPath().updateGeometry(context->getCurrentStateRef());
-    const OpenSim::Array<PathPoint*>& path = context->getCurrentPath(*dTRIlong);
+    const OpenSim::Array<AbstractPathPoint*>& path = context->getCurrentPath(*dTRIlong);
     cout << "Muscle Path" << endl;
     cout << path.getSize() << endl;
     for(int i=0; i< path.getSize(); i++)
-        cout << path.get(i)->getBodyName() << path.get(i)->getLocation() << endl;
+        cout << path.get(i)->getBodyName() << path.get(i)->getLocation(stateCopy) << endl;
     // Compare to known path 
     const OpenSim::Body& dBody = model->getBodySet().get("r_ulna_radius_hand");
     Transform xform = context->getTransform(dBody);
@@ -156,12 +156,12 @@ int main()
     cout << xform << endl;
     // Compare to known xform
     dTRIlong->updGeometryPath().updateGeometry(context->getCurrentStateRef());
-    const OpenSim::Array<PathPoint*>& newPath = context->getCurrentPath(*dTRIlong);
+    const OpenSim::Array<AbstractPathPoint*>& newPath = context->getCurrentPath(*dTRIlong);
     // Compare to known path 
     cout << "New Muscle Path" << endl;
     cout << path.getSize() << endl;
     for(int i=0; i< path.getSize(); i++)
-        cout << path.get(i)->getBodyName() << path.get(i)->getLocation() << endl;
+        cout << path.get(i)->getBodyName() << path.get(i)->getLocation(stateCopy) << endl;
     double length2 = context->getMuscleLength(*dTRIlong);
     cout << length2 << endl;
     ASSERT_EQUAL(.315748, length2, 1e-5);

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -126,7 +126,8 @@ int main()
     cout << "Muscle Path" << endl;
     cout << path.getSize() << endl;
     for(int i=0; i< path.getSize(); i++)
-        cout << path.get(i)->getBodyName() << path.get(i)->getLocation(stateCopy) << endl;
+        cout << path[i]->getParentFrame().getName()
+             << path[i]->getLocation(stateCopy) << endl;
     // Compare to known path 
     const OpenSim::Body& dBody = model->getBodySet().get("r_ulna_radius_hand");
     Transform xform = context->getTransform(dBody);
@@ -161,7 +162,8 @@ int main()
     cout << "New Muscle Path" << endl;
     cout << path.getSize() << endl;
     for(int i=0; i< path.getSize(); i++)
-        cout << path.get(i)->getBodyName() << path.get(i)->getLocation(stateCopy) << endl;
+        cout << path[i]->getParentFrame().getName() 
+             << path[i]->getLocation(stateCopy) << endl;
     double length2 = context->getMuscleLength(*dTRIlong);
     cout << length2 << endl;
     ASSERT_EQUAL(.315748, length2, 1e-5);

--- a/Bindings/Python/tests/test_component_interface.py
+++ b/Bindings/Python/tests/test_component_interface.py
@@ -15,7 +15,7 @@ class TestComponentInterface(unittest.TestCase):
             "gait10dof18musc_subject01.osim"))
         model.finalizeFromProperties();
         num_matches = model.printComponentsMatching("_r")
-        self.assertEquals(num_matches, 98)
+        self.assertEquals(num_matches, 126)
     def test_attachGeometry_memory_management(self):
         model = osim.Model()
         model.getGround().attachGeometry(osim.Sphere(1.5))

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -165,12 +165,13 @@
 %include <OpenSim/Simulation/Model/ModelVisualizer.h>
 %include <OpenSim/Simulation/Model/Model.h>
 
+%include <OpenSim/Simulation/Model/AbstractPathPoint.h>
 %include <OpenSim/Simulation/Model/PathPoint.h>
 %include <OpenSim/Simulation/Wrap/PathWrapPoint.h>
 %include <OpenSim/Simulation/Model/ConditionalPathPoint.h>
 %include <OpenSim/Simulation/Model/MovingPathPoint.h>
-%template(SetPathPoint) OpenSim::Set<OpenSim::PathPoint>;
-%template(ArrayPathPoint) OpenSim::Array<OpenSim::PathPoint*>;
+%template(SetPathPoint) OpenSim::Set<OpenSim::AbstractPathPoint>;
+%template(ArrayPathPoint) OpenSim::Array<OpenSim::AbstractPathPoint*>;
 %include <OpenSim/Simulation/Model/PathPointSet.h>
 
 %include <OpenSim/Simulation/Model/PointForceDirection.h>

--- a/OpenSim/Simulation/Model/AbstractPathPoint.cpp
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.cpp
@@ -8,7 +8,6 @@
  * through the Warrior Web program.                                           *
  *                                                                            *
  * Copyright (c) 2005-2017 Stanford University and the Authors                *
- * Author(s): Peter Loan                                                      *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *

--- a/OpenSim/Simulation/Model/AbstractPathPoint.cpp
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.cpp
@@ -24,7 +24,6 @@
 // INCLUDES
 //=============================================================================
 #include "AbstractPathPoint.h"
-#include "OpenSim/Simulation/Model/PhysicalFrame.h"
 
 //=============================================================================
 // STATICS
@@ -58,7 +57,14 @@ const std::string& AbstractPathPoint::getBodyName() const {
     return getParentFrame().getName();
 }
 
-void AbstractPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
+// PathPoint used to be the base class for all path points including
+// MovingPathPoints, which was incorrect. AbstractPathPoint was added to
+// the hierarchy to resolve that issue and since the updateFromXML code
+// still pertains to all PathPoints was included here in AbstractPathPoint
+// If derived classes have to override for future changes, do not 
+// forget to invoke Super::updateFromXMLNode.
+void AbstractPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, 
+                                          int versionNumber)
 {
     int documentVersion = versionNumber;
     if (documentVersion < XMLDocument::getLatestVersion()) {

--- a/OpenSim/Simulation/Model/AbstractPathPoint.cpp
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.cpp
@@ -1,0 +1,80 @@
+/* -------------------------------------------------------------------------- *
+ *                      OpenSim:  AbstractPathPoint.cpp                       *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Peter Loan                                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include "AbstractPathPoint.h"
+#include "OpenSim/Simulation/Model/PhysicalFrame.h"
+
+//=============================================================================
+// STATICS
+//=============================================================================
+using namespace std;
+using namespace OpenSim;
+using SimTK::Vec3;
+using SimTK::Transform;
+
+
+const PhysicalFrame& AbstractPathPoint::getParentFrame() const
+{
+    return getSocket<PhysicalFrame>("parent_frame").getConnectee();
+}
+
+void AbstractPathPoint::setParentFrame(const OpenSim::PhysicalFrame& frame)
+{
+    connectSocket_parent_frame(frame);
+}
+
+const PhysicalFrame& AbstractPathPoint::getBody() const {
+    return getParentFrame();
+}
+
+void AbstractPathPoint::setBody(const PhysicalFrame& body)
+{
+    setParentFrame(body);
+}
+
+const std::string& AbstractPathPoint::getBodyName() const {
+    return getParentFrame().getName();
+}
+
+void AbstractPathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
+{
+    int documentVersion = versionNumber;
+    if (documentVersion < XMLDocument::getLatestVersion()) {
+        if (documentVersion < 30505) {
+            // replace old properties with latest use of Connectors
+            SimTK::Xml::element_iterator bodyElement = aNode.element_begin("body");
+            std::string bodyName("");
+            if (bodyElement != aNode.element_end()) {
+                bodyElement->getValueAs<std::string>(bodyName);
+                XMLDocument::addConnector(aNode, "Connector_PhysicalFrame_",
+                    "parent_frame", bodyName);
+            }
+        }
+    }
+
+    Super::updateFromXMLNode(aNode, versionNumber);
+}
+

--- a/OpenSim/Simulation/Model/AbstractPathPoint.h
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.h
@@ -1,0 +1,101 @@
+#ifndef OPENSIM_ABSTRACT_PATH_POINT_H_
+#define OPENSIM_ABSTRACT_PATH_POINT_H_
+/* -------------------------------------------------------------------------- *
+ *                      OpenSim:  AbstractPathPoint.h                         *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Peter Loan                                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+// INCLUDE
+#include "OpenSim/Simulation/Model/Point.h"
+
+namespace OpenSim {
+
+class PhysicalFrame;
+class WrapObject;
+
+//=============================================================================
+//=============================================================================
+/**
+ * An abstract class implementing a path point interface.
+ *
+ * @author Peter Loan
+ * @version 1.0
+ */
+class OSIMSIMULATION_API AbstractPathPoint : public Point {
+    OpenSim_DECLARE_ABSTRACT_OBJECT(AbstractPathPoint, Point);
+public:
+//==============================================================================
+// SOCKETS
+//==============================================================================
+    OpenSim_DECLARE_SOCKET(parent_frame, PhysicalFrame,
+        "The frame in which this path point is located.");
+public:
+//=============================================================================
+// METHODS
+//=============================================================================
+    AbstractPathPoint() : Super() {}
+    virtual ~AbstractPathPoint() {}
+
+    /** get the relative location of the path point with respect to the body
+    it is connected to. */
+    virtual SimTK::Vec3 getLocation(const SimTK::State& s) const = 0;
+
+    /** get the parent PhysicalFrame in which the PathPointis defined */
+    const PhysicalFrame& getParentFrame() const;
+    /** set the parent PhysicalFrame in which the PathPoint is defined */
+    void setParentFrame(const OpenSim::PhysicalFrame& aFrame);
+
+    /** <b>(Deprecated)</b> Old PathPoint interface */
+    DEPRECATED_14("Use getParentFrame() instead.")
+    const  PhysicalFrame& getBody() const;
+
+    DEPRECATED_14("Use setParentFrame() instead.")
+    void setBody(const PhysicalFrame& body);
+    
+    DEPRECATED_14("Use getParentFrame().getName() instead.")
+    const std::string& getBodyName() const;
+
+    virtual void scale(const SimTK::Vec3& scaleFactors) {}
+
+    virtual const WrapObject* getWrapObject() const { return nullptr; }
+
+    virtual bool isActive(const SimTK::State& s) const { return true; }
+
+    // get the partial of the point location w.r.t. to the coordinates (Q)
+    // it is dependent on.
+    virtual SimTK::Vec3 getdPointdQ(const SimTK::State& s) const
+        { return SimTK::Vec3(0); }
+
+    static void deletePathPoint(AbstractPathPoint* aPoint) {
+        if (aPoint) delete aPoint;
+    }
+
+    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
+
+//=============================================================================
+};  // END of class AbstractPathPoint
+//=============================================================================
+
+//=============================================================================
+
+} // end of namespace OpenSim
+
+#endif // OPENSIM_ABSTRACT_PATH_POINT_H_

--- a/OpenSim/Simulation/Model/AbstractPathPoint.h
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.h
@@ -58,31 +58,34 @@ public:
     it is connected to. */
     virtual SimTK::Vec3 getLocation(const SimTK::State& s) const = 0;
 
-    /** get the parent PhysicalFrame in which the PathPointis defined */
+    /** get the parent PhysicalFrame in which the PathPoint is defined */
     const PhysicalFrame& getParentFrame() const;
     /** set the parent PhysicalFrame in which the PathPoint is defined */
     void setParentFrame(const OpenSim::PhysicalFrame& aFrame);
 
-    /** <b>(Deprecated)</b> Old PathPoint interface */
+    /** <b>(Deprecated)</b> Old PathPoint interface.
+        Use getParentFrame() instead to get the PhysicalFrame in which
+        this PathPoint is defined.*/
     DEPRECATED_14("Use getParentFrame() instead.")
     const  PhysicalFrame& getBody() const;
-
+    /** <b>(Deprecated)</b> Old PathPoint interface.
+        Use setParentFrame() instead.*/
     DEPRECATED_14("Use setParentFrame() instead.")
     void setBody(const PhysicalFrame& body);
-    
+    /** <b>(Deprecated)</b> Old PathPoint interface.
+        Use getParentFrame().getName() instead.*/
     DEPRECATED_14("Use getParentFrame().getName() instead.")
     const std::string& getBodyName() const;
 
-    virtual void scale(const SimTK::Vec3& scaleFactors) {}
+    virtual void scale(const SimTK::Vec3& scaleFactors) = 0;
 
     virtual const WrapObject* getWrapObject() const { return nullptr; }
 
     virtual bool isActive(const SimTK::State& s) const { return true; }
 
-    // get the partial of the point location w.r.t. to the coordinates (Q)
-    // it is dependent on.
-    virtual SimTK::Vec3 getdPointdQ(const SimTK::State& s) const
-        { return SimTK::Vec3(0); }
+    /** get the partial derivative of the point location in the parent frame
+        w.r.t. to the coordinates(Q) and expressed in the parent frame. */
+    virtual SimTK::Vec3 getdPointdQ(const SimTK::State& s) const = 0;
 
     static void deletePathPoint(AbstractPathPoint* aPoint) {
         if (aPoint) delete aPoint;

--- a/OpenSim/Simulation/Model/AbstractPathPoint.h
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.h
@@ -25,10 +25,10 @@
 
 // INCLUDE
 #include "OpenSim/Simulation/Model/Point.h"
+#include "OpenSim/Simulation/Model/PhysicalFrame.h"
 
 namespace OpenSim {
 
-class PhysicalFrame;
 class WrapObject;
 
 //=============================================================================
@@ -43,7 +43,7 @@ public:
 // SOCKETS
 //=============================================================================
     OpenSim_DECLARE_SOCKET(parent_frame, PhysicalFrame,
-        "The frame in which this path point is located.");
+        "The frame in which this path point is defined.");
 public:
 //=============================================================================
 // METHODS
@@ -88,6 +88,11 @@ public:
         if (aPoint) delete aPoint;
     }
 
+    /** Update the use of *body* property in previous revisions to the 
+        parent_frame (Socket) for the path point's dependency on a 
+        PhysicalFrame. 
+        @note If overriding updateFromXMLNode of derived classes, do not
+        forget to invoke Super::updateFromXMLNode to include this update.*/
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/AbstractPathPoint.h
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.h
@@ -39,16 +39,16 @@ class WrapObject;
 class OSIMSIMULATION_API AbstractPathPoint : public Point {
     OpenSim_DECLARE_ABSTRACT_OBJECT(AbstractPathPoint, Point);
 public:
-//==============================================================================
+//=============================================================================
 // SOCKETS
-//==============================================================================
+//=============================================================================
     OpenSim_DECLARE_SOCKET(parent_frame, PhysicalFrame,
         "The frame in which this path point is located.");
 public:
 //=============================================================================
 // METHODS
 //=============================================================================
-    AbstractPathPoint() : Super() {}
+    AbstractPathPoint() = default;
     virtual ~AbstractPathPoint() {}
 
     /** get the relative location of the path point with respect to the body

--- a/OpenSim/Simulation/Model/AbstractPathPoint.h
+++ b/OpenSim/Simulation/Model/AbstractPathPoint.h
@@ -35,9 +35,6 @@ class WrapObject;
 //=============================================================================
 /**
  * An abstract class implementing a path point interface.
- *
- * @author Peter Loan
- * @version 1.0
  */
 class OSIMSIMULATION_API AbstractPathPoint : public Point {
     OpenSim_DECLARE_ABSTRACT_OBJECT(AbstractPathPoint, Point);

--- a/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
+++ b/OpenSim/Simulation/Model/ConditionalPathPoint.cpp
@@ -74,7 +74,7 @@ void ConditionalPathPoint::updateFromXMLNode(SimTK::Xml::Element& node,
     }
 
     // Call base class now assuming _node has been corrected for current version
-    PathPoint::updateFromXMLNode(node, versionNumber);
+    Super::updateFromXMLNode(node, versionNumber);
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -86,8 +86,8 @@ void GeometryPath::extendConnectToModel(Model& aModel)
     addCacheVariable<double>("length", 0.0, SimTK::Stage::Position);
     addCacheVariable<double>("speed", 0.0, SimTK::Stage::Velocity);
     // Cache the set of points currently defining this path.
-    Array<PathPoint *> pathPrototype;
-    addCacheVariable<Array<PathPoint *> >
+    Array<AbstractPathPoint *> pathPrototype;
+    addCacheVariable<Array<AbstractPathPoint *> >
         ("current_path", pathPrototype, SimTK::Stage::Position);
 
     // We consider this cache entry valid any time after it has been created
@@ -124,9 +124,9 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
     // clients of this path a chance to calculate meaningful color information.
     getModel().realizeDynamics(state);
 
-    const Array<PathPoint*>& pathPoints = getCurrentPath(state);
+    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
 
-    const PathPoint* lastPoint = pathPoints[0];
+    const AbstractPathPoint* lastPoint = pathPoints[0];
     MobilizedBodyIndex mbix(0);
 
     Vec3 lastPos = lastPoint->getLocationInGround(state);
@@ -136,7 +136,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
     Vec3 pos;
 
     for (int i = 1; i < pathPoints.getSize(); ++i) {
-        PathPoint* point = pathPoints[i];
+        AbstractPathPoint* point = pathPoints[i];
         PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
 
         if (pwp) {
@@ -201,7 +201,7 @@ void GeometryPath::namePathPoints(int aStartingIndex)
     for (int i = aStartingIndex; i < get_PathPointSet().getSize(); i++)
     {
         sprintf(indx,"%d",i+1);
-        PathPoint& point = get_PathPointSet().get(i);
+        AbstractPathPoint& point = get_PathPointSet().get(i);
         if (point.getName()=="" && hasOwner()) {
             point.setName(getOwner().getName() + "-P" + indx);
         }
@@ -215,11 +215,11 @@ void GeometryPath::namePathPoints(int aStartingIndex)
  * @return The array of currently active path points.
  * 
  */
-const OpenSim::Array <PathPoint*> & GeometryPath::
+const OpenSim::Array <AbstractPathPoint*> & GeometryPath::
 getCurrentPath(const SimTK::State& s)  const
 {
     computePath(s);   // compute checks if path needs to be recomputed
-    return getCacheVariableValue< Array<PathPoint*> >(s, "current_path");
+    return getCacheVariableValue< Array<AbstractPathPoint*> >(s, "current_path");
 }
 
 // get the path as PointForceDirections directions 
@@ -230,18 +230,18 @@ getPointForceDirections(const SimTK::State& s,
                         OpenSim::Array<PointForceDirection*> *rPFDs) const
 {
     int i;
-    PathPoint* start;
-    PathPoint* end;
+    AbstractPathPoint* start;
+    AbstractPathPoint* end;
     const OpenSim::PhysicalFrame* startBody;
     const OpenSim::PhysicalFrame* endBody;
-    const Array<PathPoint*>& currentPath = getCurrentPath(s);
+    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
 
     int np = currentPath.getSize();
     rPFDs->ensureCapacity(np);
     
     for (i = 0; i < np; i++) {
         PointForceDirection *pfd = 
-            new PointForceDirection(currentPath[i]->getLocation(), 
+            new PointForceDirection(currentPath[i]->getLocation(s), 
                                     currentPath[i]->getBody(), Vec3(0));
         rPFDs->append(pfd);
     }
@@ -293,11 +293,11 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
     SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
     SimTK::Vector& mobilityForces) const
 {
-    PathPoint* start = NULL;
-    PathPoint* end = NULL;
+    AbstractPathPoint* start = NULL;
+    AbstractPathPoint* end = NULL;
     const SimTK::MobilizedBody* bo = NULL;
     const SimTK::MobilizedBody* bf = NULL;
-    const Array<PathPoint*>& currentPath = getCurrentPath(s);
+    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
     int np = currentPath.getSize();
 
     const SimTK::SimbodyMatterSubsystem& matter = 
@@ -350,14 +350,14 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             // add in the tension point forces to body forces
             if (mppo) {// moving path point location is a function of the state
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = mppo->getParentFrame().findTransformInBaseFrame();
+                auto X_BF = mppo->getBody().findTransformInBaseFrame();
                 bo->applyForceToBodyPoint(s, X_BF*mppo->getLocation(s), force,
                     bodyForces);
             }
             else {
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = start->getParentFrame().findTransformInBaseFrame();
-                bo->applyForceToBodyPoint(s, X_BF*start->getLocation(), force,
+                auto X_BF = start->getBody().findTransformInBaseFrame();
+                bo->applyForceToBodyPoint(s, X_BF*start->getLocation(s), force,
                     bodyForces);
             }
 
@@ -369,8 +369,8 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             }
             else {
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = end->getParentFrame().findTransformInBaseFrame();
-                bf->applyForceToBodyPoint(s, X_BF*end->getLocation(), -force,
+                auto X_BF = end->getBody().findTransformInBaseFrame();
+                bf->applyForceToBodyPoint(s, X_BF*end->getLocation(s), -force,
                     bodyForces);
             }
 
@@ -489,12 +489,12 @@ double GeometryPath::getPreScaleLength( const SimTK::State& s) const {
  * @param aBody The body to attach the point to.
  * @return Pointer to the newly created path point.
  */
-PathPoint* GeometryPath::
+AbstractPathPoint* GeometryPath::
 addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
 {
     PathPoint* newPoint = new PathPoint();
     newPoint->setBody(aBody);
-    Vec3& location = newPoint->getLocation();
+    Vec3& location = newPoint->getLocation(s);
     placeNewPathPoint(s, location, aIndex, aBody);
     upd_PathPointSet().insert(aIndex, newPoint);
 
@@ -517,14 +517,14 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
     return newPoint;
 }
 
-PathPoint* GeometryPath::
+AbstractPathPoint* GeometryPath::
 appendNewPathPoint(const std::string& proposedName, 
                    PhysicalFrame& aBody, const SimTK::Vec3& aPositionOnBody)
 {
     PathPoint* newPoint = new PathPoint();
     newPoint->setBody(aBody);
     newPoint->setName(proposedName);
-    newPoint->set_location(aPositionOnBody);
+    newPoint->setLocation(aPositionOnBody);
     upd_PathPointSet().adoptAndAppend(newPoint);
 
     return newPoint;
@@ -572,9 +572,9 @@ placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex,
             distance = 0.5;
         }
 
-        const Vec3& startPt = get_PathPointSet()[start].getLocation();
-        const Vec3& endPt = get_PathPointSet()[end].getLocation();
-        const Vec3& basePt = get_PathPointSet()[base].getLocation();
+        const Vec3& startPt = get_PathPointSet()[start].getLocation(s);
+        const Vec3& endPt = get_PathPointSet()[end].getLocation(s);
+        const Vec3& basePt = get_PathPointSet()[base].getLocation(s);
 
         Vec3 startPt2 = get_PathPointSet()[start].getBody()
             .findStationLocationInAnotherFrame(s, startPt, aBody);
@@ -583,11 +583,8 @@ placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex,
             .findStationLocationInAnotherFrame(s, endPt, aBody);
 
         aOffset = basePt + distance * (endPt2 - startPt2);
-    } else if (get_PathPointSet().getSize() == 1){
-        int foo = 0;
-        for (int i = 0; i < 3; i++) {
-            aOffset[i] = get_PathPointSet().get(foo).getLocation()[i] + 0.01;
-        }
+    } else if (get_PathPointSet().getSize() == 1) {
+        aOffset= get_PathPointSet()[0].getLocation(s) + 0.01;
     }
     else {  // first point, do nothing?
     }
@@ -670,8 +667,8 @@ bool GeometryPath::deletePathPoint(const SimTK::State& s, int aIndex)
  *  @param aNewPathPoint Path point to add.
  */
 bool GeometryPath::
-replacePathPoint(const SimTK::State& s, PathPoint* aOldPathPoint, 
-                 PathPoint* aNewPathPoint) 
+replacePathPoint(const SimTK::State& s, AbstractPathPoint* aOldPathPoint, 
+                 AbstractPathPoint* aNewPathPoint) 
 {
     if (aOldPathPoint != NULL && aNewPathPoint != NULL) {
         int count = 0;
@@ -844,8 +841,8 @@ void GeometryPath::computePath(const SimTK::State& s) const
     }
 
     // Clear the current path.
-    Array<PathPoint*>& currentPath = 
-        updCacheVariableValue<Array<PathPoint*> >(s, "current_path");
+    Array<AbstractPathPoint*>& currentPath = 
+        updCacheVariableValue<Array<AbstractPathPoint*> >(s, "current_path");
     currentPath.setSize(0);
 
     // Add the active fixed and moving via points to the path.
@@ -871,7 +868,7 @@ void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
     if (isCacheVariableValid(s, "speed"))
         return;
 
-    const Array<PathPoint*>& currentPath = getCurrentPath(s);
+    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
 
     double speed = 0.0;
     
@@ -887,7 +884,7 @@ void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
  * Apply the wrap objects to the current path.
  */
 void GeometryPath::
-applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const 
+applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const 
 {
     if (get_PathWrapSet().getSize() < 1)
         return;
@@ -956,7 +953,7 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                         break;
                 if (jfwd > wrapEnd) // there are no active points in the path
                     return;
-                const PathPoint* const smp = &get_PathPointSet().get(jfwd);
+                const AbstractPathPoint* const smp = &get_PathPointSet().get(jfwd);
 
                 // 3. Scan backwards from wrapEnd in get_PathPointSet() to find 
                 // the last point that is active. Store a pointer to it (emp).
@@ -966,7 +963,7 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                         break;
                 if (jrev < wrapStart) // there are no active points in the path
                     return;
-                const PathPoint* const emp = &get_PathPointSet().get(jrev);
+                const AbstractPathPoint* const emp = &get_PathPointSet().get(jrev);
 
                 // 4. Now find the indices of smp and emp in _currentPath.
                 int start=-1, end=-1;
@@ -1067,8 +1064,8 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
                     ws.updWrapPoint1().setWrapLength(0.0);
                     ws.updWrapPoint2().setWrapLength(best_wrap.wrap_path_length);
 
-                    ws.updWrapPoint1().setLocation(s,best_wrap.r1);
-                    ws.updWrapPoint2().setLocation(s,best_wrap.r2);
+                    ws.updWrapPoint1().setLocation(best_wrap.r1);
+                    ws.updWrapPoint2().setLocation(best_wrap.r2);
 
                     // Now insert the two new wrapping points into mp[] array.
                     path.insert(best_wrap.endPoint, &ws.updWrapPoint1());
@@ -1116,10 +1113,10 @@ applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path) const
  */
 double GeometryPath::
 calcPathLengthChange(const SimTK::State& s, const WrapObject& wo, 
-                     const WrapResult& wr, const Array<PathPoint*>& path)  const
+                     const WrapResult& wr, const Array<AbstractPathPoint*>& path)  const
 {
-    const PathPoint* pt1 = path.get(wr.startPoint);
-    const PathPoint* pt2 = path.get(wr.endPoint);
+    const AbstractPathPoint* pt1 = path.get(wr.startPoint);
+    const AbstractPathPoint* pt2 = path.get(wr.endPoint);
 
     double straight_length = pt1->calcDistanceBetween(s, *pt2);
 
@@ -1137,13 +1134,13 @@ calcPathLengthChange(const SimTK::State& s, const WrapObject& wo,
  */
 double GeometryPath::
 calcLengthAfterPathComputation(const SimTK::State& s, 
-                               const Array<PathPoint*>& currentPath) const
+                               const Array<AbstractPathPoint*>& currentPath) const
 {
     double length = 0.0;
 
     for (int i = 0; i < currentPath.getSize() - 1; i++) {
-        const PathPoint* p1 = currentPath[i];
-        const PathPoint* p2 = currentPath[i+1];
+        const AbstractPathPoint* p1 = currentPath[i];
+        const AbstractPathPoint* p2 = currentPath[i+1];
 
         // If both points are wrap points on the same wrap object, then this
         // path segment wraps over the surface of a wrap object, so just add in 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -494,7 +494,7 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& frame)
 {
     PathPoint* newPoint = new PathPoint();
     newPoint->setParentFrame(frame);
-    Vec3& location = newPoint->getLocation(s);
+    Vec3 location = newPoint->getLocation(s);
     placeNewPathPoint(s, location, aIndex, frame);
     upd_PathPointSet().insert(aIndex, newPoint);
 
@@ -572,9 +572,9 @@ placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex,
             distance = 0.5;
         }
 
-        const Vec3& startPt = get_PathPointSet()[start].getLocation(s);
-        const Vec3& endPt = get_PathPointSet()[end].getLocation(s);
-        const Vec3& basePt = get_PathPointSet()[base].getLocation(s);
+        const Vec3 startPt = get_PathPointSet()[start].getLocation(s);
+        const Vec3 endPt = get_PathPointSet()[end].getLocation(s);
+        const Vec3 basePt = get_PathPointSet()[base].getLocation(s);
 
         Vec3 startPt2 = get_PathPointSet()[start].getParentFrame()
             .findStationLocationInAnotherFrame(s, startPt, frame);
@@ -793,7 +793,8 @@ void GeometryPath::scale(const SimTK::State& s, const ScaleSet& aScaleSet)
 {
     for (int i = 0; i < get_PathPointSet().getSize(); i++)
     {
-        const string& bodyName = get_PathPointSet().get(i).getBodyName();
+        const string& bodyName = 
+            get_PathPointSet()[i].getParentFrame().getName();
         for (int j = 0; j < aScaleSet.getSize(); j++)
         {
             Scale& aScale = aScaleSet.get(j);

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -486,16 +486,16 @@ double GeometryPath::getPreScaleLength( const SimTK::State& s) const {
  * Add a new path point, with default location, to the path.
  *
  * @param aIndex The position in the pathPointSet to put the new point in.
- * @param aBody The body to attach the point to.
+ * @param frame The frame to attach the point to.
  * @return Pointer to the newly created path point.
  */
 AbstractPathPoint* GeometryPath::
-addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
+addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& frame)
 {
     PathPoint* newPoint = new PathPoint();
-    newPoint->setBody(aBody);
+    newPoint->setParentFrame(frame);
     Vec3& location = newPoint->getLocation(s);
-    placeNewPathPoint(s, location, aIndex, aBody);
+    placeNewPathPoint(s, location, aIndex, frame);
     upd_PathPointSet().insert(aIndex, newPoint);
 
     // Rename the path points starting at this new one.
@@ -519,10 +519,10 @@ addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody)
 
 AbstractPathPoint* GeometryPath::
 appendNewPathPoint(const std::string& proposedName, 
-                   PhysicalFrame& aBody, const SimTK::Vec3& aPositionOnBody)
+                   PhysicalFrame& frame, const SimTK::Vec3& aPositionOnBody)
 {
     PathPoint* newPoint = new PathPoint();
-    newPoint->setBody(aBody);
+    newPoint->setParentFrame(frame);
     newPoint->setName(proposedName);
     newPoint->setLocation(aPositionOnBody);
     upd_PathPointSet().adoptAndAppend(newPoint);
@@ -538,11 +538,11 @@ appendNewPathPoint(const std::string& proposedName,
  * instead)
  * @param aOffset The XYZ location to be determined.
  * @param aIndex The position in the pathPointSet to put the new point in.
- * @param aBody The body to attach the point to.
+ * @param frame The body to attach the point to.
  */
 void GeometryPath::
 placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex, 
-                  const PhysicalFrame& aBody)
+                  const PhysicalFrame& frame)
 {
     // The location of the point is determined by moving a 'distance' from 'base' 
     // along a vector from 'start' to 'end.' 'base' is the existing path point 
@@ -577,10 +577,10 @@ placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex,
         const Vec3& basePt = get_PathPointSet()[base].getLocation(s);
 
         Vec3 startPt2 = get_PathPointSet()[start].getParentFrame()
-            .findStationLocationInAnotherFrame(s, startPt, aBody);
+            .findStationLocationInAnotherFrame(s, startPt, frame);
 
         Vec3 endPt2 = get_PathPointSet()[end].getParentFrame()
-            .findStationLocationInAnotherFrame(s, endPt, aBody);
+            .findStationLocationInAnotherFrame(s, endPt, frame);
 
         aOffset = basePt + distance * (endPt2 - startPt2);
     } else if (get_PathPointSet().getSize() == 1) {

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -145,7 +145,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
             // The surface points are expressed w.r.t. the wrap surface's body frame.
             // Transform the surface points into the ground reference frame to draw
             // the surface point as the wrapping portion of the GeometryPath
-            const Transform& X_BG = pwp->getBody().getTransformInGround(state);
+            const Transform& X_BG = pwp->getParentFrame().getTransformInGround(state);
             // Cycle through each surface point and draw it the Ground frame
             for (int j = 0; j<surfacePoints.getSize(); ++j) {
                 // transform the surface point into the Ground reference frame
@@ -242,15 +242,15 @@ getPointForceDirections(const SimTK::State& s,
     for (i = 0; i < np; i++) {
         PointForceDirection *pfd = 
             new PointForceDirection(currentPath[i]->getLocation(s), 
-                                    currentPath[i]->getBody(), Vec3(0));
+                                    currentPath[i]->getParentFrame(), Vec3(0));
         rPFDs->append(pfd);
     }
 
     for (i = 0; i < np-1; i++) {
         start = currentPath[i];
         end = currentPath[i+1];
-        startBody = &start->getBody();
-        endBody = &end->getBody();
+        startBody = &start->getParentFrame();
+        endBody = &end->getParentFrame();
 
         if (startBody != endBody)
         {
@@ -258,10 +258,10 @@ getPointForceDirections(const SimTK::State& s,
             Vec3 direction(0);
 
             // Find the positions of start and end in the inertial frame.
-            //engine.getPosition(s, start->getBody(), start->getLocation(), posStart);
+            //engine.getPosition(s, start->getParentFrame(), start->getLocation(), posStart);
             posStart = start->getLocationInGround(s);
             
-            //engine.getPosition(s, end->getBody(), end->getLocation(), posEnd);
+            //engine.getPosition(s, end->getParentFrame(), end->getLocation(), posEnd);
             posEnd = end->getLocationInGround(s);
 
             // Form a vector from start to end, in the inertial frame.
@@ -315,8 +315,8 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
         start = currentPath[i];
         end = currentPath[i+1];
 
-        bo = &start->getBody().getMobilizedBody();
-        bf = &end->getBody().getMobilizedBody();
+        bo = &start->getParentFrame().getMobilizedBody();
+        bf = &end->getParentFrame().getMobilizedBody();
 
         if (bo != bf) {
             // Find the positions of start and end in the inertial frame.
@@ -350,13 +350,13 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             // add in the tension point forces to body forces
             if (mppo) {// moving path point location is a function of the state
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = mppo->getBody().findTransformInBaseFrame();
+                auto X_BF = mppo->getParentFrame().findTransformInBaseFrame();
                 bo->applyForceToBodyPoint(s, X_BF*mppo->getLocation(s), force,
                     bodyForces);
             }
             else {
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = start->getBody().findTransformInBaseFrame();
+                auto X_BF = start->getParentFrame().findTransformInBaseFrame();
                 bo->applyForceToBodyPoint(s, X_BF*start->getLocation(s), force,
                     bodyForces);
             }
@@ -369,7 +369,7 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             }
             else {
                 // transform of the frame of the point to the base mobilized body
-                auto X_BF = end->getBody().findTransformInBaseFrame();
+                auto X_BF = end->getParentFrame().findTransformInBaseFrame();
                 bf->applyForceToBodyPoint(s, X_BF*end->getLocation(s), -force,
                     bodyForces);
             }
@@ -576,10 +576,10 @@ placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex,
         const Vec3& endPt = get_PathPointSet()[end].getLocation(s);
         const Vec3& basePt = get_PathPointSet()[base].getLocation(s);
 
-        Vec3 startPt2 = get_PathPointSet()[start].getBody()
+        Vec3 startPt2 = get_PathPointSet()[start].getParentFrame()
             .findStationLocationInAnotherFrame(s, startPt, aBody);
 
-        Vec3 endPt2 = get_PathPointSet()[end].getBody()
+        Vec3 endPt2 = get_PathPointSet()[end].getParentFrame()
             .findStationLocationInAnotherFrame(s, endPt, aBody);
 
         aOffset = basePt + distance * (endPt2 - startPt2);

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -62,17 +62,21 @@ OpenSim_DECLARE_CONCRETE_OBJECT(GeometryPath, ModelComponent);
     //=============================================================================
     OpenSim_DECLARE_OUTPUT(length, double, getLength, SimTK::Stage::Position);
     // 
-    OpenSim_DECLARE_OUTPUT(lengthening_speed, double, getLengtheningSpeed, SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(lengthening_speed, double, getLengtheningSpeed,
+        SimTK::Stage::Velocity);
 
 //=============================================================================
 // DATA
 //=============================================================================
 private:
-    OpenSim_DECLARE_UNNAMED_PROPERTY(PathPointSet, "The set of points defining the path");
+    OpenSim_DECLARE_UNNAMED_PROPERTY(PathPointSet,
+        "The set of points defining the path");
 
-    OpenSim_DECLARE_UNNAMED_PROPERTY(PathWrapSet, "The wrap objects that are associated with this path");
+    OpenSim_DECLARE_UNNAMED_PROPERTY(PathWrapSet,
+        "The wrap objects that are associated with this path");
     
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(default_color, SimTK::Vec3, "Used to initialize the color cache variable");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(default_color, SimTK::Vec3,
+        "Used to initialize the color cache variable");
 
     // used for scaling tendon and fiber lengths
     double _preScaleLength;
@@ -100,8 +104,8 @@ public:
     //--------------------------------------------------------------------------
     // UTILITY
     //--------------------------------------------------------------------------
-    PathPoint* addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody);
-    PathPoint* appendNewPathPoint(const std::string& proposedName, 
+    AbstractPathPoint* addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody);
+    AbstractPathPoint* appendNewPathPoint(const std::string& proposedName, 
         PhysicalFrame& aBody, const SimTK::Vec3& aPositionOnBody);
     bool canDeletePathPoint( int aIndex);
     bool deletePathPoint(const SimTK::State& s, int aIndex);
@@ -109,7 +113,7 @@ public:
     void moveUpPathWrap(const SimTK::State& s, int aIndex);
     void moveDownPathWrap(const SimTK::State& s, int aIndex);
     void deletePathWrap(const SimTK::State& s, int aIndex);
-    bool replacePathPoint(const SimTK::State& s, PathPoint* aOldPathPoint, PathPoint* aNewPathPoint); 
+    bool replacePathPoint(const SimTK::State& s, AbstractPathPoint* aOldPathPoint, AbstractPathPoint* aNewPathPoint); 
 
     //--------------------------------------------------------------------------
     // GET
@@ -143,7 +147,7 @@ public:
     void setLength( const SimTK::State& s, double length) const;
     double getPreScaleLength( const SimTK::State& s) const;
     void setPreScaleLength( const SimTK::State& s, double preScaleLength);
-    const Array<PathPoint*>& getCurrentPath( const SimTK::State& s) const;
+    const Array<AbstractPathPoint*>& getCurrentPath( const SimTK::State& s) const;
 
     double getLengtheningSpeed(const SimTK::State& s) const;
     void setLengtheningSpeed( const SimTK::State& s, double speed ) const;
@@ -205,12 +209,12 @@ private:
 
     void computePath(const SimTK::State& s ) const;
     void computeLengtheningSpeed(const SimTK::State& s) const;
-    void applyWrapObjects(const SimTK::State& s, Array<PathPoint*>& path ) const;
+    void applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path ) const;
     double calcPathLengthChange(const SimTK::State& s, const WrapObject& wo, 
                                 const WrapResult& wr, 
-                                const Array<PathPoint*>& path) const; 
+                                const Array<AbstractPathPoint*>& path) const; 
     double calcLengthAfterPathComputation
-       (const SimTK::State& s, const Array<PathPoint*>& currentPath) const;
+       (const SimTK::State& s, const Array<AbstractPathPoint*>& currentPath) const;
 
     void constructProperties();
     void namePathPoints(int aStartingIndex);

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -104,16 +104,18 @@ public:
     //--------------------------------------------------------------------------
     // UTILITY
     //--------------------------------------------------------------------------
-    AbstractPathPoint* addPathPoint(const SimTK::State& s, int aIndex, PhysicalFrame& aBody);
+    AbstractPathPoint* addPathPoint(const SimTK::State& s, int index,
+        PhysicalFrame& frame);
     AbstractPathPoint* appendNewPathPoint(const std::string& proposedName, 
-        PhysicalFrame& aBody, const SimTK::Vec3& aPositionOnBody);
-    bool canDeletePathPoint( int aIndex);
-    bool deletePathPoint(const SimTK::State& s, int aIndex);
+        PhysicalFrame& frame, const SimTK::Vec3& locationOnFrame);
+    bool canDeletePathPoint( int index);
+    bool deletePathPoint(const SimTK::State& s, int index);
     
-    void moveUpPathWrap(const SimTK::State& s, int aIndex);
-    void moveDownPathWrap(const SimTK::State& s, int aIndex);
-    void deletePathWrap(const SimTK::State& s, int aIndex);
-    bool replacePathPoint(const SimTK::State& s, AbstractPathPoint* aOldPathPoint, AbstractPathPoint* aNewPathPoint); 
+    void moveUpPathWrap(const SimTK::State& s, int index);
+    void moveDownPathWrap(const SimTK::State& s, int index);
+    void deletePathWrap(const SimTK::State& s, int index);
+    bool replacePathPoint(const SimTK::State& s, AbstractPathPoint* oldPathPoint,
+        AbstractPathPoint* newPathPoint); 
 
     //--------------------------------------------------------------------------
     // GET
@@ -219,7 +221,7 @@ private:
     void constructProperties();
     void namePathPoints(int aStartingIndex);
     void placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, 
-                           int aIndex, const PhysicalFrame& aBody);
+                           int index, const PhysicalFrame& frame);
 
 //=============================================================================
 };  // END of class GeometryPath

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -25,8 +25,10 @@
 // INCLUDES
 //=============================================================================
 #include "MovingPathPoint.h"
+#include <OpenSim/Common/Function.h>
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/MultiplierFunction.h>
+#include <OpenSim/Simulation/Model/PhysicalFrame.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 
 
@@ -44,7 +46,7 @@ using SimTK::Vec3;
 /*
  * Default constructor.
  */
-MovingPathPoint::MovingPathPoint() : PathPoint()
+MovingPathPoint::MovingPathPoint() : Super()
 {
     constructProperties();
 }
@@ -136,14 +138,6 @@ void MovingPathPoint::extendConnectToModel(Model& model)
         "MovingPathPoint:: Components of the path point location "
         "must depend on the same Coordinate. Condition: "
         "x_coordinate == y_coordinate == z_coordinate  FAILED.");
-
-    // Overwrite any setting of a MovingPathPoint's location property.
-    // MovingPathPoint should NOT derive from Station.
-    // TODO: We should not have Path specific Points of any kind. They should
-    // be "path" Points by virtue of being subcomponents of a GeometryPath.
-    // Set it to NaN so it blows up if we attempt to use a MovingPathPoint
-    // as a Station.
-    set_location(SimTK::Vec3(SimTK::NaN));
 }
 
 //_____________________________________________________________________________
@@ -331,8 +325,6 @@ void MovingPathPoint::scale(const SimTK::Vec3& aScaleFactors)
             set_z_location(MultiplierFunction(get_z_location().clone(), aScaleFactors[2]));
         }
     }
-
-    updateGeometry();
 }
 
 

--- a/OpenSim/Simulation/Model/MovingPathPoint.h
+++ b/OpenSim/Simulation/Model/MovingPathPoint.h
@@ -24,22 +24,13 @@
  * -------------------------------------------------------------------------- */
 
 // INCLUDE
-#include <OpenSim/Common/Function.h>
 #include <OpenSim/Simulation/Model/PathPoint.h>
-
-#ifdef SWIG
-    #ifdef OSIMSIMULATION_API
-        #undef OSIMSIMULATION_API
-        #define OSIMSIMULATION_API
-    #endif
-#endif
 
 namespace OpenSim {
 
+class Function;
 class Coordinate;
-class Model;
-class GeometryPath;
-class SimbodyEngine;
+class PhysicalFrame;
 
 //=============================================================================
 //=============================================================================
@@ -50,8 +41,8 @@ class SimbodyEngine;
  * @author Peter Loan
  * @version 1.0
  */
-class OSIMSIMULATION_API MovingPathPoint : public PathPoint {
-OpenSim_DECLARE_CONCRETE_OBJECT(MovingPathPoint, PathPoint);
+class OSIMSIMULATION_API MovingPathPoint : public AbstractPathPoint {
+OpenSim_DECLARE_CONCRETE_OBJECT(MovingPathPoint, AbstractPathPoint);
 public:
 //==============================================================================
 // PROPERTIES
@@ -108,7 +99,7 @@ public:
     bool isActive(const SimTK::State& s) const override { return true; }
 
     /** Get the local location of the MovingPathPoint in its Frame */
-    SimTK::Vec3 getLocation(const SimTK::State& s) const;
+    SimTK::Vec3 getLocation(const SimTK::State& s) const override;
     /** Get the local velocity of the MovingPathPoint w.r.t to and 
         expressed in its Frame. To get the velocity of the point w.r.t.
         and expressed in Ground, call getVelocityInGround(). */

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -143,7 +143,7 @@ void PathActuator::addNewPathPoint(
          PhysicalFrame& aBody, 
          const SimTK::Vec3& aPositionOnBody) {
     // Create new PathPoint already appended to the PathPointSet for the path
-    PathPoint* newPathPoint = updGeometryPath()
+    AbstractPathPoint* newPathPoint = updGeometryPath()
         .appendNewPathPoint(proposedName, aBody, aPositionOnBody);
 }
 

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                          OpenSim:  PathPoint.cpp                           *
+ *                           OpenSim:  PathPoint.cpp                          *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -34,6 +34,39 @@ using namespace OpenSim;
 using SimTK::Vec3;
 using SimTK::Transform;
 
+PathPoint::PathPoint() : Super() 
+{
+    constructProperties();
+}
+
+void PathPoint::constructProperties()
+{
+    //Default location
+    SimTK::Vec3 origin(0.0, 0.0, 0.0);
+    // Location in Body 
+    constructProperty_location(origin);
+}
+
+void PathPoint::extendFinalizeFromProperties()
+{
+    Super::extendFinalizeFromProperties();
+    updStation().upd_location() = get_location();
+    updStation().updSocket("parent_frame").
+        setConnecteeName(updSocket("parent_frame").getConnecteeName());
+}
+
+void PathPoint::setLocation(const SimTK::Vec3& location) {
+    upd_location() = location;
+    updStation().upd_location() = location;
+}
+
+void PathPoint::extendConnectToModel(Model& model)
+{
+    Super::extendConnectToModel(model);
+    // connect the underlying Station to the PathPoint's parent_frame
+    updStation().setParentFrame(getParentFrame());
+}
+
 void PathPoint::
 changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& body)
 {
@@ -42,35 +75,23 @@ changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& body)
             " change the body on PathPoint which was not assigned to a body.");
     }
     // if it is already assigned to body, do nothing
-    const PhysicalFrame& currentFrame = getParentFrame();
+    const PhysicalFrame& currentFrame = getStation().getParentFrame();
 
     if (currentFrame == body)
         return;
 
     // Preserve location means to switch bodies without changing
     // the location of the point in the inertial reference frame.
-    upd_location() = currentFrame.findStationLocationInAnotherFrame(s, get_location(), body);
+    setLocation(
+        currentFrame.findStationLocationInAnotherFrame(s, 
+            getStation().get_location(), body) );
 
     // now make "body" this PathPoint's parent Frame
-    setParentFrame(body);
+    setBody(body);
 }
 
-void PathPoint::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
-{
-    int documentVersion = versionNumber;
-    if (documentVersion < XMLDocument::getLatestVersion()) {
-        if (documentVersion < 30505) {
-            // replace old properties with latest use of Connectors
-            SimTK::Xml::element_iterator bodyElement = aNode.element_begin("body");
-            std::string bodyName("");
-            if (bodyElement != aNode.element_end()) {
-                bodyElement->getValueAs<std::string>(bodyName);
-                XMLDocument::addConnector(aNode, "Connector_PhysicalFrame_",
-                    "parent_frame", bodyName);
-            }
-        }
-    }
-
-    Super::updateFromXMLNode(aNode, versionNumber);
+void PathPoint::scale(const SimTK::Vec3& scaleFactors) {
+    auto& loc = upd_location();
+    loc = loc.elementwiseMultiply(scaleFactors);
+    updStation().upd_location() = loc;
 }
-

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -68,26 +68,26 @@ void PathPoint::extendConnectToModel(Model& model)
 }
 
 void PathPoint::
-changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& body)
+changeBodyPreserveLocation(const SimTK::State& s, const PhysicalFrame& frame)
 {
     if (!hasOwner()) {
         throw Exception("PathPoint::changeBodyPreserveLocation attempted to "
-            " change the body on PathPoint which was not assigned to a body.");
+            " change the frame of PathPoint which was not assigned to a frame.");
     }
     // if it is already assigned to body, do nothing
     const PhysicalFrame& currentFrame = getStation().getParentFrame();
 
-    if (currentFrame == body)
+    if (currentFrame == frame)
         return;
 
     // Preserve location means to switch bodies without changing
     // the location of the point in the inertial reference frame.
     setLocation(
         currentFrame.findStationLocationInAnotherFrame(s, 
-            getStation().get_location(), body) );
+            getStation().get_location(), frame) );
 
-    // now make "body" this PathPoint's parent Frame
-    setBody(body);
+    // now make frame this PathPoint's parent Frame
+    setParentFrame(frame);
 }
 
 void PathPoint::scale(const SimTK::Vec3& scaleFactors) {

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -35,7 +35,7 @@ class PhysicalFrame;
 //=============================================================================
 //=============================================================================
 /**
- * A PathPoint that is stationary with respect to parent's PhysicalFrame
+ * A path point that is stationary with respect to parent's PhysicalFrame
  */
 class OSIMSIMULATION_API PathPoint : public AbstractPathPoint {
     OpenSim_DECLARE_CONCRETE_OBJECT(PathPoint, AbstractPathPoint);
@@ -44,7 +44,7 @@ public:
 // PROPERTIES
 //==============================================================================
     OpenSim_DECLARE_PROPERTY(location, SimTK::Vec3,
-        "The fixed location of the station expressed in its parent frame.");
+        "The fixed location of the path point expressed in its parent frame.");
 //=============================================================================
 // METHODS
 //=============================================================================
@@ -90,17 +90,20 @@ private:
     // Satisfy Point interface
     /* Calculate the location of this PathPoint in Ground as a function of
        the state. */
-    SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const final {
+    SimTK::Vec3
+        calcLocationInGround(const SimTK::State& state) const override final {
         return getStation().getLocationInGround(state);
     }
     /* Calculate the velocity of this PathPoint with respect to and expressed
        in Ground as a function of the state. */
-    SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const final {
+    SimTK::Vec3
+        calcVelocityInGround(const SimTK::State& state) const override final {
         return getStation().getVelocityInGround(state);
     }
     /* Calculate the acceleration of this PathPoint with respect to and
        expressed in ground as a function of the state. */
-    SimTK::Vec3 calcAccelerationInGround(const SimTK::State& state) const final {
+    SimTK::Vec3
+        calcAccelerationInGround(const SimTK::State& state) const override final {
         return getStation().getAccelerationInGround(state);
     }
 
@@ -110,11 +113,11 @@ private:
     MemberSubcomponentIndex stationIx{ constructSubcomponent<Station>("station") };
 
 //=============================================================================
-};  // END of class PathPoint_
+};  // END of class PathPoint
 //=============================================================================
 //=============================================================================
 
 
 } // end of namespace OpenSim
 
-#endif // OPENSIM_STATIONARY_PATH_POINT_H_
+#endif // OPENSIM_PATH_POINT_H_

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -26,7 +26,6 @@
 // INCLUDE
 #include "OpenSim/Simulation/Model/Station.h"
 #include "OpenSim/Simulation/Model/AbstractPathPoint.h"
-#include "OpenSim/Simulation/Model/PhysicalFrame.h"
 
 namespace OpenSim {
 

--- a/OpenSim/Simulation/Model/PathPoint.h
+++ b/OpenSim/Simulation/Model/PathPoint.h
@@ -69,6 +69,10 @@ public:
 
     void scale(const SimTK::Vec3& scaleFactors) override;
 
+    SimTK::Vec3 getdPointdQ(const SimTK::State& s) const override {
+        return SimTK::Vec3(0);
+    }
+
 protected:
 
     const Station& getStation() const { 

--- a/OpenSim/Simulation/Model/PathPointSet.cpp
+++ b/OpenSim/Simulation/Model/PathPointSet.cpp
@@ -42,7 +42,7 @@ PathPointSet::~PathPointSet(void)
  * Default constructor of a PathPointSet.
  */
 PathPointSet::PathPointSet() :
-    Set<PathPoint>()
+    Set<AbstractPathPoint>()
 {
     setNull();
 }
@@ -52,7 +52,7 @@ PathPointSet::PathPointSet() :
  * Copy constructor of a PathPointSet.
  */
 PathPointSet::PathPointSet(const PathPointSet& aPathPointSet):
-    Set<PathPoint>(aPathPointSet)
+    Set<AbstractPathPoint>(aPathPointSet)
 {
     setNull();
     *this = aPathPointSet;
@@ -80,7 +80,7 @@ void PathPointSet::setNull()
 #ifndef SWIG
 PathPointSet& PathPointSet::operator=(const PathPointSet &aPathPointSet)
 {
-    Set<PathPoint>::operator=(aPathPointSet);
+    Set<AbstractPathPoint>::operator=(aPathPointSet);
     return (*this);
 }
 #endif

--- a/OpenSim/Simulation/Model/PathPointSet.h
+++ b/OpenSim/Simulation/Model/PathPointSet.h
@@ -25,19 +25,18 @@
 
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <OpenSim/Common/Set.h>
-#include "PathPoint.h"
+#include "AbstractPathPoint.h"
 
 namespace OpenSim {
 
 //=============================================================================
 //=============================================================================
 /**
- * A class for holding a set of muscle points.
+ * A class for holding a set of path points.
+ * @note the Set contains any path point that derives from AbstractPathPoint
  *
  * @authors Peter Loan
- * @version 1.0
  */
-
 class OSIMSIMULATION_API PathPointSet : public Set<AbstractPathPoint> {
 OpenSim_DECLARE_CONCRETE_OBJECT(PathPointSet, Set<AbstractPathPoint>);
 

--- a/OpenSim/Simulation/Model/PathPointSet.h
+++ b/OpenSim/Simulation/Model/PathPointSet.h
@@ -38,8 +38,8 @@ namespace OpenSim {
  * @version 1.0
  */
 
-class OSIMSIMULATION_API PathPointSet : public Set<PathPoint> {
-OpenSim_DECLARE_CONCRETE_OBJECT(PathPointSet, Set<PathPoint>);
+class OSIMSIMULATION_API PathPointSet : public Set<AbstractPathPoint> {
+OpenSim_DECLARE_CONCRETE_OBJECT(PathPointSet, Set<AbstractPathPoint>);
 
 private:
     void setNull();

--- a/OpenSim/Simulation/Model/Station.h
+++ b/OpenSim/Simulation/Model/Station.h
@@ -67,9 +67,9 @@ public:
 
     virtual ~Station();
 
-    /** get the parent PhysicalFrame to which the Station is attached */
+    /** get the parent PhysicalFrame in which the Station is defined */
     const PhysicalFrame& getParentFrame() const;
-    /** setter of Reference Frame off which the Station is defined */
+    /** set the parent PhysicalFrame in which the Station is defined */
     void setParentFrame(const OpenSim::PhysicalFrame& aFrame);
 
     /** Find this Station's location in any Frame */

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -95,9 +95,9 @@ void PathWrap::extendConnectToModel(Model& model)
         const WrapObject* wo = it->getWrapObject(getWrapObjectName());
         if (wo) {
             _wrapObject = wo;
-            updWrapPoint1().setBody(wo->getFrame());
+            updWrapPoint1().setParentFrame(wo->getFrame());
             updWrapPoint1().setWrapObject(wo);
-            updWrapPoint2().setBody(wo->getFrame());
+            updWrapPoint2().setParentFrame(wo->getFrame());
             updWrapPoint2().setWrapObject(wo);
             break;
         }

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -25,8 +25,10 @@
 // INCLUDES
 //=============================================================================
 #include "WrapObject.h"
-#include <OpenSim/Simulation/Model/PathPoint.h>
 #include "WrapResult.h"
+#include <OpenSim/Simulation/Model/PathPoint.h>
+#include <OpenSim/Simulation/Model/PhysicalFrame.h>
+
 
 //=============================================================================
 // STATICS
@@ -140,7 +142,7 @@ void WrapObject::extendFinalizeFromProperties()
 }
 
 int WrapObject::wrapPathSegment(const SimTK::State& s, 
-                                PathPoint& aPoint1, PathPoint& aPoint2,
+                                AbstractPathPoint& aPoint1, AbstractPathPoint& aPoint2,
                                 const PathWrap& aPathWrap, 
                                 WrapResult& aWrapResult) const
 {
@@ -152,10 +154,10 @@ int WrapObject::wrapPathSegment(const SimTK::State& s,
     // Convert the path points from the frames of the bodies they are attached
     // to, to the frame of the wrap object's body
     pt1 = aPoint1.getBody()
-        .findStationLocationInAnotherFrame(s, aPoint1.getLocation(), getFrame());
+        .findStationLocationInAnotherFrame(s, aPoint1.getLocation(s), getFrame());
     
     pt2 = aPoint2.getBody()
-        .findStationLocationInAnotherFrame(s, aPoint2.getLocation(), getFrame());
+        .findStationLocationInAnotherFrame(s, aPoint2.getLocation(s), getFrame());
 
     // Convert the path points from the frame of the wrap object's body
     // into the frame of the wrap object

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -153,10 +153,10 @@ int WrapObject::wrapPathSegment(const SimTK::State& s,
 
     // Convert the path points from the frames of the bodies they are attached
     // to, to the frame of the wrap object's body
-    pt1 = aPoint1.getBody()
+    pt1 = aPoint1.getParentFrame()
         .findStationLocationInAnotherFrame(s, aPoint1.getLocation(s), getFrame());
     
-    pt2 = aPoint2.getBody()
+    pt2 = aPoint2.getParentFrame()
         .findStationLocationInAnotherFrame(s, aPoint2.getLocation(s), getFrame());
 
     // Convert the path points from the frame of the wrap object's body

--- a/OpenSim/Simulation/Wrap/WrapObject.h
+++ b/OpenSim/Simulation/Wrap/WrapObject.h
@@ -28,11 +28,11 @@
 #include <OpenSim/Simulation/Model/Appearance.h>
 namespace OpenSim {
 
-class PathPoint;
 class PathWrap;
 class WrapResult;
 class Model;
 class PhysicalFrame;
+class AbstractPathPoint;
 
 //=============================================================================
 //=============================================================================
@@ -127,7 +127,7 @@ public:
 * @return The status, as a WrapAction enum
 */
     int wrapPathSegment( const SimTK::State& state, 
-                         PathPoint& aPoint1, PathPoint& aPoint2,
+                         AbstractPathPoint& aPoint1, AbstractPathPoint& aPoint2,
                          const PathWrap& aPathWrap,
                          WrapResult& aWrapResult) const;
 

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -548,33 +548,35 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         GeometryPath* geomPath = paths[i];
         const PathWrapSet& wrapSet = geomPath->getWrapSet();
         const PathPointSet& viaSet = geomPath->getPathPointSet();
-        Array<PathPoint*> activePathPoints = geomPath->getCurrentPath(si);
+        Array<AbstractPathPoint*> activePathPoints = geomPath->getCurrentPath(si);
 
-        PathPoint* orgPoint = &viaSet[0];
-        PathPoint* insPoint = &viaSet[viaSet.getSize()-1];
+        AbstractPathPoint* orgPoint = &viaSet[0];
+        AbstractPathPoint* insPoint = &viaSet[viaSet.getSize()-1];
 
         cableInfo.orgBodyName = orgPoint->getBody().getName();
-        cableInfo.orgLoc = orgPoint->getLocation();
+        cableInfo.orgLoc = orgPoint->getLocation(si);
         cableInfo.insBodyName =  insPoint->getBody().getName();
-        cableInfo.insLoc = insPoint->getLocation();
+        cableInfo.insLoc = insPoint->getLocation(si);
 
         int numVias = 0, numSurfs = 0;
         for (int j = 0; j < activePathPoints.getSize(); ++j) {
-            PathPoint* pp = activePathPoints[j];
-            cout << "pp" << j << " = " << pp->getName() << " @ " << pp->getBodyName() << ", loc = " << pp->getLocation() << endl;
+            AbstractPathPoint* pp = activePathPoints[j];
+            cout << "pp" << j << " = " << pp->getName() << " @ " << pp->getBodyName()
+                << ", loc = " << pp->getLocation(si) << endl;
         }
 
         for (int j = 0; j < viaSet.getSize(); ++j) {
-            PathPoint* pp = &viaSet[j];
-            cout << "mp" << j << " = " << pp->getName() << " @ " << pp->getBodyName() << ", loc = " << pp->getLocation() << endl;
+            AbstractPathPoint* pp = &viaSet[j];
+            cout << "mp" << j << " = " << pp->getName() << " @ " << pp->getBodyName()
+                << ", loc = " << pp->getLocation(si) << endl;
         }
 
         // add vias to cableInfo
         for (int j = 1; j < viaSet.getSize()-1; ++j) { // skip first (origin) and last (insertion) points
-            const PathPoint& pp = viaSet[j];
+            const AbstractPathPoint& pp = viaSet[j];
             ObstacleInfo obs;
             obs.bodyName = pp.getBodyName();
-            obs.X_BS.setP(pp.getLocation());
+            obs.X_BS.setP(pp.getLocation(si));
             obs.wrapObjectPtr=NULL;
             obs.P_S.setToNaN(); // not used for viapoint
             obs.Q_S.setToNaN(); // not used for viapoint
@@ -608,7 +610,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         int obsIdx = 0;
         int viaPtIdx = 1; // skip first (origin) point
         for (int j = 1; j < activePathPoints.getSize()-1; ++j) { // skip first (origin) and last (insertion)
-            PathPoint* pp = activePathPoints[j];
+            AbstractPathPoint* pp = activePathPoints[j];
             if (*pp == viaSet[viaPtIdx]) {
                 viaPtIdx++;
                 obsIdx++;
@@ -617,14 +619,14 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
             else { // next two path points should be a wrap point
                 for (int k = 0; k < wrapSet.getSize(); ++k) {
                     const Vec3& wrapStartPointLoc = wrapSet[k].getPreviousWrap().r1;
-                    if (!wrapStartPointLoc.isInf() && pp->getLocation().isNumericallyEqual(wrapStartPointLoc)) {
+                    if (!wrapStartPointLoc.isInf() && pp->getLocation(si).isNumericallyEqual(wrapStartPointLoc)) {
                         ObstacleInfo* obs = wrapObs[k];
                         obs->isActive = true;
                         // pp and next pp are wrap points
                         Transform X_SB = obs->X_BS.invert();
-                        PathPoint* pp_next = activePathPoints[++i]; // increment to next pp
-                        obs->P_S = X_SB*pp->getLocation();
-                        obs->Q_S = X_SB*pp_next->getLocation();
+                        AbstractPathPoint* pp_next = activePathPoints[++i]; // increment to next pp
+                        obs->P_S = X_SB*pp->getLocation(si);
+                        obs->Q_S = X_SB*pp_next->getLocation(si);
                         cableInfo.obstacles.insert(obsIdx++, *obs);
                         break;
                     }
@@ -643,13 +645,18 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
 
         cableInfos.append(cableInfo);
 
-        cout << pathNames[i] << " path, num pts " << activePathPoints.getSize() << ", num vias = " << numVias << ", num surfs = " << numSurfs << endl;
+        cout << pathNames[i] << " path, num pts " << activePathPoints.getSize()
+            << ", num vias = " << numVias << ", num surfs = " << numSurfs << endl;
 
 
         // debugging
 
-        cout << "org" << " = " << orgPoint->getName() << " @ " << orgPoint->getBody().getName() << ", loc = " << orgPoint->getLocation() << endl;
-        cout << "ins" << " = " << insPoint->getName() << " @ " << insPoint->getBody().getName() << ", loc = " << insPoint->getLocation() << endl;
+        cout << "org" << " = " << orgPoint->getName() << " @ " << 
+            orgPoint->getBody().getName() << ", loc = " 
+            << orgPoint->getLocation(si) << endl;
+        cout << "ins" << " = " << insPoint->getName() << " @ " <<
+            insPoint->getBody().getName() << ", loc = " 
+            << insPoint->getLocation(si) << endl;
 
         for (int j = 0; j < cableInfo.obstacles.getSize(); ++j) {
             ObstacleInfo oi = cableInfo.obstacles[j];

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -553,9 +553,9 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         AbstractPathPoint* orgPoint = &viaSet[0];
         AbstractPathPoint* insPoint = &viaSet[viaSet.getSize()-1];
 
-        cableInfo.orgBodyName = orgPoint->getBody().getName();
+        cableInfo.orgBodyName = orgPoint->getParentFrame().getName();
         cableInfo.orgLoc = orgPoint->getLocation(si);
-        cableInfo.insBodyName =  insPoint->getBody().getName();
+        cableInfo.insBodyName =  insPoint->getParentFrame().getName();
         cableInfo.insLoc = insPoint->getLocation(si);
 
         int numVias = 0, numSurfs = 0;
@@ -652,10 +652,10 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         // debugging
 
         cout << "org" << " = " << orgPoint->getName() << " @ " << 
-            orgPoint->getBody().getName() << ", loc = " 
+            orgPoint->getParentFrame().getName() << ", loc = " 
             << orgPoint->getLocation(si) << endl;
         cout << "ins" << " = " << insPoint->getName() << " @ " <<
-            insPoint->getBody().getName() << ", loc = " 
+            insPoint->getParentFrame().getName() << ", loc = " 
             << insPoint->getLocation(si) << endl;
 
         for (int j = 0; j < cableInfo.obstacles.getSize(); ++j) {

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -561,21 +561,23 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         int numVias = 0, numSurfs = 0;
         for (int j = 0; j < activePathPoints.getSize(); ++j) {
             AbstractPathPoint* pp = activePathPoints[j];
-            cout << "pp" << j << " = " << pp->getName() << " @ " << pp->getBodyName()
-                << ", loc = " << pp->getLocation(si) << endl;
+            cout << "pp" << j << " = " << pp->getName() << " @ "
+                 << pp->getParentFrame().getName() << ", loc = "
+                 << pp->getLocation(si) << endl;
         }
 
         for (int j = 0; j < viaSet.getSize(); ++j) {
             AbstractPathPoint* pp = &viaSet[j];
-            cout << "mp" << j << " = " << pp->getName() << " @ " << pp->getBodyName()
-                << ", loc = " << pp->getLocation(si) << endl;
+            cout << "mp" << j << " = " << pp->getName() << " @ "
+                 << pp->getParentFrame().getName() << ", loc = "
+                 << pp->getLocation(si) << endl;
         }
 
         // add vias to cableInfo
         for (int j = 1; j < viaSet.getSize()-1; ++j) { // skip first (origin) and last (insertion) points
             const AbstractPathPoint& pp = viaSet[j];
             ObstacleInfo obs;
-            obs.bodyName = pp.getBodyName();
+            obs.bodyName = pp.getParentFrame().getName();
             obs.X_BS.setP(pp.getLocation(si));
             obs.wrapObjectPtr=NULL;
             obs.P_S.setToNaN(); // not used for viapoint

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -53,7 +53,7 @@ const std::string modelFilename = "arm26.osim";
 // to recompose existing components, this will need continual updating. For example,
 // Joint's often add PhysicalOffsetFrames to handle what used to be baked in location
 // and orientation offsets.
-const int expectedNumComponents = 134;
+const int expectedNumComponents = 180;
 const int expectedNumJointsWithStateVariables = 2;
 const int expectedNumModelComponentsWithStateVariables = 10;
 // Below updated from 1 to 3 to account for offset frame and its geometry added

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -1029,13 +1029,16 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
 
     const PathPointSet& pts = aMuscle.getGeometryPath().getPathPointSet();
 
+    // get a state for the purpose of probing path points
+    const SimTK::State& s = aMuscle.getSystem().getDefaultState();
+
     aStream << "beginpoints" << endl;
     for (int i = 0; i < pts.getSize(); i++)
     {
-        PathPoint& pt = pts.get(i);
+        AbstractPathPoint& pt = pts.get(i);
         if (pt.getConcreteClassName()==("ConditionalPathPoint")) {
             ConditionalPathPoint* mvp = (ConditionalPathPoint*)(&pt);
-            Vec3& attachment = mvp->getLocation();
+            Vec3& attachment = mvp->getLocation(s);
             double range[]{ mvp->get_range(0), mvp->get_range(1) };
             aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << mvp->getBody().getName();
             
@@ -1052,7 +1055,7 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
             }
         } else if (pt.getConcreteClassName()==("MovingPathPoint")) {
             MovingPathPoint* mpp = (MovingPathPoint*)(&pt);
-            const Vec3& attachment = mpp->get_location();
+            const Vec3 attachment(0);
             if (mpp->hasXCoordinate()) {
                 aStream << "f" << addMuscleFunction(&mpp->get_x_location(), mpp->getXCoordinate().getMotionType(), Coordinate::Translational) << "(" << mpp->getXCoordinate().getName() << ") ";
             } else {
@@ -1068,9 +1071,9 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
             } else {
                 aStream << attachment[2];
             }
-            aStream << " segment " << mpp->getBody().getName() << endl;
+            aStream << " segment " << mpp->getParentFrame().getName() << endl;
         } else {
-            Vec3& attachment = pt.getLocation();
+            Vec3& attachment = pt.getLocation(s);
             aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << pt.getBody().getName() << endl;
         }
     }

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -1073,7 +1073,7 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
             }
             aStream << " segment " << mpp->getParentFrame().getName() << endl;
         } else {
-            Vec3& attachment = pt.getLocation(s);
+            Vec3 attachment = pt.getLocation(s);
             aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << pt.getParentFrame().getName() << endl;
         }
     }

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -1038,7 +1038,7 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
         AbstractPathPoint& pt = pts.get(i);
         if (pt.getConcreteClassName()==("ConditionalPathPoint")) {
             ConditionalPathPoint* mvp = (ConditionalPathPoint*)(&pt);
-            Vec3& attachment = mvp->getLocation(s);
+            Vec3 attachment = mvp->getLocation(s);
             double range[]{ mvp->get_range(0), mvp->get_range(1) };
             aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << mvp->getParentFrame().getName();
             

--- a/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
+++ b/OpenSim/Utilities/simmFileWriterDLL/SimbodySimmModel.cpp
@@ -1040,7 +1040,7 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
             ConditionalPathPoint* mvp = (ConditionalPathPoint*)(&pt);
             Vec3& attachment = mvp->getLocation(s);
             double range[]{ mvp->get_range(0), mvp->get_range(1) };
-            aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << mvp->getBody().getName();
+            aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << mvp->getParentFrame().getName();
             
             if (mvp->hasCoordinate()) {
                 const Coordinate& coord = mvp->getCoordinate();
@@ -1074,7 +1074,7 @@ bool SimbodySimmModel::writeMuscle(Muscle& aMuscle, const ForceSet& aActuatorSet
             aStream << " segment " << mpp->getParentFrame().getName() << endl;
         } else {
             Vec3& attachment = pt.getLocation(s);
-            aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << pt.getBody().getName() << endl;
+            aStream << attachment[0] << " " << attachment[1] << " " << attachment[2] << " segment " << pt.getParentFrame().getName() << endl;
         }
     }
     aStream << "endpoints" << endl;


### PR DESCRIPTION
Fixes issue #1179 

### Brief summary of changes
 1. Introduced a new base `AbstractPathPoint` class from which (stationary) `PathPoint` and `MovingPathPoint` derive
 2. `PathPoint` now uses a `Station` component internally instead of deriving from `Station` (to avoid multiple inheritance)
 3. Deprecated old `PathPoint` methods of `get/setBody()` now members of `AbstractPathPoint`

### Testing I've completed
 - existing test should pass
 - *testIterators* updated to account for internal `Station` components

### Looking for feedback on...
 - impact on the GUI (if any) from @aymanhab 

### CHANGELOG.md 
-  no need to update because old interface was preserved (but deprecated)

