### PR TITLE
[TGCS] Update default muscle activation in RunHopperGUI

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/RunHopperGUI.m
+++ b/Bindings/Java/Matlab/Hopper_Device/RunHopperGUI.m
@@ -43,9 +43,8 @@ function RunHopperGUI(varargin)
 p = inputParser();
 
 defaultVisualize = true;
-% TODO copy over modified activations from BuildHopper.m.
-defaultMuscleActivation = [0.0 1.0 2.0 3.9;
-                           0.0 0.3 1.0 0.1];
+defaultMuscleActivation = [0.0 1.99 2.0 3.89 3.9 4.0;
+                           0.3 0.3  1.0 1.0  0.1 0.1];
 defaultAddPassiveDevice = false;
 defaultPassivePatellaWrap = false;
 defaultSpringStiffness = 1;


### PR DESCRIPTION
I copied over the updated default muscle activation from BuildHopper to RunHopperGUI. This default activation makes the hopper look like it is trying (but failing) to jump.

This PR goes into the `tgcs2017` branch; only those working on the TGCS example need look at it.

@nickbianco could you review this?