### PR TITLE
Remove unused variable in TimeSeriesTable

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -156,7 +156,7 @@ public:
                 this->validateRow(i, indVec[i], depData.row(int(i)));
             }
         }
-        catch (std::exception& x) {
+        catch (std::exception&) {
             // wipe out the data loaded if any
             this->_indData.clear();
             this->_depData.clear();


### PR DESCRIPTION
### Brief summary of changes

Remove an unused variable to avoid a warning with MSVC.

### CHANGELOG.md

- no need to update because this is not user-facing.