### PR TITLE
Added addMarker() to swig wrapping

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -37,7 +37,7 @@ using namespace SimTK;
     };
 
     void setInertia(Array<double>& aInertia) {
-        self->setInertia(SimTK::Inertia(aInertia[0], aInertia[1], aInertia[2], 
+        self->setInertia(SimTK::Inertia(aInertia[0], aInertia[1], aInertia[2],
                                         aInertia[3], aInertia[4], aInertia[5]));
     }
 };
@@ -72,7 +72,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
       }
       catch(UnsatisfiedLinkError e){
           new JOptionPane("Required library failed to load. Check that the " +
-                          "dynamic library osimJavaJNI is in your PATH\n" + e, 
+                          "dynamic library osimJavaJNI is in your PATH\n" + e,
         JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
       }
   }
@@ -80,6 +80,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %javamethodmodifiers OpenSim::Model::addModelComponent "private";
 %javamethodmodifiers OpenSim::Model::addBody "private";
+%javamethodmodifiers OpenSim::Model::addMarker "private";
 %javamethodmodifiers OpenSim::Model::addConstraint "private";
 %javamethodmodifiers OpenSim::Model::addForce "private";
 %javamethodmodifiers OpenSim::Model::addProbe "private";
@@ -90,6 +91,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %rename OpenSim::Model::addModelComponent private_addModelComponent;
 %rename OpenSim::Model::addBody private_addBody;
+%rename OpenSim::Model::addMarker private_addMarker;
 %rename OpenSim::Model::addConstraint private_addConstraint;
 %rename OpenSim::Model::addForce private_addForce;
 %rename OpenSim::Model::addProbe private_addProbe;
@@ -103,24 +105,24 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %typemap(javacode) OpenSim::Model %{
   private String originalModelPath = null;
-  // Important that we only refer to originalModelPath if the model's 
+  // Important that we only refer to originalModelPath if the model's
   // getInputFileName() is not set.
   public void setOriginalModelPathFromModel(Model model) {
     originalModelPath = null;
-    if(model.getInputFileName()!=null && 
+    if(model.getInputFileName()!=null &&
        !model.getInputFileName().equals(""))
-        originalModelPath = 
+        originalModelPath =
             (new java.io.File(model.getInputFileName())).getParent();
-    else if(model.originalModelPath!=null && 
+    else if(model.originalModelPath!=null &&
             !model.originalModelPath.equals(""))
       originalModelPath = model.originalModelPath;
   }
 
   public String getFilePath() {
-      if(getInputFileName()!=null && 
-         !getInputFileName().equals("") && 
+      if(getInputFileName()!=null &&
+         !getInputFileName().equals("") &&
          (new java.io.File(getInputFileName())).getParent()!=null)
-          return (new java.io.File(getInputFileName())).getParent() + 
+          return (new java.io.File(getInputFileName())).getParent() +
               java.io.File.separator;
       else if(originalModelPath!=null && !originalModelPath.equals(""))
           return originalModelPath + java.io.File.separator;
@@ -145,8 +147,13 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
   public void addProbe(Probe aProbe) {
       aProbe.markAdopted();
       private_addProbe(aProbe);
-  }  
-  
+  }
+
+  public void addMarker(Marker aMarker) {
+      aMarker.markAdopted();
+      private_addMarker(aMarker);
+  }
+
   public void addContactGeometry(ContactGeometry aContactGeometry) {
       aContactGeometry.markAdopted();
       private_addContactGeometry(aContactGeometry);
@@ -177,7 +184,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
     static void LoadOpenSimLibrary(std::string libraryName){
         LoadOpenSimLibrary(libraryName, true);
     }
-    
+
     void setDefaultControls(SimTK::Vector& newControls) {
         self->updDefaultControls() = newControls;
     }
@@ -188,7 +195,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
        prescribedFunction.markAdopted();
        prescribeControlForActuator_private(index, prescribedFunction);
     }
-    
+
     public void prescribeControlForActuator(String name, Function prescribedFunction) {
        prescribedFunction.markAdopted();
        prescribeControlForActuator_private(name, prescribedFunction);

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -33,7 +33,7 @@ using namespace SimTK;
 // program to crash.
 %include "exception.i"
 // Delete any previous exception handlers.
-%exception; 
+%exception;
 %exception {
     try {
         $action
@@ -66,6 +66,7 @@ note: ## is a "glue" operator: `a ## b` --> `ab`.
 
 MODEL_ADOPT_HELPER(ModelComponent);
 MODEL_ADOPT_HELPER(Body);
+MODEL_ADOPT_HELPER(Marker)
 MODEL_ADOPT_HELPER(Probe);
 MODEL_ADOPT_HELPER(Joint);
 MODEL_ADOPT_HELPER(Frame);
@@ -110,7 +111,7 @@ MODEL_ADOPT_HELPER(Controller);
     def __iter__(self):
         """Get an iterator for this Set, to be used as such (where `states` is
         the StatesTrajectory object)::
-           
+
             for state in states:
                 model.calcMassCenterPosition(state)
         """
@@ -176,4 +177,3 @@ SET_ADOPT_HELPER(Analysis);
         return $self->get(i);
     }
 };
-


### PR DESCRIPTION
### Fixes issue 
Marker.addMarker() was causing a segfault in Matlab. Ajay found that addMarker() needed to be added in the swig wrapping.

### Brief summary of changes
I added code to java_simulation.i for addMarker(). This code was identical to the other addComponent methods. 

### Testing I've completed
I built these changes and ran testing code in Matlab. The testing code made a model and added markers. With these changes, the code no longer causes a Matlab segfault. 

### Looking for feedback on...
If this was implemented correctly

### CHANGELOG.md (choose one)
no need to update because this was a bug