### PR TITLE
Support Python 3 for python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - OPENSIM_HOME=~/opensim-core
     - OPENSIM_DEPENDENCIES_BUILD_DIR=~/opensim_dependencies-build
     - OPENSIM_DEPENDENCIES_INSTALL_DIR=~/opensim_dependencies-install
-    - SWIG_VER=3.0.6
+    - SWIG_VER=3.0.8
     - PATH="$PATH:$TRAVIS_BUILD_DIR/.github"
     - USE_CACHE=false
 

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    # We require 3.0.8 for the reason mentioned here (for Yython 3):
+    # We require 3.0.8 for the reason mentioned here (for Python 3):
     # https://github.com/tensorflow/tensorflow/issues/830
     find_package(SWIG 3.0.8 REQUIRED)
 endif()

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,11 +1,7 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    if(${OPENSIM_PYTHON_VERSION} STREQUAL "2")
-        set(required_swig_version 3.0.6)
-    elseif(${OPENSIM_PYTHON_VERSION} STREQUAL "3")
-        # https://github.com/tensorflow/tensorflow/issues/830
-        set(required_swig_version 3.0.8)
-    endif()
-    find_package(SWIG ${required_swig_version} REQUIRED)
+    # We require 3.0.8 for the reason mentioned here (for Yython 3):
+    # https://github.com/tensorflow/tensorflow/issues/830
+    find_package(SWIG 3.0.8 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,11 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 3.0.6 REQUIRED)
+    if(${OPENSIM_PYTHON_VERSION} STREQUAL "2")
+        set(required_swig_version 3.0.6)
+    elseif(${OPENSIM_PYTHON_VERSION} STREQUAL "3")
+        # https://github.com/tensorflow/tensorflow/issues/830
+        set(required_swig_version 3.0.8)
+    endif()
+    find_package(SWIG ${required_swig_version} REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,9 +1,9 @@
-from simbody import *
-from common import *
-from simulation import *
-from actuators import *
-from analyses import *
-from tools import *
-from examplecomponents import *
+from .simbody import *
+from .common import *
+from .simulation import *
+from .actuators import *
+from .analyses import *
+from .tools import *
+from .examplecomponents import *
 
 from .version import __version__

--- a/Bindings/Python/swig/python_actuators.i
+++ b/Bindings/Python/swig/python_actuators.i
@@ -1,4 +1,4 @@
-%module(directors="1") actuators
+%module(package="opensim", directors="1") actuators
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."

--- a/Bindings/Python/swig/python_analyses.i
+++ b/Bindings/Python/swig/python_analyses.i
@@ -1,4 +1,4 @@
-%module(directors="1") analyses
+%module(package="opensim", directors="1") analyses
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."

--- a/Bindings/Python/swig/python_common.i
+++ b/Bindings/Python/swig/python_common.i
@@ -1,4 +1,4 @@
-%module(directors="1") common
+%module(package="opensim", directors="1") common
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."
@@ -196,6 +196,7 @@ note: ## is a "glue" operator: `a ## b` --> `ab`.
             else:
                 # This is how Python knows to stop iterating.
                  raise StopIteration()
+        __next__ = next # For Python 3.
 
     def __iter__(self):
         """Get an iterator for this Set, starting at index 0."""

--- a/Bindings/Python/swig/python_examplecomponents.i
+++ b/Bindings/Python/swig/python_examplecomponents.i
@@ -1,4 +1,4 @@
-%module(directors="1") examplecomponents
+%module(package="opensim", directors="1") examplecomponents
 #pragma SWIG nowarn=822,451,503,516,325, 401
 
 %{

--- a/Bindings/Python/swig/python_simbody.i
+++ b/Bindings/Python/swig/python_simbody.i
@@ -1,4 +1,4 @@
-%module(directors="1") simbody
+%module(package="opensim", directors="1") simbody
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -1,4 +1,4 @@
-%module(directors="1") simulation
+%module(package="opensim", directors="1") simulation
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."

--- a/Bindings/Python/swig/python_tools.i
+++ b/Bindings/Python/swig/python_tools.i
@@ -1,4 +1,4 @@
-%module(directors="1") tools
+%module(package="opensim", directors="1") tools
 #pragma SWIG nowarn=822,451,503,516,325
 // 401 is "Nothing known about base class *some-class*.
 //         Maybe you forgot to instantiate *some-template* using %template."

--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -6,21 +6,21 @@ import opensim as osim
 
 class TestDataTable(unittest.TestCase):
     def test_vector_rowvector(self):
-        print
-        print 'Test transpose RowVector to Vector.'
+        print()
+        print('Test transpose RowVector to Vector.')
         row = osim.RowVector([1, 2, 3, 4])
         col = row.transpose()
         assert (col[0] == row[0] and
                 col[1] == row[1] and
                 col[2] == row[2] and
                 col[3] == row[3])
-        print 'Test transpose Vector to RowVector.'
+        print('Test transpose Vector to RowVector.')
         row_copy = col.transpose()
         assert (row_copy[0] == row[0] and
                 row_copy[1] == row[1] and
                 row_copy[2] == row[2] and
                 row_copy[3] == row[3])
-        print 'Test transpose RowVectorOfVec3 to VectorOfVec3.'
+        print('Test transpose RowVectorOfVec3 to VectorOfVec3.')
         row = osim.RowVectorOfVec3([osim.Vec3(1, 2, 3), 
                                     osim.Vec3(4, 5, 6),
                                     osim.Vec3(7, 8, 9)])
@@ -28,14 +28,14 @@ class TestDataTable(unittest.TestCase):
         assert (str(col[0]) == str(row[0]) and
                 str(col[1]) == str(row[1]) and
                 str(col[2]) == str(row[2]))
-        print 'Test transpose VectorOfVec3 to RowVectorOfVec3.'
+        print('Test transpose VectorOfVec3 to RowVectorOfVec3.')
         row_copy = col.transpose()
         assert (str(row_copy[0]) == str(row[0]) and
                 str(row_copy[1]) == str(row[1]) and
                 str(row_copy[2]) == str(row[2]))
     
     def test_DataTable(self):
-        print
+        print()
         table = osim.DataTable()
         # Set column labels.
         table.setColumnLabels(['0', '1', '2', '3'])
@@ -59,7 +59,7 @@ class TestDataTable(unittest.TestCase):
                 row0[1] == row[1] and
                 row0[2] == row[2] and
                 row0[3] == row[3])
-        print table
+        print(table)
         # Append another row to the table.
         row[0] *= 2
         row[1] *= 2
@@ -73,7 +73,7 @@ class TestDataTable(unittest.TestCase):
                 row1[1] == row[1] and
                 row1[2] == row[2] and
                 row1[3] == row[3])
