### PR TITLE
[doxygen] Avoid truncating short descriptions

### DIFF
--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -287,17 +287,17 @@ public:
     double getTendonForce(const SimTK::State& s) const;
 
     /** get the current fiber stiffness (N/m) defined as the partial derivative
-        of fiber force w.r.t. fiber length */
+        of fiber force with respect to fiber length */
     double getFiberStiffness(const SimTK::State& s) const;
     /**get the stiffness of the fiber (N/m) along the direction of the tendon,
     that is the partial derivative of the fiber force along the tendon with
     respect to small changes in fiber length along the tendon*/
     double getFiberStiffnessAlongTendon(const SimTK::State& s) const;
     /** get the current tendon stiffness (N/m) defined as the partial derivative
-        of tendon force w.r.t. tendon length */
+        of tendon force with respect to tendon length */
     double getTendonStiffness(const SimTK::State& s) const;
     /** get the current muscle stiffness (N/m) defined as the partial derivative
-        of muscle force w.r.t. muscle length */
+        of muscle force with respect to muscle length */
     double getMuscleStiffness(const SimTK::State& s) const;
 
     /** get the current active fiber power (W) */


### PR DESCRIPTION
Fixes line breaks like this:
![doxygen](https://user-images.githubusercontent.com/4203505/28203844-3cd76d5c-6830-11e7-8fba-f9adc53eff2c.png)

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.