### PR TITLE
Fix Travis-CI ccache with Clang on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,8 @@ before_install:
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then tar -xJf clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang"; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX = *clang* ]]; then export CXX="$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang++"; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then ln -s $HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang /usr/lib/clang; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX = *clang* ]]; then ln -s $HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang++ /usr/lib/clang++; fi
   #############################################################################
   
   ## Ensure that there are no tabs in source code.
@@ -120,11 +120,11 @@ before_install:
   # Put /usr/lib/ccache on the path.
   # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
-  # - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
+  # TODO - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
+  # TODO - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
   # Without the following lines, ccache causes clang to not print in color.
-  - if [[ "$CC" = *clang* ]]; then export CC="$CC -fcolor-diagnostics"; fi;
-  - if [[ "$CXX" = *clang* ]]; then export CXX="$CXX -fcolor-diagnostics"; fi;
+  - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
+  - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;
 
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,10 +118,9 @@ before_install:
   ## Set up ccache.
   # Lots of this is borrowed from https://github.com/weitjong/Urho3D/blob/master/.travis.yml.
   # Put /usr/lib/ccache on the path.
-  # Unnecessary now - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
-  # For some reason the Travis CI clang compiler toolchain installation does not
-  # have a symlink in the ccache symlinks directory, so workaround it
-  # Unnecessary now - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
+  # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
+  # Since we install our own Clang, it's not set up for ccache. Workaround:
+  - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
   # Without the following lines, ccache causes clang to not print in color.
   - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ addons:
       # For gcc >= 4.8
       - ubuntu-toolchain-r-test
       # for clang
-      #- llvm-toolchain-precise-3.5
+      - llvm-toolchain-precise-3.5
       # For cmake >= 2.8.8 (for CMakePackageConfigHelpers)
       - kubuntu-backports
       - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
@@ -64,7 +64,7 @@ addons:
       # For Simbody.
       - liblapack-dev
       - g++-4.9
-      #- clang-3.5
+      - clang-3.5
       # In case someone wants to check for memory leaks.
       - valgrind
       # To build doxygen documentation.
@@ -94,9 +94,9 @@ before_install:
   
   #############################################################################
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then tar -xJf clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export PATH=$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin:$PATH; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then tar -xJf clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export PATH=$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin:$PATH; fi
   #############################################################################
   
   ## Ensure that there are no tabs in source code.
@@ -120,7 +120,7 @@ before_install:
   # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
   # TODO - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
-  # TODO - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
+  - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
   # Without the following lines, ccache causes clang to not print in color.
   - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ before_install:
   # Only if compiling with gcc, update environment variables
   # to use the new gcc.
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "clang++" ]]; then export CXX="clang++-3.5" CC="clang-3.5"; fi
 
   ## Set up ccache.
   # Lots of this is borrowed from https://github.com/weitjong/Urho3D/blob/master/.travis.yml.
@@ -120,17 +121,14 @@ before_install:
   # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
   # TODO - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
-  - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX" = *clang* ]]; then ln -s $(which ccache) $HOME/clang-3.5 && ln -s $(which ccache) $HOME/clang++-3.5 && export PATH=$HOME:$PATH; fi
   # Without the following lines, ccache causes clang to not print in color.
-  - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
-  - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;
+  # - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
+  # - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;
 
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi
 
-  # Temporary fix until llvm.org/apt is up again. See above.
-  # - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "clang++" ]]; then export CXX="clang++-3.5" CC="clang-3.5"; fi
-  
   ## Temporary hack to find libblas and liblapack.
   # TODO. Currently Simbody is using Travis CI's Ubuntu 14.04 VMs, which link with 
   # liblapack.so.3 and libblas.so.3. These files don't exist on the 12.04 machines.

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,7 @@ before_install:
   # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then tar -xJf clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then ln -s $HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang /usr/lib/clang; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX = *clang* ]]; then ln -s $HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin/clang++ /usr/lib/clang++; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export PATH=$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin:$PATH; fi
   #############################################################################
   
   ## Ensure that there are no tabs in source code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,10 +120,11 @@ before_install:
   # Put /usr/lib/ccache on the path.
   # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