-        print table
+        print(table)
         # Append another row to the table.
         row[0] *= 2
         row[1] *= 2
@@ -87,7 +87,7 @@ class TestDataTable(unittest.TestCase):
                 row2[1] == row[1] and
                 row2[2] == row[2] and
                 row2[3] == row[3])
-        print table
+        print(table)
         # Retrieve independent column.
         assert table.getIndependentColumn() == (0.1, 0.2, 0.3)
         # Retrieve dependent columns.
@@ -129,7 +129,7 @@ class TestDataTable(unittest.TestCase):
                 row2[1] == 20 and
                 row2[2] == 20 and
                 row2[3] == 20)
-        print table
+        print(table)
         # Edit columns of the table.
         col1 = table.getDependentColumnAtIndex(1)
         col1[0] = 30
@@ -147,7 +147,7 @@ class TestDataTable(unittest.TestCase):
         assert (col3[0] == 40 and
                 col3[1] == 40 and
                 col3[2] == 40)
-        print table
+        print(table)
         # Append columns to table.
         col = osim.Vector([1, 2, 3])
         table.appendColumn("4", col)
@@ -159,7 +159,7 @@ class TestDataTable(unittest.TestCase):
         table.addTableMetaDataString('subject-yob' , '1991')
         assert table.getTableMetaDataString('subject-name') == 'Python'
         assert table.getTableMetaDataString('subject-yob' ) == '1991'
