### PR TITLE
Add DataTable::setRow()

### DIFF
--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -73,6 +73,12 @@ class TestTables {
         assert table.hasColumn(0);
         assert table.hasColumn(2);
         // Edit rows of the table.
+        row.set(0, 0); row.set(1, 1); row.set(2, 2); row.set(3, 3);
+        table.setRowAtIndex(0, row);
+        assert table.getRowAtIndex(0).get(0) == 0 &&
+               table.getRowAtIndex(0).get(1) == 1 &&
+               table.getRowAtIndex(0).get(2) == 2 &&
+               table.getRowAtIndex(0).get(3) == 3;
         row0 = table.getRowAtIndex(0);
         row0.set(0, 10); row0.set(1, 10); row0.set(2, 10); row0.set(3, 10);
         assert table.getRowAtIndex(0).get(0) == 10 &&

--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -102,6 +102,13 @@ class TestDataTable(unittest.TestCase):
         assert table.hasColumn(0)
         assert table.hasColumn(2)
         # Edit rows of the table.
+        row = osim.RowVector([100, 200, 300, 400])
+        table.setRowAtIndex(0, row)
+        row = table.getRowAtIndex(0)
+        assert (row[0] == 100 and
+                row[1] == 200 and
+                row[2] == 300 and
+                row[3] == 400)
         row0 = table.getRowAtIndex(0)
         row0[0] = 10
         row0[1] = 10

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -721,6 +721,56 @@ public:
         return _depData.updRow((int)std::distance(_indData.cbegin(), iter));
     }
 
+    /** Set row at index. Equivalent to
+    ```
+    updRowAtIndex(index) = depRow;
+    ```
+
+    \throws RowIndexOutOfRange If the index is out of range.                  */
+    void setRowAtIndex(size_t index, const RowVectorView& depRow) {
+        updRowAtIndex(index) = depRow;
+    }
+
+    /** Set row corresponding to the given entry in the independent column.
+    This function searches the independent column for exact equality, which may 
+    not be appropriate if `ETX` is of type `double`. See 
+    TimeSeriesTable_::updNearestRow().
+    Equivalent to
+    ```
+    updRow(ind) = depRow;
+    ```
+
+    \throws KeyNotFound If the independent column has no entry with given
+                        value.                                                */
+    void setRow(const ETX& ind, const RowVector& depRow) {
+        updRow(ind) = depRow;
+    }
+
+    /** Set row at index. Equivalent to
+    ```
+    updRowAtIndex(index) = depRow;
+    ```
+
+    \throws RowIndexOutOfRange If the index is out of range.                  */
+    void setRowAtIndex(size_t index, const RowVector& depRow) {
+        updRowAtIndex(index) = depRow;
+    }
+
+    /** Set row corresponding to the given entry in the independent column.
+    This function searches the independent column for exact equality, which may 
+    not be appropriate if `ETX` is of type `double`. See 
+    TimeSeriesTable_::updNearestRow().
+    Equivalent to
+    ```
+    updRow(ind) = depRow;
+    ```
+
+    \throws KeyNotFound If the independent column has no entry with given
+                        value.                                                */
+    void setRow(const ETX& ind, const RowVectorView& depRow) {
+        updRow(ind) = depRow;
+    }
+
     /** Remove row at index.
 
     \throws RowIndexOutOfRange If the index is out of range.                  */

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -731,21 +731,6 @@ public:
         updRowAtIndex(index) = depRow;
     }
 
-    /** Set row corresponding to the given entry in the independent column.
-    This function searches the independent column for exact equality, which may 
-    not be appropriate if `ETX` is of type `double`. See 
-    TimeSeriesTable_::updNearestRow().
-    Equivalent to
-    ```
-    updRow(ind) = depRow;
-    ```
-
-    \throws KeyNotFound If the independent column has no entry with given
-                        value.                                                */
-    void setRow(const ETX& ind, const RowVector& depRow) {
-        updRow(ind) = depRow;
-    }
-
     /** Set row at index. Equivalent to
     ```
     updRowAtIndex(index) = depRow;
@@ -768,6 +753,21 @@ public:
     \throws KeyNotFound If the independent column has no entry with given
                         value.                                                */
     void setRow(const ETX& ind, const RowVectorView& depRow) {
+        updRow(ind) = depRow;
+    }
+
+    /** Set row corresponding to the given entry in the independent column.
+    This function searches the independent column for exact equality, which may 
+    not be appropriate if `ETX` is of type `double`. See 
+    TimeSeriesTable_::updNearestRow().
+    Equivalent to
+    ```
+    updRow(ind) = depRow;
+    ```
+
+    \throws KeyNotFound If the independent column has no entry with given
+                        value.                                                */
+    void setRow(const ETX& ind, const RowVector& depRow) {
         updRow(ind) = depRow;
     }
 


### PR DESCRIPTION
Addressing #1591.

I have added the function on C++ side because it was less work that adding the function to every specialization in SWIG interface file. The documentation for this function makes it clear it is equivalent to calling `updRow()`.