### PR TITLE
A bug in JointReaction anslysis when used in combination of iterative forward simulation

### DIFF
--- a/Applications/Analyze/test/testJointReactions.cpp
+++ b/Applications/Analyze/test/testJointReactions.cpp
@@ -28,24 +28,32 @@
 using namespace OpenSim;
 using namespace std;
 
+void testJointReactionDuringIterativeForwardSimulation();
+
 int main()
 {
     try {
         AnalyzeTool analyze("SinglePin_Setup_JointReaction.xml");
         analyze.run();
-        Storage result1("SinglePin_JointReaction_ReactionLoads.sto"), standard1("std_SinglePin_JointReaction_ReactionLoads.sto");
+        Storage result1("SinglePin_JointReaction_ReactionLoads.sto"), 
+            standard1("std_SinglePin_JointReaction_ReactionLoads.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-            std::vector<double>(standard1.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
-            "SinglePin failed");
+            std::vector<double>(standard1.getSmallestNumberOfStates(), 1e-5),
+            __FILE__, __LINE__, "SinglePin failed");
         cout << "SinglePin passed" << endl;
 
         AnalyzeTool analyze2("DoublePendulum3D_Setup_JointReaction.xml");
         analyze2.run();
-        Storage result2("DoublePendulum3D_JointReaction_ReactionLoads.sto"), standard2("std_DoublePendulum3D_JointReaction_ReactionLoads.sto");
+        Storage result2("DoublePendulum3D_JointReaction_ReactionLoads.sto"), 
+            standard2("std_DoublePendulum3D_JointReaction_ReactionLoads.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
-            std::vector<double>(standard2.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
-            "DoublePendulum3D failed");
+            std::vector<double>(standard2.getSmallestNumberOfStates(), 1e-5), 
+            __FILE__, __LINE__, "DoublePendulum3D failed");
         cout << "DoublePendulum3D passed" << endl;
+
+        // check if joint reaction analysis behaves correctly during
+        // iterative forward simulation
+        testJointReactionDuringIterativeForwardSimulation();
     }
     catch (const Exception& e) {
         e.print(cerr);
@@ -53,4 +61,58 @@ int main()
     }
     cout << "Done" << endl;
     return 0;
+}
+
+void testJointReactionDuringIterativeForwardSimulation() {
+    Model model;
+
+    // toy model
+    auto ground = model.updGround();
+    double m = 1, r = 0.01, l = 1;
+    auto body = new OpenSim::Body("body1", m, SimTK::Vec3(0), 
+        m * SimTK::Inertia::cylinderAlongY(r, l / 2));
+    SimTK::Vec3 body_start(0, -l / 2, 0);
+    SimTK::Vec3 body_end(0, l / 2, 0);
+    auto joint = new OpenSim::PinJoint("joint1",
+        ground, SimTK::Vec3(0), SimTK::Vec3(0),
+        *body, body_start, SimTK::Vec3(0));
+    joint->upd_coordinates(0).
+        setDefaultValue(SimTK::convertDegreesToRadians(45));
+    auto geom = new OpenSim::Cylinder(r, l / 2);
+    geom->setName("cylinder");
+    body->attachGeometry(geom);
+    model.addBody(body);
+    model.addJoint(joint);
+
+    // analysis
+    JointReaction* reaction = new JointReaction(&model);
+    model.addAnalysis(reaction);
+
+    // build model
+    //model.setUseVisualizer(true);
+    model.finalizeFromProperties();
+    model.buildSystem();
+    auto s = model.initializeState();
+
+    double dt = 0.01;
+    double t_start = 0;
+    double t_end = 0.5;
+    SimTK::RungeKuttaMersonIntegrator integrator(model.getSystem());
+    Manager manager(model, integrator);
+    manager.setInitialTime(t_start);
+
+    // iterative numerical integration  
+    for (unsigned int i = 1; i*dt <= t_end; ++i) {
+        double t0 = s.getTime();
+        double tf = i * dt;
+
+        // do something ...
+
+        manager.setFinalTime(tf);
+        manager.integrate(s);
+        manager.setInitialTime(tf);
+    }
+    // if storage is reseted then it will not start from start time and the bug
+    // is exposed
+    ASSERT(reaction->getReactionLoads().getFirstTime() == t_start);
 }