-        print table
+        print(table)
         # Access eleemnt with index out of bounds. Exception expected.
         try:
             shouldThrow = row0[6]
@@ -210,43 +210,43 @@ class TestDataTable(unittest.TestCase):
         assert len(table.getColumnLabels()) == 12
         assert table.getNumRows()           == 3
         assert table.getNumColumns()        == 12
-        print table
+        print(table)
         tableVec3 = table.packVec3(('_x', '_y', '_z'))
         tableVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableVec3.getNumRows()    == 3
         tableVec3.getNumColumns() == 4
-        print tableVec3
+        print(tableVec3)
         tableFlat = tableVec3.flatten()
         assert len(tableFlat.getColumnLabels()) == 12
         assert tableFlat.getColumnLabel( 0) == 'col0_1'
         assert tableFlat.getColumnLabel(11) == 'col3_3'
         assert tableFlat.getNumRows()           == 3
         assert tableFlat.getNumColumns()        == 12
-        print tableFlat
+        print(tableFlat)
         tableVec3 = table.packVec3()
         tableVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableVec3.getNumRows()    == 3
         tableVec3.getNumColumns() == 4
-        print tableVec3
+        print(tableVec3)
         tableFlat = tableVec3.flatten()
         assert len(tableFlat.getColumnLabels()) == 12
         assert tableFlat.getColumnLabel( 0) == 'col0_1'
         assert tableFlat.getColumnLabel(11) == 'col3_3'
         assert tableFlat.getNumRows()           == 3
         assert tableFlat.getNumColumns()        == 12
-        print tableFlat
+        print(tableFlat)
         tableUnitVec3 = table.packUnitVec3()
         tableUnitVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableUnitVec3.getNumRows()    == 3
         tableUnitVec3.getNumColumns() == 4
-        print tableUnitVec3
+        print(tableUnitVec3)
         tableFlat = tableUnitVec3.flatten()
         assert len(tableFlat.getColumnLabels()) == 12
         assert tableFlat.getColumnLabel( 0) == 'col0_1'
         assert tableFlat.getColumnLabel(11) == 'col3_3'
         assert tableFlat.getNumRows()           == 3
         assert tableFlat.getNumColumns()        == 12
-        print tableFlat
+        print(tableFlat)
         table.setColumnLabels(('col0.0', 'col0.1', 'col0.2', 'col0.3',
                                'col1.0', 'col1.1', 'col1.2', 'col1.3',
                                'col2.0', 'col2.1', 'col2.2', 'col2.3'))
@@ -254,14 +254,14 @@ class TestDataTable(unittest.TestCase):
         tableQuat.getColumnLabels() == ('col0', 'col1', 'col2')
         tableQuat.getNumRows()    == 3
         tableQuat.getNumColumns() == 3
-        print tableQuat
+        print(tableQuat)
         tableFlat = tableQuat.flatten()
         assert len(tableFlat.getColumnLabels()) == 12
         assert tableFlat.getColumnLabel( 0) == 'col0_1'
         assert tableFlat.getColumnLabel(11) == 'col2_4'
         assert tableFlat.getNumRows()           == 3
         assert tableFlat.getNumColumns()        == 12
