### PR TITLE
Fix crash of AbstractTools when XML has empty <model_file>

### DIFF
--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -300,7 +300,7 @@ void testRunTool() {
             "Printing 'testruntool_cmc_setup.xml'.\n");
     // This fails because this setup file doesn't have much in it.
     testCommand("run-tool testruntool_cmc_setup.xml", EXIT_FAILURE,
-            std::regex(RE_ANY + "(ERROR- A model has not been set.)" + RE_ANY));
+            std::regex(RE_ANY + "(No model file was specified)" + RE_ANY));
     // Similar to the previous two commands, except for scaling
     // (since ScaleTool goes through a different branch of the code).
     testCommand("print-xml scale testruntool_scale_setup.xml", EXIT_SUCCESS,

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -232,6 +232,8 @@ OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" opensim)
 # Test files. If you require more test resource files, list them here.
 foreach(test_file
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/storage.sto"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/gait2392_setup_forward_empty_model.xml"
+        "${CMAKE_CURRENT_SOURCE_DIR}/tests/gait2392_cmc_actuators_empty_model.xml"
         "${OPENSIM_SHARED_TEST_FILES_DIR}/arm26.osim"
         "${OPENSIM_SHARED_TEST_FILES_DIR}/gait10dof18musc_subject01.osim"
         "${CMAKE_SOURCE_DIR}/OpenSim/Sandbox/futureOrientationInverseKinematics.trc"

--- a/Bindings/Python/tests/gait2392_cmc_actuators_empty_model.xml
+++ b/Bindings/Python/tests/gait2392_cmc_actuators_empty_model.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSimDocument Version="20302">
+	<ForceSet name="gait2392_CMC">
+	<objects>
+			<PointActuator name="FX">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<body> pelvis </body>
+				<point>      -0.07243760       0.00000000       0.00000000 </point>
+				<point_is_global> false </point_is_global>
+				<direction>       1.00000000      -0.00000000      -0.00000000 </direction>
+				<force_is_global> true </force_is_global>
+			<optimal_force> 100.00000000 </optimal_force>
+			</PointActuator>
+			<PointActuator name="FY">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<body> pelvis </body>
+				<point>      -0.07243760       0.00000000       0.00000000 </point>
+				<point_is_global> false </point_is_global>
+				<direction>      -0.00000000       1.00000000      -0.00000000 </direction>
+				<force_is_global> true </force_is_global>
+			<optimal_force> 200.00000000 </optimal_force>
+			</PointActuator>
+			<PointActuator name="FZ">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<body> pelvis </body>
+				<point>      -0.07243760       0.00000000       0.00000000 </point>
+				<point_is_global> false </point_is_global>
+				<direction>      -0.00000000      -0.00000000       1.00000000 </direction>
+				<force_is_global> true </force_is_global>
+			<optimal_force> 100.00000000 </optimal_force>
+			</PointActuator>
+			<TorqueActuator name="MX">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<bodyA> pelvis </bodyA>
+				<bodyB> ground </bodyB>
+				<torque_is_global> true </torque_is_global>
+				<axis>       1.00000000      -0.00000000      -0.00000000 </axis>
+			<optimal_force> 80.00000000 </optimal_force>
+			</TorqueActuator>
+			<TorqueActuator name="MY">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<bodyA> pelvis </bodyA>
+				<bodyB> ground </bodyB>
+				<torque_is_global> true </torque_is_global>
+				<axis>      -0.00000000       1.00000000      -0.00000000 </axis>
+			<optimal_force> 80.00000000 </optimal_force>
+			</TorqueActuator>
+			<TorqueActuator name="MZ">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+				<bodyA> pelvis </bodyA>
+				<bodyB> ground </bodyB>
+				<torque_is_global> true </torque_is_global>
+				<axis>      -0.00000000      -0.00000000       1.00000000 </axis>
+			<optimal_force> 80.00000000 </optimal_force>
+			</TorqueActuator>
+			<CoordinateActuator name="hip_flexion_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_flexion_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_adduction_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_adduction_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_rotation_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_rotation_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="knee_angle_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> knee_angle_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="ankle_angle_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> ankle_angle_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="subtalar_angle_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> subtalar_angle_r </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="mtp_angle_r_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> mtp_angle_r </coordinate>
+				<optimal_force>     100.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_flexion_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_flexion_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_adduction_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_adduction_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="hip_rotation_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> hip_rotation_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="knee_angle_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> knee_angle_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="ankle_angle_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> ankle_angle_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="subtalar_angle_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> subtalar_angle_l </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="mtp_angle_l_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> mtp_angle_l </coordinate>
+				<optimal_force>     100.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="lumbar_extension_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> lumbar_extension </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="lumbar_bending_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> lumbar_bending </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+			<CoordinateActuator name="lumbar_rotation_reserve">
+				<isDisabled> false </isDisabled>
+				<!--Minimum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<min_control> -infinity </min_control>
+				<!--Maximum allowed value for control signal. Used primarily when solving
+				    for control values-->
+				<max_control> infinity </max_control>
+			<coordinate> lumbar_rotation </coordinate>
+				<optimal_force>       1.00000000 </optimal_force>
+			</CoordinateActuator>
+	</objects>
+		<groups/>
+	</ForceSet>
+</OpenSimDocument>
+

--- a/Bindings/Python/tests/gait2392_setup_forward_empty_model.xml
+++ b/Bindings/Python/tests/gait2392_setup_forward_empty_model.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSimDocument Version="20302">
+	<ForwardTool name="subject01_walk1">
+	<!--Name of the .osim file used to construct a model.-->
+	<model_file></model_file>
+		<!--Replace the model's force set with sets specified in
+		    <force_set_files>? If false, the force set is appended to.-->
+		<replace_force_set> false </replace_force_set>
+		<!--List of xml files used to construct an force set for the model.-->
+		<force_set_files> gait2392_cmc_actuators_empty_model.xml </force_set_files>
+	<!--Directory used for writing results.-->
+	<results_directory> ResultsForward </results_directory>
+		<!--Output precision.  It is 20 by default.-->
+	<output_precision> 20 </output_precision>
+	<!--Initial time for the simulation.-->
+		<initial_time>       0.80000000 </initial_time>
+	<!--Final time for the simulation.-->
+		<final_time>       1.18000000 </final_time>
+		<!--Flag indicating whether or not to compute equilibrium values for
+		    states other than the coordinates or speeds.  For example, equilibrium
+		    muscle fiber lengths or muscle forces.-->
+		<solve_for_equilibrium_for_auxiliary_states> false </solve_for_equilibrium_for_auxiliary_states>
+	<!--Maximum number of integrator steps.-->
+	<maximum_number_of_integrator_steps> 30000 </maximum_number_of_integrator_steps>
+	<!--Maximum integration step size.-->
+		<maximum_integrator_step_size>       1.00000000 </maximum_integrator_step_size>
+		<!--Minimum integration step size.-->
+		<minimum_integrator_step_size>       0.00000100 </minimum_integrator_step_size>
+	<!--Integrator error tolerance. When the error is greater, the integrator
+	    step size is decreased.-->
+		<integrator_error_tolerance>       0.00005000 </integrator_error_tolerance>
+	<!--Set of analyses to be run during the investigation.-->
+	<AnalysisSet name="Analyses">
+		<objects>
+			<Kinematics name="Kinematics">
+				<!--Flag (true or false) specifying whether whether on. True by default.-->
+				<on> true </on>
+					<!--Start time.-->
+					<start_time>       0.80000000 </start_time>
+					<!--End time.-->
+					<end_time>       1.18000000 </end_time>
+				<!--Specifies how often to store results during a simulation. More
+				    specifically, the interval (a positive integer) specifies how many
+				    successful integration steps should be taken before results are
+				    recorded again.-->
+				<step_interval> 10 </step_interval>
+				<!--Flag (true or false) indicating whether the results are in degrees or
+				    not.-->
+				<in_degrees> true </in_degrees>
+					<!--Names of generalized coordinates to record kinematics for.  Use 'all'
+					    to record all coordinates.-->
+					<coordinates> all </coordinates>
+			</Kinematics>
+			<Actuation name="Actuation">
+				<!--Flag (true or false) specifying whether whether on. True by default.-->
+				<on> true </on>
+					<!--Start time.-->
+					<start_time>       0.80000000 </start_time>
+					<!--End time.-->
+					<end_time>       1.18000000 </end_time>
+				<!--Specifies how often to store results during a simulation. More
+				    specifically, the interval (a positive integer) specifies how many
+				    successful integration steps should be taken before results are
+				    recorded again.-->
+				<step_interval> 10 </step_interval>
+				<!--Flag (true or false) indicating whether the results are in degrees or
+				    not.-->
+				<in_degrees> true </in_degrees>
+			</Actuation>
+			<BodyKinematics name="BodyKinematics">
+				<!--Flag (true or false) specifying whether whether on. True by default.-->
+				<on> true </on>
+					<!--Start time.-->
+					<start_time>       0.80000000 </start_time>
+					<!--End time.-->
+					<end_time>       1.18000000 </end_time>
+				<!--Specifies how often to store results during a simulation. More
+				    specifically, the interval (a positive integer) specifies how many
+				    successful integration steps should be taken before results are
+				    recorded again.-->
+				<step_interval> 10 </step_interval>
+				<!--Flag (true or false) indicating whether the results are in degrees or
+				    not.-->
+				<in_degrees> true </in_degrees>
+					<!--Names of bodies to record kinematics for.  Use 'all' to record all
+					    bodies.  The special name 'center_of_mass' refers to the combined
+					    center of mass.-->
+					<bodies> all </bodies>
+					<!--Flag (true or false) indicating whether to express results in the
+					    global frame or local-frames of the bodies. Body positions and center
+					    of mass results are always given in the global frame. This flag is set
+					    to false by default.-->
+					<express_results_in_body_local_frame> false </express_results_in_body_local_frame>
+			</BodyKinematics>
+			<MuscleAnalysis name="MuscleAnalysis">
+					<!--Flag (true or false) specifying whether whether on. True by default.-->
+				<on> false </on>
+					<!--Start time.-->
+					<start_time> -infinity </start_time>
+					<!--End time.-->
+					<end_time> infinity </end_time>
+					<!--Specifies how often to store results during a simulation. More
+					    specifically, the interval (a positive integer) specifies how many
+					    successful integration steps should be taken before results are
+					    recorded again.-->
+				<step_interval> 1 </step_interval>
+					<!--Flag (true or false) indicating whether the results are in degrees or
+					    not.-->
+				<in_degrees> true </in_degrees>
+					<!--List of muscles for which to perform the analysis. Use 'all' to
+					    perform the analysis for all muscles.-->
+				<muscle_list> med_gas_r lat_gas_r soleus_r </muscle_list>
+					<!--List of generalized coordinates for which to compute moment arms. Use
+					    'all' to compute for all coordinates.-->
+				<moment_arm_coordinate_list> hip_flexion_r knee_angle_r ankle_angle_r </moment_arm_coordinate_list>
+					<!--Flag indicating whether moments should be computed.-->
+					<compute_moments> false </compute_moments>
+			</MuscleAnalysis>
+		</objects>
+			<groups/>
+	</AnalysisSet>
+		<!--Controller objects in the model.-->
+		<ControllerSet name="Controllers">
+			<objects>
+				<ControlSetController name="">
+					<!--A list of actuators that this controller will control.The keyword ALL
+					    indicates the controller will controll all the acuators in the model-->
+					<actuator_list> </actuator_list>
+					<!--Flag (true or false) indicating whether or not the controller is
+					    disabled.-->
+					<isDisabled> false </isDisabled>
+					<!--XML file containing the controls for the controlSet.-->
+	<controls_file> ResultsCMC/subject01_walk1_controls.xml </controls_file>
+				</ControlSetController>
+				<CorrectionController name="">
+					<!--A list of actuators that this controller will control.The keyword ALL
+					    indicates the controller will controll all the acuators in the model-->
+					<actuator_list> </actuator_list>
+					<!--Flag (true or false) indicating whether or not the controller is
+					    disabled.-->
+					<isDisabled> false </isDisabled>
+					<!--Gain for position errors-->
+					<kp>      16.00000000 </kp>
+					<!--Gain for velocity errors-->
+					<kv>       8.00000000 </kv>
+				</CorrectionController>
+			</objects>
+			<groups/>
+		</ControllerSet>
+		<!--XML file (.xml) containing the forces applied to the model as
+		    ExternalLoads.-->
+		<external_loads_file> subject01_walk1_grf.xml </external_loads_file>
+	<!--Storage file (.sto) containing the initial states for the forward
+	    simulation. This file often contains multiple rows of data, each row
+	    being a time-stamped array of states. The first column contains the
+	    time.  The rest of the columns contain the states in the order
+	    appropriate for the model. In a storage file, unlike a motion file
+	    (.mot), non-uniform time spacing is allowed.  If the user-specified
+	    initial time for a simulation does not correspond exactly to one of
+	    the time stamps in this file, inerpolation is NOT used because it is
+	    usually necessary to being a simulation from an exact set of states.
+		    Instead, the closest earlier set of states is used. Having a states
+		    file that contains the entire trajectory of a simulations allows for
+		    corrective springs for perturbation analysis to be added.-->
+	<states_file> ResultsCMC/subject01_walk1_states.sto </states_file>
+	<!--Flag (true or false) indicating whether or not the integrator should
+	    use a particular time stepping.  If true, the time stepping is
+	    extracted from the initial states file.  In this situation, therefore,
+	    the initial states file must contain all the time steps in a
+	    simulation and be written out to high precision (usually 20 decimal
+	    places).  Setting this flag to true can be useful when reproducing a
+	    previous forward simulation with as little drift as possible.  If this
+	    flag is false, the integrator is left to determine its own time
+	    stepping.-->
+		<use_specified_dt> false </use_specified_dt>
+	</ForwardTool>
+</OpenSimDocument>
+

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -105,10 +105,9 @@ class TestBasics(unittest.TestCase):
                     'std_subject01_walk1_ik.mot')), [], 5, 0)
 
     def test_deserialize_tool_with_empty_model_file(self):
