### PR TITLE
[cmake] Find consistent python libraries.

### DIFF
--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -1,7 +1,4 @@
 
-# Find python.
-# ============
-
 # Location of the opensim python package in the build directory, for testing.
 if(MSVC OR XCODE)
     # Multi-configuration generators like MSVC and XCODE use one build tree for

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,16 +448,43 @@ endif()
 if(${BUILD_PYTHON_WRAPPING})
     # PythonInterp is supposed to come before PythonLibs.
     find_package(PythonInterp 2.7 REQUIRED)
-    find_package(PythonLibs 2.7 REQUIRED)
 
     # We update the python install dir to include the python version,
     # now that we know it. We replace the token "VERSION" with the actual python
     # version.
-    string(REPLACE "VERSION" "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
+    set(python_version_majmin "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+    string(REPLACE "VERSION" "${python_version_majmin}"
         OPENSIM_INSTALL_PYTHONDIR "${OPENSIM_INSTALL_PYTHONDIR}")
     # This must be done before adding the OpenSim libraries, since
     # OPENSIM_INSTALL_PYTHONDIR is used in OpenSimAddLibrary (in
     # OpenSimMacros.cmake).
+
+    if(APPLE)
+        # If you have Homebrew's Python, then by default, PythonInterp finds
+        # Apple's Python, but PythonLibs finds Homebrew's Python, causing
+        # runtime crashes. This also occurs if one has Anaconda Python.
+        # So we use the python-config executable to get the
+        # correct library and include directory.
+        # https://github.com/Homebrew/legacy-homebrew/issues/25118
+        execute_process(COMMAND "${PYTHON_EXECUTABLE}-config" --prefix
+                    OUTPUT_VARIABLE python_prefix
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(CONCAT pyinc_desc
+            "Location of Python header files, to compile bindings. "
+            "Must be consistent with PYTHON_EXECUTABLE.")
+        set(PYTHON_INCLUDE_DIR
+            "${python_prefix}/include/python${python_version_majmin}/"
+            CACHE PATH "${pyinc_desc}")
+
+        string(CONCAT pylib_desc
+            "Location of Python library, to compile bindings. "
+            "Must be consistent with PYTHON_EXECUTABLE.")
+        set(PYTHON_LIBRARY
+            "${python_prefix}/lib/libpython${python_version_majmin}.dylib"
+            CACHE FILEPATH "${pylib_desc}")
+    endif()
+    find_package(PythonLibs 2.7 REQUIRED)
+
 endif()
 
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -556,11 +556,7 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above. CMake sets `PYTHON_*` variables to tell you the
-      Python it will use for building the wrappers. (If you installed Python
-      with Homebrew, [CMake will not find the Homebrew Python libraries on its
-      own](https://github.com/Homebrew/homebrew/issues/25118); you must set the
-      CMake variable `PYTHON_LIBRARIES` manually. Use `'$(python-config
-      --prefix)/lib/libpython2.7.dylib'` in bash to get the correct value.)
+      Python it will use for building the wrappers.
     * `BUILD_API_ONLY` if you don't want to build the command-line applications.
 8. Click the **Configure** button again. Then, click **Generate** to create
    Xcode project files in the build directory.


### PR DESCRIPTION
Fixes #1303

### Brief summary of changes

This change makes sure that on macOS, we find python libraries that are consistent with the found python executable.

### Testing I've completed

Built python bindings locally and ran python tests.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...this issue was introduced after 3.3.
