### PR TITLE
Fix MarkerPlacer time range errors for the average pose

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -105,8 +105,8 @@ public:
                    const double max) :
         Exception(file, line, func) {
         std::string msg = "Time " + std::to_string(time) + 
-            " is out of time range {" + std::to_string(min) +
-            ", " + std::to_string(max) + "}";
+            " is out of time range [" + std::to_string(min) +
+            ", " + std::to_string(max) + "]";
 
         addMessage(msg);
     }

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -104,9 +104,9 @@ public:
                    const double min,
                    const double max) :
         Exception(file, line, func) {
-        std::string msg = "min = " + std::to_string(min);
-        msg += " max = " + std::to_string(max);
-        msg += " time = " + std::to_string(time);
+        std::string msg = "Time " + std::to_string(time) + 
+            " is out of time range {" + std::to_string(min) +
+            ", " + std::to_string(max) + "}";
 
         addMessage(msg);
     }
@@ -120,8 +120,9 @@ public:
                      const double begTime,
                      const double endTime) :
         Exception(file, line, func) {
-        std::string msg = "Begin-Time = " + std::to_string(begTime);
-        msg += " End-Time = " + std::to_string(endTime);
+        std::string msg = " Invalid time range: initial time " + 
+            std::to_string(begTime)  + " >= final time = " +
+            std::to_string(endTime);
 
         addMessage(msg);
     }
@@ -343,11 +344,11 @@ public:
         OPENSIM_THROW_IF(beginTime < timeCol.front() ||
                          beginTime > timeCol.back(),
                          TimeOutOfRange,
-                         timeCol.front(), timeCol.back(), beginTime);
+                         beginTime, timeCol.front(), timeCol.back(),);
         OPENSIM_THROW_IF(endTime < timeCol.front() ||
                          endTime > timeCol.back(),
                          TimeOutOfRange,
-                         timeCol.front(), timeCol.back(), endTime);
+                         endTime, timeCol.front(), timeCol.back());
 
         std::vector<double> comps(DT::numComponentsPerElement(), 0);
         RowVector row{static_cast<int>(DT::getNumColumns()),

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -264,7 +264,7 @@ bool MarkerPlacer::processModel(Model* aModel,
 
     const auto avgRow = staticPoseTable.averageRow(_timeRange[0],
                                                    _timeRange[1]);
-    for(int r = staticPoseTable.getNumRows() - 1; r > 0; --r)
+    for(size_t r = staticPoseTable.getNumRows() - 1; r > 0; --r)
         staticPoseTable.removeRowAtIndex(r);
     staticPoseTable.updRowAtIndex(0) = avgRow;
     

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -251,6 +251,17 @@ bool MarkerPlacer::processModel(Model* aModel,
                                             return val >= _timeRange[0] &&
                                                    val <= _timeRange[1];
                                         });
+
+    // Users often set a time range that purposely exceeds the range of
+    // their data with the mindset that all their data will be used.
+    // To allow for that, we have to narrow the provided range to data
+    // range, since the TimeSeriesTable will correctly throw that the 
+    // desired time exceeds the data range.
+    if (_timeRange[0] < timeCol.front())
+        _timeRange[0] = timeCol.front();
+    if (_timeRange[1] > timeCol.back())
+        _timeRange[1] = timeCol.back();
+
     const auto avgRow = staticPoseTable.averageRow(_timeRange[0],
                                                    _timeRange[1]);
     for(int r = staticPoseTable.getNumRows() - 1; r > 0; --r)


### PR DESCRIPTION
Fixes point 4 of issue [GUI 183](https://github.com/opensim-org/opensim-gui/issues/183) related to the `MarkerPlacer`'s `TimerSeriesTable` of marker data handling of  an invalid time range when computing the average of marker data.

`TimerSeriesTable` is correct in throwing `TimeOutOfRange` when the range over which the average is to be computed exceeds the range of the data. However, our users are likely accustomed to providing large time ranges as away of ensuring the full time range of their data is used. MarkePlacer no *clamps* to the valid time range of the data if the range provide exceeds the range.

### Brief summary of changes
- made the `TimeSeriesTable::TimeOutOfRange` easier to understand 
- fixed a bug in order of the arguments passed to the `TimeOutOfRange` exception
- enable`MarkePlacer` to take up the slop when users provide large time-ranges as away of capturing all the time frames in their data.

### Testing I've completed
- all tests (including testScale) still pass
- ran isb2017 scale example successfully

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is just a bug fix
