### PR TITLE
Fix Model::initSystem() from dirtying isObjectUpToDateWithProperties()

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1398,13 +1398,7 @@ void Component::extendRealizeAcceleration(const SimTK::State& s) const
 
 const SimTK::MultibodySystem& Component::getSystem() const
 {
-    if (!hasSystem()){
-        std::string msg = getConcreteClassName()+"::getSystem() ";
-        msg += getName() + " has no reference to a System.\n";
-        msg += "Make sure you added the Component to the Model and ";
-        msg += "called Model::initSystem(). ";
-        throw Exception(msg, __FILE__, __LINE__);
-    }
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
     return _system.getRef();
 }
 

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1402,6 +1402,12 @@ const SimTK::MultibodySystem& Component::getSystem() const
     return _system.getRef();
 }
 
+SimTK::MultibodySystem& Component::updSystem() const
+{
+    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
+    return _system.getRef();
+}
+
 //------------------------------------------------------------------------------
 //                         OTHER REALIZE METHODS
 //------------------------------------------------------------------------------

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2060,8 +2060,7 @@ protected:
      * Get writable reference to the MultibodySystem that this component is
      * connected to.
      */
-    SimTK::MultibodySystem& updSystem() const
-        { return *_system; } 
+    SimTK::MultibodySystem& updSystem() const;
 
     /** Get the index of a Component's continuous state variable in the Subsystem for
         allocations. This method is intended for derived Components that may need direct

--- a/OpenSim/Simulation/Model/ControllerSet.cpp
+++ b/OpenSim/Simulation/Model/ControllerSet.cpp
@@ -137,7 +137,6 @@ void ControllerSet::constructStorage()
         columnLabels.append(_actuatorSet->get(i).getName());
 
     _controlStore->setColumnLabels(columnLabels);
-        
 }
 
 void ControllerSet::storeControls( const SimTK::State& s, int step  )

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -384,9 +384,6 @@ SimTK::State& Model::initializeState() {
     for (int i=0; i<getProbeSet().getSize(); ++i)
         getProbeSet().get(i).reset(_workingState);
 
-    // Reset the controller's storage
-    upd_ControllerSet().constructStorage();
-    
     // Do the assembly
     createAssemblySolver(_workingState);
     assemble(_workingState);

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -420,13 +420,13 @@ public:
 
     /** Get read-only access to the internal Simbody MultibodySystem that was
     created by this %Model at the last initSystem() call. **/    
-    const SimTK::MultibodySystem& getMultibodySystem() const {return *_system; }
+    const SimTK::MultibodySystem& getMultibodySystem() const {return getSystem(); }
     /** (Advanced) Get writable access to the internal Simbody MultibodySystem 
     that was created by this %Model at the last initSystem() call. Be careful
     if you make modifications to the System because that will invalidate 
     initialization already performed by the Model. 
     @see initStateWithoutRecreatingSystem() **/    
-    SimTK::MultibodySystem& updMultibodySystem() const {return *_system; }
+    SimTK::MultibodySystem& updMultibodySystem() const {return updSystem(); }
 
     /** Get read-only access to the internal DefaultSystemSubsystem allocated
     by this %Model's Simbody MultibodySystem. **/

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -290,7 +290,7 @@ void testComponent(const Component& instanceToTest)
     }
     
     // This method calls connect().
-    cout << "Call Model::setup()." << endl;
+    cout << "Calling Model::setup()." << endl;
     try{
         model.setup();
     }
@@ -301,7 +301,6 @@ void testComponent(const Component& instanceToTest)
         cout << " having structural dependencies that are not specified as Sockets.";
         cout << endl;
     }
-
 
     // 7. Build the system.
     // --------------------
@@ -314,6 +313,12 @@ void testComponent(const Component& instanceToTest)
         cout << " '" << x.what() << "'" << endl;
         cout << "Skipping ... " << endl;
     }
+
+    // Verify that the Model (and its System) remains up-to-date with its
+    // properties after initSystem (or attempt). Throw if not.
+    OPENSIM_THROW_IF(!model.isObjectUpToDateWithProperties(), Exception,
+        "testComponents:: model.initSystem() caused Model to no longer be "
+        "up-to-date with its properties.");
 
     // Outputs.
     // --------


### PR DESCRIPTION
Fixes #1587 

### Brief summary of changes
Added a condition to `testComponents` to throw when `model.isObjectUpToDateWithProperties()` after `initSystem()`. This caused `testComponents` to fail.

`Model::initializeState` was updating the model's `ControllerSet` property for the purpose of constructing the correct header for resulting controls Storage files. This is unnecessary because `ControllerSet::constructStorage()` is called when actuators are set on the `ControllerSet` at the end of `Model::extendConnectToModel()`. The unnecessary update was removed and `testComponents` passed.

Also updated `Component::get/updSystem()` to throw `ComponentHasNoSystem` if `hasSystem()` is false. Update `Model::get/updMultibodySystem()` to use `Component` accessors. 

### Testing I've completed
Added a condition to `testComponents` to throw when `model.isObjectUpToDateWithProperties()` after `initSystem()`. All tests pass locally.

### CHANGELOG.md (choose one)
- no need to update because there are not changes to the API (just a bug fix)

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
