### PR TITLE
[doxygen] Controller: actuators must have unique names.

### DIFF
--- a/OpenSim/Simulation/Control/Controller.h
+++ b/OpenSim/Simulation/Control/Controller.h
@@ -44,6 +44,13 @@ class Actuator;
  * The defining method of a Controller is its computeControls() method.
  * @see computeControls()
  *
+ * @note Version 4.0 introduced the ability to have multiple components
+ * with the same name as long as the components have unique absolute paths
+ * (i.e., they are located in different components). However, Controllers 
+ * will currently not work properly if you have multiple actuators with
+ * the same name; the controller will always only actuate the first 
+ * actuator with a given name.
+ *
  * @author Ajay Seth
  */
 class OSIMSIMULATION_API Controller : public ModelComponent {

--- a/OpenSim/Simulation/Control/Controller.h
+++ b/OpenSim/Simulation/Control/Controller.h
@@ -44,12 +44,10 @@ class Actuator;
  * The defining method of a Controller is its computeControls() method.
  * @see computeControls()
  *
- * @note Version 4.0 introduced the ability to have multiple components
- * with the same name as long as the components have unique absolute paths
- * (i.e., they are located in different components). However, Controllers 
- * will currently not work properly if you have multiple actuators with
- * the same name; the controller will always only actuate the first 
- * actuator with a given name.
+ * @note Controllers currently do not use the Socket mechanism to locate 
+ * and connect to the Actuators that Controllers depend on. As a result,
+ * for now, Controllers do not support controlling multiple actuators with 
+ * the same name.
  *
  * @author Ajay Seth
  */


### PR DESCRIPTION
In developing the MATLAB hopper example, we ran into a bug wherein Controllers will not be able to control multiple actuators with the same name. I talked with @aseth1 about how we should fix this, and we decided to use list sockets, when they are available. Since adding that feature will take time, I thought it would be good to at least document the current unexpected behavior.