### PR TITLE
Update property comment for GeometryPath

### DIFF
--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -49,7 +49,7 @@ public:
 // PROPERTIES
 //=============================================================================
     OpenSim_DECLARE_UNNAMED_PROPERTY(GeometryPath,
-        "The set of points defining the path of the muscle.");
+        "The set of points defining the path of the actuator.");
     OpenSim_DECLARE_PROPERTY(optimal_force, double,
         "The maximum force this actuator can produce.");
 


### PR DESCRIPTION
Since not all PathActuators are muscles, do not mention "muscles" in the description of PathActuator's GeometryPath property.

### CHANGELOG.md (choose one)

- no need to update because...it's just fixing documentation.