-        # Previously, there was a bug where loading an AbstractTool (e.g.,
-        # ForwardTool) setup file with an empty model_file but with some
-        # force_set_files would cause a segfault. Now, we make sure to throw an
-        # exception if trying to construct the tool with an empty model_file.
+        # Ensure an exception is thrown when loading an AbstractTool (e.g.,
+        # ForwardTool) setup file with an empty model_file. In particular, we
+        # want to check the case where force_set_files is not empty.
         with self.assertRaises(RuntimeError):
             rra = osim.ForwardTool(os.path.join(test_dir,
                 'gait2392_setup_forward_empty_model.xml'))

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -98,5 +98,26 @@ class TestBasics(unittest.TestCase):
         controller = osim.ToyReflexController()
         
     def test_GCVSplineSet(self):
-        splineset = osim.GCVSplineSet(os.path.join(test_dir, 'std_subject01_walk1_ik.mot'))
-        splineset = osim.GCVSplineSet(osim.TimeSeriesTable(os.path.join(test_dir, 'std_subject01_walk1_ik.mot')), [], 5, 0)
+        splineset = osim.GCVSplineSet(os.path.join(test_dir,
+            'std_subject01_walk1_ik.mot'))
+        splineset = osim.GCVSplineSet(
+                osim.TimeSeriesTable(os.path.join(test_dir,
+                    'std_subject01_walk1_ik.mot')), [], 5, 0)
+
+    def test_deserialize_tool_with_empty_model_file(self):
+        # Previously, there was a bug where loading an AbstractTool (e.g.,
+        # ForwardTool) setup file with an empty model_file but with some
+        # force_set_files would cause a segfault. Now, we make sure to throw an
+        # exception if trying to construct the tool with an empty model_file.
+        with self.assertRaises(RuntimeError):
+            rra = osim.ForwardTool(os.path.join(test_dir,
+                'gait2392_setup_forward_empty_model.xml'))
+
+        # No exception if we pass loadModel=False
+        rra = osim.ForwardTool(
+                os.path.join(test_dir,
+                    'gait2392_setup_forward_empty_model.xml'),
+                True, # updateFromXMLNode
+                False, # loadModel
+                )
+

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -108,10 +108,6 @@ AbstractTool::AbstractTool(const string &aFileName, bool aUpdateFromXMLNode):
     _analysisSet.setMemoryOwner(false);
     setNull();
     if(aUpdateFromXMLNode) updateFromXMLDocument();
