### PR TITLE
AbstractTool: Do not check address from reference.

### DIFF
--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -462,7 +462,6 @@ addAnalysisSetToModel()
     int size = _analysisSet.getSize();
     _analysisCopies.setMemoryOwner(false);
     for(int i=0;i<size;i++) {
-        if(!&_analysisSet.get(i)) continue;
         Analysis *analysis = _analysisSet.get(i).clone();
         _model->addAnalysis(analysis);
         _analysisCopies.adoptAndAppend(analysis);
@@ -491,7 +490,6 @@ addControllerSetToModel()
     int size = _controllerSet.getSize();
     _controllerCopies.setMemoryOwner(false);
     for(int i=0;i<size;i++) {
-        if(!&_controllerSet.get(i)) continue;
         Controller *controller = _controllerSet.get(i).clone();
         _model->addController(controller);
         _controllerCopies.adoptAndAppend(controller);


### PR DESCRIPTION

### Brief summary of changes

Recent versions of clang generate the following warning:

![image](https://cloud.githubusercontent.com/assets/846001/26748471/e93a2f24-47b2-11e7-9e2b-e64847262d21.png)

To avoid the warning, I deleted the lines that tried to check the addresses for these references.

### Testing I've completed

I ran the test suite.

### Looking for feedback on...

Is it okay to remove these lines of code? Is there a reason to suspect the entries of the set could be null? If not, I can create a function on Set `bool isNull(int index)`.

### CHANGELOG.md (choose one)

- no need to update because this does not affect users.