### PR TITLE
[TGCS] Address remaining dry run feedback.

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/RunHopperWithDevice_answers.m
+++ b/Bindings/Java/Matlab/Hopper_Device/RunHopperWithDevice_answers.m
@@ -73,6 +73,7 @@ anchorB.connectSocket_parent_frame(shankAttach);
 % ANSWER{
 hopper.addComponent(device);
 % }
+% Note: After this step, simulating will not work until after completing Task F.
 
 % (Done for you) Configure the device to wrap over the patella.
 if hopper.hasComponent('device_active') || hopper.hasComponent('device_passive') 
@@ -105,8 +106,9 @@ contr.connectInput_activation(...
 %% Report quantities of interest.
 % -------------------------------
 % Configure the outputs we wish to display during the simulation.
-% TODO: Create a TableReporter, give it a name, and set its reporting interval
-%       to 0.2 seconds. Wire the following outputs to the reporter:
+% TODO: Create a TableReporter (assign it to a variable named `reporter`),
+%       set a name for the reporter, and set its reporting interval to 0.2
+%       seconds. Wire the following outputs to the reporter:
 %         - hopper's height,
 %         - vastus muscle activation,
 %         - device controller's control signal output.

--- a/Bindings/Java/Matlab/Hopper_Device/RunHopperWithDevice_answers.m
+++ b/Bindings/Java/Matlab/Hopper_Device/RunHopperWithDevice_answers.m
@@ -141,6 +141,7 @@ if exist('reporter') == 1
     results = osimTableToStruct(table);
     fieldnames(results);
     if isfield(results, 'height')
+        hold on; % Attempt to plot on top of the RunHopper.m graph.
         plot(results.time, results.height);
         xlabel('time');
         ylabel('height');

--- a/Bindings/Java/Matlab/Hopper_Device/Simulate.m
+++ b/Bindings/Java/Matlab/Hopper_Device/Simulate.m
@@ -66,6 +66,7 @@ if visualize
     silo = model.updVisualizer().updInputSilo();
 end
 
+simulatedAtLeastOnce = false;
 while true
     if visualize
         % Ignore any previous key presses.
@@ -81,6 +82,9 @@ while true
         % Key 27 is ESC; see the SimTK::Visualizer::InputListener::KeyCode enum.
         if key == 27
             sviz.shutdown();
+            if ~simulatedAtLeastOnce
+                error('User exited visualizer without running any simulations.')
+            end
             return;
         end
     end
@@ -103,6 +107,7 @@ while true
     state = State(initState);
     manager = Manager(model);
     manager.integrate(state, 5.0);
+    simulatedAtLeastOnce = true;
 
     % If there is no visualizer, only simulate once.
     if ~visualize


### PR DESCRIPTION
### Brief summary of changes

- Give a more useful error message for when users exit the visualizer without simulating once.
- Instruct users to use an appropriate variable name for the reporter, since the remaining code assumes a specific name.
- Tell users that simulating won't work after adding the device but before wiring up the controller's input.

### Testing I've completed

Ran all 3 parts of the tutorial successfully.

### CHANGELOG.md (choose one)

- no need to update because hopper example was not in 3.3.
