### PR TITLE
Automatic invocation of Model::finalizeFromProperties 1693

### DIFF
--- a/Applications/Analyze/test/testInducedAccelerations.cpp
+++ b/Applications/Analyze/test/testInducedAccelerations.cpp
@@ -81,7 +81,6 @@ void testDoublePendulumWithSolver()
     statesStore.getDataForIdentifier("q", states);
 
     Model pendulum("double_pendulum.osim");
-    pendulum.finalizeFromProperties();
     
     PrescribedController* controller=
         new PrescribedController();

--- a/Applications/RRA/rra.cpp
+++ b/Applications/RRA/rra.cpp
@@ -126,14 +126,11 @@ int main(int argc,char **argv)
     cout<<"-----------------------------------------------------------------------\n";
     cout<<"Loaded library\n";
     cout<<"-----------------------------------------------------------------------\n";
-    model.finalizeFromProperties();
     model.printBasicInfo();
     cout<<"-----------------------------------------------------------------------\n\n";
 
-
     // RUN
     rra.run();
-
 
     //----------------------------
     // Catch any thrown exceptions

--- a/Bindings/Java/Matlab/tests/testAccessSubcomponents.m
+++ b/Bindings/Java/Matlab/tests/testAccessSubcomponents.m
@@ -2,7 +2,6 @@
 import org.opensim.modeling.*
 
 model = Model('arm26.osim');
-model.finalizeFromProperties();
 
 % Individual components
 % =====================

