### PR TITLE
Replace use of model.replaceMarkerSet with model.updateMarkerSet 

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -325,8 +325,9 @@ void OpenSimContext::setBody(Marker& currentMarker, PhysicalFrame&  newBody, boo
     return;
 }
 
-int OpenSimContext::replaceMarkerSet(Model& model, MarkerSet& aMarkerSet) {
-  return model.replaceMarkerSet( *_configState, aMarkerSet);
+void OpenSimContext::updateMarkerSet(Model& model, MarkerSet& aMarkerSet) {
+   model.updateMarkerSet(aMarkerSet);
+   recreateSystemKeepStage();
 }
 
 // Analyses

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -165,7 +165,7 @@ public:
     void deletePathWrap(GeometryPath& p, int num);
     // Markers
     void setBody(Marker& currentMarker, PhysicalFrame& newBody, bool  b);
-    int replaceMarkerSet(Model& model, MarkerSet& aMarkerSet);
+    void updateMarkerSet(Model& model, MarkerSet& aMarkerSet);
 
     void getCenterOfMassInGround(double com[3]) const {
         SimTK::Vec3 comV = _model->getMatterSubsystem().calcSystemMassCenterLocationInGround(*_configState);


### PR DESCRIPTION
notee that this changes the semantics from previous behavior, that may need documentation

Fixes issue #<issue_number>
GUI issue 2 ISB 2017

### Brief summary of changes
GUI used to call Model.replaceMarkerSet, that left the model in broken state since "connections" were not re-established after editing. Solution suggested was to unify model.replaceMerkerSet, model.updateMarkerSet and to reinitialize the system afterwards.

### Testing I've completed
GUI doesn't throw exception before hitting Run when loading setup file with MarkerSet specification

### Looking for feedback on...

### CHANGELOG.md (choose one)
- This is in progress and needs documentation. The method to replaceMarkerSet need to be removed to avoid confusion,

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
