### PR TITLE
Properly override connectToModelAndBody in WrapDoubleCylinderObst.

### DIFF
--- a/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.cpp
+++ b/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.cpp
@@ -142,8 +142,12 @@ void WrapDoubleCylinderObst::setupProperties()
 *
 * @param aModel simbody model
 */
-void WrapDoubleCylinderObst::connectToModelAndBody(Model& aModel, OpenSim::Body& aBody)
+void WrapDoubleCylinderObst::connectToModelAndBody(Model& aModel,
+        PhysicalFrame& aBody)
 {
+    OPENSIM_THROW_IF_FRMOBJ(!dynamic_cast<Body*>(&aBody),
+        Exception, "Non-Body PhysicalFrames not yet supported.");
+
     // Base class
     Super::connectToModelAndBody(aModel, aBody);
 
@@ -191,6 +195,7 @@ void WrapDoubleCylinderObst::connectToModelAndBody(Model& aModel, OpenSim::Body&
     _model = &aModel;   // Save this for use in wrapLine
 
     // Obtain wrapVcylHomeBody based on wrapVcylHomeBodyName
+    // TODO should look for PhysicalFrames anywhere in the model.
     if(!aModel.updBodySet().contains(_wrapVcylHomeBodyName)) {
         string errorMessage = "Error: wrapVcylHomeBody " + _wrapVcylHomeBodyName + " for wrap obstacle " + getName() + " was not found in model.";
         throw Exception(errorMessage);

--- a/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.h
+++ b/OpenSim/Simulation/Wrap/WrapDoubleCylinderObst.h
@@ -1,5 +1,5 @@
-#ifndef __WrapDoubleCylinderObst_h__
-#define __WrapDoubleCylinderObst_h__
+#ifndef OPENSIM_WRAP_DOUBLE_CYLINDER_OBST_H_
+#define OPENSIM_WRAP_DOUBLE_CYLINDER_OBST_H_
 /* -------------------------------------------------------------------------- *
  *                     OpenSim:  WrapDoubleCylinderObst.h                     *
  * -------------------------------------------------------------------------- *
@@ -77,8 +77,8 @@ OpenSim_DECLARE_CONCRETE_OBJECT(WrapDoubleCylinderObst, WrapObject);
     // Name of body to which B cylinder is attached
     PropertyStr _wrapVcylHomeBodyNameProp;
     std::string& _wrapVcylHomeBodyName;
-    OpenSim::Body* _wrapVcylHomeBody;
-    OpenSim::Body* _wrapUcylHomeBody;
+    PhysicalFrame* _wrapVcylHomeBody;
+    PhysicalFrame* _wrapUcylHomeBody;
 
     PropertyDblArray _xyzBodyRotationVcylProp;
     Array<double>& _xyzBodyRotationVcyl;
@@ -119,7 +119,7 @@ public:
     const char* getWrapTypeName() const override;
     std::string getDimensionsString() const override;
     void scale(const SimTK::Vec3& aScaleFactors) override { }
-    virtual void connectToModelAndBody(Model& aModel, OpenSim::Body& aBody);
+    void connectToModelAndBody(Model& aModel, PhysicalFrame& aBody) override;
 protected:
     int wrapLine(const SimTK::State& s, SimTK::Vec3& aPoint1, SimTK::Vec3& aPoint2,
         const PathWrap& aPathWrap, WrapResult& aWrapResult, bool& aFlag) const override;
@@ -131,12 +131,12 @@ private:
 
 
 //=============================================================================
-};  // END of class WrapCylinder
+};  // END of class WrapDoubleCylinderObst
 //=============================================================================
 //=============================================================================
 
 } // end of namespace OpenSim
 
-#endif // __WrapCylinder_h__
+#endif // OPENSIM_WRAP_DOUBLE_CYLINDER_OBST_H_
 
 


### PR DESCRIPTION
Fixes #1864

### Brief summary of changes

I changed the signature of `WrapDoubleCylinderObst::connectToModelAndBody()` so that it properly overrides the virtual function in the base class.

I did not go so far as making WrapDoubleCylinderObst work with PhysicalFrames that are not bodies; this would require more work. I simply wanted to fix the bug where WrapDoubleCylinderObst doesn't even work with bodies. 

### Testing I've completed

Ran all API tests.

### CHANGELOG.md (choose one)

- no need to update because PhysicalFrames are new to 4.0

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
