### PR TITLE
Fix invalid name issue with matlab structs.

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
+++ b/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
@@ -77,9 +77,15 @@ for iLabel = 0 : nLabels - 1
     
     % Get the osim table column label
     col_label  = char(osimtable.getColumnLabels.get(iLabel));
-    % replace fwd slashes if present
-    if isempty(strfind(col_label, '/'))
+    
+    % MATLAB structs must start with a letter, and can only contain
+    % letters, digits, and underscores.
+    % Remove an initial slash.
+    col_label = regexprep(col_label, '^/', '');
+    % replace '/' and '|' if present
+    if ~isempty(strfind(col_label, '/')) || ~isempty(strfind(col_label, '|'))
         col_label = strrep(col_label,'/', '_');
+        col_label = strrep(col_label,'|', '_');
     end
     % Add the label and data to the data struct
     structdata.(col_label) = dataArray;

--- a/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
+++ b/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
@@ -82,11 +82,9 @@ for iLabel = 0 : nLabels - 1
     % letters, digits, and underscores.
     % Remove an initial slash.
     col_label = regexprep(col_label, '^/', '');
-    % replace '/' and '|' if present
-    if ~isempty(strfind(col_label, '/')) || ~isempty(strfind(col_label, '|'))
-        col_label = strrep(col_label,'/', '_');
-        col_label = strrep(col_label,'|', '_');
-    end
+    % Replace '/' and '|' if they are present.
+    col_label = strrep(col_label,'/', '_');
+    col_label = strrep(col_label,'|', '_');
     % Add the label and data to the data struct
     structdata.(col_label) = dataArray;
 end


### PR DESCRIPTION

### Brief summary of changes

The syntax for input connectee names changed, requiring an update for how struct
fieldnames are formed.

### Testing I've completed

Locally ran `ctest -R Matlab_osimTableToStruct -V`.

### CHANGELOG.md (choose one)

- no need to update because...this file is new to 4.0.