--- a/Applications/Analyze/test/testJointReactions.cpp
+++ b/Applications/Analyze/test/testJointReactions.cpp
@@ -90,9 +90,7 @@ void testJointReactionDuringIterativeForwardSimulation() {
 
     // build model
     //model.setUseVisualizer(true);
-    model.finalizeFromProperties();
-    model.buildSystem();
-    auto s = model.initializeState();
+    auto s = model.initSystem();
 
     double dt = 0.1;
     double t_start = 0;
@@ -109,7 +107,6 @@ void testJointReactionDuringIterativeForwardSimulation() {
         // do something ...
 
         manager.integrate(s, tf);
-        s.setTime(tf);
     }
     // if storage is reseted then it will not start from start time and the bug
     // is exposed

--- a/Applications/Analyze/test/testJointReactions.cpp
+++ b/Applications/Analyze/test/testJointReactions.cpp
@@ -94,12 +94,12 @@ void testJointReactionDuringIterativeForwardSimulation() {
     model.buildSystem();
     auto s = model.initializeState();
 
-    double dt = 0.01;
+    double dt = 0.1;
     double t_start = 0;
     double t_end = 0.5;
     SimTK::RungeKuttaMersonIntegrator integrator(model.getSystem());
     Manager manager(model, integrator);
-    manager.setInitialTime(t_start);
+    s.setTime(t_start);
 
     // iterative numerical integration  
     for (unsigned int i = 1; i*dt <= t_end; ++i) {
@@ -108,9 +108,8 @@ void testJointReactionDuringIterativeForwardSimulation() {
 
         // do something ...
 
-        manager.setFinalTime(tf);
-        manager.integrate(s);
-        manager.setInitialTime(tf);
+        manager.integrate(s, tf);
+        s.setTime(tf);
     }
     // if storage is reseted then it will not start from start time and the bug
     // is exposed

--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -168,6 +168,17 @@ setNull()
     _inFrame[0] = "ground";
 
     _storeActuation = NULL;
+    /* [bug fix notes 4/5/17]
+    Storage reset should not be called in setupStorage which is called in
+    begin method. This can be problematic if Manager.integrate is called in an
+    iterative manner, due to the fact that each time the integrate is called
+    the initialize method is issued that calls begin. If the storage is reset
+    to 0 then at the end of the simulation only the last record will be kept. 
+    Instead reset(0) is moved in setNull from setupStorage. This is only 
+    observed for JointReaction and not for the rest of the Analysis that do 
+    not reset their storage in the begin method.
+    */
+    _storeReactionLoads.reset(0);
 
 }
 //_____________________________________________________________________________
@@ -444,7 +455,6 @@ void JointReaction::
 setupStorage()
 {
     // Reaction Loads
-    _storeReactionLoads.reset(0);
     _storeReactionLoads.setName("Joint Reaction Loads");
     _storeReactionLoads.setDescription(getDescription());
     _storeReactionLoads.setColumnLabels(getColumnLabels());

--- a/OpenSim/Analyses/JointReaction.h
+++ b/OpenSim/Analyses/JointReaction.h
@@ -180,6 +180,8 @@ public:
      /** Public accessors for the inFrame property */
     const Array<std::string>& getInFrame() const { return _inFrame; }
     void setInFrame( Array<std::string>& inFrame) { _inFrame = inFrame; }
+    /** Public accessors for the reaction loads storage */
+    const Storage& getReactionLoads() { return _storeReactionLoads; }
 
     //-------------------------------------------------------------------------
     // INTEGRATION


### PR DESCRIPTION
### Bug explanation

If JointReaction analysis is added to a model and the simulation (forward) is performed in iterative manner, by stepping the integrate function of Manager, JointReaction analysis keeps only the last time instance. 

By closer inspection of the problem [Manager.integrate](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Simulation/Manager/Manager.cpp#L680) calls `initializeStorageAndAnalyses  `which calls `begin `for each analysis. In JointReaction analysis due to the [JointReaction.setupStorage](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Analyses/JointReaction.cpp#L447) called by `begin `method the storage is reset to 0. The rest of analyses do not reset their storages in the `begin `method so the problem was not observed for any other analysis. Please note that if the manager is not used in iterative manner then begin method is called one and there is not any problem.

### Brief summary of changes

The `_storeReactionLoads.reset(0);` is moved from `setupStorage `to `setNull()`

### Testing I've completed

The behavior of JointReaction have been tested on custom code which reproduces the problem. Moreover, the JointReaction test passes.