-
-    if(_modelFile.empty())
-        throw Exception{"No model file (with tag <model_file>) specified in"
-                        " the xml."};
 }
 
 //_____________________________________________________________________________
@@ -386,28 +382,29 @@ getAnalysisSet() const
 void AbstractTool::
 loadModel(const string &aToolSetupFileName, ForceSet *rOriginalForceSet )
 {
-    if (_modelFile != "") {
-        string saveWorkingDirectory = IO::getCwd();
-        string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);
-        IO::chDir(directoryOfSetupFile);
+    OPENSIM_THROW_IF_FRMOBJ(_modelFile.empty(), Exception,
+            "No model file was specified (<model_file> tag is empty) in the "
+            "Tool's Setup file. Consider passing `false` for the constructor's "
+            "`aLoadModel` parameter");
+    string saveWorkingDirectory = IO::getCwd();
+    string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);
+    IO::chDir(directoryOfSetupFile);
 
-        cout<<"AbstractTool "<<getName()<<" loading model '"<<_modelFile<<"'"<<endl;
+    cout<<"AbstractTool "<<getName()<<" loading model '"<<_modelFile<<"'"<<endl;
 
-        Model *model = 0;
+    Model *model = 0;
 
-        try {
-            model = new Model(_modelFile);
-            model->finalizeFromProperties();
-            if (rOriginalForceSet!=NULL)
-                *rOriginalForceSet = model->getForceSet();
-        } catch(...) { // Properly restore current directory if an exception is thrown
-            IO::chDir(saveWorkingDirectory);
-            throw;
-        }
-        _model = model;
+    try {
+        model = new Model(_modelFile);
+        model->finalizeFromProperties();
+        if (rOriginalForceSet!=NULL)
+            *rOriginalForceSet = model->getForceSet();
+    } catch(...) { // Properly restore current directory if an exception is thrown
         IO::chDir(saveWorkingDirectory);
-
+        throw;
     }
