### PR TITLE
Fix unnecessary resampling of uniform input data

### DIFF
--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2287,15 +2287,6 @@ pad(int aPadSize)
     delete[] vecs;
 }
 
-//_____________________________________________________________________________
-/**
- * Smooth spline each of the columns in the storage.  Note that as a part
- * of this operation, the storage is resampled so that the statevectors are
- * at equal spacing.
- *
- * @param aOrder Order of the spline.
- * @param aCutoffFrequency Cutoff frequency.
- */
 void Storage::
 smoothSpline(int aOrder,double aCutoffFrequency)
 {
@@ -2336,16 +2327,6 @@ smoothSpline(int aOrder,double aCutoffFrequency)
     delete[] signal;
 }
 
-
-//_____________________________________________________________________________
-/**
- * Lowpass filter each of the columns in the storage.  Note that as a part
- * of this operation, the storage is resampled so that the statevectors are
- * at equal spacing.
- *
- * @param aOrder Order of the FIR filter.
- * @param aCutoffFrequency Cutoff frequency.
- */
 void Storage::
 lowpassIIR(double aCutoffFrequency)
 {
@@ -2383,16 +2364,6 @@ lowpassIIR(double aCutoffFrequency)
     delete[] signal;
 }
 
-
-//_____________________________________________________________________________
-/**
- * Lowpass filter each of the columns in the storage.  Note that as a part
- * of this operation, the storage is resampled so that the statevectors are
- * at equal spacing.
- *
- * @param aOrder Order of the FIR filter.
- * @param aCutoffFrequency Cutoff frequency.
- */
 void Storage::
 lowpassFIR(int aOrder,double aCutoffFrequency)
 {

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2299,16 +2299,21 @@ pad(int aPadSize)
 void Storage::
 smoothSpline(int aOrder,double aCutoffFrequency)
 {
+    int size = getSize();
     double dtmin = getMinTimeStep();
+    double avgDt = (_storage[size - 1].getTime() - _storage[0].getTime()) / size;
 
     if(dtmin<SimTK::Zero) {
         cout<<"Storage.SmoothSpline: storage cannot be resampled."<<endl;
         return;
     }
 
-    // RESAMPLE
-    dtmin = resample(dtmin,aOrder);
-    int size = getSize();
+    // RESAMPLE if the sampling interval is not uniform
+    if ((avgDt - dtmin) > SimTK::Eps) {
+        dtmin = resample(dtmin, aOrder);
+        size = getSize();
+    }
+
     if(size<(2*aOrder)) {
         cout<<"Storage.SmoothSpline: too few data points to filter."<<endl;
         return;
@@ -2344,16 +2349,21 @@ smoothSpline(int aOrder,double aCutoffFrequency)
 void Storage::
 lowpassIIR(double aCutoffFrequency)
 {
+    int size = getSize();
     double dtmin = getMinTimeStep();
+    double avgDt = (_storage[size - 1].getTime() - _storage[0].getTime()) / size;
 
-    if(dtmin<SimTK::Zero) {
+    if(dtmin<SimTK::Eps) {
         cout<<"Storage.lowpassIIR: storage cannot be resampled."<<endl;
         return;
     }
 
-    // RESAMPLE
-    dtmin = resample(dtmin,5);
-    int size = getSize();
+    // RESAMPLE if the sampling interval is not uniform
+    if ((avgDt - dtmin) > SimTK::Eps) {
+        dtmin = resample(dtmin, 5);
+        size = getSize();
+    }
+
     if(size<(4)) {
         cout<<"Storage.lowpassIIR: too few data points to filter."<<endl;
         return;
@@ -2386,16 +2396,21 @@ lowpassIIR(double aCutoffFrequency)
 void Storage::
 lowpassFIR(int aOrder,double aCutoffFrequency)
 {
+    int size = getSize();
     double dtmin = getMinTimeStep();
+    double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / size;
 
-    if(dtmin<SimTK::Zero) {
+    if (dtmin<SimTK::Eps) {
         cout<<"Storage.lowpassFIR: storage cannot be resampled."<<endl;
         return;
     }
 
-    // RESAMPLE
-    dtmin = resample(dtmin,5);
-    int size = getSize();
+    // RESAMPLE if the sampling interval is not uniform
+    if ((avgDt - dtmin) > SimTK::Eps) {
+        dtmin = resample(dtmin, 5);
+        size = getSize();
+    }
+
     if(size<(2*aOrder)) {
         cout<<"Storage.lowpassFIR: too few data points to filter."<<endl;
         return;

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2294,7 +2294,7 @@ smoothSpline(int aOrder,double aCutoffFrequency)
     double dtmin = getMinTimeStep();
     double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / (size-1);
 
-    if(dtmin<SimTK::Zero) {
+    if(dtmin<SimTK::Eps) {
         cout<<"Storage.SmoothSpline: storage cannot be resampled."<<endl;
         return;
     }

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2292,7 +2292,7 @@ smoothSpline(int aOrder,double aCutoffFrequency)
 {
     int size = getSize();
     double dtmin = getMinTimeStep();
-    double avgDt = (_storage[size - 1].getTime() - _storage[0].getTime()) / size;
+    double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / (size-1);
 
     if(dtmin<SimTK::Zero) {
         cout<<"Storage.SmoothSpline: storage cannot be resampled."<<endl;
@@ -2332,7 +2332,7 @@ lowpassIIR(double aCutoffFrequency)
 {
     int size = getSize();
     double dtmin = getMinTimeStep();
-    double avgDt = (_storage[size - 1].getTime() - _storage[0].getTime()) / size;
+    double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / (size-1);
 
     if(dtmin<SimTK::Eps) {
         cout<<"Storage.lowpassIIR: storage cannot be resampled."<<endl;
@@ -2369,7 +2369,7 @@ lowpassFIR(int aOrder,double aCutoffFrequency)
 {
     int size = getSize();
     double dtmin = getMinTimeStep();
-    double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / size;
+    double avgDt = (_storage[size-1].getTime() - _storage[0].getTime()) / (size-1);
 
     if (dtmin<SimTK::Eps) {
         cout<<"Storage.lowpassFIR: storage cannot be resampled."<<endl;

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -286,9 +286,34 @@ public:
     int computeAverage(int aN,double *aAve) const;
     int computeAverage(double aTI,double aTF,int aN,double *aAve) const;
     void pad(int aPadSize);
-    void smoothSpline(int aOrder,double aCutoffFrequency);
-    void lowpassIIR(double aCutoffFequency);
-    void lowpassFIR(int aOrder,double aCutoffFequency);
+    /**
+    * Smooth spline each of the columns in the storage.  Note that as a part
+    * of this operation, the storage is re-sampled to obtain uniform samples
+    * unless its time steps are already uniform.
+    *
+    * @param order Order of the spline.
+    * @param cutoffFrequency Cutoff frequency of the smoothing filter.
+    */
+    void smoothSpline(int order,double cutoffFrequency);
+    /**
+    * Low-pass filter each of the columns in the storage using a 3rd order
+    * lowpass IIR Butterworth digital filter. Note that as a part of this
+    * operation, the storage is re-sampled to obtain uniform samples unless
+    * its time steps are already uniform.
+    *
+    * @param cutoffFrequency Cutoff frequency of the lowpass filter.
+    */
+    void lowpassIIR(double cutoffFequency);
+    /**
+    * Lowpass filter each of the columns in the storage using an FIR non-
+    * recursive digital filter. Note that as a part of this operation, the
+    * storage is re-sampled to obtain uniform samples unless its time steps
+    * are already uniform.
+    *
+    * @param order Order of the FIR filter.
+    * @param cutoffFrequency Cutoff frequency.
+    */
+    void lowpassFIR(int order,double cutoffFequency);
     // Append rows of two storages at matched time
     void addToRdStorage(Storage& rStorage, double aStartTime, double aEndTime);
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue with reported start and end-times that are slightly off from their range specified in the Tool setup file.

Noticed this running ISB 2017 example running SO in both 3.3 and 4.0. SO start time is being changed to -3.04423e-13 when both the user specified start time and the experimental data start at 0.0. The problem is that during filtering the data is re-sampled according to the minimum step-size (intended to accurately sample simulation results) but this applied to evenly sampled data where you end up with a minim step size that differs from the typical/average just due to round-off error. That causes all data points to be shifted by the that round-off. 

### Brief summary of changes
Check if the data is uniformly sampled and do not re-sample the data if it is uniform. This fixes the side-effect of having user-specified start and end-times shifted due to round-off when uniform timeline is provided but re-sampling with the min step size.

### Testing I've completed
All tests passed locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because because this is a minor bug fix