### PR TITLE
Avoid inadvertently creating task list in PR message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@ Fixes issue #<issue_number>
 
 ### CHANGELOG.md (choose one)
 
-- [ ] no need to update
-- [ ] updated
+- no need to update because...
+- updated...


### PR DESCRIPTION
Fixes issue #[no issue opened]

### Brief summary of changes
Removed `- [ ]` to avoid creating task list in PR summary, as shown below:
![task list](https://cloud.githubusercontent.com/assets/4203505/24058773/b0c312ae-0b09-11e7-8c5c-b58b8305c3c3.png)

### Testing I've completed
No testing.

### Looking for feedback on...
No feedback requested.

### CHANGELOG.md (choose one)
No need to update CHANGELOG.md.