### PR TITLE
Fix InverseKinematicsTool's model out of date with its properties

### DIFF
--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -141,12 +141,6 @@ int main(int argc,char **argv)
     // CONSTRUCT
     cout<<"Constructing tool from setup file "<<setupFileName<<".\n\n";
     InverseKinematicsTool ik(setupFileName);
-    //ik.print("ik_setup_check.xml");
-
-    // PRINT MODEL INFORMATION
-    //Model& model = ik.getModel();
-    //model.finalizeFromProperties();
-    //model.printBasicInfo();
 
     // start timing
     std::clock_t startTime = std::clock();

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -262,6 +262,9 @@ bool InverseKinematicsTool::run()
         else
             modelFromFile = false;
 
+        // although newly loaded model will be finalized
+        // there is no gaurantee that the _model has not been edited/modified
+        _model->finalizeFromProperties();
         _model->printBasicInfo();
 
         // Do the maneuver to change then restore working directory 


### PR DESCRIPTION
Fixes issue #[GUI 249](https://github.com/opensim-org/opensim-gui/issues/249)

### Brief summary of changes
Explicitly call `Model::finalizeFromProperties()` before `Model::printBasicInfo`.
This isn't an issue about loading a new model. The model is modified outside the Tool somehow, e.g. during plotting. And future attempts to execute the tool subsequently fail.

### Testing I've completed
Tests and tools pass/run locally. 

### Looking for feedback on...
Needs to be verified in the GUI.

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix


