### PR TITLE
Fix the method Model.replaceMarkerSet so that it calls initSystem 

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1686,7 +1686,7 @@ void Model::writeMarkerFile(const string& aFileName)
  * @param aMarkerSet The new marker set to copy.
  * @return Number of markers that were successfully added to the model.
  */
-int Model::replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet)
+int Model::replaceMarkerSet(SimTK::State& s, const MarkerSet& aMarkerSet)
 {
     int i, numAdded = 0;
 
@@ -1700,7 +1700,8 @@ int Model::replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet)
         upd_MarkerSet().adoptAndAppend(marker);
         ++numAdded;
     }
-
+    // Reconnect the model now that we added aMarkerSet to the Property
+    s = initSystem();
     cout << "Replaced marker set in model " << getName() << endl;
     return numAdded;
 }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -883,7 +883,7 @@ public:
     //--------------------------------------------------------------------------
     MarkerSet& updMarkerSet() { return upd_MarkerSet(); }
     const MarkerSet& getMarkerSet() const { return get_MarkerSet(); }
-    int replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet);
+    int replaceMarkerSet(SimTK::State& s, const MarkerSet& aMarkerSet);
     void writeMarkerFile(const std::string& aFileName);
     void updateMarkerSet(MarkerSet& aMarkerSet);
     int deleteUnusedMarkers(const Array<std::string>& aMarkerNames);


### PR DESCRIPTION
Fix the method Model.replaceMarkerSet so that it calls initSystem after removing old markers and adding new markers to model's Properties. Signature needs to change so state is not const so that we don't hang on to stale/bad state downstream.

Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
