### PR TITLE
Added Outputs to Frame

### DIFF
--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -111,6 +111,16 @@ const SimTK::SpatialVec& Frame::getVelocityInGround(const State& s) const
         getCacheEntry(s, _velocityIndex)).get();
 }
 
+const SimTK::Vec3& Frame::getAngularVelocityInGround(const State& s) const
+{
+    return getVelocityInGround(s)[0];
+}
+
+const SimTK::Vec3& Frame::getLinearVelocityInGround(const State& s) const
+{
+    return getVelocityInGround(s)[1];
+}
+
 const SimTK::SpatialVec& Frame::getAccelerationInGround(const State& s) const
 {
     if (!getSystem().getDefaultSubsystem().
@@ -127,6 +137,16 @@ const SimTK::SpatialVec& Frame::getAccelerationInGround(const State& s) const
     return SimTK::Value<SpatialVec>::downcast(
         getSystem().getDefaultSubsystem().
         getCacheEntry(s, _accelerationIndex)).get();
+}
+
+const SimTK::Vec3& Frame::getAngularAccelerationInGround(const State& s) const
+{
+    return getAccelerationInGround(s)[0];
+}
+
+const SimTK::Vec3& Frame::getLinearAccelerationInGround(const State& s) const
+{
+    return getAccelerationInGround(s)[1];
 }
 
 void Frame::attachGeometry(OpenSim::Geometry* geom)

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -98,15 +98,15 @@ public:
         SimTK::Stage::Position);
     OpenSim_DECLARE_OUTPUT(velocity, SimTK::SpatialVec, getVelocityInGround,
         SimTK::Stage::Velocity);
