### PR TITLE
DelimFileAdapter: exception for empty files.

### DIFF
--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -365,7 +365,7 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     // container.
     auto column_labels = nextLine();
     OPENSIM_THROW_IF(column_labels.size() == 0, Exception,
-                     "No column labels detectedin file '" + fileName + "'.");
+                     "No column labels detected in file '" + fileName + "'.");
     ++line_num;
     // Column 0 is the time column. Check and get rid of it. The data in this
     // column is maintained separately from rest of the data.

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -306,6 +306,10 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     OPENSIM_THROW_IF(!in_stream.good(),
                      FileDoesNotExist,
                      fileName);
+    
+    OPENSIM_THROW_IF(in_stream.peek() == std::ifstream::traits_type::eof(),
+                     FileIsEmpty,
+                     fileName);
 
     auto table = std::make_shared<TimeSeriesTable_<T>>();
 
@@ -360,6 +364,8 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     // Read the line containing column labels and fill up the column labels
     // container.
     auto column_labels = nextLine();
+    OPENSIM_THROW_IF(column_labels.size() == 0, Exception,
+                     "No column labels detectedin file '" + fileName + "'.");
     ++line_num;
     // Column 0 is the time column. Check and get rid of it. The data in this
     // column is maintained separately from rest of the data.

--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -200,7 +200,7 @@ int main() {
     std::cout << "Testing STOFileAdapter::read() and STOFileAdapter::write()"
               << std::endl;
     for(const auto& filename : filenames) {
-        std::cout << " " << filename << std::endl;
+        std::cout << "  " << filename << std::endl;
         STOFileAdapter_<double> stofileadapter{};
         auto table = stofileadapter.read(filename);
         stofileadapter.write(table, tmpfile);
@@ -253,8 +253,15 @@ int main() {
     std::cout << "Testing reading/writing STOFileAdapter_<SimTK::SpatialVec>"
               << std::endl;
     testReadingWriting<SimTK::SpatialVec>();
-    std::cout << "\nAll tests passed!" << std::endl;
 
+    std::cout << "Testing exception for reading an empty file"
+              << std::endl;
+    std::string emptyFileName("testSTOFileAdapter_empty.sto");
+    std::ofstream emptyFile(emptyFileName);
+    SimTK_TEST_MUST_THROW_EXC(STOFileAdapter::read(emptyFileName), FileIsEmpty);
+    std::remove(emptyFileName.c_str());
+
+    std::cout << "\nAll tests passed!" << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Fixes #1702 

### Brief summary of changes

This PR adds an exception for when any file read by a `DelimFileAdapter` is empty.

### Testing I've completed

Added a test in `testSTOFileAdapter` to catch an exception when trying to read an empty file. Since the `DelimFileAdapter` is the base for STO, CSV, etc., I don't think it is necessary to separately test CSV files, etc.

### CHANGELOG.md (choose one)

- no need to update because...we haven't released the adapters yet

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
