### PR TITLE
Fix missing state columns warnings

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1917,7 +1917,7 @@ void Model::setAllControllersEnabled( bool enabled ) {
 
 void Model::formStateStorage(const Storage& originalStorage,
                              Storage& statesStorage,
-                             bool warnUnspecifiedStates)
+                             bool warnUnspecifiedStates) const
 {
     Array<string> rStateNames = getStateVariableNames();
     int numStates = getNumStateVariables();

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1914,14 +1914,10 @@ bool Model::getAllControllersEnabled() const{
 void Model::setAllControllersEnabled( bool enabled ) {
     _allControllersEnabled = enabled;
 }
-/**
- * Model::formStateStorage is intended to take any storage and populate stateStorage.
- * stateStorage is supposed to be a Storage with labels identical to those obtained by 
- * calling Model::getStateVariableNames(). Columns/entries found in the "originalStorage"
- * are copied to the output statesStorage. Entries not found are populated with 
- * 0s (should be default value).
- */
-void Model::formStateStorage(const Storage& originalStorage, Storage& statesStorage)
+
+void Model::formStateStorage(const Storage& originalStorage,
+                             Storage& statesStorage,
+                             bool warnUnspecifiedStates)
 {
     Array<string> rStateNames = getStateVariableNames();
     int numStates = getNumStateVariables();
@@ -1973,7 +1969,7 @@ void Model::formStateStorage(const Storage& originalStorage, Storage& statesStor
             }
         }
         mapColumns[i] = fix;
-        if (fix==-1){
+        if (fix==-1 && warnUnspecifiedStates){
             cout << "Column "<< rStateNames[i] << 
                 " not found by Model::formStateStorage(). "
                 "Assuming its default value of "

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -404,7 +404,7 @@ public:
      */
     void formStateStorage(const Storage& originalStorage, 
                           Storage& statesStorage,
-                          bool warnUnspecifiedStates = true);
+                          bool warnUnspecifiedStates = true) const;
 
     void formQStorage(const Storage& originalStorage, Storage& qStorage);
     

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -394,12 +394,18 @@ public:
     /** Check that the underlying computational system representing the model is valid. 
         That is, is the system ready for performing calculations. */
     bool isValidSystem() const;
+
     /**
-     * create a storage (statesStorage) that has same label order as model's states
-     * with values populated from originalStorage, 0.0 for those states unspecified
-     * in the originalStorage.
+     * Create a storage (statesStorage) that has same label order as model's states
+     * with values populated from originalStorage. Use the default state value if
+     * a state is unspecified in the originalStorage. If warnUnspecifiedStates is
+     * true then a warning is printed that includes the default value used for
+     * the state value unspecified in originalStorage.
      */
-    void formStateStorage(const Storage& originalStorage, Storage& statesStorage);
+    void formStateStorage(const Storage& originalStorage, 
+                          Storage& statesStorage,
+                          bool warnUnspecifiedStates = true);
+
     void formQStorage(const Storage& originalStorage, Storage& qStorage);
     
     /**

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -371,7 +371,7 @@ loadStatesFromFile(SimTK::State& s)
         cout<<"\nLoading states from file "<<_statesFileName<<"."<<endl;
         Storage temp(_statesFileName);
         _statesStore = new Storage();
-        _model->formStateStorage(temp, *_statesStore);
+        _model->formStateStorage(temp, *_statesStore, true);
     } else {
         if(!_coordinatesFileNameProp.isValidFileName()) 
             throw Exception("AnalyzeTool.initializeFromFiles: Either a states file or a coordinates file must be specified.",__FILE__,__LINE__);
@@ -409,7 +409,7 @@ loadStatesFromFile(SimTK::State& s)
         delete _statesStore;
         _statesStore = new Storage(512, "states");
 
-        _model->formStateStorage(*qStore, *_statesStore);
+        _model->formStateStorage(*qStore, *_statesStore, false);
 
         delete qStore;
         delete uStore;
@@ -449,7 +449,7 @@ setStatesFromMotion(const SimTK::State& s, const Storage &aMotion, bool aInDegre
     delete _statesStore;
     _statesStore = new Storage(512, "states");
 
-    _model->formStateStorage(*qStore, *_statesStore);
+    _model->formStateStorage(*qStore, *_statesStore, false);
     delete qStore;
     delete uStore;
 }


### PR DESCRIPTION
Fixes issue raised in [GUI #183](https://github.com/opensim-org/opensim-gui/issues/183) that StaticOptimization (but generally the AnalyzeTool) is too verbose about missing state values when forming the state storage from file. In #1686 we consolidated methods used to form the states storage. When forming states storage from coordinates only, the previous method did not warn about missing/unspecified states. Therefore, this PR adds the option/flag to warn about unspecified states and it is used to suppress warnings when forming states storage from coordinates only.

### Brief summary of changes
Added the `warnUnspecifiedStates` optional flag (default is *true*) to `Model::formStateStorage()`.
Updated `AnalyzeTool` so that when calling `formStateStorage` with coordinates only, to turn `warnUnspecifiedStates` off (to *false*).

### Testing I've completed
Ran all tests and ISB tutorial and observed that warnings are no longer printed to the console.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because it restores previous behavior of the `AnalyzeTool`
- the `Model::formStateStorage()` interface changed by adding the option, but the default value enables user code to remain unchanged and have the expected/previous warning behavior.
