### PR TITLE
Fix bug in scaleRotationalDofColumns.

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -1072,7 +1072,7 @@ void SimbodyEngine::scaleRotationalDofColumns(TimeSeriesTable& table,
             const Coordinate& coord = coordinateSet.get(index);
             if (coord.getMotionType() == Coordinate::Rotational) {
                 // assumes first data column is 0 whereas labels has time as 0
-                table.updDependentColumnAtIndex(i) *= SimTK_RADIAN_TO_DEGREE;
+                table.updDependentColumnAtIndex(i) *= factor;
             }
         }
     }
@@ -1114,6 +1114,16 @@ void SimbodyEngine::convertRadiansToDegrees(TimeSeriesTable& table) const {
     scaleRotationalDofColumns(table, SimTK_RADIAN_TO_DEGREE);
     table.removeTableMetaDataKey("inDegrees");
     table.addTableMetaData("inDegrees", std::string{"yes"});
+}
+
+void SimbodyEngine::convertDegreesToRadians(TimeSeriesTable& table) const {
+    OPENSIM_THROW_IF(table.getTableMetaData<std::string>("inDegrees") == "no",
+                     Exception,
+                     "Columns of the table provided are already in radians.");
+
+    scaleRotationalDofColumns(table, SimTK_DEGREE_TO_RADIAN);
+    table.removeTableMetaDataKey("inDegrees");
+    table.addTableMetaData("inDegrees", std::string{"no"});
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h
@@ -146,6 +146,7 @@ public:
     void convertRadiansToDegrees(Storage &rStorage) const;
     void convertRadiansToDegrees(TimeSeriesTable& table) const;
     void convertDegreesToRadians(Storage &rStorage) const;
+    void convertDegreesToRadians(TimeSeriesTable& table) const;
     void convertDegreesToRadians(double *aQDeg, double *rQRad) const;
     void convertRadiansToDegrees(double *aQRad, double *rQDeg) const;
 


### PR DESCRIPTION
Create SimbodyEngine::convertDegreesToRadians(TimeSeriesTable&)

Fixes #1727 .

### Brief summary of changes
- Introduces `convertDegreesToRadians()` for `TimeSeriesTable`.
- No longer ignore the `factor` parameter to `scaleRotationalDofColumns()`.

### Testing I've completed

- Tested locally with the direct collocation code base.

### CHANGELOG.md (choose one)

- no need to update because...this is a fairly minor change, and the bug did not exist in 3.x.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
