### PR TITLE
DataTable::toString() should not throw EmptyTable exception; improve exceptions thrown by DataTable

### DIFF
--- a/OpenSim/Common/AbstractDataTable.h
+++ b/OpenSim/Common/AbstractDataTable.h
@@ -470,7 +470,7 @@ protected:
     /** Get number of columns. Implemented by derived classes.                */
     virtual size_t implementGetNumColumns() const    = 0;
     
-    /** Check if metadata for independent column is valid . Implemented by 
+    /** Check if metadata for independent column is valid. Implemented by 
     derived classes.                                                          */
     virtual void validateIndependentMetaData() const = 0;
 

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -670,8 +670,10 @@ public:
 
     /** Get row at index.                                                     
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If index is out of range.                      */
     const RowVectorView getRowAtIndex(size_t index) const {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, 
                          index, 0, static_cast<unsigned>(_indData.size() - 1));
@@ -697,8 +699,10 @@ public:
 
     /** Update row at index.                                                  
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If the index is out of range.                  */
     RowVectorView updRowAtIndex(size_t index) {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, 
                          index, 0, static_cast<unsigned>(_indData.size() - 1));
@@ -727,6 +731,7 @@ public:
     updRowAtIndex(index) = depRow;
     ```
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If the index is out of range.                  */
     void setRowAtIndex(size_t index, const RowVectorView& depRow) {
         updRowAtIndex(index) = depRow;
@@ -737,6 +742,7 @@ public:
     updRowAtIndex(index) = depRow;
     ```
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If the index is out of range.                  */
     void setRowAtIndex(size_t index, const RowVector& depRow) {
         updRowAtIndex(index) = depRow;
@@ -774,8 +780,10 @@ public:
 
     /** Remove row at index.
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If the index is out of range.                  */
     void removeRowAtIndex(size_t index) {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(index),
                          RowIndexOutOfRange, 
                          index, 0, static_cast<unsigned>(_indData.size() - 1));
@@ -945,9 +953,11 @@ public:
 
     /** Get dependent column at index.
 
+    \throws EmptyTable If the table is empty.
     \throws ColumnIndexOutOfRange If index is out of range for number of columns
                                   in the table.                               */
     VectorView getDependentColumnAtIndex(size_t index) const {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isColumnIndexOutOfRange(index),
                          ColumnIndexOutOfRange, index, 0,
                          static_cast<size_t>(_depData.ncol() - 1));
@@ -965,9 +975,11 @@ public:
 
     /** Update dependent column at index.
 
+    \throws EmptyTable If the table is empty.
     \throws ColumnIndexOutOfRange If index is out of range for number of columns
                                   in the table.                               */
     VectorView updDependentColumnAtIndex(size_t index) {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isColumnIndexOutOfRange(index),
                          ColumnIndexOutOfRange, index, 0,
                          static_cast<size_t>(_depData.ncol() - 1));
@@ -985,10 +997,12 @@ public:
 
     /** %Set value of the independent column at index.
 
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If rowIndex is out of range.
     \throws InvalidRow If this operation invalidates the row. Validation is
                        performed by derived classes.                          */
     void setIndependentValueAtIndex(size_t rowIndex, const ETX& value) {
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(rowIndex),
                          RowIndexOutOfRange, 
                          rowIndex, 0, 
@@ -1013,6 +1027,7 @@ public:
     /** Get a read-only view of a block of the underlying matrix.             
 
     \throws InvalidArgument If numRows or numColumns is zero.
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If one or more rows of the desired block is out
                                of range of the matrix.
     \throws ColumnIndexOutOfRange If one or more columns of the desired block is
@@ -1024,6 +1039,7 @@ public:
         OPENSIM_THROW_IF(numRows == 0 || numColumns == 0,
                          InvalidArgument,
                          "Either numRows or numColumns is zero.");
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(rowStart),
                          RowIndexOutOfRange,
                          rowStart, 0, 
@@ -1055,6 +1071,7 @@ public:
     /** Get a writable view of a block of the underlying matrix.
 
     \throws InvalidArgument If numRows or numColumns is zero.
+    \throws EmptyTable If the table is empty.
     \throws RowIndexOutOfRange If one or more rows of the desired block is out
                                of range of the matrix.
     \throws ColumnIndexOutOfRange If one or more columns of the desired block is
@@ -1066,6 +1083,7 @@ public:
         OPENSIM_THROW_IF(numRows == 0 || numColumns == 0,
                          InvalidArgument,
                          "Either numRows or numColumns is zero.");
+        OPENSIM_THROW_IF(isEmpty(), EmptyTable);
         OPENSIM_THROW_IF(isRowIndexOutOfRange(rowStart),
                          RowIndexOutOfRange,
                          rowStart, 0, 
@@ -1416,8 +1434,12 @@ protected:
         makeElement_helper(elem, begin, end);
         return elem;
     }
-    
-    
+
+    /** Determine whether table is empty. */
+    bool isEmpty() const {
+        return _depData.nrow() == 0 || _depData.ncol() == 0;
+    }
+
     /** Check if row index is out of range.                                   */
     bool isRowIndexOutOfRange(size_t index) const {
         return index >= _indData.size();

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1187,12 +1187,13 @@ protected:
                               const bool       withMetaData = true,
                               unsigned         splitSize    = 25,
                               unsigned         maxWidth     = 80,
-                              unsigned         precision    = 4) const {
+                              unsigned         precision    = 4) const
+    {
+        if (getNumRows() == 0 || getNumColumns() == 0) { return ""; }
+
         static_assert(std::is_same<ETX, double>::value,
                       "This function can only be called for a table with "
                       "independent column of type 'double'.");
-        OPENSIM_THROW_IF(getNumRows() == 0 || getNumColumns() == 0,
-                         EmptyTable);
 
         // Defaults.
         const unsigned    defSplitSize{25};

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1189,7 +1189,8 @@ protected:
                               unsigned         maxWidth     = 80,
                               unsigned         precision    = 4) const
     {
-        if (getNumRows() == 0 || getNumColumns() == 0) { return ""; }
+        if (getNumRows() == 0 || getNumColumns() == 0)
+            return "(Table is empty)\n";
 
         static_assert(std::is_same<ETX, double>::value,
                       "This function can only be called for a table with "

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1207,7 +1207,7 @@ protected:
                               unsigned         maxWidth     = 80,
                               unsigned         precision    = 4) const
     {
-        if (getNumRows() == 0 || getNumColumns() == 0)
+        if (isEmpty())
             return "(Table is empty)\n";
 
         static_assert(std::is_same<ETX, double>::value,
@@ -1437,7 +1437,7 @@ protected:
 
     /** Determine whether table is empty. */
     bool isEmpty() const {
-        return _depData.nrow() == 0 || _depData.ncol() == 0;
+        return getNumRows() == 0 || getNumColumns() == 0;
     }
 
     /** Check if row index is out of range.                                   */

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1614,8 +1614,9 @@ void testTableReporter() {
             TimeStepper ts(system, integ);
             ts.initialize(s);
             ts.stepTo(1.0);
-            std::cout << "TableReporter table after simulating:\n";
             const auto& table = reporter->getTable();
+            std::cout << "TableReporter table after simulating:\n"
+                      << table.toString() << std::endl;
             SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
                                       ColumnIndexOutOfRange);
         }
@@ -1623,7 +1624,8 @@ void testTableReporter() {
         // Ensure that clearing the table and performing a new simulation works
         // even if the reporter's input has no connectees.
         reporter->clearTable();
-        std::cout << "TableReporter table after clearing:\n";
+        std::cout << "TableReporter table after clearing:\n"
+                  << reporter->getTable().toString() << std::endl;
         SimTK_TEST_MUST_THROW_EXC(
             reporter->getTable().getDependentColumnAtIndex(0),
             ColumnIndexOutOfRange);
@@ -1635,8 +1637,9 @@ void testTableReporter() {
             TimeStepper ts(system, integ);
             ts.initialize(s);
             ts.stepTo(1.0);
-            std::cout << "TableReporter table after simulating again:\n";
             const auto& table = reporter->getTable();
+            std::cout << "TableReporter table after simulating again:\n"
+                      << table.toString() << std::endl;
             SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
                                       ColumnIndexOutOfRange);
         }

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1616,14 +1616,17 @@ void testTableReporter() {
             ts.stepTo(1.0);
             std::cout << "TableReporter table after simulating:\n";
             const auto& table = reporter->getTable();
-            SimTK_TEST_MUST_THROW_EXC(table.toString(), EmptyTable);
+            SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
+                                      ColumnIndexOutOfRange);
         }
 
         // Ensure that clearing the table and performing a new simulation works
         // even if the reporter's input has no connectees.
         reporter->clearTable();
         std::cout << "TableReporter table after clearing:\n";
-        SimTK_TEST_MUST_THROW_EXC(reporter->getTable().toString(), EmptyTable);
+        SimTK_TEST_MUST_THROW_EXC(
+            reporter->getTable().getDependentColumnAtIndex(0),
+            ColumnIndexOutOfRange);
     
         {
             SimTK::State s = system.realizeTopology();
@@ -1634,7 +1637,8 @@ void testTableReporter() {
             ts.stepTo(1.0);
             std::cout << "TableReporter table after simulating again:\n";
             const auto& table = reporter->getTable();
-            SimTK_TEST_MUST_THROW_EXC(table.toString(), EmptyTable);
+            SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
+                                      ColumnIndexOutOfRange);
         }
     }
 }

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1618,7 +1618,7 @@ void testTableReporter() {
             std::cout << "TableReporter table after simulating:\n"
                       << table.toString() << std::endl;
             SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
-                                      ColumnIndexOutOfRange);
+                                      EmptyTable);
         }
 
         // Ensure that clearing the table and performing a new simulation works