-    OpenSim_DECLARE_OUTPUT(angularVelocity, SimTK::Vec3, getAngularVelocityInGround,
+    OpenSim_DECLARE_OUTPUT(angular_velocity, SimTK::Vec3, getAngularVelocityInGround,
         SimTK::Stage::Velocity);
-    OpenSim_DECLARE_OUTPUT(linearVelocity, SimTK::Vec3, getLinearVelocityInGround,
+    OpenSim_DECLARE_OUTPUT(linear_velocity, SimTK::Vec3, getLinearVelocityInGround,
         SimTK::Stage::Velocity);
     OpenSim_DECLARE_OUTPUT(acceleration, SimTK::SpatialVec, getAccelerationInGround,
         SimTK::Stage::Acceleration);
-    OpenSim_DECLARE_OUTPUT(angularAcceleration, SimTK::Vec3, getAngularAccelerationInGround,
+    OpenSim_DECLARE_OUTPUT(angular_acceleration, SimTK::Vec3, getAngularAccelerationInGround,
         SimTK::Stage::Acceleration);
-    OpenSim_DECLARE_OUTPUT(linearAcceleration, SimTK::Vec3, getLinearAccelerationInGround,
+    OpenSim_DECLARE_OUTPUT(linear_acceleration, SimTK::Vec3, getLinearAccelerationInGround,
         SimTK::Stage::Acceleration);
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -134,40 +134,46 @@ public:
     const SimTK::Transform&
         getTransformInGround(const SimTK::State& state) const;
 
-    /** The spatial velocity V_GF {omega; v} of this Frame in ground.
-        It can be used to compute the velocity of any stationary point on F,
-        located at r_F (Vec3), in ground, G, as:
+    /** The spatial velocity V_GF {omega; v} of this Frame, measured with
+        respect to and expressed in the ground frame. It can be used to compute
+        the velocity of any stationary point on F, located at r_F (Vec3), in
+        ground, G, as:
             v_G = V_GF[1] + SimTK::cross(V_GF[0], r_F);
         Is only valid at Stage::Velocity or higher. */
     const SimTK::SpatialVec&
         getVelocityInGround(const SimTK::State& state) const;
 
-    /** The angular velocity of this Frame in ground.
-        @see getVelocityInGround() */
+    /** The angular velocity of this Frame, measured with respect to and
+        expressed in the ground frame (i.e., the first half of the SpatialVec
+        returned by getVelocityInGround()). */
     const SimTK::Vec3&
         getAngularVelocityInGround(const SimTK::State& state) const;
 
-    /** The linear velocity of this Frame in ground.
-        @see getVelocityInGround() */
+    /** The linear velocity of this Frame, measured with respect to and
+        expressed in the ground frame (i.e., the second half of the SpatialVec
+        returned by getVelocityInGround()). */
     const SimTK::Vec3&
         getLinearVelocityInGround(const SimTK::State& state) const;
 
-    /** The spatial acceleration A_GF {alpha; a} of this Frame in ground.
-        It can also be used to compute the acceleration of any stationary point
-        on F, located at r_F (Vec3), in ground, G, as:
+    /** The spatial acceleration A_GF {alpha; a} of this Frame, measured with
+        respect to and expressed in the ground frame. It can also be used to
+        compute the acceleration of any stationary point on F, located at r_F
+        (Vec3), in ground, G, as:
             a_G = A_GF[1] + SimTK::cross(A_GF[0], r_F) + 
                   SimTK::cross(V_GF[0], SimTK::cross(V_GF[0], r_F));
         Is only valid at Stage::Acceleration or higher. */
     const SimTK::SpatialVec&
         getAccelerationInGround(const SimTK::State& state) const;
 
-    /** The angular acceleration of this Frame in ground.
-        @see getAccelerationInGround() */
+    /** The angular acceleration of this Frame, measured with respect to and
+        expressed in the ground frame (i.e., the first half of the SpatialVec
+        returned by getAccelerationInGround()). */
     const SimTK::Vec3&
         getAngularAccelerationInGround(const SimTK::State& state) const;
 
-    /** The linear acceleration of this Frame in ground.
-        @see getAccelerationInGround() */
+    /** The linear acceleration of this Frame, measured with respect to and
+        expressed in the ground frame (i.e., the second half of the SpatialVec
+        returned by getAccelerationInGround()). */
     const SimTK::Vec3&
         getLinearAccelerationInGround(const SimTK::State& state) const;
 

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -98,7 +98,15 @@ public:
         SimTK::Stage::Position);
     OpenSim_DECLARE_OUTPUT(velocity, SimTK::SpatialVec, getVelocityInGround,
         SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(angularVelocity, SimTK::Vec3, getAngularVelocityInGround,
+        SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(linearVelocity, SimTK::Vec3, getLinearVelocityInGround,
+        SimTK::Stage::Velocity);
     OpenSim_DECLARE_OUTPUT(acceleration, SimTK::SpatialVec, getAccelerationInGround,
+        SimTK::Stage::Acceleration);
+    OpenSim_DECLARE_OUTPUT(angularAcceleration, SimTK::Vec3, getAngularAccelerationInGround,
+        SimTK::Stage::Acceleration);
+    OpenSim_DECLARE_OUTPUT(linearAcceleration, SimTK::Vec3, getLinearAccelerationInGround,
         SimTK::Stage::Acceleration);
 
     //--------------------------------------------------------------------------
@@ -126,7 +134,7 @@ public:
     const SimTK::Transform&
         getTransformInGround(const SimTK::State& state) const;
 
-    /** The spatial velocity V_GF {omega; v} for this Frame in ground.
+    /** The spatial velocity V_GF {omega; v} of this Frame in ground.
         It can be used to compute the velocity of any stationary point on F,
         located at r_F (Vec3), in ground, G, as:
             v_G = V_GF[1] + SimTK::cross(V_GF[0], r_F);
@@ -134,7 +142,17 @@ public:
     const SimTK::SpatialVec&
         getVelocityInGround(const SimTK::State& state) const;
 
-    /** The spatial acceleration A_GF {alpha; a} for this Frame in ground.
+    /** The angular velocity of this Frame in ground.
+        @see getVelocityInGround() */
+    const SimTK::Vec3&
+        getAngularVelocityInGround(const SimTK::State& state) const;
+
+    /** The linear velocity of this Frame in ground.
+        @see getVelocityInGround() */
+    const SimTK::Vec3&
+        getLinearVelocityInGround(const SimTK::State& state) const;
+
+    /** The spatial acceleration A_GF {alpha; a} of this Frame in ground.
         It can also be used to compute the acceleration of any stationary point
         on F, located at r_F (Vec3), in ground, G, as:
             a_G = A_GF[1] + SimTK::cross(A_GF[0], r_F) + 
@@ -142,6 +160,16 @@ public:
         Is only valid at Stage::Acceleration or higher. */
     const SimTK::SpatialVec&
         getAccelerationInGround(const SimTK::State& state) const;
+
+    /** The angular acceleration of this Frame in ground.
+        @see getAccelerationInGround() */
+    const SimTK::Vec3&
+        getAngularAccelerationInGround(const SimTK::State& state) const;
+
+    /** The linear acceleration of this Frame in ground.
+        @see getAccelerationInGround() */
+    const SimTK::Vec3&
+        getLinearAccelerationInGround(const SimTK::State& state) const;
 
 
     /**

--- a/OpenSim/Simulation/Test/testFrames.cpp
+++ b/OpenSim/Simulation/Test/testFrames.cpp
@@ -526,4 +526,15 @@ void testVelocityAndAccelerationMethods()
         SimTK_TEST_EQ(v, vo);
         SimTK_TEST_EQ(a, ao);
     }
+
+    // Test convenience methods for accessing angular and linear components of
+    // velocity and acceleration.
+    SimTK_TEST_EQ(rod2.getVelocityInGround(s)[0],
+                  rod2.getAngularVelocityInGround(s));
+    SimTK_TEST_EQ(rod2.getVelocityInGround(s)[1],
+                  rod2.getLinearVelocityInGround(s));
+    SimTK_TEST_EQ(rod2.getAccelerationInGround(s)[0],
+                  rod2.getAngularAccelerationInGround(s));
+    SimTK_TEST_EQ(rod2.getAccelerationInGround(s)[1],
+                  rod2.getLinearAccelerationInGround(s));
 }


### PR DESCRIPTION
Fixes issue #1415.

### Brief summary of changes
Added Outputs to Frame for conveniently reporting only angular or linear components of velocity and acceleration.

### CHANGELOG.md (choose one)
No need to update because… new functionality in 4.0.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.