### PR TITLE
[TGCS] InteractiveHopper demo only works on MATLAB 2014b or later, README update

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/README.txt
+++ b/Bindings/Java/Matlab/Hopper_Device/README.txt
@@ -1,6 +1,8 @@
 MATLAB Example: *Hopper Device*
 ===============================
 
+NOTE: This example only works with MATLAB versions R2014b and later.
+
 This is the MATLAB version of the Hopper Device example (there is also a C++
 version). The example demonstrates some of the new features of the OpenSim 4.0
 API. The Component architecture allows us to join sub-assemblies using Sockets
@@ -36,6 +38,4 @@ The following files are used by the InteractiveHopper GUI:
   - BuildInteractiveHopperSolution.m
   - InteractiveHopperParameters.m
   - InteractiveHopperSettings.m
-
-These files have been tested with MATLAB versions R2014b and later.
 


### PR DESCRIPTION
### Brief summary of changes
- Confirmed that InteractiveHopper demo only works on MATLAB 2014b or later, since graphics handles [were switched from doubles to objects](https://www.mathworks.com/help/matlab/graphics_transition/graphics-handles-are-now-objects-not-doubles.html) in MATLAB 2014b.
- Made update to README in Hopper_Device.

Based on feedback from Colin Smith's beta test.