@@ -1628,7 +1628,7 @@ void testTableReporter() {
                   << reporter->getTable().toString() << std::endl;
         SimTK_TEST_MUST_THROW_EXC(
             reporter->getTable().getDependentColumnAtIndex(0),
-            ColumnIndexOutOfRange);
+            EmptyTable);
     
         {
             SimTK::State s = system.realizeTopology();
@@ -1641,7 +1641,7 @@ void testTableReporter() {
             std::cout << "TableReporter table after simulating again:\n"
                       << table.toString() << std::endl;
             SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
-                                      ColumnIndexOutOfRange);
+                                      EmptyTable);
         }
     }
 }

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -76,11 +76,16 @@ int main() {
                 throw Exception{"Test failed: "
                                 "table.getColumnIndex(labels.at(i)) != i"};
     }
-    // Print out the DataTable to console.
-    try {
-        table.getDependentColumnAtIndex(0);
-        throw Exception{"Test failed: Exception expected."};
-    } catch(const OpenSim::ColumnIndexOutOfRange&) {}
+
+    // Test exceptions (table should be empty here).
+    SimTK_TEST_MUST_THROW_EXC(table.getRowAtIndex(0),
+                              OpenSim::RowIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.updRowAtIndex(0),
+                              OpenSim::RowIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
+                              OpenSim::ColumnIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.updDependentColumnAtIndex(0),
+                              OpenSim::ColumnIndexOutOfRange);
 
     table.setDependentsMetaData(dep_metadata);
     table.setIndependentMetaData(ind_metadata);

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -78,9 +78,9 @@ int main() {
     }
     // Print out the DataTable to console.
     try {
-        std::cout << table << std::endl;
+        table.getDependentColumnAtIndex(0);
         throw Exception{"Test failed: Exception expected."};
-    } catch(const OpenSim::EmptyTable&) {}
+    } catch(const OpenSim::ColumnIndexOutOfRange&) {}
 
     table.setDependentsMetaData(dep_metadata);
     table.setIndependentMetaData(ind_metadata);

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -79,13 +79,13 @@ int main() {
 
     // Test exceptions (table should be empty here).
     SimTK_TEST_MUST_THROW_EXC(table.getRowAtIndex(0),
-                              OpenSim::RowIndexOutOfRange);
+                              OpenSim::EmptyTable);
     SimTK_TEST_MUST_THROW_EXC(table.updRowAtIndex(0),
-                              OpenSim::RowIndexOutOfRange);
+                              OpenSim::EmptyTable);
     SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(0),