+    _model = model;
+    IO::chDir(saveWorkingDirectory);
 }
 
 void AbstractTool::

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -383,9 +383,9 @@ void AbstractTool::
 loadModel(const string &aToolSetupFileName, ForceSet *rOriginalForceSet )
 {
     OPENSIM_THROW_IF_FRMOBJ(_modelFile.empty(), Exception,
-            "No model file was specified (<model_file> tag is empty) in the "
-            "Tool's Setup file. Consider passing `false` for the constructor's "
-            "`aLoadModel` parameter");
+            "No model file was specified (<model_file> element is empty) in "
+            "the Tool's Setup file. Consider passing `false` for the "
+            "constructor's `aLoadModel` parameter");
     string saveWorkingDirectory = IO::getCwd();
     string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);
     IO::chDir(directoryOfSetupFile);

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -313,7 +313,8 @@ public:
     * Load and construct a model based on the property settings of
     * this investigation.
     */
-    void loadModel(const std::string &aToolSetupFileName, ForceSet *rOriginalForceSet = 0 );
+    void loadModel(const std::string &aToolSetupFileName,
+            ForceSet *rOriginalForceSet = 0 ) SWIG_DECLARE_EXCEPTION;
     
     /**
     * Update the forces applied to a model.


### PR DESCRIPTION
Fixes #697. This PR is a redo of PR #793.

### Brief summary of changes

In general, the tools *do* throw exceptions if no model file is provided. However, you instead get a crash if you have specified `force_set_files` but no `model_file`. This PR causes the AbstractTools to throw an exception more generally if `model_file` is empty. The exception message tells users to use `aLoadModel=false` if they want to load a tool setup file that does not have a model file in it (which is a reasonable desire; for example, they may want to set the model programmatically in MATLAB).

### Testing I've completed

I reproduced the error with the gait2392 pipeline (as @jimmyDunne had done) and made a test out of these XML files.

### Looking for feedback on...

@aymanhab : is it necessary to add `SWIG_DECLARE_EXCEPTION` for `loadModel()`?

### CHANGELOG.md (choose one)

- no need to update because this was a minor bug.