### PR TITLE
opensim-cmd: Fix loading model for AbstractTool.

### DIFF
--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -300,9 +300,7 @@ void testRunTool() {
             "Printing 'testruntool_cmc_setup.xml'.\n");
     // This fails because this setup file doesn't have much in it.
     testCommand("run-tool testruntool_cmc_setup.xml", EXIT_FAILURE,
-            std::regex("(Preparing to run CMCTool.)" + RE_ANY +
-                       "(Running tool default.)" + RE_ANY +
-                       "(ERROR- A model has not been set.)" + RE_ANY));
+            std::regex(RE_ANY + "(ERROR- A model has not been set.)" + RE_ANY));
     // Similar to the previous two commands, except for scaling
     // (since ScaleTool goes through a different branch of the code).
     testCommand("print-xml scale testruntool_scale_setup.xml", EXIT_SUCCESS,

--- a/OpenSim/Tools/osimTools.h
+++ b/OpenSim/Tools/osimTools.h
@@ -24,6 +24,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "ScaleTool.h"
+#include "RRATool.h"
 #include "CMCTool.h"
 #include "ForwardTool.h"
 #include "AnalyzeTool.h"


### PR DESCRIPTION
Fixes #1623 

### Brief summary of changes

There is currently a bug in that, when attempting to run an AbstractTool (e.g., CMC, RRA, Analyze), the model won't be loaded even if a valid model file is specified in the XML file. This PR fixes that bug by calling the concrete constructors for the AbstractTools.

This solution fixes the bug, but is not very generalizable. I could have attempted a more general solution by moving the model-loading code to the AbstractTool. However, I wanted to limit the scope of this PR and make sure I did not introduce new bugs. We are not currently eager to introduce new tools, so I think it is fine that this solution is not very generic; I believe it is still an improvement over the separate command-line executables we had for 3.3.

### Testing I've completed

I used `opensim-cmd run-tool` for a number of setup files in the RRA, CMC, Forward, and Analyze test directories, and the tool was able to run successfully.

### CHANGELOG.md (choose one)

- no need to update because opensim-cmd did not exist in 3.3.
