### PR TITLE
Improve warning about nonzero inertia.

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -127,15 +127,16 @@ const SimTK::Inertia& Body::getInertia() const
     if (_inertia.isNaN()){
         // initialize from properties
         const double& m = getMass();
+        const SimTK::Vec6& Ivec = get_inertia();
         // if mass is zero, non-zero inertia makes no sense
-        if (-SimTK::SignificantReal <= m && m <= SimTK::SignificantReal){
+        if (std::abs(m) <= SimTK::SignificantReal &&
+                Ivec.norm() > SimTK::SignificantReal) {
             // force zero inertia
             cout<<"Body '"<<getName()<<"' is massless but nonzero inertia provided.";
             cout<<" Inertia reset to zero. "<<"Otherwise provide nonzero mass."<< endl;
             _inertia = SimTK::Inertia(0);
         }
         else{
-            const SimTK::Vec6& Ivec = get_inertia();
             try {
                 _inertia = SimTK::Inertia(Ivec.getSubVec<3>(0), Ivec.getSubVec<3>(3));
             } 
@@ -195,7 +196,7 @@ void Body::scale(const SimTK::Vec3& aScaleFactors, bool aScaleMass)
         upd_mass_center()[i] *= aScaleFactors[i];
     }
 
-        scaleInertialProperties(aScaleFactors, aScaleMass);
+    scaleInertialProperties(aScaleFactors, aScaleMass);
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Fixes issue #427 

Related PR: #225

### Brief summary of changes

There is currently a warning for if the user specifies zero mass for a body with a nonzero inertia, but the if-statement for this error didn't actually check if the inertia was nonzero. Now, the if-statement checks the inertia first.

### Testing I've completed

Using the python bindings, I made sure that calling `initSystem()` on a model with massless bodies no longer emits this warning.

### CHANGELOG.md (choose one)

- no need to update because...this warning was introduced after 3.3.