### PR TITLE
Make wrapping of SimTK::Array_<CoordinateReference> consistent with other classes

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -197,7 +197,7 @@
 
 %template(ReferenceVec3) OpenSim::Reference_<SimTK::Vec3>;
 %template(ReferenceDouble) OpenSim::Reference_<double>;
-%template(ArrayCoordinateReference) SimTK::Array_<OpenSim::CoordinateReference>;
+%template(SimTKArrayCoordinateReference) SimTK::Array_<OpenSim::CoordinateReference>;
 
 
 %include <OpenSim/Simulation/MarkersReference.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ MATLAB and Python interfaces
 - The SimbodyMatterSubsystem class--which provides operators related to the mass
 matrix, Jacobians, inverse dynamics, etc.--is now accessible in MATLAB and
 Python (PR #930).
+- Changed wrapping of `SimTK::Array_<OpenSim::CoordinateReference>` from `ArrayCoordinateReference` to `SimTKArrayCoordinateReference` for consistency with other classes. (PR #1842)
 
 MATLAB interface
 ----------------


### PR DESCRIPTION
Fixes issue #1822

### CHANGELOG.md (choose one)
- Updated.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.