-        print tableFlat
+        print(tableFlat)
         table.setColumnLabels(('col0_0', 'col0_1', 'col0_2',
                                'col0_3', 'col0_4', 'col0_5',
                                'col1_0', 'col1_1', 'col1_2',
@@ -270,17 +270,17 @@ class TestDataTable(unittest.TestCase):
         tableSVec.getColumnLabels() == ('col0', 'col1')
         tableSVec.getNumRows()    == 3
         tableSVec.getNumColumns() == 2
-        print tableSVec
+        print(tableSVec)
         tableFlat = tableSVec.flatten()
         assert len(tableFlat.getColumnLabels()) == 12
         assert tableFlat.getColumnLabel( 0) == 'col0_1'
         assert tableFlat.getColumnLabel(11) == 'col1_6'
         assert tableFlat.getNumRows()           == 3
         assert tableFlat.getNumColumns()        == 12
-        print tableFlat
+        print(tableFlat)
 
     def test_TimeSeriesTable(self):
-        print
+        print()
         table = osim.TimeSeriesTable()
         table.setColumnLabels(('col1', 'col2', 'col3', 'col4'))
         assert(table.getColumnLabels() == ('col1', 'col2', 'col3', 'col4'))
@@ -329,7 +329,7 @@ class TestDataTable(unittest.TestCase):
         assert len(table.getColumnLabels()) == 12
         assert table.getNumRows()           == 3
         assert table.getNumColumns()        == 12
-        print table
+        print(table)
         avgRow = table.averageRow(1, 3)
         assert avgRow.ncol() == 12
         assert abs(avgRow[ 0] - 2) < 1e-8#epsilon
@@ -342,12 +342,12 @@ class TestDataTable(unittest.TestCase):
         tableVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableVec3.getNumRows()    == 3
         tableVec3.getNumColumns() == 4
-        print tableVec3
+        print(tableVec3)
         tableVec3 = table.packVec3()
         tableVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableVec3.getNumRows()    == 3
         tableVec3.getNumColumns() == 4
-        print tableVec3
+        print(tableVec3)
         avgRow = tableVec3.averageRow(1, 2)
         assert avgRow.ncol() == 4
         assert abs(avgRow[0][0] - 1.5) < 1e-8#epsilon
@@ -360,7 +360,7 @@ class TestDataTable(unittest.TestCase):
         tableUnitVec3.getColumnLabels() == ('col0', 'col1', 'col2', 'col3')
         tableUnitVec3.getNumRows()    == 3
         tableUnitVec3.getNumColumns() == 4
-        print tableUnitVec3
+        print(tableUnitVec3)
         table.setColumnLabels(('col0.0', 'col0.1', 'col0.2', 'col0.3',
                                'col1.0', 'col1.1', 'col1.2', 'col1.3',
                                'col2.0', 'col2.1', 'col2.2', 'col2.3'))
@@ -368,7 +368,7 @@ class TestDataTable(unittest.TestCase):
         tableQuat.getColumnLabels() == ('col0', 'col1', 'col2')
         tableQuat.getNumRows()    == 3
         tableQuat.getNumColumns() == 3
-        print tableQuat
+        print(tableQuat)
         table.setColumnLabels(('col0_0', 'col0_1', 'col0_2',
                                'col0_3', 'col0_4', 'col0_5',
                                'col1_0', 'col1_1', 'col1_2',
@@ -377,7 +377,7 @@ class TestDataTable(unittest.TestCase):
         tableSVec.getColumnLabels() == ('col0', 'col1')
         tableSVec.getNumRows()    == 3
         tableSVec.getNumColumns() == 2
-        print tableSVec
+        print(tableSVec)
 
     def test_DataTableVec3(self):
         table = osim.DataTableVec3()
@@ -395,7 +395,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row0[0]) == str(row[0]) and
                 str(row0[1]) == str(row[1]) and
                 str(row0[2]) == str(row[2]))
-        print table
+        print(table)
         # Append another row to the table.
         row = osim.RowVectorOfVec3([osim.Vec3( 2,  4,  6), 
                                     osim.Vec3( 8, 10, 12),
@@ -407,7 +407,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row1[0]) == str(row[0]) and
                 str(row1[1]) == str(row[1]) and
                 str(row1[2]) == str(row[2]))
-        print table
+        print(table)
         # Append another row to the table.
         row = osim.RowVectorOfVec3([osim.Vec3( 4,  8, 12), 
                                     osim.Vec3(16, 20, 24),
@@ -419,7 +419,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row2[0]) == str(row[0]) and
                 str(row2[1]) == str(row[1]) and
                 str(row2[2]) == str(row[2]))
-        print table
+        print(table)
         # Retrieve independent column.
         assert table.getIndependentColumn() == (0.1, 0.2, 0.3)
         # Retrieve dependent columns.
@@ -445,13 +445,13 @@ class TestDataTable(unittest.TestCase):
         assert tableDouble.getRowAtIndex(0)[8] == 9
         assert tableDouble.getRowAtIndex(1)[8] == 18
         assert tableDouble.getRowAtIndex(2)[8] == 36
-        print tableDouble
+        print(tableDouble)
         
         tableDouble = table.flatten(['_x', '_y', '_z'])
         assert tableDouble.getColumnLabels() == ('0_x', '0_y', '0_z',
                                                  '1_x', '1_y', '1_z',
                                                  '2_x', '2_y', '2_z')
-        print tableDouble
+        print(tableDouble)
         
         # Edit rows of the table.
         row0 = table.getRowAtIndex(0)
@@ -470,7 +470,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row2[0]) == str(osim.Vec3(20, 20, 20)) and
                 str(row2[1]) == str(osim.Vec3(20, 20, 20)) and
                 str(row2[2]) == str(osim.Vec3(20, 20, 20)))
