### PR TITLE
ComponentListIterator<[...]>::_root is now a pointer.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2881,7 +2881,7 @@ ComponentListIterator<T>& ComponentListIterator<T>::operator++() {
     }
     // If processing a subtree under _root we stop when our successor is the same
     // as the successor of _root as this indicates we're leaving the _root's subtree.
-    else if (_node->_nextComponent.get() == _root._nextComponent.get())
+    else if (_node->_nextComponent.get() == _root->_nextComponent.get())
         _node = nullptr;
     else // move on to the next component we computed earlier for the full tree
         _node = _node->_nextComponent.get();
@@ -2896,7 +2896,7 @@ void ComponentListIterator<T>::advanceToNextValidComponent() {
     // Similar logic to operator++ but applies _filter->isMatch()
     while (_node != nullptr && (dynamic_cast<const T*>(_node) == nullptr || 
                                 !_filter.isMatch(*_node) || 
-                                (_node == &_root))){
+                                (_node == _root))){
         if (_node->_memberSubcomponents.size() > 0) {
             _node = _node->_memberSubcomponents[0].get();
         }
@@ -2907,7 +2907,7 @@ void ComponentListIterator<T>::advanceToNextValidComponent() {
             _node = _node->_adoptedSubcomponents[0].get();
         }
         else {
-            if (_node->_nextComponent.get() == _root._nextComponent.get()){ // end of subtree under _root
+            if (_node->_nextComponent.get() == _root->_nextComponent.get()){ // end of subtree under _root
                 _node = nullptr;
                 continue;
             }

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -143,7 +143,7 @@ public:
     descendants). ComponentFilterMatchAll is used internally. You can
     change the filter using setFilter() method. 
     */
-    ComponentList(const Component& root) : _root(root){
+    ComponentList(const Component& root) : _root(root) {
         setDefaultFilter();
     }
     /// Destructor of ComponentList.
@@ -349,7 +349,7 @@ private:
     // just before giving the node to the user (operator*() and operator->()).
     const Component* _node;
     // Root of subtree of Components that we're iterating over.
-    const Component& _root;
+    const Component* _root = nullptr;
     /** Optional filter to further select Components under _root, defaults to
     Filter by type. */
     const ComponentFilter& _filter;
@@ -361,7 +361,7 @@ private:
     ComponentListIterator(const Component* node,
                           const ComponentFilter& filter) :
         _node(node),
-        _root(*node),
+        _root(node),
         _filter(filter) {
         advanceToNextValidComponent(); // in case node is not a match.
     }


### PR DESCRIPTION
Fixes #1247 

### Brief summary of changes

No longer store a nullptr in a reference.

### Testing I've completed

Ran all ctests. I believe our coverage of the iterators in C++, python, Java, and MATLAB is sufficient for the changes introduced in this PR.

### pointer vs smart pointer

I considered using a smart pointer but none seemed relevant. This pointer does not own the memory, so shared_ptr and smart_ptr would not work. ReferencePtr resets to nullptr on copy, which is not what we want for the iterator: every copy of the iterator should have the same value for `_root`.

### CHANGELOG.md (choose one)

- no need to update because...the ComponentListIterator was not in 3.3.