--- a/Bindings/Java/tests/TestBasics.java
+++ b/Bindings/Java/tests/TestBasics.java
@@ -3,7 +3,6 @@ import org.opensim.modeling.*;
 class TestBasics {
     public static void testBasics() {
         Model m = new Model();
-        m.finalizeFromProperties();
         m.print("empty_model.osim");
         Frame gnd = m.getGround();
         FrameList frames = m.getFrameList();

--- a/Bindings/Java/tests/TestIterators.java
+++ b/Bindings/Java/tests/TestIterators.java
@@ -3,7 +3,6 @@ import org.opensim.modeling.*;
 class TestIterators {
   public static void main(String[] args) {
     Model model = new Model();
-    model.finalizeFromProperties();
 
     // Iterate through 
     model.printSubcomponentInfo();

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -110,7 +110,6 @@ class TestReporter {
         
         String modelFileName = "double_pendulum_markers.osim";
         Model model = new Model(modelFileName);
-        model.finalizeFromProperties();
 
         ConsoleReporter consoleReporter = new ConsoleReporter();
         consoleReporter.set_report_time_interval(timeInterval);

--- a/Bindings/Python/tests/test_access_subcomponents.py
+++ b/Bindings/Python/tests/test_access_subcomponents.py
@@ -13,8 +13,6 @@ osim.Model.setDebugLevel(0)
 class TestAccessSubcomponents(unittest.TestCase):
     def test_individual_components(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-        model.finalizeFromProperties()
-        
         muscle = model.getComponent('BICshort')
         assert muscle.getName() == 'BICshort'
         # No downcasting necessary!
@@ -24,7 +22,6 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_list(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-        model.finalizeFromProperties()
 
         num_components = 0
         for comp in model.getComponentsList():
@@ -80,8 +77,6 @@ class TestAccessSubcomponents(unittest.TestCase):
 
     def test_component_filter(self):
         model = osim.Model(os.path.join(test_dir, "arm26.osim"))
-        model.finalizeFromProperties()
-
         comps = model.getMuscleList()
         comps.setFilter(osim.ComponentFilterAbsolutePathNameContainsString('BIC'))
         count = 0

--- a/Bindings/Python/tests/test_component_interface.py
+++ b/Bindings/Python/tests/test_component_interface.py
@@ -13,7 +13,6 @@ class TestComponentInterface(unittest.TestCase):
     def test_printComponentsMatching(self):
         model = osim.Model(os.path.join(test_dir,
             "gait10dof18musc_subject01.osim"))
-        model.finalizeFromProperties();
         num_matches = model.printComponentsMatching("_r")
         self.assertEquals(num_matches, 126)
     def test_attachGeometry_memory_management(self):

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -433,7 +433,6 @@ void testClutchedPathSpring()
     //Test deserialization
     delete model;
     model = new Model("ClutchedPathSpringModel.osim");
-    model->finalizeFromProperties();
 
     // Create the force reporter
     ForceReporter* reporter = new ForceReporter(model);

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -901,7 +901,6 @@ void testThelen2003Muscle()
         // Print model and read back in.
         myModel.print(filename);
         Model myModel2(filename);
-        myModel2.finalizeFromProperties();
 
         const Thelen2003Muscle& myMcl2 = dynamic_cast<const Thelen2003Muscle&>(
             myModel2.getMuscles().get("myMuscle") );

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -46,10 +46,12 @@ public:
         size_t line,
         const std::string& func,
         const Object& obj,
-        const std::string& propertyName) :
+        const std::string& propertyName,
+        const std::string& errorMsg = "") :
         Exception(file, line, func, obj) {
         std::string msg = "Property '" + propertyName;
         msg += "' has an invalid value.";
+        msg += (errorMsg.empty()) ? "\n" : ("\n(details: " + errorMsg + ").");
         addMessage(msg);
     }
 };

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -46,9 +46,9 @@ public:
         size_t line,
         const std::string& func,
         const Object& obj,
-        const std::string& propertName) :
+        const std::string& propertyName) :
         Exception(file, line, func, obj) {
-        std::string msg = "Property '" + propertName;
+        std::string msg = "Property '" + propertyName;
         msg += "' has an invalid value.";
         addMessage(msg);
     }

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -218,9 +218,6 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the hopper.
         auto hopper = buildHopper(showVisualizer);
-        // Update the hopper model's internal data members, which includes
-        // identifying its subcomponents from its properties.
-        hopper.finalizeFromProperties();
 
         // Show all Components in the model.
         hopper.printSubcomponentInfo();
@@ -255,7 +252,6 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the testbed and device.
         auto testbed = buildTestbed(showVisualizer);
-        testbed.finalizeFromProperties();
 
         // Step 2, Task A
         // ==============
@@ -271,7 +267,6 @@ void run(bool showVisualizer, bool simulateOnce)
         // ==============
         // Go to buildDeviceModel.cpp and complete the "TODO"s in buildDevice().
         auto device = buildDevice();
-        device->finalizeFromProperties();
 
         // Show all Components in the device and testbed.
         device->printSubcomponentInfo();
@@ -313,9 +308,7 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the hopper and device.
         auto assistedHopper = buildHopper(showVisualizer);
-        assistedHopper.finalizeFromProperties();
         auto kneeDevice = buildDevice();
-        kneeDevice->finalizeFromProperties();
 
         // Step 3, Task A
         // ==============

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -290,9 +290,6 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the hopper.
         auto hopper = buildHopper(showVisualizer);
-        // Update the hopper model's internal data members, which includes
-        // identifying its subcomponents from its properties.
-        hopper.finalizeFromProperties();
 
         // Show all Components in the model.
         hopper.printSubcomponentInfo();
@@ -327,7 +324,6 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the testbed and device.
         auto testbed = buildTestbed(showVisualizer);
-        testbed.finalizeFromProperties();
 
         // Step 2, Task A
         // ==============
@@ -343,7 +339,6 @@ void run(bool showVisualizer, bool simulateOnce)
         // ==============
         // Go to buildDeviceModel.cpp and complete the "TODO"s in buildDevice().
         auto device = buildDevice();
-        device->finalizeFromProperties();
 
         // Show all Components in the device and testbed.
         device->printSubcomponentInfo();
@@ -385,9 +380,7 @@ void run(bool showVisualizer, bool simulateOnce)
     {
         // Build the hopper and device.
         auto assistedHopper = buildHopper(showVisualizer);
-        assistedHopper.finalizeFromProperties();
         auto kneeDevice = buildDevice();
-        kneeDevice->finalizeFromProperties();
 
         // Step 3, Task A
         // ==============

--- a/OpenSim/Sandbox/TaskSpace/futureTaskSpace.cpp
+++ b/OpenSim/Sandbox/TaskSpace/futureTaskSpace.cpp
@@ -89,7 +89,6 @@ void switchMuscles(Model& model, State& state, bool appliesForce)
 void testTaskSpace()
 {
     Model model("futureTaskSpace.osim");
-    model.finalizeFromProperties();
 
     std::string indexBodyName = "hand_r";
     Vec3 indexOffset(0.05, -0.14, 0.011);

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -85,6 +85,7 @@ Model::Model() : ModelComponent(),
 {
     constructProperties();
     setNull();
+    finalizeFromProperties();
 }
 //_____________________________________________________________________________
 /*
@@ -102,6 +103,7 @@ Model::Model(const string &aFileName) :
     constructProperties();
     setNull();
     updateFromXMLDocument();
+    finalizeFromProperties();
 
     _fileName = aFileName;
     cout << "Loaded model " << getName() << " from file " << getInputFileName() << endl;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -103,17 +103,37 @@ Model::Model(const string &aFileName) :
     constructProperties();
     setNull();
     updateFromXMLDocument();
-    finalizeFromProperties();
 
     _fileName = aFileName;
     cout << "Loaded model " << getName() << " from file " << getInputFileName() << endl;
+
+    try {
+        finalizeFromProperties();
+    }
+    catch(const InvalidPropertyValue& err) {
+        std::cout << "WARNING: Model was unable to finalizeFromProperties "
+            "due to: " << err.what() <<
+            "\nUpdate the model file and reload OR update the property and call "
+            "finalizeFromProperties() on the model." << endl;
+    }
 }
 
 Model* Model::clone() const
 {
     // Invoke default copy constructor.
     Model* clone = new Model(*this);
-    clone->finalizeFromProperties();
+
+    try {
+        clone->finalizeFromProperties();
+    }
+    catch (const InvalidPropertyValue& err) {
+        std::cout << "WARNING: clone() was unable to finalizeFromProperties "
+            "due to: " << err.what() <<
+            "\nUpdate the model and call clone() again OR update the "
+            "clone's property and call finalizeFromProperties() on it."
+            << endl;
+    }
+
     return clone;
 }
 

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -72,7 +72,7 @@ using namespace SimTK;
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
 //_____________________________________________________________________________
-/**
+/*
  * Default constructor.
  */
 Model::Model() : ModelComponent(),
@@ -87,7 +87,7 @@ Model::Model() : ModelComponent(),
     setNull();
 }
 //_____________________________________________________________________________
-/**
+/*
  * Constructor from an XML file
  */
 Model::Model(const string &aFileName) :
@@ -107,8 +107,16 @@ Model::Model(const string &aFileName) :
     cout << "Loaded model " << getName() << " from file " << getInputFileName() << endl;
 }
 
+Model* Model::clone() const
+{
+    // Invoke default copy constructor.
+    Model* clone = new Model(*this);
+    clone->finalizeFromProperties();
+    return clone;
+}
+
 //_____________________________________________________________________________
-/**
+/*
  * Override default implementation by object to intercept and fix the XML node
  * underneath the model to match current version
  */

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -111,10 +111,10 @@ Model::Model(const string &aFileName) :
         finalizeFromProperties();
     }
     catch(const InvalidPropertyValue& err) {
-        cout << "WARNING: Model was unable to finalizeFromProperties "
-            "due to: " << err.what() <<
-            "\nUpdate the model file and reload OR update the property and call "
-            "finalizeFromProperties() on the model." << endl;
+        cout << "WARNING: Model was unable to finalizeFromProperties.\n" <<
+            "Update the model file and reload OR update the property and call "
+            "finalizeFromProperties() on the model.\n" <<
+            "(details: " << err.what() << ")." << endl;
     }
 }
 
