### PR TITLE
[cmake] Remove include_directories() for Simbody

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,10 +597,6 @@ elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)
         COMMENT ${MESSAGE})
 endif()
 
-# Directories for Simbody headers and libraries for building.
-# -----------------------------------------------------------
-include_directories("${Simbody_INCLUDE_DIR}")
-
 
 # Copy files over from the Simbody installation.
 # ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,11 @@ elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)
         COMMENT ${MESSAGE})
 endif()
 
+# Directories for Simbody headers and libraries for building.
+# -----------------------------------------------------------
+# TODO no longer necessary; Simbody's library targets provide the 
+# include directories.
+include_directories("${Simbody_INCLUDE_DIR}")
 
 # Copy files over from the Simbody installation.
 # ----------------------------------------------

--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -50,6 +50,9 @@ list(APPEND @CMAKE_PROJECT_NAME@_INCLUDE_DIRS
     "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/Vendors/lepton/include"
     )
 
+# TODO This should be removed, especially when we copy the intact Simbody
+# installation into the OpenSim installation. Simbody's library targets now
+# provide the necessary include directories.
 if(@OPENSIM_COPY_SIMBODY@)
     # Simbody headers have been copied to OpenSim.
     list(APPEND @CMAKE_PROJECT_NAME@_INCLUDE_DIRS

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -147,7 +147,7 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        9e761bbb372e5da90ae478d2a5d3a4952ad94b27 
+              TAG        9f2123212dadcedcd680a8d8b3832d4fe40e1f8b
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION
### Brief summary of changes

Latest changes to Simbody make it unnecessary to use
include_directories() for Simbody; Simbody's library targets provide the
necessary include directories. For now, I'm leaving in our `include_directories()` so that members of the dev team need not update their simbody builds, and because Travis is using an out-of-date simbody build.

### Testing I've completed

Ran ctest locally. 
 
