### PR TITLE
Bindings model copyctor

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -163,6 +163,7 @@
 %include <OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h>
 %include <OpenSim/Simulation/Model/ModelVisualPreferences.h>
 %include <OpenSim/Simulation/Model/ModelVisualizer.h>
+%copyctor OpenSim::Model;
 %include <OpenSim/Simulation/Model/Model.h>
 
 %include <OpenSim/Simulation/Model/AbstractPathPoint.h>


### PR DESCRIPTION
Fixes issue (multiple opensim-gui crashes due to early garbage collection)

### Brief summary of changes
Force generation of Model copy constructor that returns an object of the right type that can be maintained and communicates ownership correctly to the Java runtime. Other users of the API may do the same in their code to create a fresh copy of a Model in Matlab or Python.
 
### Testing I've completed
Run variety of tools multiple times without crashing the GUI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because this is more of a bug fix.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
