### PR TITLE
Bug fix for STOFileAdapter AND add DataTable::reorderColumns()

### DIFF
--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -58,14 +58,6 @@ class TestTables {
         System.out.println(table);
         // Clone table.
         DataTable tableClone = table.clone();
-        // Reorder columns of the table.
-        StdVectorInt newColumnIndices = new StdVectorInt();
-        newColumnIndices.add(3); newColumnIndices.add(1);
-        newColumnIndices.add(0); newColumnIndices.add(2);
-        table.reorderColumns(newColumnIndices);
-        newColumnIndices.set(0, 2); newColumnIndices.set(1, 1);
-        newColumnIndices.set(2, 3); newColumnIndices.set(3, 0);
-        table.reorderColumns(newColumnIndices);
         // Get independent column.
         StdVectorDouble indCol = table.getIndependentColumn();
         assert indCol.get(0) == 0.1 &&
@@ -114,6 +106,18 @@ class TestTables {
                table.getDependentColumn("3").get(1) == 40 &&
                table.getDependentColumn("3").get(2) == 40;
         System.out.println(table);
+        // Reorder columns of the table.
+        StdVectorInt newColumnIndices = new StdVectorInt();
+        newColumnIndices.add(3); newColumnIndices.add(1);
+        newColumnIndices.add(0); newColumnIndices.add(2);
+        table.reorderColumns(newColumnIndices);
+        assert table.getDependentColumnAtIndex(0).get(0) == 40 &&
+               table.getDependentColumnAtIndex(1).get(0) == 10 &&
+               table.getDependentColumnAtIndex(2).get(0) == 30 &&
+               table.getDependentColumnAtIndex(3).get(0) == 10;
+        newColumnIndices.set(0, 2); newColumnIndices.set(1, 1);
+        newColumnIndices.set(2, 3); newColumnIndices.set(3, 0);
+        table.reorderColumns(newColumnIndices);
         // Assert that clone was not edited due to above operations
         // on rows/columns.
         assert tableClone.getNumRows() == 3;

--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -58,6 +58,14 @@ class TestTables {
         System.out.println(table);
         // Clone table.
         DataTable tableClone = table.clone();
+        // Reorder columns of the table.
+        StdVectorInt newColumnIndices = new StdVectorInt();
+        newColumnIndices.add(3); newColumnIndices.add(1);
+        newColumnIndices.add(0); newColumnIndices.add(2);
+        table.reorderColumns(newColumnIndices);
+        newColumnIndices.set(0, 2); newColumnIndices.set(1, 1);
+        newColumnIndices.set(2, 3); newColumnIndices.set(3, 0);
+        table.reorderColumns(newColumnIndices);
         // Get independent column.
         StdVectorDouble indCol = table.getIndependentColumn();
         assert indCol.get(0) == 0.1 &&

--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -88,6 +88,9 @@ class TestDataTable(unittest.TestCase):
                 row2[2] == row[2] and
                 row2[3] == row[3])
         print table
+        # Reorder columns of the table.
+        table.reorderColumns([3, 1, 0, 2])
+        table.reorderColumns([2, 1, 3, 0])
         # Retrieve independent column.
         assert table.getIndependentColumn() == (0.1, 0.2, 0.3)
         # Retrieve dependent columns.

--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -90,6 +90,22 @@ class TestDataTable(unittest.TestCase):
         print table
         # Reorder columns of the table.
         table.reorderColumns([3, 1, 0, 2])
+        col0 = table.getDependentColumnAtIndex(0)
+        col1 = table.getDependentColumnAtIndex(1)
+        col2 = table.getDependentColumnAtIndex(2)
+        col3 = table.getDependentColumnAtIndex(3)
+        assert (col0[0] == 4  and
+                col0[1] == 8  and
+                col0[2] == 16 and
+                col1[0] == 2  and
+                col1[1] == 4  and
+                col1[2] == 8  and
+                col2[0] == 1  and
+                col2[1] == 2  and
+                col2[2] == 4  and
+                col3[0] == 3  and
+                col3[1] == 6  and
+                col3[2] == 12)
         table.reorderColumns([2, 1, 3, 0])
         # Retrieve independent column.
         assert table.getIndependentColumn() == (0.1, 0.2, 0.3)

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -28,8 +28,6 @@
 #include "TimeSeriesTable.h"
 #include "Event.h"
 
-template<typename> class shrik;
-
 namespace OpenSim {
 
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
@@ -44,10 +42,13 @@ public:
     C3DFileAdapter& operator=(C3DFileAdapter&&)      = default;
     ~C3DFileAdapter()                                = default;
 
+    explicit C3DFileAdapter(const bool& useSIMMColumnOrdering);
+
     C3DFileAdapter* clone() const override;
     
     static
-    Tables read(const std::string& fileName);
+    Tables read(const std::string& fileName,
+                const bool& useSIMMColumnOrdering = false);
 
     static
     void write(const Tables& markerTable, const std::string& fileName);
@@ -63,7 +64,7 @@ protected:
 
 private:
     static const std::unordered_map<std::string, std::size_t> _unit_index;
-
+    bool _useSIMMColumnOrdering;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -32,6 +32,7 @@ in-memory container for data access and manipulation.                         */
 #include "FileAdapter.h"
 #include "SimTKcommon/internal/BigMatrix.h"
 
+#include <unordered_set>
 #include <iomanip>
 #include <numeric>
 
@@ -995,6 +996,82 @@ public:
 
         validateRow(rowIndex, value, _depData.row((int)rowIndex));
         _indData[rowIndex] = value;
+    }
+
+    /** Reorder columns of the DataTable by providing the new order of 
+    column indices. The new order is basically a permutation of column indices
+    0 to num-columns-1. For example:
+    \code
+    // Change order of last three columns only. Leave the first two columns 
+    // as is.
+    table.reorderColumns({0, 1, 5, 3, 4});
+    \endcode
+
+    \throws IncorrectNumColumns If the input array contains incorrect number of
+                                elements compared to number of columns in the
+                                DataTable.
+    \throws ColumnIndexOutOfRange If any index in the input array is out of
+                                  range.
+    \throws InvalidArgument If input array contains duplicates. A valid input
+                            array is a permutation of column indices.         */
+    void reorderColumns(const std::vector<int>& columnIndices) {
+        OPENSIM_THROW_IF(columnIndices.size() !=
+                         static_cast<size_t>(_depData.ncol()),
+                         IncorrectNumColumns,
+                         static_cast<size_t>(_depData.ncol()),
+                         columnIndices.size());
+
+        {
+            std::unordered_set<int> setOfInds{};
+            for(const auto& ind : columnIndices) {
+                OPENSIM_THROW_IF(ind < 0 || isColumnIndexOutOfRange(ind),
+                                 InvalidArgument,
+                                 "Index (" + std::to_string(ind) +
+                                 ") out of range [0," +
+                                 std::to_string(_depData.ncol() - 1) + "].");
+                OPENSIM_THROW_IF(setOfInds.find(ind) != setOfInds.end(),
+                                 InvalidArgument,
+                                 "Input array of indices cannot have "
+                                 "duplicates. Found duplicate = " +
+                                 std::to_string(ind));
+                setOfInds.emplace(ind);
+            }
+        }
+        
+        auto depDataCopy = _depData;
+        auto columnLabelsCopy = getColumnLabels();
+        for(auto c = 0; c < _depData.ncol(); ++c) {
+            if(c != columnIndices[c]) {
+                _depData.updCol(c) = depDataCopy.col(columnIndices[c]);
+                setColumnLabel(c, columnLabelsCopy[columnIndices[c]]);
+            }
+        }
+
+    }
+    
+    /** Reorder columns of the DataTable by providing the new order of 
+    column labels. The new order is basically a permutation of existing 
+    column labels. For example:
+    \code
+    // Change order of last three columns only. Leave the first two columns 
+    // as is. Here "col0", "col1", ... are existing column-labels.
+    table.reorderColumns({"col0", "col1", "col5", "col3", "col4"});
+    \endcode
+
+    \throws IncorrectNumColumns If the input array contains incorrect number of
+                                elements compared to number of columns in the
+                                DataTable.
+    \throws ColumnIndexOutOfRange If any index in the input array is out of
+                                  range.
+    \throws InvalidArgument If input array contains duplicates. A valid input
+                            array is a permutation of column indices.         
+    \throws KeyNotFound If any column-label specified in the input array does
+                        not exist in the table.                               */
+    void reorderColumns(const std::vector<std::string>& columnLabels) {
+        std::vector<int> columnIndices{};
+        for(const auto& label : columnLabels)
+            columnIndices.push_back(getColumnIndex(label));
+        reorderColumns(columnIndices);
     }
 
     /// @}

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -999,12 +999,12 @@ public:
     }
 
     /** Reorder columns of the DataTable by providing the new order of 
-    column indices. The new order is basically a permutation of column indices
+    column indices. The new order is simply a permutation of column indices
     0 to num-columns-1. For example:
     \code
     // Change order of last three columns only. Leave the first two columns 
     // as is.
-    table.reorderColumns({0, 1, 5, 3, 4});
+    table.reorderColumns({0, 1, 4, 2, 3});
     \endcode
 
     \throws IncorrectNumColumns If the input array contains incorrect number of
@@ -1050,12 +1050,12 @@ public:
     }
     
     /** Reorder columns of the DataTable by providing the new order of 
-    column labels. The new order is basically a permutation of existing 
+    column labels. The new order is simply a permutation of existing 
     column labels. For example:
     \code
     // Change order of last three columns only. Leave the first two columns 
     // as is. Here "col0", "col1", ... are existing column-labels.
-    table.reorderColumns({"col0", "col1", "col5", "col3", "col4"});
+    table.reorderColumns({"col0", "col1", "col4", "col2", "col3"});
     \endcode
 
     \throws IncorrectNumColumns If the input array contains incorrect number of

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -545,7 +545,7 @@ DelimFileAdapter<T>::extendWrite(const InputTables& absTables,
                               template getTableMetaData<std::string>(key) 
                            << "\n";
         } catch(const InvalidTemplateArgument&) {
-            out_stream << "<cannot-convert-to-string>\n";
+            out_stream << "\n";
         }
     }
     // Write name of the data-type -- vec3, vec6, etc.

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -544,7 +544,9 @@ DelimFileAdapter<T>::extendWrite(const InputTables& absTables,
                            << table->
                               template getTableMetaData<std::string>(key) 
                            << "\n";
-        } catch(const InvalidTemplateArgument&) {}
+        } catch(const InvalidTemplateArgument&) {
+            out_stream << "<cannot-convert-to-string>\n";
+        }
     }
     // Write name of the data-type -- vec3, vec6, etc.
     out_stream << _dataTypeString << "=" << dataTypeName() << "\n";

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -122,17 +122,29 @@ Storage::Storage(const string &aFileName, bool readHeadersOnly) :
 
     // OPEN FILE
     std::unique_ptr<ifstream> fp{IO::OpenInputFile(aFileName)};
-    if(fp==NULL) throw Exception("Storage: ERROR- failed to open file " + aFileName, __FILE__,__LINE__);
+    if(fp==NULL)
+        throw Exception("Storage: ERROR- failed to open file " + aFileName,
+                        __FILE__,__LINE__);
 
     int nr=0,nc=0;
-    if (!parseHeaders(*fp, nr, nc)) throw Exception("Storage: ERROR- failed to parse headers of file " + aFileName, __FILE__,__LINE__);
-    cout << "Storage: file=" << aFileName << " (nr=" << nr << " nc=" << nc << ")" << endl;
+    if (!parseHeaders(*fp, nr, nc))
+        throw Exception("Storage: ERROR- failed to parse headers of file " +
+                        aFileName, __FILE__,__LINE__);
+    cout << "Storage: file=" << aFileName << " (nr=" << nr << " nc=" << nc
+         << ")" << endl;
     // Motion files from SIMM are in degrees
-    if (_fileVersion < 1 && (0 == aFileName.compare (aFileName.length() - 4, 4, ".mot"))) _inDegrees = true;
-    if (_fileVersion < 1) cout << ".. assuming rotations in " << (_inDegrees?"Degrees.":"Radians.") << endl;
-    if(_fileVersion > 1)
-      throw Exception{"Error: File version (" + std::to_string(_fileVersion) +
-                      ") not supported. Use STOFileAdapter instead."};
+    if (_fileVersion < 1 &&
+        (0 == aFileName.compare (aFileName.length() - 4, 4, ".mot")))
+        _inDegrees = true;
+    if (_fileVersion < 1)
+        cout << ".. assuming rotations in "
+             << (_inDegrees?"Degrees.":"Radians.") << endl;
+    if(_fileVersion > 1) {
+        TimeSeriesTable timeSeriesTable{aFileName};
+        createFromTimeSeriesTable(timeSeriesTable);
+        return;
+    }
+    
     // IGNORE blank lines after header -- treat \r and \n as end of line chars
     while(fp->good()) {
         int c = fp->peek();
@@ -155,11 +167,12 @@ Storage::Storage(const string &aFileName, bool readHeadersOnly) :
     _storage.ensureCapacity(nr);
     _storage.setCapacityIncrement(-1);
 
-    // There are situations where we don't want to read the whole file in advance just header
+    // There are situations where we don't want to read the whole file in
+    // advance just header.
     if (readHeadersOnly) return;
 
-    //MM using the occurrence of time and range in the column labels to distinguish between
-    //SIMM and non SIMMOtion files.
+    //MM using the occurrence of time and range in the column labels to
+    // distinguish between SIMM and non SIMMOtion files.
     Array<std::string> currentLabels = getColumnLabels();
     int indexTime = currentLabels.findIndex("time");
     int indexRange = currentLabels.findIndex("range");
@@ -194,7 +207,8 @@ Storage::Storage(const string &aFileName, bool readHeadersOnly) :
     // If what we read was really a sIMM motion file, adjust the data 
     // to account for different assumptions between SIMM.mot OpenSim.sto
 
-    //MM if this is a SIMM Motion file, post process it as one. Else don't touch the data
+    //MM if this is a SIMM Motion file, post process it as one. Else don't
+    // touch the data.
     size_t found = aFileName.find(".mot");
     if(indexTime == -1 && found!=string::npos){
         postProcessSIMMMotion();
@@ -1293,6 +1307,27 @@ TimeSeriesTable Storage::getAsTimeSeriesTable() const {
     }
 
     return table;
+}
+
+void Storage::createFromTimeSeriesTable(const TimeSeriesTable& table) {
+    _columnLabels.setSize(table.getNumColumns());
+    for(auto c = 0u; c < table.getNumColumns(); ++c)
+        _columnLabels.set(c, table.getColumnLabel(c));
+
+    _storage.setSize(table.getNumRows());
+    for(auto r = 0u; r < table.getNumRows(); ++r)
+        _storage.set(r, StateVector{table.getIndependentColumn().at(r),
+                                    table.getRowAtIndex(r).getAsVector()});
+
+    _fileVersion = 1;
+    const auto& metadata = table.getTableMetaData();
+    for(const auto& key : metadata.getKeys()) {
+        if(key == "units")
+            _units = Units{metadata.getValueAsString(key)};
+        if(key == "inDegrees")
+            _inDegrees =
+                metadata.getValueAsString(key).find("yes") != std::string::npos;
+    }
 }
 
 
@@ -3133,6 +3168,7 @@ bool Storage::parseHeaders(std::ifstream& aStream, int& rNumRows, int& rNumColum
             cout << "Old version storage/motion file encountered" << endl;
         }
     }
+    
     return true;
 }
 //_____________________________________________________________________________

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -109,6 +109,7 @@ Storage::Storage(int aCapacity,const string &aName) :
 /**
  * Construct an Storage instance from file.
  * This constructor is far from bullet proof.
+ * This constructor also reads files written by STOFileAdapter with version 2.
  *
  * @param aFileName Name of the file from which the Storage is to be
  * constructed.
@@ -1320,6 +1321,7 @@ void Storage::createFromTimeSeriesTable(const TimeSeriesTable& table) {
                     table.getRowAtIndex(r).transpose().getAsVector()});
 
     _fileVersion = 1;
+    _inDegrees = true;
     const auto& metadata = table.getTableMetaData();
     for(const auto& key : metadata.getKeys()) {
         if(key == "units")

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -1317,7 +1317,7 @@ void Storage::createFromTimeSeriesTable(const TimeSeriesTable& table) {
     _storage.setSize(table.getNumRows());
     for(auto r = 0u; r < table.getNumRows(); ++r)
         _storage.set(r, StateVector{table.getIndependentColumn().at(r),
-                                    table.getRowAtIndex(r).getAsVector()});
+                    table.getRowAtIndex(r).transpose().getAsVector()});
 
     _fileVersion = 1;
     const auto& metadata = table.getTableMetaData();

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -144,6 +144,7 @@ private:
     bool isSimmReservedToken(const std::string& aToken);
     void postProcessSIMMMotion();
     void exchangeTimeColumnWith(int aColumnIndex);
+    void createFromTimeSeriesTable(const TimeSeriesTable& table);
 public:
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue #1650 

* Bug fix -- Make sure to write new line when writing STO files if the metadata cannot be converted to string. This fixes the problem with header reported in #1650.
* Add method `DataTable::reorderColumns()` to allow reordering of columns of a DataTable in-place.