-                              OpenSim::ColumnIndexOutOfRange);
+                              OpenSim::EmptyTable);
     SimTK_TEST_MUST_THROW_EXC(table.updDependentColumnAtIndex(0),
-                              OpenSim::ColumnIndexOutOfRange);
+                              OpenSim::EmptyTable);
 
     table.setDependentsMetaData(dep_metadata);
     table.setIndependentMetaData(ind_metadata);
@@ -104,6 +104,16 @@ int main() {
     try {
         table.appendRow(0.5, row);
     } catch (OpenSim::Exception&) {}
+
+    // Test exceptions (table should have 5 rows and 5 dependent columns here).
+    SimTK_TEST_MUST_THROW_EXC(table.getRowAtIndex(10),
+                              OpenSim::RowIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.updRowAtIndex(10),
+                              OpenSim::RowIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.getDependentColumnAtIndex(10),
+                              OpenSim::ColumnIndexOutOfRange);
+    SimTK_TEST_MUST_THROW_EXC(table.updDependentColumnAtIndex(10),
+                              OpenSim::ColumnIndexOutOfRange);
 
     const auto& avgRow = table.averageRow(0.2, 0.8);
     for(int i = 0; i < avgRow.ncol(); ++i)


### PR DESCRIPTION
Fixes issue #1825

### Brief summary of changes
- Now prints `(Table is empty)` when `toString()`ing an empty table rather than throwing `EmptyTable` exception.
- Updated tests that relied on `EmptyTable` exception being thrown when printing an empty table.

### CHANGELOG.md (choose one)
- No need to update because `!DataTable.exist() in OpenSim < 4.0`

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
