### PR TITLE
Fix warnings from Visual Studio

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -154,7 +154,7 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
 
     SimTK::State s = model.getWorkingState();
     // Independently compute the active fiber force at every state
-    for (int i = 0; i < nstates; ++i) {
+    for (size_t i = 0; i < nstates; ++i) {
         s = statesTraj[i];
         // When the muscle states are not supplied in the input dataStore
         // (isCoordinatesOnly == true), then set it to its default value.

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -965,7 +965,7 @@ void testMuscleEquilibriumSolve(const Model& model, const Storage& statesStore)
 
     SimTK::State s = model.getWorkingState();
     // Independently compute the active fiber force at every state
-    for (int i = 0; i < nstates; ++i) {
+    for (size_t i = 0; i < nstates; ++i) {
         s = statesTraj[i];
 
         // test a full sweep of default activations at each state
@@ -976,7 +976,7 @@ void testMuscleEquilibriumSolve(const Model& model, const Storage& statesStore)
             try {
                 muscle.computeEquilibrium(s);
             }
-            catch (const MuscleCannotEquilibrate& x) {
+            catch (const MuscleCannotEquilibrate&) {
                 // Write out the muscle equilibrium error as a function of
                 // fiber lengths.
                 if (const auto* thelen =

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2117,12 +2117,15 @@ protected:
     // End of System Creation and Access Methods.
     //@} 
 
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunsupported-friend"
+#if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunsupported-friend"
+#endif
     template<class C>
     friend void Socket<C>::findAndConnect(const Component& root);
-#pragma clang diagnostic pop
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#endif
 
     /** Utility method to find a component in the list of sub components of this
         component and any of their sub components, etc..., by name or state variable name.

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -109,7 +109,7 @@ public:
     DelimFileAdapter* clone() const override;
 
     /** Key used for table associative array returned/accepted by write/read. */
-    static inline const std::string tableString();
+    static const std::string tableString();
 
     /** Name of the data type T (template parameter).                         */
     static inline std::string dataTypeName();


### PR DESCRIPTION

### Brief summary of changes


This PR gets rid of the following warnings from MSVC:

```
C:\projects\opensim-core\OpenSim\Common\Test\testSTOFileAdapter.cpp(278): warning C4506: no definition for inline function 'const std::string OpenSim::DelimFileAdapter<double>::tableString(void)' [C:\projects\opensim_build\OpenSim\Common\Test\testSTOFileAdapter.vcxproj]
C:\projects\opensim-core\OpenSim\Simulation\Test\testProbes.cpp(623): warning C4506: no definition for inline function 'const std::string OpenSim::DelimFileAdapter<double>::tableString(void)' [C:\projects\opensim_build\OpenSim\Simulation\Test\testProbes.vcxproj]
C:\projects\opensim-core\OpenSim\Simulation\Test\testMuscleMetabolicsProbes.cpp(1414): warning C4506: no definition for inline function 'const std::string OpenSim::DelimFileAdapter<double>::tableString(void)' [C:\projects\opensim_build\OpenSim\Simulation\Test\testMuscleMetabolicsProbes.vcxproj]
C:\projects\opensim-core\OpenSim\Simulation\SimbodyEngine\Test\testConstraints.cpp(1125): warning C4506: no definition for inline function 'const std::string OpenSim::DelimFileAdapter<double>::tableString(void)' [C:\projects\opensim_build\OpenSim\Simulation\SimbodyEngine\Test\testConstraints.vcxproj]
...
C:\projects\opensim-core\Applications\Analyze\test\testAnalyzeTool.cpp(157): warning C4018: '<': signed/unsigned mismatch [C:\projects\opensim_build\Applications\Analyze\test\testAnalyzeTool.vcxproj]
...
C:\projects\opensim-core\OpenSim\Actuators\Test\testMuscles.cpp(968): warning C4018: '<': signed/unsigned mismatch [C:\projects\opensim_build\OpenSim\Actuators\Test\testMuscles.vcxproj]
C:\projects\opensim-core\OpenSim\Actuators\Test\testMuscles.cpp(979): warning C4101: 'x': unreferenced local variable [C:\projects\opensim_build\OpenSim\Actuators\Test\testMuscles.vcxproj]
```

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...these changes are not seen by users.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.