### PR TITLE
Fix manipulation of PathPoint(s) invoked from OpenSimContext for Path editing

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -264,7 +264,7 @@ void OpenSimContext::addPathPoint(GeometryPath& p, int menuChoice, PhysicalFrame
 
 bool OpenSimContext::deletePathPoint(GeometryPath& p, int menuChoice) {
     bool ret = p.deletePathPoint(*_configState, menuChoice );
-  _configState->invalidateAll(SimTK::Stage::Position);
+  _configState->invalidateAll(SimTK::Stage::Position); // This maynot be enough anymore in 4.0
   _model->getMultibodySystem().realize(*_configState, SimTK::Stage::Position);
   return ret;
 }

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -250,9 +250,10 @@ void OpenSimContext::addPathPoint(GeometryPath& p, int menuChoice, PhysicalFrame
 }
 
 bool OpenSimContext::deletePathPoint(GeometryPath& p, int menuChoice) {
-    bool ret = p.deletePathPoint(*_configState, menuChoice );
-    recreateSystemKeepStage();
-    return ret;
+    bool deletedSuccessfully = p.deletePathPoint(*_configState, menuChoice );
+    if (deletedSuccessfully) 
+        recreateSystemKeepStage();
+    return deletedSuccessfully;
 }
 
 bool OpenSimContext::isActivePathPoint(AbstractPathPoint& mp) {

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -191,7 +191,7 @@ int main()
     // Exercise PathPoint operations used to edit Path in GUI
     PathPointSet& pathPoints = dTRIlong->updGeometryPath().updPathPointSet();
     AbstractPathPoint& savePoint = pathPoints.get("TRIlong-P2");
-    const PhysicalFrame& saveBody = savePoint.getBody();
+    const PhysicalFrame& saveBody = savePoint.getParentFrame();
     AbstractPathPoint* clonedPoint = savePoint.clone();
     // Delete second PathPoint from TRIlong muscle
     context->deletePathPoint(dTRIlong->updGeometryPath(), 2); 

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -190,13 +190,33 @@ int main()
 
     // Exercise PathPoint operations used to edit Path in GUI
     PathPointSet& pathPoints = dTRIlong->updGeometryPath().updPathPointSet();
+    std::string pathBeforeInXML = dTRIlong->updGeometryPath().dump();
+    std::cout << pathBeforeInXML << endl;
+    int origSize = pathPoints.getSize();
     AbstractPathPoint& savePoint = pathPoints.get("TRIlong-P2");
-    const PhysicalFrame& saveBody = savePoint.getParentFrame();
+    const std::string& saveFrameName = savePoint.getParentFrame().getName();
     AbstractPathPoint* clonedPoint = savePoint.clone();
     // Delete second PathPoint from TRIlong muscle
     context->deletePathPoint(dTRIlong->updGeometryPath(), 2); 
+    assert(pathPoints.getSize() == origSize - 1);
+    std::string pathAfterDeletionInXML = dTRIlong->updGeometryPath().dump();
+    std::cout << pathAfterDeletionInXML << endl;
     // TODO Insert new PathPoint same location 
-    // TODO change type of a path point from Stationary to Via or Moving or vice versa
+    Component& frame = model->updComponent(saveFrameName);
+    PhysicalFrame* physFrame = PhysicalFrame::safeDownCast(&frame);
+    context->addPathPoint(dTRIlong->updGeometryPath(), 3, *physFrame);
+    assert(pathPoints.getSize() == origSize);
+    std::string pathAfterReinsertionInXML = dTRIlong->updGeometryPath().dump();
+    std::cout << pathAfterReinsertionInXML << endl;
+    ConditionalPathPoint* newPoint = new ConditionalPathPoint();
+    AbstractPathPoint& oldPoint = pathPoints.get(2);
+    newPoint->setCoordinate(model->getCoordinateSet().get(0));
+    newPoint->setParentFrame(oldPoint.getParentFrame());
+    context->replacePathPoint(dTRIlong->updGeometryPath(), oldPoint, *newPoint);
+    assert(pathPoints.getSize() == origSize);
+    std::string pathAfterTypeChangeToViaInXML = dTRIlong->updGeometryPath().dump();
+    std::cout << pathAfterTypeChangeToViaInXML << endl;
+ 
     return status;
   } catch (const std::exception& e) {
       cout << "Exception: " << e.what() << endl;

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -196,24 +196,29 @@ int main()
     AbstractPathPoint& savePoint = pathPoints.get("TRIlong-P2");
     const std::string& saveFrameName = savePoint.getParentFrame().getName();
     AbstractPathPoint* clonedPoint = savePoint.clone();
-    // Delete second PathPoint from TRIlong muscle
+
+    // Test delete second PathPoint from TRIlong muscle
     context->deletePathPoint(dTRIlong->updGeometryPath(), 2); 
     assert(pathPoints.getSize() == origSize - 1);
     std::string pathAfterDeletionInXML = dTRIlong->updGeometryPath().dump();
     std::cout << pathAfterDeletionInXML << endl;
-    // TODO Insert new PathPoint same location 
+    
+    // Test adding PathPoint to TRIlong muscle (Stationary)
     Component& frame = model->updComponent(saveFrameName);
     PhysicalFrame* physFrame = PhysicalFrame::safeDownCast(&frame);
     context->addPathPoint(dTRIlong->updGeometryPath(), 3, *physFrame);
     assert(pathPoints.getSize() == origSize);
     std::string pathAfterReinsertionInXML = dTRIlong->updGeometryPath().dump();
     std::cout << pathAfterReinsertionInXML << endl;
+
+    // Test changing type to ConditionalPathPoint
     ConditionalPathPoint* newPoint = new ConditionalPathPoint();
     AbstractPathPoint& oldPoint = pathPoints.get(2);
     newPoint->setCoordinate(model->getCoordinateSet().get(0));
     newPoint->setParentFrame(oldPoint.getParentFrame());
     context->replacePathPoint(dTRIlong->updGeometryPath(), oldPoint, *newPoint);
     assert(pathPoints.getSize() == origSize);
+
     std::string pathAfterTypeChangeToViaInXML = dTRIlong->updGeometryPath().dump();
     std::cout << pathAfterTypeChangeToViaInXML << endl;
  

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -187,6 +187,16 @@ int main()
     context->cacheModelAndState();
     PropertyHelper::setValueDouble(v, massProp);
     context->restoreStateFromCachedModel();
+
+    // Exercise PathPoint operations used to edit Path in GUI
+    PathPointSet& pathPoints = dTRIlong->updGeometryPath().updPathPointSet();
+    AbstractPathPoint& savePoint = pathPoints.get("TRIlong-P2");
+    const PhysicalFrame& saveBody = savePoint.getBody();
+    AbstractPathPoint* clonedPoint = savePoint.clone();
+    // Delete second PathPoint from TRIlong muscle
+    context->deletePathPoint(dTRIlong->updGeometryPath(), 2); 
+    // TODO Insert new PathPoint same location 
+    // TODO change type of a path point from Stationary to Via or Moving or vice versa
     return status;
   } catch (const std::exception& e) {
       cout << "Exception: " << e.what() << endl;


### PR DESCRIPTION
So far deletion only is tested, rest will come later in this PR but investigation into this can start now and will clarify what to change in 4.0

Fixes issue #1670

### Brief summary of changes
In the past, changes to GeometryPath didn't require recreating the system under the model but rather to re-realize the state. Now that PathPoints are Components and are part of the system, edits by insertion, deletion or typechange require recreating the system.

### Testing I've completed
testContext has been made stronger to make the calls done by GUI path editing. This guarantees the calls don't crash or throw anymore.
Testing addition, removal and/or type change from GUI works with this PR in place, though MovingPathPoints have not been thoroughly  tested.

### Looking for feedback on...
The change of type is adhoc and doesn't cover all the combination of pairs of types of PathPoints, Need more exercise from GUI.
 
### CHANGELOG.md (choose one)

- no need to update because this is internal bug-fix. 

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
