### PR TITLE
Fix #1584: throw exception when attempting to access the System after finalizeFromProperties

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -215,7 +215,7 @@ void Component::componentsFinalizeFromProperties() const
 }
 
 // Base class implementation of non-virtual finalizeConnections method.
-void Component::finalizeConnections(Component &root)
+void Component::finalizeConnections(Component& root)
 {
     if (!isObjectUpToDateWithProperties()){
         // if edits occur between construction and connect() this is
@@ -1674,7 +1674,7 @@ void Component::clearStateAllocations()
 
 void Component::reset()
 {
-    _system.release();
+    _system.reset();
     _simTKcomponentIndex.invalidate();
     clearStateAllocations();
 

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1663,4 +1663,22 @@ void Component::initComponentTreeTraversal(const Component &root) const {
     }
 }
 
+
+void Component::clearStateAllocations()
+{
+    _namedModelingOptionInfo.clear();
+    _namedStateVariableInfo.clear();
+    _namedDiscreteVariableInfo.clear();
+    _namedCacheVariableInfo.clear();
+}
+
+void Component::reset()
+{
+    _system.release();
+    _simTKcomponentIndex.invalidate();
+    clearStateAllocations();
+
+    resetSubcomponentOrder();
+}
+
 } // end of namespace OpenSim

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -149,7 +149,7 @@ public:
                          const std::string& func,
                          const Object& obj) :
         Exception(file, line, func, obj) {
-        std::string msg = "Component has not been added to a System.\n";
+        std::string msg = "Component has no underlying System.\n";
         msg += "You must call initSystem() on the top-level Component ";
         msg += "(i.e. Model) first.";
         addMessage(msg);
@@ -716,6 +716,7 @@ public:
     */
     template <class C = Component>
     C& updComponent(const std::string& name) {
+        clearObjectIsUpToDateWithProperties();
         return *const_cast<C*>(&(this->template getComponent<C>(name)));
     }
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -422,9 +422,9 @@ public:
     void finalizeFromProperties();
 
     /** Satisfy the Component's connections specified by its Sockets and Inputs.
-        Locate Component and their Outputs to satisfy the connections in an
-        aggregate Component, which is the root of a tree of Components, which
-        for example, forms a complete model. */
+        Locate Components and their Outputs to satisfy the connections in an
+        aggregate Component (e.g. Model), which is the root of a tree of
+        Components. */
     void finalizeConnections(Component& root);
 
     /** Disconnect/clear this Component from its aggregate component. Empties 
@@ -586,6 +586,7 @@ public:
         static_assert(std::is_base_of<Component, T>::value,
                 "Template argument must be Component or a derived class.");
         initComponentTreeTraversal(*this);
+        clearObjectIsUpToDateWithProperties();
         return ComponentList<T>(*this);
     }
 
@@ -708,7 +709,12 @@ public:
         return getComponent<Component>(pathname);
     }
 
-    /** Get a writable reference to a subcomponent.
+    /** Get a writable reference to a subcomponent. Use this method
+    * to edit the properties and connections of the subcomponent.
+    * Note: the method will mark this Component as not up-to-date with
+    * its properties and will require finalizeFromProperties() to be
+    * invoked directly or indirectly (by finalizeConnections() or 
+    * Model::initSystem())
     * @param name       the pathname of the Component of interest
     * @return Component the component of interest
     * @throws ComponentNotFoundOnSpecifiedPath if no component exists

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -711,7 +711,7 @@ public:
 
     /** Get a writable reference to a subcomponent. Use this method
     * to edit the properties and connections of the subcomponent.
-    * Note: the method will mark this Component as not up-to-date with
+    * Note: the method will mark this Component as out-of-date with
     * its properties and will require finalizeFromProperties() to be
     * invoked directly or indirectly (by finalizeConnections() or 
     * Model::initSystem())

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -149,9 +149,9 @@ public:
                          const std::string& func,
                          const Object& obj) :
         Exception(file, line, func, obj) {
-        std::string msg = "This Component has not been added to a System.\n";
-        msg += "You must call initSystem on the top-level Component ";
-        msg += "(i.e., Model) first.";
+        std::string msg = "Component has not been added to a System.\n";
+        msg += "You must call initSystem() on the top-level Component ";
+        msg += "(i.e. Model) first.";
         addMessage(msg);
     }
 };
@@ -414,13 +414,17 @@ public:
     /** Define a Component's internal data members and structure according to
         its properties. This includes its subcomponents as part of the component
         ownership tree and identifies its owner (if present) in the tree.
-        finalizeFromProperties propagates to all of the component's
-        subcomponents prior to invoking the virtual extendFinalizeFromProperties()
-        on itself.*/
+        finalizeFromProperties propagates to all of the component's subcomponents
+        prior to invoking the virtual extendFinalizeFromProperties() on itself.
+        Note, finalizeFromProperties() disassociates the Component from the
+        System it was added to (result of addToSystem()), which results from
+        calling  Model::initSystem(), for example.*/
     void finalizeFromProperties();
 
-    /** Connect this Component to its aggregate component, which is the root
-        of a tree of components.*/
+    /** Satisfy the Component's connections specified by its Sockets and Inputs.
+        Locate Component and their Outputs to satisfy the connections in an
+        aggregate Component, which is the root of a tree of Components, which
+        for example, forms a complete model. */
     void finalizeConnections(Component& root);
 
     /** Disconnect/clear this Component from its aggregate component. Empties 
@@ -2556,20 +2560,12 @@ private:
     SimTK::DefaultSystemSubsystem& updDefaultSubsystem() const
         {   return updSystem().updDefaultSubsystem(); }
 
-    void clearStateAllocations() {
-        _namedModelingOptionInfo.clear();
-        _namedStateVariableInfo.clear();
-        _namedDiscreteVariableInfo.clear();
-        _namedCacheVariableInfo.clear();    
-    }
+    // Clear all modeling options, continuous and discrete state variables,
+    // and cache variable allocated by this Component
+    void clearStateAllocations();
 
     // Reset by clearing underlying system indices.
-    void reset() {
-        _simTKcomponentIndex.invalidate();
-        clearStateAllocations();
-
-        resetSubcomponentOrder();
-    }
+    void reset();
 
 protected:
     //Derived Components must create concrete StateVariables to expose their state 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -416,9 +416,10 @@ public:
         ownership tree and identifies its owner (if present) in the tree.
         finalizeFromProperties propagates to all of the component's subcomponents
         prior to invoking the virtual extendFinalizeFromProperties() on itself.
-        Note, finalizeFromProperties() disassociates the Component from the
-        System it was added to (result of addToSystem()), which results from
-        calling  Model::initSystem(), for example.*/
+        Note that if the Component has already been added to a System (result of
+        addToSystem(); e.g., Model::initSystem()) when finalizeFromProperties()
+        is called, then finalizeFromProperties() disassociates the component from
+        that System.*/
     void finalizeFromProperties();
 
     /** Satisfy the Component's connections specified by its Sockets and Inputs.

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2124,14 +2124,7 @@ void Model::realizeReport(const SimTK::State& state) const
  */
 void Model::computeStateVariableDerivatives(const SimTK::State &s) const
 {
-    try {
-        realizeAcceleration(s);
-    }
-    catch (const std::exception& e){
-        string exmsg = e.what();
-        throw Exception(
-            "Model::computeStateVariableDerivatives: failed. See: "+exmsg);
-    }
+    realizeAcceleration(s);
 }
 
 /**

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -577,6 +577,9 @@ void Model::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
+    // wipe-out the existing System 
+    _system.reset();
+
     if(getForceSet().getSize()>0)
     {
         ForceSet &fs = updForceSet();

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -578,6 +578,9 @@ void Model::extendFinalizeFromProperties()
     Super::extendFinalizeFromProperties();
 
     // wipe-out the existing System 
+    _matter.reset();
+    _forceSubsystem.reset();
+    _contactSubsystem.reset();
     _system.reset();
 
     if(getForceSet().getSize()>0)

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -2047,7 +2047,6 @@ void testAddedFreeJointForBodyWithoutJoint()
     model.initSystem();
 
     ASSERT_EQUAL(6, model.getNumCoordinates(), 0);
-    model.finalizeFromProperties();
     model.printBasicInfo();
 }
 

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -1,0 +1,133 @@
+/* -------------------------------------------------------------------------- *
+ *                       OpenSim:  testModelInterface.cpp                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
+#include <OpenSim/Simulation/Manager/Manager.h>
+#include <OpenSim/Common/LoadOpenSimLibrary.h>
+
+using namespace OpenSim;
+using namespace std;
+
+
+int main() {
+    LoadOpenSimLibrary("osimActuators");
+
+    try {
+        // the specific model used here is not important
+        Model model("arm26.osim");
+        model.finalizeFromProperties();
+
+        // model should be up-to-date with its properties
+        ASSERT(model.isObjectUpToDateWithProperties());
+
+        // make an edit to a Component contained in the model's Set
+        model.updMuscles()[0].upd_min_control() = 0.02;
+        ASSERT(!model.isObjectUpToDateWithProperties());
+
+        model.finalizeFromProperties();
+        ASSERT(model.isObjectUpToDateWithProperties());
+
+        // make an edit to a Component contained in another Set
+        model.updBodySet()[1].upd_mass() = 0.05;
+        ASSERT(!model.isObjectUpToDateWithProperties());
+
+        model.finalizeFromProperties();
+        ASSERT(model.isObjectUpToDateWithProperties());
+
+        // make an edit through model's ComponentList access
+        for (auto& body : model.updComponentList<Body>()) {
+            body.upd_mass_center() = SimTK::Vec3(0);
+        }
+        ASSERT(!model.isObjectUpToDateWithProperties());
+
+        SimTK::State dummy_state;
+
+        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+        ASSERT_THROW(ComponentHasNoSystem, model.realizeDynamics(dummy_state));
+        ASSERT_THROW(ComponentHasNoSystem, 
+                     model.computeStateVariableDerivatives(dummy_state));
+        // should be able to create a Manager either
+        ASSERT_THROW(ComponentHasNoSystem,
+                     Manager manager(model));
+
+        // get a valid state
+        SimTK::State state = model.initSystem();
+        Manager manager(model);
+        state.setTime(0.0);
+
+        // this should invalidate the System
+        model.finalizeFromProperties();
+
+        // verify that finalizeFromProperties() wipes out the underlying System
+        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+
+        // should not be able to "trick" the manager into integrating a model
+        // given a stale but compatible state
+        ASSERT_THROW(ComponentHasNoSystem, manager.integrate(state, 1.));
+
+        state = model.initSystem();
+        //re-establish all the connections in the model
+        model.finalizeConnections(model);
+
+        // verify that finalizeConnections() does not wipe out the underlying 
+        // System iff there are no changes to the dependencies
+        auto& sys = model.getSystem();
+
+        auto elbowInHumerus = new PhysicalOffsetFrame("elbow_in_humerus",
+            model.getComponent<Body>("r_humerus"),
+            SimTK::Transform(SimTK::Vec3(0, -0.33, 0.0)) );
+
+        model.addComponent(elbowInHumerus);
+
+        // establish the new offset frame as part of the model but not
+        // used by any joints, constraints or forces
+        state = model.initSystem();
+
+        // now update the elbow and connect to the new frame
+        Joint& elbow = model.updComponent<Joint>("r_elbow");
+        elbow.connectSocket_parent_frame(*elbowInHumerus);
+
+        // satisfy the new connections in the model
+        model.finalizeConnections(model);
+
+        // now changing the connections should invalidate the System
+        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+
+        // verify the new connection was made
+        ASSERT(model.getComponent<Joint>("r_elbow").getParentFrame().getName()
+                == "elbow_in_humerus");
+    }
+    catch (const std::exception& ex) {
+        std::cout << ex.what() << std::endl;
+        return 1;
+    }
+
+    cout << "Done" << endl;
+
+    return 0;
+}
+
+
+
+

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -40,15 +40,17 @@ int main() {
         // model should be up-to-date with its properties
         ASSERT(model.isObjectUpToDateWithProperties());
 
-        // make an edit to a Component contained in the model's Set
-        model.updMuscles()[0].upd_min_control() = 0.02;
+        // get writable access to Components contained in the model's Set
+        auto& muscles = model.updMuscles();
+        // to make edits, for example, muscles[0].upd_min_control() = 0.02;
         ASSERT(!model.isObjectUpToDateWithProperties());
 
         model.finalizeFromProperties();
         ASSERT(model.isObjectUpToDateWithProperties());
 
-        // make an edit to a Component contained in another Set
-        model.updBodySet()[1].upd_mass() = 0.05;
+        // get writable access to another Set for the purpose of editing
+        auto& bodies = model.updBodySet();
+        // for example, bodies[1].upd_mass() = 0.05;
         ASSERT(!model.isObjectUpToDateWithProperties());
 
         model.finalizeFromProperties();
@@ -57,6 +59,7 @@ int main() {
         // make an edit through model's ComponentList access
         for (auto& body : model.updComponentList<Body>()) {
             body.upd_mass_center() = SimTK::Vec3(0);
+            break;
         }
         ASSERT(!model.isObjectUpToDateWithProperties());
 

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -35,9 +35,19 @@ int main() {
 
     try {
         Model model("arm26.osim");
+        // finalizeFromProperties() is required to build internal ownership tree
+        // attempt to access the ComponentList will throw that the model (root)
+        // has no subcomponents
+        ASSERT_THROW(ComponentIsRootWithNoSubcomponents, 
+            model.countNumComponents());
+
+        // finalize internal data structures from its properties
         model.finalizeFromProperties();
 
-        // model should be up-to-date with its properties
+        // all subcomponents are now accounted for.
+        ASSERT(model.countNumComponents() > 0);
+
+        // model must be up-to-date with its properties
         ASSERT(model.isObjectUpToDateWithProperties());
 
         // get writable access to Components contained in the model's Set

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -862,10 +862,8 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
 
 }// end of simulateModelWithCables()
 
-void simulate(Model& osimModel, State& si, double initialTime, double finalTime) {
-    // osimModel.finalizeFromProperties();
-    // osimModel.printBasicInfo();
-
+void simulate(Model& osimModel, State& si, double initialTime, double finalTime)
+{
     // Dump model back out; no automated test provided here though.
     // osimModel.print(osimModel.getName() + "_out.osim");
 


### PR DESCRIPTION
Fixes issue #1584 

In #1584 the `Model` was treating the `System` as valid after `finalizeFromProperties()` was called leading to a cryptic message downstream and failure when attempting to access the cache of an invalid state.

### Brief summary of changes
Key change was to reset the `Component`'s reference to the system in `finalizeFromProperties()` which was already calling its own `reset()`

### Testing I've completed
Originally used code snippet from #1584 to reproduce the failure and corresponding message. 
Then generalized into its own test `testModelInterface` was added to verify the correct behavior when the system or derivatives are accessed on a `Model` but no longer has a `System`.

### Looking for feedback on...
- is the test case adequate

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix with no interface changes

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
