### PR TITLE
Restore declaration of AnalysisWrapper in SWIG interface 

### DIFF
--- a/Bindings/Java/swig/java_actuators.i
+++ b/Bindings/Java/swig/java_actuators.i
@@ -18,6 +18,10 @@ using namespace OpenSim;
 using namespace SimTK;
 %}
 
+%feature("director") OpenSim::AnalysisWrapper;
+%feature("director") OpenSim::SimtkLogCallback;
+
+
 %include "arrays_java.i";
 
 /* Load the required libraries when this module is loaded.                    */


### PR DESCRIPTION
AnalysisWrapper is subclassed in GUI as such needs to be declared in SWIG interface file. This was lost when we refactored the swig interface files. AnalysisWrapper is used for animation in GUI/Tools that stopped working.

Fixes issue #<issue_number>

### Brief summary of changes
restore %feature("director") OpenSim::AnalysisWrapper; in swig interface file for java as was the case pre 4.0

### Testing I've completed
GUI uses the AnalysisWrapper subclasses and does animation while running tools.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it's all internal (unused by clients other than GUI)


The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