-        print table
+        print(table)
         # Edit columns of the table.
         col1 = table.getDependentColumnAtIndex(1)
         col1[0] = osim.Vec3(30, 30, 30)
@@ -488,7 +488,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(col2[0]) == str(osim.Vec3(40, 40, 40)) and
                 str(col2[1]) == str(osim.Vec3(40, 40, 40)) and
                 str(col2[2]) == str(osim.Vec3(40, 40, 40)))
-        print table
+        print(table)
 
 
     def test_TimeSeriesTableVec3(self):
@@ -507,7 +507,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row0[0]) == str(row[0]) and
                 str(row0[1]) == str(row[1]) and
                 str(row0[2]) == str(row[2]))
-        print table
+        print(table)
         # Append another row to the table.
         row = osim.RowVectorOfVec3([osim.Vec3( 2,  4,  6), 
                                     osim.Vec3( 8, 10, 12),
@@ -519,7 +519,7 @@ class TestDataTable(unittest.TestCase):
         assert (str(row1[0]) == str(row[0]) and
                 str(row1[1]) == str(row[1]) and
                 str(row1[2]) == str(row[2]))
-        print table
+        print(table)
         # Append another row to the table with a timestamp
         # less than the previous one. Exception expected.
         try:
@@ -536,11 +536,11 @@ class TestDataTable(unittest.TestCase):
         assert tableDouble.getRowAtIndex(1)[0] == 2
         assert tableDouble.getRowAtIndex(0)[8] == 9
         assert tableDouble.getRowAtIndex(1)[8] == 18
-        print tableDouble
+        print(tableDouble)
 
         tableDouble = table.flatten(['_x', '_y', '_z'])
         assert tableDouble.getColumnLabels() == ('0_x', '0_y', '0_z',
                                                  '1_x', '1_y', '1_z',
                                                  '2_x', '2_y', '2_z')
-        print tableDouble
+        print(tableDouble)
         

--- a/Bindings/Python/tests/test_swig_additional_interface.py
+++ b/Bindings/Python/tests/test_swig_additional_interface.py
@@ -65,17 +65,17 @@ class TestSwigAddtlInterface(unittest.TestCase):
         orient_in_parent = osim.Vec3(0, 0, 0)
         loc_in_body = osim.Vec3(0, 0, 0)
         orient_in_body = osim.Vec3(0, 0, 0)
-        print "creating Weld Joint.."
+        print("creating Weld Joint..")
         joint = osim.WeldJoint("weld_joint",
                 a.getGround(),
                 loc_in_parent, orient_in_parent,
                 body,
                 loc_in_body, orient_in_parent)
-        print "adding a body .."
+        print("adding a body ..")
         a.addBody(body)
-        print "adding a joint .."
+        print("adding a joint ..")
         a.addJoint(joint)
-        print "Creating a ConstantDistanceConstraint.."
+        print("Creating a ConstantDistanceConstraint..")
         constr = osim.ConstantDistanceConstraint()
         constr.setBody1ByName("ground")
         constr.setBody1PointLocation(osim.Vec3(0, 0, 0))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Python interface
 ----------------
 - Improved error handling. Now, OpenSim's error messages show up as exceptions
 in Python.
+- The Python bindings can now be built for Python 3 (as well as Python 2).
 
 Other Changes
 -------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,11 @@ set(BUILD_JAVA_WRAPPING OFF CACHE BOOL "Build Java wrapping (needed if you're bu
 
 set(BUILD_PYTHON_WRAPPING OFF CACHE BOOL "Build Python wrapping (needed if you're building the Python wrapping; requires that you have SWIG and Python installed on your machine.)")
 
+set(OPENSIM_PYTHON_VERSION 2 CACHE STRING
+    "The major Python version (2 or 3) for which to build the wrapping.")
+# To create a drop-down in the CMake GUI:
+set_property(CACHE OPENSIM_PYTHON_VERSION PROPERTY STRINGS "2" "3")
+
 if(${BUILD_JAVA_WRAPPING})
     # If we can find a MATLAB installation, we'll try to run some MATLAB tests.
     # To print info on where MATLAB is found: set(MATLAB_FIND_DEBUG ON)
@@ -444,7 +449,14 @@ endif()
 
 if(${BUILD_PYTHON_WRAPPING})
     # PythonInterp is supposed to come before PythonLibs.
-    find_package(PythonInterp 2.7 REQUIRED)
+    if(${OPENSIM_PYTHON_VERSION} STREQUAL "2")
+        set(required_python_version 2.7)
+    elseif(${OPENSIM_PYTHON_VERSION} STREQUAL "3")
+        set(required_python_version 3)
+    else()
+        message(FATAL_ERROR "OPENSIM_PYTHON_VERSION should be '2' or '3'.")
+    endif()
+    find_package(PythonInterp ${required_python_version} REQUIRED)
 
     # We update the python install dir to include the python version,
     # now that we know it. We replace the token "VERSION" with the actual python
@@ -456,8 +468,8 @@ if(${BUILD_PYTHON_WRAPPING})
     # OPENSIM_INSTALL_PYTHONDIR is used in OpenSimAddLibrary (in
     # OpenSimMacros.cmake).
 
-    if(APPLE)
-        # If you have Homebrew's Python, then by default, PythonInterp finds
+    if(APPLE AND ${OPENSIM_PYTHON_VERSION} STREQUAL "2")
+        # If you have Homebrew's Python2, then by default, PythonInterp finds
         # Apple's Python, but PythonLibs finds Homebrew's Python, causing
         # runtime crashes. This also occurs if one has Anaconda Python.
         # So we use the python-config executable to get the
@@ -480,7 +492,7 @@ if(${BUILD_PYTHON_WRAPPING})
             "${python_prefix}/lib/libpython${python_version_majmin}.dylib"
             CACHE FILEPATH "${pylib_desc}")
     endif()
-    find_package(PythonLibs 2.7 REQUIRED)
+    find_package(PythonLibs ${required_python_version} REQUIRED)
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ On Windows using Visual Studio
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
     * **Python scripting** (optional): Python >= 2.7 (including Python 3)
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
+        * Note: Python 3 requires SWIG 3.0.8.
     * The choice between 32-bit/64-bit must be the same between Java, Python,
       and OpenSim.
 
@@ -459,6 +460,7 @@ ctest -j8
         * Mac OSX comes with Python, but you could also use:
         * [`brew install python`](http://brew.sh),
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
+        * Note: Python 3 requires SWIG 3.0.8.
 
 You can get most of these dependencies using [Homebrew](http://brew.sh):
 
@@ -638,6 +640,8 @@ specific Ubuntu versions under 'For the impatient' below.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
     * **Python scripting** (optional):  Python >= 2.7 (including Python 3); `python-dev`.
+    * **Python scripting** (optional): Python >= 2.7 (including Python 3); `python-dev`.
+        * Note: Python 3 requires SWIG 3.0.8.
 
 For example, you could get the required dependencies (except Simbody) via:
 

--- a/README.md
+++ b/README.md
@@ -639,7 +639,6 @@ specific Ubuntu versions under 'For the impatient' below.
       `openjdk-6-jdk` or `openjdk-7-jdk`.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional):  Python >= 2.7 (including Python 3); `python-dev`.
     * **Python scripting** (optional): Python >= 2.7 (including Python 3); `python-dev`.
         * Note: Python 3 requires SWIG 3.0.8.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ On Windows using Visual Studio
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional): Python >= 2.7 (including Python 3)
+    * **Python scripting** (optional): Python 2 >= 2.7 or Python 3 >= 3.5
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
     * The choice between 32-bit/64-bit must be the same between Java, Python,
       and OpenSim.
@@ -455,7 +455,7 @@ ctest -j8
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional): Python >= 2.7 (including Python 3)
+    * **Python scripting** (optional): Python 2 >= 2.7 or Python 3 >= 3.5
         * Mac OSX comes with Python, but you could also use:
         * [`brew install python`](http://brew.sh),
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
@@ -637,7 +637,7 @@ specific Ubuntu versions under 'For the impatient' below.
       `openjdk-6-jdk` or `openjdk-7-jdk`.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional): Python >= 2.7 (including Python 3); `python-dev`.
+    * **Python scripting** (optional): Python 2 >= 2.7 or Python 3 >= 3.5; `python-dev`.
 
 For example, you could get the required dependencies (except Simbody) via:
 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ On Windows using Visual Studio
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional):
-        * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
+    * **Python scripting** (optional): Python >= 2.7 (including Python 3)
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
     * The choice between 32-bit/64-bit must be the same between Java, Python,
       and OpenSim.
