### PR TITLE
Remove fatal error for config mismatch on UNIX.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,9 @@ if(COMMAND cmake_policy)
     cmake_policy(SET CMP0005 NEW)
 endif(COMMAND cmake_policy)
 
-string(CONCAT DEP_BUILD_MSG
-  "\n-------------------------IMPORTANT----------------------------------\n"
-  "| Make sure that all OpenSim dependencies are built with the same   |\n"
-  "| CMAKE_BUILD_TYPE (Linux) or CONFIGURATION (Xcode/MSVC) as OpenSim |\n"
-  "| to avoid mysterious runtime errors.                               |\n"
-  "-------------------------IMPORTANT----------------------------------\n")
-message(${DEP_BUILD_MSG})
+message(STATUS "NOTICE: Make sure all OpenSim dependencies are built with the \
+same CMAKE_BUILD_TYPE (Linux) or CONFIGURATION (Xcode/MSVC) as OpenSim to \
+avoid mysterious runtime errors.")
 
 # To create a folder hierarchy within Visual Studio.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -641,23 +637,13 @@ string(CONCAT MESSAGE
     "Checking if Simbody was built with same BUILD_TYPE or CONFIGURATION as "
     "the current OpenSim BUILD_TYPE or CONFIGURATION.")
 
-if(${PLATFORM_NAME} STREQUAL Windows)
+if(WIN32)
     string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)
     add_custom_target(Simbody_CONFIG_check ALL
         COMMAND "set" "Simbody_CONFIG=${Simbody_CONFIGURATION_STR}"
         COMMAND "if"
            "\"%Simbody_CONFIG:$<LOWER_CASE:$<CONFIG>>=%\"==\"%Simbody_CONFIG%\""
            "exit" "1"
-        COMMENT ${MESSAGE})
-elseif(${PLATFORM_NAME} STREQUAL Mac OR ${PLATFORM_NAME} STREQUAL Linux)
-    string(TOLOWER "${Simbody_CONFIGURATION}" Simbody_CONFIGURATION_STR)
-    string(CONCAT CONTENT "if [[ $1 != *\"$2\"* ]]\; then\n"
-                          "exit 1\n"
-                          "fi\n")
-    file(WRITE "${CMAKE_BINARY_DIR}/simbody_config_check.sh" ${CONTENT})
-    add_custom_target(Simbody_CONFIG_check ALL
-        COMMAND "bash" "simbody_config_check.sh"
-                "\"${Simbody_CONFIGURATION_STR}\"" "\"$<LOWER_CASE:$<CONFIG>>\""
         COMMENT ${MESSAGE})
 endif()
 

--- a/OpenSim/Actuators/CMakeLists.txt
+++ b/OpenSim/Actuators/CMakeLists.txt
@@ -10,5 +10,3 @@ OpenSimAddLibrary(
     SOURCES ${SOURCES}
     TESTDIRS "Test"
     )
-
-add_dependencies(osimActuators Simbody_CONFIG_check)

--- a/OpenSim/Analyses/CMakeLists.txt
+++ b/OpenSim/Analyses/CMakeLists.txt
@@ -9,5 +9,3 @@ OpenSimAddLibrary(
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}
     )
-
-add_dependencies(osimAnalyses Simbody_CONFIG_check)

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -20,5 +20,7 @@ OpenSimAddLibrary(
     TESTDIRS "Test"
     )
 
-add_dependencies(osimCommon Simbody_CONFIG_check)
+if(WIN32)
+    add_dependencies(osimCommon Simbody_CONFIG_check)
+endif()
   

--- a/OpenSim/ExampleComponents/CMakeLists.txt
+++ b/OpenSim/ExampleComponents/CMakeLists.txt
@@ -9,5 +9,3 @@ OpenSimAddLibrary(
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}
     )
-
-add_dependencies(osimExampleComponents Simbody_CONFIG_check)

--- a/OpenSim/Simulation/CMakeLists.txt
+++ b/OpenSim/Simulation/CMakeLists.txt
@@ -25,5 +25,3 @@ OpenSimAddLibrary(
     TESTDIRS SimbodyEngine Test
     INCLUDEDIRS ${SIMULATION_SUBDIRS}
     )
-
-add_dependencies(osimSimulation Simbody_CONFIG_check)

--- a/OpenSim/Tools/CMakeLists.txt
+++ b/OpenSim/Tools/CMakeLists.txt
@@ -10,5 +10,3 @@ OpenSimAddLibrary(
     SOURCES ${SOURCES}
     TESTDIRS "Test"
     )
-
-add_dependencies(osimTools Simbody_CONFIG_check)  


### PR DESCRIPTION
Fixes issue #1793 

### Brief summary of changes

1. Improved formatting of message about config mismatch. Also, using a non-status type of message for this message was making `ccmake` (the command-line GUI interface) harder to use.
2. Removed the fatal check on UNIX.
3. Removed unnecessary `add_dependencies()` calls, as dependencies will be inherited from osimCommon.

Since mixing config types is discouraged in general, we always print the "notice." But we only stop the build process on Windows.

### Testing I've completed

Ensured that no error occurs now on macOS when configs do not match.

### CHANGELOG.md (choose one)

- no need to update because the original check did not exist in 3.3.