@@ -127,11 +127,10 @@ Model* Model::clone() const
         clone->finalizeFromProperties();
     }
     catch (const InvalidPropertyValue& err) {
-        cout << "WARNING: clone() was unable to finalizeFromProperties "
-            "due to: " << err.what() <<
-            "\nUpdate the model and call clone() again OR update the "
-            "clone's property and call finalizeFromProperties() on it."
-            << endl;
+        cout << "WARNING: clone() was unable to finalizeFromProperties.\n" <<
+            "Update the model and call clone() again OR update the clone's "
+            "property and call finalizeFromProperties() on it.\n"
+            "(details: " << err.what() << ")." << endl;
     }
 
     return clone;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -111,7 +111,7 @@ Model::Model(const string &aFileName) :
         finalizeFromProperties();
     }
     catch(const InvalidPropertyValue& err) {
-        std::cout << "WARNING: Model was unable to finalizeFromProperties "
+        cout << "WARNING: Model was unable to finalizeFromProperties "
             "due to: " << err.what() <<
             "\nUpdate the model file and reload OR update the property and call "
             "finalizeFromProperties() on the model." << endl;
@@ -127,7 +127,7 @@ Model* Model::clone() const
         clone->finalizeFromProperties();
     }
     catch (const InvalidPropertyValue& err) {
-        std::cout << "WARNING: clone() was unable to finalizeFromProperties "
+        cout << "WARNING: clone() was unable to finalizeFromProperties "
             "due to: " << err.what() <<
             "\nUpdate the model and call clone() again OR update the "
             "clone's property and call finalizeFromProperties() on it."

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -129,6 +129,11 @@ method, in which case it will allocate and maintain a ModelVisualizer.
 **/
 
 class OSIMSIMULATION_API Model  : public ModelComponent {
+// Note, a concrete object typically employs the OpenSim_DECLARE_CONCRETE_OBJECT
+// macro, but, for Model we do not want its clone() method to be auto-generated.
+// Instead, we want to override and customize it and so we employ the subset of
+// macros that OpenSim_DECLARE_CONCRETE_OBJECT calls, excluding one that
+// implements clone() and getConcreteClassName(), which are implemented below.
 OpenSim_OBJECT_ANY_DEFS(Model, ModelComponent);
 OpenSim_OBJECT_NONTEMPLATE_DEFS(Model, ModelComponent);
 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -256,8 +256,8 @@ public:
      */
     void cleanup();
 
-    /** Model clone() override that invokes finalizeFromProperties 
-        on defualt copy constructed Model */
+    /** Model clone() override that invokes finalizeFromProperties() 
+        on a default copy constructed Model, prior to returning the Model. */
     Model* clone() const override;
     
     const std::string& getConcreteClassName() const override

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -129,7 +129,9 @@ method, in which case it will allocate and maintain a ModelVisualizer.
 **/
 
 class OSIMSIMULATION_API Model  : public ModelComponent {
-OpenSim_DECLARE_CONCRETE_OBJECT(Model, ModelComponent);
+OpenSim_OBJECT_ANY_DEFS(Model, ModelComponent);
+OpenSim_OBJECT_NONTEMPLATE_DEFS(Model, ModelComponent);
+
 public:
 //==============================================================================
 // PROPERTIES
@@ -254,6 +256,12 @@ public:
      */
     void cleanup();
 
+    /** Model clone() override that invokes finalizeFromProperties 
+        on defualt copy constructed Model */
+    Model* clone() const override;
+    
+    const std::string& getConcreteClassName() const override
+    {   return getClassName(); }
 
     //--------------------------------------------------------------------------
     // VISUALIZATION

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -1009,8 +1009,6 @@ void testRollingOnSurfaceConstraint()
     arrowGeom.setColor(Vec3(1, 0, 0));
     ground.attachGeometry(arrowGeom.clone());
 
-    osimModel->finalizeFromProperties();
-
     //OpenSim rod
     auto osim_rod = new OpenSim::Body("rod", mass, comInRod, inertiaAboutCom);
     OpenSim::PhysicalOffsetFrame* cylFrame = new PhysicalOffsetFrame(*osim_rod, Transform(comInRod));

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1941,8 +1941,6 @@ void testEquivalentBodyForceFromGeneralizedForce()
     LoadOpenSimLibrary("osimActuators");
 
     Model gaitModel("testJointConstraints.osim");
-    gaitModel.finalizeFromProperties();
-    gaitModel.print("testJointConstraints.osim_30503.osim");
 
     testEquivalentBodyForceForGenForces(gaitModel);
     

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -609,7 +609,6 @@ void testBushingForce()
     osimModel.print("BushingForceModel.osim");
 
     Model previousVersionModel("BushingForceModel_30000.osim");
-    previousVersionModel.finalizeFromProperties();
     previousVersionModel.print("BushingForceModel_30000_in_Latest.osim");
 
     const BushingForce& bushingForceFromPrevious =
@@ -1222,7 +1221,6 @@ void testCoordinateLimitForce()
 
     // Check serialization and deserialization
     Model loadedModel{"CoordinateLimitForceTest.osim"};
-    loadedModel.finalizeFromProperties();
 
     ASSERT(loadedModel == *osimModel,
         "Deserialized CoordinateLimitForceTest failed to be equivalent to original.");

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -172,7 +172,6 @@ void testPhysicalOffsetFrameOnBody()
 
     cout << "\nRunning testOffsetFrameOnBody" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
-    pendulum->finalizeFromProperties();
 
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
 
@@ -248,7 +247,6 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrame()
 
     cout << "\nRunning testPhysicalOffsetFrameOnPhysicalOffsetFrame" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
-    pendulum->finalizeFromProperties();
 
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
     
@@ -263,10 +261,6 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrame()
 
     //connect a second frame to the first PhysicalOffsetFrame 
     PhysicalOffsetFrame* secondFrame = offsetFrame->clone();
-    // Hack since clone does not copy internal ownership (parent) references
-    // TODO: should be removed when Component cloning preserves ownership
-    // relationships.
-    secondFrame->finalizeFromProperties();
 
     secondFrame->setName("second");
     secondFrame->setParentFrame(*offsetFrame);
@@ -318,7 +312,6 @@ void testPhysicalOffsetFrameOnBodySerialize()
 
     cout << "\nRunning testPhysicalOffsetFrameOnBodySerialize" << endl;
     Model* pendulum = new Model("double_pendulum.osim");
-    pendulum->finalizeFromProperties();
 
     const OpenSim::Body& rod1 = pendulum->getBodySet().get("rod1");
 
@@ -364,7 +357,6 @@ void testPhysicalOffsetFrameOnPhysicalOffsetFrameOrder()
     // PhysicalOffsetFrames occur in the order of the Multibody tree instead of
     // the order in Model's property list, which can be arbitrary.
     Model pendulum("double_pendulum.osim");
-    pendulum.finalizeFromProperties();
 
     SimTK::Transform X_RO;
     X_RO.setP(SimTK::Vec3(0.1, 0.2, 0.3));
@@ -430,7 +422,6 @@ void testFilterByFrameType()
     cout << "\nRunning testFilterByFrameType" << endl;
     // Previous model with a PhysicalOffsetFrame attached to rod1
     Model* pendulumWFrame = new Model("double_pendulum_extraFrame.osim");
-    pendulumWFrame->finalizeFromProperties();
 
     // Create an ordinary (non-physical) OffsetFrame attached to rod2
     const OpenSim::Body& rod2 = pendulumWFrame->getBodySet().get("rod2");

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -156,7 +156,6 @@ void testMemoryUsage(const string& modelFile)
     // Estimate the size of the model when loaded into memory
     auto creator = [modelFile]() { 
         Model* model = new Model(modelFile);
-        model->finalizeFromProperties();
         return model;
     };
 

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -507,7 +507,6 @@ generateMarkerDataFromModelAndStates(const Model& model,
     std::normal_distribution<double> noise(0.0, 1);
 
     unique_ptr<Model> m{ model.clone() };
-    m->finalizeFromProperties();
     
     auto* markerReporter = new TableReporterVec3();
     

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -36,7 +36,8 @@ int main() {
     try {
         Model model("arm26.osim");
 
-        // all subcomponents are now accounted for.
+        // all subcomponents are accounted for since Model constructor invokes
+        // finalizeFromProperties().
         ASSERT(model.countNumComponents() > 0);
 
         // model must be up-to-date with its properties

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -35,14 +35,6 @@ int main() {
 
     try {
         Model model("arm26.osim");
-        // finalizeFromProperties() is required to build internal ownership tree
-        // attempt to access the ComponentList will throw that the model (root)
-        // has no subcomponents
-        ASSERT_THROW(ComponentIsRootWithNoSubcomponents, 
-            model.countNumComponents());
-
-        // finalize internal data structures from its properties
-        model.finalizeFromProperties();
 
         // all subcomponents are now accounted for.
         ASSERT(model.countNumComponents() > 0);

--- a/OpenSim/Simulation/Test/testNestedModelComponents.cpp
+++ b/OpenSim/Simulation/Test/testNestedModelComponents.cpp
@@ -64,7 +64,6 @@ void testPendulumModelWithNestedJoints()
 
     // Load the pendulum model
     Model* pendulum = new Model("double_pendulum.osim");
-    pendulum->finalizeFromProperties();
     
     // Create a new empty device;
     C* device = new C();

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -55,7 +55,6 @@ Real getStorageEntry(const Storage& sto,
 
 void testPopulateTrajectoryAndStatesTrajectoryReporter() {
     Model model("gait2354_simbody.osim");
-    model.finalizeFromProperties();
 
     // To assist with creating interesting (non-zero) coordinate values:
     model.updCoordinateSet().get("pelvis_ty").setDefaultLocked(true);
@@ -142,7 +141,6 @@ void testFrontBack() {
 void createStateStorageFile() {
 
     Model model("gait2354_simbody.osim");
-    model.finalizeFromProperties();
 
     // To assist with creating interesting (non-zero) coordinate values:
     model.updCoordinateSet().get("pelvis_ty").setDefaultLocked(true);

--- a/OpenSim/Simulation/Wrap/WrapCylinder.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinder.cpp
@@ -125,7 +125,7 @@ void WrapCylinder::extendFinalizeFromProperties()
     {
         string errorMessage = "Error: radius for WrapCylinder " + getName() +
             " was either not specified, or is negative.";
-        throw Exception(errorMessage);
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
     }
 }
 

--- a/OpenSim/Simulation/Wrap/WrapCylinder.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinder.cpp
@@ -123,9 +123,10 @@ void WrapCylinder::extendFinalizeFromProperties()
     // maybe set a parent pointer, _body = aBody;
     if (get_radius() < 0.0)
     {
-        string errorMessage = "Error: radius for WrapCylinder " + getName() +
-            " was either not specified, or is negative.";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
+        string errorMessage = getProperty_radius().getName()
+            + " is not specified or is negative.";
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue,
+            getProperty_radius().getName(), errorMessage);
     }
 }
 

--- a/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
@@ -140,9 +140,10 @@ void WrapCylinderObst::connectToModelAndBody(Model& aModel, PhysicalFrame& aBody
     // maybe set a parent pointer, _body = aBody;
     if (_radius < 0.0)
     {
-        string errorMessage = "Error: radius for WrapCylinderObst " + getName()
-            + " was either not specified, or is negative.";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
+        string errorMessage = _radiusProp.getName() +
+            " was either not specified, or is negative.";
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, _radiusProp.getName(),
+                             errorMessage);
     }
 /*
     Cylinder* cyl = new Cylinder(_radius, _length);
@@ -157,8 +158,11 @@ void WrapCylinderObst::connectToModelAndBody(Model& aModel, PhysicalFrame& aBody
     if (_wrapDirectionName == "Unassigned")  // wrapDirection was not specified in obstacle object definition; use default
         { _wrapDirection = righthand;   _wrapDirectionName = "righthand";   }
     else {  // wrapDirection was specified incorrectly in obstacle object definition; throw an exception
-        string errorMessage = "Error: wrapDirection for wrap obstacle " + getName() + " was specified incorrectly.  Use \"righthand\" or \"lefthand\".";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
+        string errorMessage = "wrapDirection was specified incorrectly. "
+                                "Use \"righthand\" or \"lefthand\".";
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue,
+                            _wrapDirectionNameProp.getName(),
+                            errorMessage);
     }
 
 }

--- a/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
@@ -140,8 +140,9 @@ void WrapCylinderObst::connectToModelAndBody(Model& aModel, PhysicalFrame& aBody
     // maybe set a parent pointer, _body = aBody;
     if (_radius < 0.0)
     {
-        string errorMessage = "Error: radius for WrapCylinderObst " + getName() + " was either not specified, or is negative.";
-        throw Exception(errorMessage);
+        string errorMessage = "Error: radius for WrapCylinderObst " + getName()
+            + " was either not specified, or is negative.";
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
     }
 /*
     Cylinder* cyl = new Cylinder(_radius, _length);
@@ -157,7 +158,7 @@ void WrapCylinderObst::connectToModelAndBody(Model& aModel, PhysicalFrame& aBody
         { _wrapDirection = righthand;   _wrapDirectionName = "righthand";   }
     else {  // wrapDirection was specified incorrectly in obstacle object definition; throw an exception
         string errorMessage = "Error: wrapDirection for wrap obstacle " + getName() + " was specified incorrectly.  Use \"righthand\" or \"lefthand\".";
-        throw Exception(errorMessage);
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
     }
 
 }

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -135,9 +135,7 @@ void WrapObject::extendFinalizeFromProperties()
         _wrapSign = 0;
     } else {
         // quadrant was specified incorrectly in wrap object definition; 
-        string errorMessage = "Error: quadrant '" + _quadrantName + "' for wrap object "
-            + getName() + " was specified incorrectly.";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, getProperty_quadrant().getName());
     }
 }
 

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -137,7 +137,7 @@ void WrapObject::extendFinalizeFromProperties()
         // quadrant was specified incorrectly in wrap object definition; 
         string errorMessage = "Error: quadrant '" + _quadrantName + "' for wrap object "
             + getName() + " was specified incorrectly.";
-        throw Exception(errorMessage);
+        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, errorMessage);
     }
 }
 

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -903,7 +903,6 @@ void testWrapObjectUpdateFromXMLNode30515() {
     // updated.
     SimTK_TEST(doc.getDocumentVersion() == 20302);
     Model model("testWrapObject_updateFromXMLNode30515.osim");
-    model.finalizeFromProperties();
     model.print("testWrapObject_updateFromXMLNode30515_updated.osim");
     const auto& wrapObjSet = model.getGround().getWrapObjectSet();
 

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -128,11 +128,6 @@ void testNestedComponentListConsistency() {
 void testComponentListConst() {
 
     Model model(modelFilename);
-
-    ASSERT_THROW( ComponentIsRootWithNoSubcomponents,
-                    model.getComponentList());
-
-    model.finalizeFromProperties();
     model.printSubcomponentInfo();
 
     ComponentList<const Component> componentsList = model.getComponentList();

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -95,7 +95,6 @@ void testNestedComponentListConsistency() {
     device->addComponent(elbow);
 
     model.addModelComponent(device);
-    model.finalizeFromProperties();
 
     std::vector<const Joint*> joints1{}, joints2{};
     std::set<const Coordinate*> coords{};
@@ -270,7 +269,6 @@ void testComponentListConst() {
 // components.
 void testComponentListNonConstWithConstIterator() {
     Model model(modelFilename);
-    model.finalizeFromProperties();
 
     // Making this a const ComponentList causes us to use the const
     // begin()/end() methods, which return const_iterators, and thus avoids
@@ -403,7 +401,6 @@ void testComponentListNonConstWithConstIterator() {
 // allow modifying the elements of the list.
 void testComponentListNonConstWithNonConstIterator() {
     Model model(modelFilename);
-    model.finalizeFromProperties();
 
     ComponentList<Component> componentsList = model.updComponentList();
     int numComponents = 0;
@@ -504,7 +501,6 @@ void testComponentListNonConstWithNonConstIterator() {
 // Ensure that we can compare const_iterator and (non-const) iterator.
 void testComponentListComparisonOperators() {
     Model model(modelFilename);
-    model.finalizeFromProperties();
 
     ComponentList<Body> list = model.updComponentList<Body>();
     ComponentList<Body>::const_iterator constIt = list.cbegin();

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -262,7 +262,6 @@ bool InverseKinematicsTool::run()
         else
             modelFromFile = false;
 
-        _model->finalizeFromProperties();
         _model->printBasicInfo();
 
         // Do the maneuver to change then restore working directory 

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -219,11 +219,10 @@ void testPrescribedControllerOnBlock(bool enabled)
     osimModel.addController(&actuatorController);
     
     osimModel.print("blockWithPrescribedController.osim");
-    Model modelfileFromFile("blockWithPrescribedController.osim");
-    modelfileFromFile.finalizeFromProperties();
+    Model modelFromFile("blockWithPrescribedController.osim");
 
     // Verify that serialization and then deserialization is correct
-    ASSERT(osimModel == modelfileFromFile);
+    ASSERT(osimModel == modelFromFile);
 
     // Initialize the system and get the state representing the state system
     SimTK::State& si = osimModel.initSystem();

--- a/OpenSim/Tools/Test/testModelCopy.cpp
+++ b/OpenSim/Tools/Test/testModelCopy.cpp
@@ -82,8 +82,6 @@ int main()
         armAssigned = arm;
         ASSERT(armAssigned == arm);
 
-        arm.finalizeFromProperties();
-
         LoadOpenSimLibrary("osimActuators");
         testCopyModel("arm26.osim", 2, "ground", 6);
         testCopyModel("Neck3dof_point_constraint.osim", 25, "spine", 1);
@@ -103,7 +101,6 @@ void testCopyModel(const string& fileName, const int nbod,
 
     // Automatically finalizes properties by default when loading from file
     Model* model = new Model(fileName);
-    model->finalizeFromProperties();
 
     // Catch a possible decrease in the memory footprint, which will cause
     // size_t (unsigned int) to wrap through zero.
@@ -137,7 +134,7 @@ void testCopyModel(const string& fileName, const int nbod,
 
     //  Now delete original model and make sure copy can stand
     Model *cloneModel = modelCopy->clone();
-    cloneModel->finalizeFromProperties();
+
     ASSERT(*model == *cloneModel);
     ASSERT(model->getActuators().getSize() ==
            cloneModel->getActuators().getSize());
@@ -154,7 +151,7 @@ void testCopyModel(const string& fileName, const int nbod,
     modelCopy->finalizeFromProperties();
 
     Model* modelSerialized = new Model(latestFile);
-    modelSerialized->finalizeFromProperties();
+
     ASSERT(*modelSerialized == *modelCopy);
 
     int nb = modelSerialized->getNumBodies();

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -85,7 +85,7 @@ int main()
             } //Ignore the validity of the property values
             // TODO this should specifically handle "InvalidPropertyValue" exceptions
             // once we have that in place.
-            catch (const std::exception&) {
+            catch (const InvalidPropertyValue&) {
                 // const string& errMsg = err.getMessage();
                 //std::cout << errMsg << std::endl;
             }
@@ -97,19 +97,7 @@ int main()
         //Serialize all the components
         testModel.print("allComponents.osim");
 
-        // Now, deserilaize the Model from file 
         Model deserializedModel("allComponents.osim");
-
-        try {
-            deserializedModel.finalizeFromProperties();
-        }
-        //Ignore the validity of the property values
-        // TODO this should specifically handle "InvalidPropertyValue" exceptions
-        // once we have that in place.
-        catch (const std::exception&) {
-            // const string& errMsg = err.getMessage();
-            //std::cout << errMsg << std::endl;
-        }
 
         nc = deserializedModel.getMiscModelComponentSet().getSize();
         cout << nc << " model components were deserialized from file." << endl;

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -83,8 +83,6 @@ int main()
             try {
                 testModel.addModelComponent(ModelComponent::safeDownCast(randClone));
             } //Ignore the validity of the property values
-            // TODO this should specifically handle "InvalidPropertyValue" exceptions
-            // once we have that in place.
             catch (const InvalidPropertyValue&) {
                 // const string& errMsg = err.getMessage();
                 //std::cout << errMsg << std::endl;


### PR DESCRIPTION
Fixes issue #1693 and reverses PR #1511

### Brief summary of changes
- Re-enabled `Model` constructors invocation of `finalizeFromProperties()` so users do not have to explicitly call it after loading a Model, which addresses the primary issue in #1693

- Implemented a custom override of `Muscle::clone()` which now invokes `finalizeFromProperties()` before returning the clone. This addresses a consistency issue between construction vs. cloning that #1511 attempted to address by requiring  `finalizeFromProperties()` to be called explicitly.

- Removed the now unnecessary calls to `Model::finalizeFromProperties()` in examples and test cases.

- There remains an inconsistency if using the default copy constructor, where `finalizeFromProperties()` must still be invoked manually. This can be mitigated by using `clone()` in all examples instead of the copy constructor.

### Testing I've completed
- examples and all tests cases passing.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because the change is more consistent with the expected behavior. The need to explicitly call `finalizeFromProperties()` from #1511 was not documented.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
