### PR TITLE
InverseKinematicsTool adds a KinematicsReporter for internal use, remove it when done. 

### DIFF
--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -369,6 +369,8 @@ bool InverseKinematicsTool::run()
         if (_outputMotionFileName!= "" && _outputMotionFileName!="Unassigned"){
             kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
         }
+        // Once done, remove the analysis we added
+        _model->removeAnalysis(&kinematicsReporter);
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);


### PR DESCRIPTION
This PR removes the KinemaicsReporter used internally by IKTool at the end of run so that running the tool has no side-effects on the model.

Fixes issue #1656, #1632 

### Brief summary of changes
Added a line to remove the reporter after usage is complete inside the run method

### Testing I've completed
This used to crash the GUI which needs to reuse the model after IK run, with the fix the crash is gone. 

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because no API changes

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
