### PR TITLE
Avoid excluding single-character Component name in path

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -745,7 +745,7 @@ Array<std::string> Component::getStateVariableNames() const
         std::string::size_type front = subCompName.find_first_not_of(" \t\r\n");
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
-        if (back > front) // have non-whitespace name
+        if (back >= front) // have non-whitespace name
             prefix = subCompName + "/";
         for (int j = 0; j<nsubs; ++j) {
             names.append(prefix + subnames[j]);
@@ -760,7 +760,7 @@ Array<std::string> Component::getStateVariableNames() const
         std::string::size_type front = subCompName.find_first_not_of(" \t\r\n");
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
-        if(back > front) // have non-whitespace name
+        if(back >= front) // have non-whitespace name
             prefix = subCompName+"/";
         for(int j =0; j<nsubs; ++j){
             names.append(prefix+subnames[j]);
@@ -774,7 +774,7 @@ Array<std::string> Component::getStateVariableNames() const
         std::string::size_type front = subCompName.find_first_not_of(" \t\r\n");
         std::string::size_type back = subCompName.find_last_not_of(" \t\r\n");
         std::string prefix = "";
-        if (back > front) // have non-whitespace name
+        if (back >= front) // have non-whitespace name
             prefix = subCompName + "/";
         for (int j = 0; j<nsubs; ++j) {
             names.append(prefix + subnames[j]);


### PR DESCRIPTION
Fixes issue #1599.

### Brief summary of changes
Fixed off-by-one string parsing bug.

### Testing I've completed
Tests pass locally. Also tested on example code provided in #1599.

### Looking for feedback on...
No specific feedback sought.

### CHANGELOG.md (choose one)
No need to update because this code is part of the new 4.0 API.