### PR TITLE
Fixed compiler warnings

### DIFF
--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1143,10 +1143,10 @@ protected:
             precision  = defPrecision;
         if(rows.empty())
             for(size_t i = 0u; i < getNumRows()   ; ++i)
-                rows.push_back(i);
+                rows.push_back(static_cast<int>(i));
         if(cols.empty())
             for(size_t i = 0u; i < getNumColumns(); ++i)
-                cols.push_back(i);
+                cols.push_back(static_cast<int>(i));
 
         auto toStr = [&] (const double val) {
             std::ostringstream stream{};
@@ -1161,7 +1161,7 @@ protected:
         table.push_back({std::string{}, indColLabel});
         for(int col : cols) {
             if(col < 0)
-                col += getNumColumns();
+                col += static_cast<int>(getNumColumns());
             if(numComponentsPerElement() == 1)
                 table.front().push_back(getColumnLabel(col));
             else
@@ -1174,7 +1174,7 @@ protected:
         // Fill up the rows, including row-number, time column, row data.
         for(int row : rows) {
             if(row < 0)
-                row += getNumRows();
+                row += static_cast<int>(getNumRows());
             std::vector<std::string> rowData{};
             rowData.push_back(std::to_string(row) + rowNumSepChar);
             rowData.push_back(toStr(getIndependentColumn()[row]));
@@ -1228,17 +1228,17 @@ protected:
                     width -= columnWidths[endCol];
                 }
                 result.append(columnWidths[0], fillChar);
-                for(unsigned col = beginCol; col < endCol; ++col) {
+                for(size_t col = beginCol; col < endCol; ++col) {
                     result.append(columnWidths[col] - table[0][col].length(),
                                   fillChar);
                     result.append(table[0][col]);
                 }
                 result.push_back(newlineChar);
-                for(unsigned row = beginRow; row < endRow; ++row) {
+                for(size_t row = beginRow; row < endRow; ++row) {
                     result.append(columnWidths[0] - table[row][0].length(),
                                   fillChar);
                     result.append(table[row][0]);
-                    for(unsigned col = beginCol; col < endCol; ++col) {
+                    for(size_t col = beginCol; col < endCol; ++col) {
                         result.append(columnWidths[col] -
                                       table[row][col].length(), fillChar);
                         result.append(table[row][col]);

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -383,17 +383,17 @@ int main() {
         tableVec3.appendRow(0.3, {{2, 2, 2}, {3, 3, 3}, {1, 1, 1}});
 
         const auto& avgRowVec3 = tableVec3.averageRow(0.1, 0.2);
-        for(size_t i = 0; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
             OPENSIM_THROW_IF(std::abs(avgRowVec3[0][i] - 2) > 1e-8/*epsilon*/,
                              Exception,
                              "Test failed: averageRow() failed.");
 
         const auto& nearRowVec3 = tableVec3.getNearestRow(0.29);
-        for(size_t i = 0; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
             ASSERT(nearRowVec3[0][i] == 2);
         tableVec3.updNearestRow(0.29) += SimTK::Vec3{2};
         tableVec3.updNearestRow(0.29) -= SimTK::Vec3{2};
-        for(size_t i = 0; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
             ASSERT(nearRowVec3[0][i] == 2);
 
         std::cout << tableVec3 << std::endl;
@@ -450,14 +450,14 @@ int main() {
         tableQuat.appendRow(0.3, {{2, 2, 2, 2}, {3, 3, 3, 3}, {1, 1, 1, 1}});
 
         const auto& avgRowQuat = tableQuat.averageRow(0.1, 0.2);
-        for(size_t i = 0; i < 4; ++i) {
+        for(int i = 0; i < 4; ++i) {
             OPENSIM_THROW_IF(std::abs(avgRowQuat[0][i] - 0.5) > 1e-8/*epsilon*/,
                              Exception,
                              "Test failed: averageRow() failed.");
         }
 
         const auto& nearRowQuat = tableQuat.getNearestRow(0.29);
-        for(size_t i = 0; i < 4; ++i)
+        for(int i = 0; i < 4; ++i)
             ASSERT(std::abs(nearRowQuat[0][i] - 0.5) < 1e-8/*eps*/);
 
         std::cout << tableQuat << std::endl;
@@ -501,21 +501,21 @@ int main() {
                                         {{1, 1, 1}, {1, 1, 1}}});
 
         const auto& avgRowSVec = tableSpatialVec.averageRow(0.1, 0.2);
-        for(size_t i = 0; i < 3; ++i) {
+        for(int i = 0; i < 3; ++i) {
             OPENSIM_THROW_IF(std::abs(avgRowSVec[0][0][i] - 2) > 1e-8/*eps*/,
                              Exception,
                              "Test failed: averageRow() failed.");
         }
 
         const auto& nearRowSVec = tableSpatialVec.getNearestRow(0.29);
-        for(size_t i = 0; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
             ASSERT(nearRowSVec[0][0][i] == 2);
 
         tableSpatialVec.updNearestRow(0.29) += SimTK::SpatialVec{{2, 2, 2},
                                                                  {2, 2, 2}};
         tableSpatialVec.updNearestRow(0.29) -= SimTK::SpatialVec{{2, 2, 2},
                                                                  {2, 2, 2}};
-        for(size_t i = 0; i < 3; ++i)
+        for(int i = 0; i < 3; ++i)
             ASSERT(nearRowSVec[0][0][i] == 2);
 
         std::cout << tableSpatialVec << std::endl;

--- a/OpenSim/Simulation/MarkersReference.cpp
+++ b/OpenSim/Simulation/MarkersReference.cpp
@@ -103,8 +103,9 @@ populateFromMarkerData(const TimeSeriesTable_<SimTK::Vec3>& markerTable,
     const auto& markerNames = markerTable.getColumnLabels();
     _markerNames.clear();
     _weights.clear();
-    _markerNames.assign(markerNames.size(), "");
-    _weights.assign(markerNames.size(), get_default_weight());
+    _markerNames.assign(static_cast<unsigned>(markerNames.size()), "");
+    _weights.assign(static_cast<unsigned>(markerNames.size()),
+                    get_default_weight());
 
     for(unsigned i = 0; i < markerNames.size(); ++i) {
         _markerNames[i] = markerNames[i];


### PR DESCRIPTION
Fixes issue #[no issue opened].

### Brief summary of changes
Implicit type conversions cause compiler warnings when data loss is possible.

### Testing I've completed
Code compiles locally.

### Looking for feedback on...
No particular feedback sought.

### CHANGELOG.md (choose one)
No need to update because these changes do not substantially affect users.