-  - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
+  # - ln -s $(which ccache) $HOME/clang && ln -s $(which ccache) $HOME/clang++ && export PATH=$HOME:$PATH
   # Without the following lines, ccache causes clang to not print in color.
-  - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
-  - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;
+  - if [[ "$CC" = *clang* ]]; then export CC="$CC -fcolor-diagnostics"; fi;
+  - if [[ "$CXX" = *clang* ]]; then export CXX="$CXX -fcolor-diagnostics"; fi;
 
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ before_install:
   # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
   # TODO - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX" = *clang* ]]; then ln -s $(which ccache) $HOME/clang-3.5 && ln -s $(which ccache) $HOME/clang++-3.5 && export PATH=$HOME:$PATH; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX = *clang* ]]; then ln -s $(which ccache) $HOME/clang-3.5 && ln -s $(which ccache) $HOME/clang++-3.5 && export PATH=$HOME:$PATH; fi
   # Without the following lines, ccache causes clang to not print in color.
   # - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
   # - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,13 +92,6 @@ before_install:
   # `/Users/travis/build.sh: line 109: shell_session_update: command not found`
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
   
-  #############################################################################
-  # Temporary fix until llvm.org/apt is back up. Manually download clang binaries and use them.
-  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then cd && wget http://llvm.org/releases/3.5.0/clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then tar -xJf clang+llvm-3.5.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
-  #- if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export PATH=$HOME/clang+llvm-3.5.0-x86_64-linux-gnu/bin:$PATH; fi
-  #############################################################################
-  
   ## Ensure that there are no tabs in source code.
   # GREP returns 0 (true) if there are any matches, and
   # we don't want any matches. If there are matches,
@@ -110,21 +103,18 @@ before_install:
   - if grep --line-num --recursive --exclude-dir="*dependencies*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
 
   ## Set up environment variables.
-  # Only if compiling with gcc, update environment variables
-  # to use the new gcc.
+  # Only if compiling with gcc, update environment variables to use the new
+  # gcc.
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "clang++" ]]; then export CXX="clang++-3.5" CC="clang-3.5"; fi
 
   ## Set up ccache.
   # Lots of this is borrowed from https://github.com/weitjong/Urho3D/blob/master/.travis.yml.
-  # Put /usr/lib/ccache on the path.
-  # Unnecessary now? - export PATH=$(whereis -b ccache |grep -o '\S*lib\S*'):$PATH
   # Since we install our own Clang, it's not set up for ccache. Workaround:
-  # TODO - if [[ "$TRAVIS_OS_NAME" = "linux" && $CC = *clang* ]]; then export CC="ccache $CC" && export CXX="ccache $CXX"; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && $CXX = *clang* ]]; then ln -s $(which ccache) $HOME/clang-3.5 && ln -s $(which ccache) $HOME/clang++-3.5 && export PATH=$HOME:$PATH; fi
   # Without the following lines, ccache causes clang to not print in color.
-  # - if [ "$CC" == "clang" ]; then export CC="clang -fcolor-diagnostics"; fi;
-  # - if [ "$CXX" == "clang++" ]; then export CXX="clang++ -fcolor-diagnostics"; fi;
+  - if [[ "$CC" = *clang* ]]; then export CC="$CC -fcolor-diagnostics"; fi;
+  - if [[ "$CXX" = *clang* ]]; then export CXX="$CXX -fcolor-diagnostics"; fi;
 
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install ccache; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then PATH=/usr/local/opt/ccache/libexec:$PATH; fi


### PR DESCRIPTION
Fixes issue #1794 

### Brief summary of changes

- Fixes the use of ccache with clang on linux, which wasn't actually working in #1800. Test times for a rebuild (without any changes to the code) are now as follows:

![image](https://user-images.githubusercontent.com/846001/27573047-8dc7e102-5ac4-11e7-8dae-a5c6bbefbb58.png)


### Testing I've completed

Ran Travis-CI.

### CHANGELOG.md (choose one)

- no need to update because this doesn't affect users.