@@ -306,7 +305,9 @@ On Windows using Visual Studio
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above. CMake sets `PYTHON_*` variables to tell you the
-      Python it will use for building the wrappers.
+      Python version used when building the wrappers.
+    * `OPENSIM_PYTHON_VERSION` to choose if the Python wrapping is built for
+      Python 2 or Python 3.
     * `BUILD_API_ONLY` if you don't want to build the command-line applications.
 8. Click the **Configure** button again. Then, click **Generate** to make
    Visual Studio project files in the build directory.
@@ -454,10 +455,9 @@ ctest -j8
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional):
+    * **Python scripting** (optional): Python >= 2.7 (including Python 3)
         * Mac OSX comes with Python, but you could also use:
         * [`brew install python`](http://brew.sh),
-        * [Enthought Canopy](https://www.enthought.com/products/canopy/), or
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
 
 You can get most of these dependencies using [Homebrew](http://brew.sh):
@@ -554,7 +554,9 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above. CMake sets `PYTHON_*` variables to tell you the
-      Python it will use for building the wrappers.
+      Python version used when building the wrappers.
+    * `OPENSIM_PYTHON_VERSION` to choose if the Python wrapping is built for
+      Python 2 or Python 3.
     * `BUILD_API_ONLY` if you don't want to build the command-line applications.
 8. Click the **Configure** button again. Then, click **Generate** to create
    Xcode project files in the build directory.
@@ -635,7 +637,7 @@ specific Ubuntu versions under 'For the impatient' below.
       `openjdk-6-jdk` or `openjdk-7-jdk`.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
-    * **Python scripting** (optional): `python-dev`.
+    * **Python scripting** (optional):  Python >= 2.7 (including Python 3); `python-dev`.
 
 For example, you could get the required dependencies (except Simbody) via:
 
@@ -754,6 +756,8 @@ And you could get all the optional dependencies via:
       Java; see dependencies above.
     * `BUILD_PYTHON_WRAPPING` if you want to access OpenSim through Python; see
       dependencies above.
+    * `OPENSIM_PYTHON_VERSION` to choose if the Python wrapping is built for
+      Python 2 or Python 3.
     * `BUILD_API_ONLY` if you don't want to build the command-line applications.
     * `OPENSIM_COPY_DEPENDENCIES` to decide if Simbody and BTK are copied into
       the OpenSim installation; you want this off if you're installing OpenSim

--- a/README.md
+++ b/README.md
@@ -192,13 +192,12 @@ On Windows using Visual Studio
     * [TortoiseGit](https://code.google.com/p/tortoisegit/wiki/Download),
       intermediate; good for TortoiseSVN users;
     * [GitHub for Windows](https://windows.github.com/), easiest.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
     * **Python scripting** (optional): Python >= 2.7 (including Python 3)
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
-        * Note: Python 3 requires SWIG 3.0.8.
     * The choice between 32-bit/64-bit must be the same between Java, Python,
       and OpenSim.
 
@@ -452,7 +451,7 @@ ctest -j8
 * **version control** (optional): git.
     * Xcode Command Line Tools gives you git on the command line.
     * [GitHub for Mac](https://mac.github.com), for a simple-to-use GUI.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
@@ -460,7 +459,6 @@ ctest -j8
         * Mac OSX comes with Python, but you could also use:
         * [`brew install python`](http://brew.sh),
         * [Anaconda](https://store.continuum.io/cshop/anaconda/)
-        * Note: Python 3 requires SWIG 3.0.8.
 
 You can get most of these dependencies using [Homebrew](http://brew.sh):
 
@@ -612,7 +610,7 @@ On Ubuntu using Unix Makefiles
 #### Get the dependencies
 
 Most dependencies can be obtained via the Ubuntu software repositories;
-especially if you are using Ubuntu 15.10 or later. On each line below, we show
+especially if you are using Ubuntu 16.04 or later. On each line below, we show
 the Ubuntu package names for the dependencies. You can find instructions for
 specific Ubuntu versions under 'For the impatient' below.
 
@@ -634,13 +632,12 @@ specific Ubuntu versions under 'For the impatient' below.
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6;
   `doxygen`.
 * **version control** (optional): git; `git`.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.6; must get from SWIG website.
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8; `swig`.
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7;
       `openjdk-6-jdk` or `openjdk-7-jdk`.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
     * **Python scripting** (optional): Python >= 2.7 (including Python 3); `python-dev`.
-        * Note: Python 3 requires SWIG 3.0.8.
 
 For example, you could get the required dependencies (except Simbody) via:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,9 @@ install:
 
   ## Use Chocolatey to install SWIG.
   # Only install swig if it isn't present (as a result of AppVeyor's caching).
-  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --version 3.0.8 --yes --limit-output #> $null
+  # SWIG 3.0.8 is the minimum required version, but it does not yet exist in
+  # Chocolatey.
+  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --version 3.0.9 --yes --limit-output #> $null
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
 
   ## Use Chocolatey to install SWIG.
   # Only install swig if it isn't present (as a result of AppVeyor's caching).
-  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --version 3.0.6 --yes --limit-output #> $null
+  - IF NOT EXIST C:\ProgramData\chocolatey\bin\swig.exe choco install swig --version 3.0.8 --yes --limit-output #> $null
   
   ## Install python-nose for python testing.
   - "%PYTHON_DIR%\\Scripts\\pip install nose"


### PR DESCRIPTION
Fixes #1113 

### Brief summary of changes

This PR allows the python bindings to be built for Python 3, and introduces a CMake option to let developers decide whether they want to build for Python 2 or Python 3 (it is very likely to have both on one's computer).

### Testing I've completed

Ran the python test cases.

### Looking for feedback on...

- Building for Python 3 requires a newer version of SWIG (3.0.8). Currently, I've set it up so that 3.0.6 is required in general, but 3.0.8 is required if building for Python 3. Is this too complicated? Should we just increase the required SWIG version to 3.0.8?
- Should we hold off on merging/reviewing this until after 4.0 is released?

### CHANGELOG.md (choose one)

- updated.
