### PR TITLE
Simbody: include improvements to Visualizer

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -147,7 +147,7 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        9f2123212dadcedcd680a8d8b3832d4fe40e1f8b
+              TAG        332fd91cc6c17d4fbc1a2b1d41757f814174c8b6
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION

Fixes part of issue #1572 (on non-Windows machines)

### Brief summary of changes

Update the Simbody commit hash to include fixes to the Visualizer:

1. Visualizer searches for simbody-visualizer using a relative path.
2. The visualizer shuts down the listener thread upon destruction (this was causing MATLAB to use a lot of CPU).


### Testing I've completed

None!

### CHANGELOG.md (choose one)

- no need to update because we have not yet created a Simbody release for 4.0.