### PR TITLE
Remove initSystem() call from Model::updateMarkerSet() #1781

### DIFF
--- a/Applications/Scale/test/testScale.cpp
+++ b/Applications/Scale/test/testScale.cpp
@@ -154,10 +154,11 @@ void scaleGait2354_GUI(bool useMarkerPlacement)
     Model guiModel("gait2354_simbody.osim");
     
     // Keep track of the folder containing setup file, will be used to locate results to compare against
-    guiModel.initSystem();
     std::unique_ptr<MarkerSet> markerSet{ 
         new MarkerSet(guiModel, setupFilePath + subject->getGenericModelMaker().getMarkerSetFileName()) };
     guiModel.updateMarkerSet(*markerSet);
+
+    guiModel.initSystem();
 
     // processedModelContext.processModelScale(scaleTool.getModelScaler(), processedModel, "", scaleTool.getSubjectMass())
     guiModel.getMultibodySystem().realizeTopology();

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1752,11 +1752,6 @@ void Model::updateMarkerSet(MarkerSet& aMarkerSet)
         }
     }
 
-    // Todo_AYMAN: We need to call connectMarkerToModel() again to make sure the
-    // _body pointers are up to date; but note that we've already called 
-    // it before so we need to make sure the connectMarkerToModel() function
-    // supports getting called multiple times.
-    initSystem();
     cout << "Updated markers in model " << getName() << endl;
 }
 

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1706,50 +1706,21 @@ int Model::replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet)
 }
 
 //_____________________________________________________________________________
-/**
- * Update all markers in the model with the ones in the
- * passed-in marker set. If the marker does not yet exist
- * in the model, it is added.
- *
- * @param aMarkerSet set of markers to be updated/added
- */
-void Model::updateMarkerSet(MarkerSet& aMarkerSet)
+void Model::updateMarkerSet(MarkerSet& newMarkerSet)
 {
-    for (int i = 0; i < aMarkerSet.getSize(); i++)
-    {
-        Marker& updatingMarker = aMarkerSet.get(i);
+    for (int i = 0; i < newMarkerSet.getSize(); i++) {
+        Marker& updatingMarker = newMarkerSet.get(i);
 
         /* If there is already a marker in the model with that name,
-         * update it with the parameters from the updating marker,
-         * moving it to a new body if necessary.
+         * replace it with the updating marker.
          */
-        if (updMarkerSet().contains(updatingMarker.getName()))
-        {
+        if (updMarkerSet().contains(updatingMarker.getName())) {
             Marker& modelMarker = updMarkerSet().get(updatingMarker.getName());
-            /* If the updating marker is on a different body, delete the
-             * marker from the model and add the updating one (as long as
-             * the updating marker's body exists in the model).
-             */
-            //if (modelMarker.getBody().getName() != updatingBodyName)
-            //{
-                upd_MarkerSet().remove(&modelMarker);
-                // Eran: we append a *copy* since both _markerSet and aMarkerSet own their elements (so they will delete them)
-                //upd_MarkerSet().adoptAndAppend(updatingMarker.clone());
-            //}
-            //else
-            //{
-            //  modelMarker.updateFromMarker(updatingMarker);
-            //}
+            // Delete the marker from the model and add the updating one
+            upd_MarkerSet().remove(&modelMarker);
         }
-        //else
-        {
-            /* The model does not contain a marker by that name. If it has
-             * a body by that name, add the updating marker to the markerset.
-             */
-            // Eran: we append a *copy* since both _markerSet and aMarkerSet own their elements (so they will delete them)
-            //if (getBodySet().contains(updatingBodyName))
-                addMarker(updatingMarker.clone());
-        }
+        // append the marker to the model's Set
+        addMarker(updatingMarker.clone());
     }
 
     cout << "Updated markers in model " << getName() << endl;

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -885,7 +885,15 @@ public:
     const MarkerSet& getMarkerSet() const { return get_MarkerSet(); }
     int replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet);
     void writeMarkerFile(const std::string& aFileName);
-    void updateMarkerSet(MarkerSet& aMarkerSet);
+
+    /**
+    * Update the markers in the model by appending the ones in the
+    * passed-in marker set. If the marker of the same name exists
+    * in the model, then replace it.
+    *
+    * @param newMarkerSet the set of markers used to update the model's set.
+    */
+    void updateMarkerSet(MarkerSet& newMarkerSet);
     int deleteUnusedMarkers(const Array<std::string>& aMarkerNames);
  
     /**


### PR DESCRIPTION
Fixes issue #1781

### Brief summary of changes
testScale was relying on a side-effect of updateMarkerSet() which was not necessary. Simply invoking initSystem() after editing the model markers works.

### Testing I've completed
testScale (and all tests) passed locally

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because no API change

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
