### PR TITLE
Avoid "Policy CMP0054 is not set" warning in CMake when using examples

### DIFF
--- a/OpenSim/Examples/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Examples/ControllerExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/CustomActuatorExample/OutputReference/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/OutputReference/CMakeLists.txt
@@ -15,8 +15,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleMain/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Examples/MuscleExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 set(PLUGIN_NAME "osimPlugin" CACHE STRING "Name of shared library to create")
 
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 set(PLUGIN_NAME "BodyDragForce" CACHE STRING "Name of shared library to create")
 
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
@@ -12,8 +12,8 @@ set(PLUGIN_NAME "osimCoupledBushingForcePlugin"
     CACHE STRING "Name of shared library to create")
 
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
+++ b/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
@@ -53,8 +53,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/OpenSim/Examples/checkEnvironment/CMakeLists.txt
+++ b/OpenSim/Examples/checkEnvironment/CMakeLists.txt
@@ -11,8 +11,8 @@ set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
 # Find and hook up to OpenSim.
 # ----------------------------
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -12,8 +12,8 @@ set(my_source_files myexe.cpp)
 set(my_header_files myexe.h)
 
 # OpenSim uses C++11 language features.
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-        "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+        ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Using C++11 on OSX requires using libc++ instead of libstd++.
     # libc++ is an implementation of the C++ standard library for OSX.
     if(APPLE)


### PR DESCRIPTION
See https://cmake.org/cmake/help/v3.8/policy/CMP0054.html. Identical lines in [this file](https://github.com/opensim-org/opensim-core/blob/master/CMakeLists.txt#L296) do not have quotes.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.