### PR TITLE
[TGCS] Add back CMakeLists code to create student Hopper files.

### DIFF
--- a/Bindings/Java/Matlab/CMakeLists.txt
+++ b/Bindings/Java/Matlab/CMakeLists.txt
@@ -11,6 +11,34 @@ install(DIRECTORY examples/ DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 install(DIRECTORY Hopper_Device DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 install(DIRECTORY Utilities DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 
+# Remove parts from the hopper device example that the tutorial audience is
+# expected to fill in.
+# Anything matching `% ANSWER{ ... % }` is cut from the file.
+foreach(fname RunHopper RunHopperWithDevice)
+    set(file_contents "")
+    file(STRINGS Hopper_Device/${fname}_answers.m file_contents_answers)
+    list(LENGTH file_contents_answers num_lines)
+    set(line_num 0)
+    while(${line_num} LESS ${num_lines})
+        list(GET file_contents_answers ${line_num} current_line)
+        if("${current_line}" MATCHES "% ANSWER{")
+            while(NOT "${current_line}" MATCHES "% }")
+                math(EXPR line_num "${line_num} + 1")
+                list(GET file_contents_answers ${line_num} current_line)
+            endwhile()
+            # Add an empty line in place of the ANSWERS block.
+            set(file_contents "${file_contents}\n")
+        else()
+            set(file_contents "${file_contents}${current_line}\n")
+        endif()
+        math(EXPR line_num "${line_num} + 1")
+    endwhile()
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/Hopper_Device/${fname}.m"
+               "${file_contents}")
+    install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/Hopper_Device/${fname}.m"
+            DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Hopper_Device")
+endforeach()
+
 # The configureOpenSim.m script contains paths into the OpenSim installation
 # that may be different on different platforms, so we configure it with CMake
 # variables.

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -147,7 +147,7 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        9f2123212dadcedcd680a8d8b3832d4fe40e1f8b
+              TAG        332fd91cc6c17d4fbc1a2b1d41757f814174c8b6
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION
This PR adds back CMakeLists code to create student Hopper files in the installation. Also, this PR updates the Simbody commit to include an improved search path for simbody-visualizer.
