### PR TITLE
Update README.md - Add cmake command to fix import error in python (Windows 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ make -j8
 ctest -j8
 make -j8 install
 ```
-Note: You may need to add `<FULL-DIR>/opensim_install/bin` to your PATH variable as per [these instructions](#set-environment-variables).  
+Note: You may need to add `<FULL-DIR>/opensim_install/bin` to your PATH variable as per [these instructions](#set-environment-variables-2).  
 Example: If opensim_install is in your home directory:
 
         $ echo 'export PATH=~/opensim_install/bin:$PATH' >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -386,8 +386,9 @@ cmake ..\opensim-core                                              `
       -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install" `
       -DBUILD_JAVA_WRAPPING=ON                                     `
       -DBUILD_PYTHON_WRAPPING=ON                                   `
-      -DWITH_BTK=ON
+      -DWITH_BTK=ON                                                `                                  
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
+cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
 ctest -C RelWithDebInfo --parallel 8
 ```
 

--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ ctest -C RelWithDebInfo --parallel 8
 cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
 ```
 
-Note: Please add **<FULL-DIR>\opensim_install\bin** to your PATH variable as per [these instructions](#set-environment-variables).  
-(Example: If `opensim_install` is in `C:`, add `C:\opensim_install\bin` to your PATH.)  
+Note: Please add `<FULL-DIR>\opensim_install\bin` to your PATH variable as per [these instructions](#set-environment-variables).  
+Example: If `opensim_install` is in `C:`, add `C:\opensim_install\bin` to your PATH.  
 
 On Mac OSX using Xcode
 ======================
@@ -899,7 +899,7 @@ make -j8
 ctest -j8
 make -j8 install
 ```
-Note: You may need to add **<FULL-DIR>/opensim_install/bin** to your PATH variable as per [these instructions](#set-environment-variables).  
+Note: You may need to add `<FULL-DIR>/opensim_install/bin` to your PATH variable as per [these instructions](#set-environment-variables).  
 Example: If opensim_install is in your home directory:
 
         $ echo 'export PATH=~/opensim_install/bin:$PATH' >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -388,9 +388,12 @@ cmake ..\opensim-core                                              `
       -DBUILD_PYTHON_WRAPPING=ON                                   `
       -DWITH_BTK=ON                                                `                                  
 cmake --build . --config RelWithDebInfo -- /maxcpucount:8
-cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
 ctest -C RelWithDebInfo --parallel 8
+cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
 ```
+
+Note: Please add Add **<FULL-DIR>\opensim_install\bin** to your PATH variable as per [these instructions](#set-environment-variables).  
+(Example: If `opensim_install` is in `C:`, add `C:\opensim_install\bin` to your PATH.)  
 
 On Mac OSX using Xcode
 ======================
@@ -833,6 +836,7 @@ cmake ../opensim-core \
       -DWITH_BTK=ON
 make -j8
 ctest -j8
+make -j8 install
  ```
 ##### Ubuntu 15.10 Wily Werewolf
 In **Terminal** --
@@ -863,6 +867,7 @@ cmake ../opensim-core \
       -DWITH_BTK=ON
 make -j8
 ctest -j8
+make -j8 install
 ```
 ##### Ubuntu 16.04 Xenial Xerus AND Ubuntu 16.10 Yakkety Yak
 In **Terminal** --
@@ -892,7 +897,13 @@ cmake ../opensim-core \
       -DWITH_BTK=ON
 make -j8
 ctest -j8
+make -j8 install
 ```
+Note: You may need to add **<FULL-DIR>/opensim_install/bin** to your PATH variable as per [these instructions](#set-environment-variables).  
+Example: If opensim_install is in your home directory:
+
+        $ echo 'export PATH=~/opensim_install/bin:$PATH' >> ~/.bashrc
+ 
 
 [buildstatus_image_travis]: https://travis-ci.org/opensim-org/opensim-core.svg?branch=master
 [travisci]: https://travis-ci.org/opensim-org/opensim-core

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ ctest -C RelWithDebInfo --parallel 8
 cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
 ```
 
-Note: Please add Add **<FULL-DIR>\opensim_install\bin** to your PATH variable as per [these instructions](#set-environment-variables).  
+Note: Please add **<FULL-DIR>\opensim_install\bin** to your PATH variable as per [these instructions](#set-environment-variables).  
 (Example: If `opensim_install` is in `C:`, add `C:\opensim_install\bin` to your PATH.)  
 
 On Mac OSX using Xcode


### PR DESCRIPTION
Added an extra command in the 'Impatient Method' for Windows to fix import error in python. 

Fixes issue #1839  

### Brief summary of changes
Added extra cmake command (to Impatient Method - Windows) to fix python import error.

### Testing I've completed
Tested on Windows 10, Python 3.5
`import opensim` works without any errors.

### Looking for feedback on...
None

### CHANGELOG.md (choose one)

-added extra cmake command with `--target` parameter

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
