### PR TITLE
Add message when addBody() and addJoint() encounter duplicate names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Converting from v3.x to v4.0
 `Millard2012EquilibriumMuscle::computeFiberEquilibrium(SimTK::State&, bool useZeroVelocity)`
 where fiber-velocity can be estimated from the state or assumed to be zero if the flag is *true*.
 - `Millard2012EquilibriumMuscle::computeInitialFiberEquilibrium(SimTK::State&)` invokes `computeFiberEquilibrium()` with `useZeroVelocity = true` to maintain its previous behavior.
-- The name of each Body and Joint component must be unique (PR #1866).
+- Each Body and Joint must have a unique absolute path name (PR #1866).
 
 Composing a Component from other components
 -------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Converting from v3.x to v4.0
 `Millard2012EquilibriumMuscle::computeFiberEquilibrium(SimTK::State&, bool useZeroVelocity)`
 where fiber-velocity can be estimated from the state or assumed to be zero if the flag is *true*.
 - `Millard2012EquilibriumMuscle::computeInitialFiberEquilibrium(SimTK::State&)` invokes `computeFiberEquilibrium()` with `useZeroVelocity = true` to maintain its previous behavior.
+- The name of each Body and Joint component must be unique (PR #1866).
 
 Composing a Component from other components
 -------------------------------------------

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -661,9 +661,15 @@ void Model::createMultibodyTree()
 
     auto bodies = getComponentList<Body>();
     for (auto& body : bodies) {
-        _multibodyTree.addBody( body.getAbsolutePathName(),
-                                body.getMass(), false,
-                                const_cast<Body*>(&body) );
+        try {
+            _multibodyTree.addBody( body.getAbsolutePathName(),
+                                    body.getMass(), false,
+                                    const_cast<Body*>(&body) );
+        } catch (const std::runtime_error& e) {
+            cout << "Duplicate Body names are not permitted. Please update "
+                 << "your model's .osim file accordingly." << std::endl;
+            throw e;
+        }
     }
 
     std::vector<SimTK::ReferencePtr<Joint>> joints;
@@ -695,14 +701,20 @@ void Model::createMultibodyTree()
             finalizeConnections(*this);
 
         // Use joints to define the underlying multibody tree
-        _multibodyTree.addJoint(name,
-            joint->getConcreteClassName(),
-            // Multibody tree builder only cares about bodies not intermediate
-            // frames that joints actually connect to.
-            joint->getParentFrame().findBaseFrame().getAbsolutePathName(),
-            joint->getChildFrame().findBaseFrame().getAbsolutePathName(),
-            false,
-            joint.get());
+        try {
+            _multibodyTree.addJoint(name,
+                joint->getConcreteClassName(),
+                // Multibody tree builder only cares about bodies not
+                // intermediate frames that joints actually connect to.
+                joint->getParentFrame().findBaseFrame().getAbsolutePathName(),
+                joint->getChildFrame().findBaseFrame().getAbsolutePathName(),
+                false,
+                joint.get());
+        } catch (const std::runtime_error& e) {
+            cout << "Duplicate Joint names are not permitted. Please update "
+                 << "your model's .osim file accordingly." << std::endl;
+            throw e;
+        }
     }
 }
 

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -666,9 +666,8 @@ void Model::createMultibodyTree()
                                     body.getMass(), false,
                                     const_cast<Body*>(&body) );
         } catch (const std::runtime_error& e) {
-            cout << "Duplicate Body names are not permitted. Please update "
-                 << "your model's .osim file accordingly." << std::endl;
-            throw e;
+            OPENSIM_THROW_FRMOBJ(MultibodyGraphMakerFailed,
+                                 std::string(e.what()));
         }
     }
 
@@ -711,9 +710,8 @@ void Model::createMultibodyTree()
                 false,
                 joint.get());
         } catch (const std::runtime_error& e) {
-            cout << "Duplicate Joint names are not permitted. Please update "
-                 << "your model's .osim file accordingly." << std::endl;
-            throw e;
+            OPENSIM_THROW_FRMOBJ(MultibodyGraphMakerFailed,
+                                 std::string(e.what()));
         }
     }
 }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -105,6 +105,22 @@ public:
     }
 };
 
+class MultibodyGraphMakerFailed : public Exception {
+public:
+    MultibodyGraphMakerFailed(const std::string& file,
+        size_t line,
+        const std::string& func,
+        const Object& obj,
+        const std::string& err) :
+        Exception(file, line, func, obj) {
+        std::string msg;
+        msg += "Unable to define a valid multibody tree.\nPlease ensure that ";
+        msg += "all bodies and joints have unique absolute path names.\nThe ";
+        msg += "MultibodyGraphMaker reported the following error:\n" + err;
+        addMessage(msg);
+    }
+};
+
 //==============================================================================
 //                                  MODEL
 //==============================================================================


### PR DESCRIPTION
Fixes issue #1768.

### Brief summary of changes
Catch `runtime_error`s thrown by Simbody's MultibodyGraphMaker (e.g., [here](https://github.com/simbody/simbody/blob/master/SimTKmath/src/MultibodyGraphMaker.cpp#L109)) and add an OpenSim-specific message.

### CHANGELOG.md (choose one)
Added note to "Converting from v3.x to v4.0" section.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
