### PR TITLE
add checks for valid property values for ClutchedPathSpring and PathSpring classes

### DIFF
--- a/OpenSim/Actuators/ClutchedPathSpring.cpp
+++ b/OpenSim/Actuators/ClutchedPathSpring.cpp
@@ -122,6 +122,19 @@ void ClutchedPathSpring::setInitialStretch(double stretch0)
      set_initial_stretch(getStretch(state));
  }
  
+ void ClutchedPathSpring::extendFinalizeFromProperties()
+ {
+     Super::extendFinalizeFromProperties();
+
+     OPENSIM_THROW_IF_FRMOBJ(get_stiffness() < 0,
+         InvalidPropertyValue, getProperty_stiffness().getName());
+     OPENSIM_THROW_IF_FRMOBJ(get_dissipation() < 0,
+         InvalidPropertyValue, getProperty_dissipation().getName());
+     OPENSIM_THROW_IF_FRMOBJ(get_relaxation_time_constant() < 0,
+         InvalidPropertyValue, getProperty_relaxation_time_constant().getName());
+     OPENSIM_THROW_IF_FRMOBJ(get_initial_stretch() < 0,
+         InvalidPropertyValue, getProperty_initial_stretch().getName());
+ }
 
 
 

--- a/OpenSim/Actuators/ClutchedPathSpring.cpp
+++ b/OpenSim/Actuators/ClutchedPathSpring.cpp
@@ -126,13 +126,18 @@ void ClutchedPathSpring::setInitialStretch(double stretch0)
  {
      Super::extendFinalizeFromProperties();
 
-     OPENSIM_THROW_IF_FRMOBJ(get_stiffness() < 0,
+     OPENSIM_THROW_IF_FRMOBJ(
+         (SimTK::isNaN(get_stiffness()) || get_stiffness() < 0),
          InvalidPropertyValue, getProperty_stiffness().getName());
-     OPENSIM_THROW_IF_FRMOBJ(get_dissipation() < 0,
+     OPENSIM_THROW_IF_FRMOBJ(
+         (SimTK::isNaN(get_dissipation()) || get_dissipation() < 0),
          InvalidPropertyValue, getProperty_dissipation().getName());
-     OPENSIM_THROW_IF_FRMOBJ(get_relaxation_time_constant() < 0,
-         InvalidPropertyValue, getProperty_relaxation_time_constant().getName());
-     OPENSIM_THROW_IF_FRMOBJ(get_initial_stretch() < 0,
+     OPENSIM_THROW_IF_FRMOBJ(
+         (SimTK::isNaN(get_relaxation_time_constant()) || get_relaxation_time_constant() < 0),
+         InvalidPropertyValue, 
+         getProperty_relaxation_time_constant().getName());
+     OPENSIM_THROW_IF_FRMOBJ(
+         (SimTK::isNaN(get_initial_stretch()) || get_initial_stretch() < 0),
          InvalidPropertyValue, getProperty_initial_stretch().getName());
  }
 

--- a/OpenSim/Actuators/ClutchedPathSpring.h
+++ b/OpenSim/Actuators/ClutchedPathSpring.h
@@ -78,6 +78,9 @@ public:
 //=============================================================================
 // PUBLIC METHODS
 //=============================================================================
+    /** Construct a ClutchedPathSpring with default parameters. Users should
+        note that the default values for stiffness and dissipation are `NaN`
+        so they must be set before simulating. */
     ClutchedPathSpring();
     
     /** Convenience constructor with ClutchedPathSpring parameters
@@ -138,6 +141,7 @@ protected:
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
     void extendInitStateFromProperties(SimTK::State& state) const override;
     void extendSetPropertiesFromState(const SimTK::State& state) override;
+    void extendFinalizeFromProperties() override;
     void computeStateVariableDerivatives(const SimTK::State& s) const override;
 
 private:

--- a/OpenSim/Simulation/Model/PathSpring.cpp
+++ b/OpenSim/Simulation/Model/PathSpring.cpp
@@ -109,8 +109,12 @@ void PathSpring::extendFinalizeFromProperties()
     GeometryPath& path = upd_GeometryPath();
     path.setDefaultColor(DefaultPathSpringColor);
 
-    // Resting length must be greater than 0.0.
-    assert(get_resting_length() > 0.0);
+    OPENSIM_THROW_IF_FRMOBJ(get_resting_length() < 0,
+        InvalidPropertyValue, getProperty_resting_length().getName());
+    OPENSIM_THROW_IF_FRMOBJ(get_stiffness() < 0,
+        InvalidPropertyValue, getProperty_resting_length().getName());
+    OPENSIM_THROW_IF_FRMOBJ(get_dissipation() < 0,
+        InvalidPropertyValue, getProperty_resting_length().getName());
 }
 
 

--- a/OpenSim/Simulation/Model/PathSpring.cpp
+++ b/OpenSim/Simulation/Model/PathSpring.cpp
@@ -109,12 +109,15 @@ void PathSpring::extendFinalizeFromProperties()
     GeometryPath& path = upd_GeometryPath();
     path.setDefaultColor(DefaultPathSpringColor);
 
-    OPENSIM_THROW_IF_FRMOBJ(get_resting_length() < 0,
+    OPENSIM_THROW_IF_FRMOBJ(
+        (SimTK::isNaN(get_resting_length()) || get_resting_length() < 0),
         InvalidPropertyValue, getProperty_resting_length().getName());
-    OPENSIM_THROW_IF_FRMOBJ(get_stiffness() < 0,
-        InvalidPropertyValue, getProperty_resting_length().getName());
-    OPENSIM_THROW_IF_FRMOBJ(get_dissipation() < 0,
-        InvalidPropertyValue, getProperty_resting_length().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        (SimTK::isNaN(get_stiffness()) || get_stiffness() < 0),
+        InvalidPropertyValue, getProperty_stiffness().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        (SimTK::isNaN(get_dissipation()) || get_dissipation() < 0),
+        InvalidPropertyValue, getProperty_dissipation().getName());
 }
 
 

--- a/OpenSim/Simulation/Model/PathSpring.h
+++ b/OpenSim/Simulation/Model/PathSpring.h
@@ -82,8 +82,8 @@ public:
 // PUBLIC METHODS
 //==============================================================================
     
-    /** Construct a ClutchedPathSpring with default parameters. Users should
-    note that the default values for resting_length, stiffness, and dissipation
+    /** Construct a PathSpring with default parameters. Users should note
+    that the default values for resting_length, stiffness, and dissipation
     are `NaN` so they must be set before simulating. */
     PathSpring();
 

--- a/OpenSim/Simulation/Model/PathSpring.h
+++ b/OpenSim/Simulation/Model/PathSpring.h
@@ -82,7 +82,9 @@ public:
 // PUBLIC METHODS
 //==============================================================================
     
-    /** Default constructor */
+    /** Construct a ClutchedPathSpring with default parameters. Users should
+    note that the default values for resting_length, stiffness, and dissipation
+    are `NaN` so they must be set before simulating. */
     PathSpring();
 
     /** Convenience constructor with PathSpring parameters


### PR DESCRIPTION
Fixes issue #1607

### Brief summary of changes
Ensures that property values are valid through `extendFinalizeFromProperties()`. Will throw an exception if any are not valid. Note that the issue mentioned also noted `CoordinateLimitForce` but it appeared to me that that class initializes all its properties to a valid number, and that the coordinate name was checked to exist as well.

### Testing I've completed
All tests pass locally on a Windows x32 build.

### Looking for feedback on...
- The checks are sufficient and cover all properties needed.
- Doxygen comment for the default constructors.

### CHANGELOG.md (choose one)
no need to update: just a bug fix
