### PR TITLE
Fix 1650 c3 d file adapter column order

### DIFF
--- a/Bindings/Java/tests/TestC3DFileAdapter.java
+++ b/Bindings/Java/tests/TestC3DFileAdapter.java
@@ -69,11 +69,11 @@ class TestC3DFileAdapter {
         StdVectorString units = forceTable.getDependentsMetaDataString("units");
         assert units.size() == 6;
         assert units.get(0).equals("N");
-        assert units.get(1).equals("Nmm");
-        assert units.get(2).equals("mm");
+        assert units.get(1).equals("mm");
+        assert units.get(2).equals("Nmm");
         assert units.get(3).equals("N");
-        assert units.get(4).equals("Nmm");
-        assert units.get(5).equals("mm");
+        assert units.get(4).equals("mm");
+        assert units.get(5).equals("Nmm");
             
 
         // Flatten forces data.

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -91,8 +91,8 @@ class TestDataAdapter(unittest.TestCase):
         assert fpOrigins[0].ncol() == 1
         assert fpOrigins[1].nrow() == 3
         assert fpOrigins[1].ncol() == 1
-        assert forces.getDependentsMetaDataString('units') == ('N', 'Nmm', 'mm',
-                                                               'N', 'Nmm', 'mm')
+        assert forces.getDependentsMetaDataString('units') == ('N', 'mm', 'Nmm',
+                                                               'N', 'mm', 'Nmm')
 
         # Flatten forces data.
         forcesFlat = forces.flatten()

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -197,15 +197,15 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                 at(_unit_index.at("force"));
             units.upd().push_back(SimTK::Value<std::string>(force_unit));
 
-            labels.push_back(SimTK::Value<std::string>("m" + fp_str));
-            auto moment_unit = acquisition->GetPointUnits().
-                at(_unit_index.at("moment"));
-            units.upd().push_back(SimTK::Value<std::string>(moment_unit));
-
             labels.push_back(SimTK::Value<std::string>("p" + fp_str));
             auto position_unit = acquisition->GetPointUnits().
                 at(_unit_index.at("marker"));
             units.upd().push_back(SimTK::Value<std::string>(position_unit));
+
+            labels.push_back(SimTK::Value<std::string>("m" + fp_str));
+            auto moment_unit = acquisition->GetPointUnits().
+                at(_unit_index.at("moment"));
+            units.upd().push_back(SimTK::Value<std::string>(moment_unit));
         }
 
         const int nf = fp_force_pts->GetFrontItem()->GetFrameNumber();
@@ -230,13 +230,13 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                                        (*fit)->GetValues().coeff(f, 1),
                                        (*fit)->GetValues().coeff(f, 2)};
                 ++col;
+                row[col] = SimTK::Vec3{ (*pit)->GetValues().coeff(f, 0),
+                    (*pit)->GetValues().coeff(f, 1),
+                    (*pit)->GetValues().coeff(f, 2) };
+                ++col;
                 row[col] = SimTK::Vec3{(*mit)->GetValues().coeff(f, 0),
                                        (*mit)->GetValues().coeff(f, 1),
                                        (*mit)->GetValues().coeff(f, 2)};
-                ++col;
-                row[col] = SimTK::Vec3{(*pit)->GetValues().coeff(f, 0),
-                                       (*pit)->GetValues().coeff(f, 1),
-                                       (*pit)->GetValues().coeff(f, 2)};
                 ++col;
             }
             force_matrix.updRow(f) = row;


### PR DESCRIPTION
Fixes issue #1650 

### Brief summary of changes
Directly addresses the issue by ordering the force, cop and moment columns associated with a force-plate (analog data) in the order expected in 3.3 and earlier version of OpenSim. The order is arbitrary anyway so choosing the one that is easiest to handle makes the most sense. A simpler fix than that attempted in #1652. It will significantly simplify and speedup #1434.

### Testing I've completed
C3DFileAdapter related tests pass locally including scripting tests. 

### Looking for feedback on...
Would be great to see how this impacts #1434, @jimmyDunne.

### CHANGELOG.md (choose one)
- no need to update because is being introduced for the first time in 4.0 and does not change any interfaces.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
