### PR TITLE
Copy DataTable / TimeSeriesTable in Matlab / Java

### DIFF
--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -56,6 +56,8 @@ class TestTables {
                row2.get(2) == 3 &&
                row2.get(3) == 3;
         System.out.println(table);
+        // Clone table.
+        DataTable tableClone = table.clone();
         // Get independent column.
         StdVectorDouble indCol = table.getIndependentColumn();
         assert indCol.get(0) == 0.1 &&
@@ -104,6 +106,22 @@ class TestTables {
                table.getDependentColumn("3").get(1) == 40 &&
                table.getDependentColumn("3").get(2) == 40;
         System.out.println(table);
+        // Assert that clone was not edited due to above operations
+        // on rows/columns.
+        assert tableClone.getNumRows() == 3;
+        assert tableClone.getNumColumns() == 4;
+        assert tableClone.getRowAtIndex(0).get(0) == 1 &&
+               tableClone.getRowAtIndex(0).get(1) == 1 &&
+               tableClone.getRowAtIndex(0).get(2) == 1 &&
+               tableClone.getRowAtIndex(0).get(3) == 1 &&
+               tableClone.getRowAtIndex(1).get(0) == 2 &&
+               tableClone.getRowAtIndex(1).get(1) == 2 &&
+               tableClone.getRowAtIndex(1).get(2) == 2 &&
+               tableClone.getRowAtIndex(1).get(3) == 2 &&
+               tableClone.getRowAtIndex(2).get(0) == 3 &&
+               tableClone.getRowAtIndex(2).get(1) == 3 &&
+               tableClone.getRowAtIndex(2).get(2) == 3 &&
+               tableClone.getRowAtIndex(2).get(3) == 3;
         // Append columns to the table.
         Vector col = new Vector(3, 1);
         table.appendColumn("4", col);

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -180,8 +180,8 @@ namespace OpenSim {
                                         const std::vector<std::string>&);
 %ignore OpenSim::DataTable_<double, double>::flatten;
 %extend OpenSim::DataTable_ {
-    OpenSim::DataTable_<ETX, ETY> clone() const {
-        return OpenSim::DataTable_<ETX, ETY>{*$self};
+    OpenSim::DataTable_<ETX, ETY>* clone() const {
+        return new OpenSim::DataTable_<ETX, ETY>{*$self};
     }
 }
 %extend OpenSim::DataTable_<double, double> {

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -179,6 +179,11 @@ namespace OpenSim {
 %ignore OpenSim::DataTable_::DataTable_(const DataTable_<double, double>&,
                                         const std::vector<std::string>&);
 %ignore OpenSim::DataTable_<double, double>::flatten;
+%extend OpenSim::DataTable_ {
+    OpenSim::DataTable_<ETX, ETY> clone() const {
+        return OpenSim::DataTable_<ETX, ETY>{*$self};
+    }
+}
 %extend OpenSim::DataTable_<double, double> {
     DataTable_<double, SimTK::Vec3>
     packVec3() {
@@ -215,6 +220,11 @@ namespace OpenSim {
 }
 
 %ignore OpenSim::TimeSeriesTable_::TimeSeriesTable_(TimeSeriesTable_ &&);
+%extend OpenSim::TimeSeriesTable_ {
+    OpenSim::TimeSeriesTable_<ETY> clone() const {
+        return OpenSim::TimeSeriesTable_<ETY>{*$self};
+    }
+}
 %extend OpenSim::TimeSeriesTable_<double> {
     TimeSeriesTable_<SimTK::Vec3>
     packVec3() {

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -221,8 +221,8 @@ namespace OpenSim {
 
 %ignore OpenSim::TimeSeriesTable_::TimeSeriesTable_(TimeSeriesTable_ &&);
 %extend OpenSim::TimeSeriesTable_ {
-    OpenSim::TimeSeriesTable_<ETY> clone() const {
-        return OpenSim::TimeSeriesTable_<ETY>{*$self};
+    OpenSim::TimeSeriesTable_<ETY>* clone() const {
+        return new OpenSim::TimeSeriesTable_<ETY>{*$self};
     }
 }
 %extend OpenSim::TimeSeriesTable_<double> {


### PR DESCRIPTION
@jimmyDunne experienced a problem in Matlab where assigning one table (DataTable/TimeSeriesTable) to another variable only copies the handle -- shallow copy of the object. Editing the copy also changes the original in this case. This PR adds a clone() method to the tables to obtain a real (deep) copy of the original table.