### PR TITLE
Fix Clang warnings for unused variables and functions

### DIFF
--- a/OpenSim/Actuators/osimActuatorsDLL.cpp
+++ b/OpenSim/Actuators/osimActuatorsDLL.cpp
@@ -82,7 +82,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
     return TRUE;
 }
-#elif defined(__linux__)
+#else
 static void __attribute__((constructor)) Shared_Object_Constructor()
 {
    Plugin_Attach();

--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -536,7 +536,6 @@ record(const SimTK::State& s)
     }
     // VARIABLES
     const Ground& ground = _model->getGround();
-    int numJoints = _model->getNumJoints();
 
     _model->realizeAcceleration(s_analysis);
 

--- a/OpenSim/Analyses/osimAnalysesDLL.cpp
+++ b/OpenSim/Analyses/osimAnalysesDLL.cpp
@@ -78,7 +78,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
     return TRUE;
 }
-#elif defined(__linux__)
+#else
 static void __attribute__((constructor)) Shared_Object_Constructor()
 {
    Plugin_Attach();

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1551,7 +1551,6 @@ void Component::printSubcomponentInfo() const {
 }
 
 void Component::printOutputInfo(const bool includeDescendants) const {
-    using ValueType = std::pair<std::string, SimTK::ClonePtr<AbstractOutput>>;
 
     // Do not display header for Components with no outputs.
     if (getNumOutputs() > 0) {

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -600,8 +600,12 @@ public:
     template <typename T = Component>
     unsigned countNumComponents() const {
         unsigned count = 0u;
-        for (const auto& comp : getComponentList<T>())
+        const auto compList = getComponentList<T>();
+        auto it = compList.begin();
+        while (it != compList.end()) {
             ++count;
+            ++it;
+        }
         return count;
     }
 

--- a/OpenSim/Common/LoadOpenSimLibrary.cpp
+++ b/OpenSim/Common/LoadOpenSimLibrary.cpp
@@ -146,7 +146,7 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
 OSIMCOMMON_API void
 OpenSim::LoadOpenSimLibrary(const std::string &aLibraryName)
 {
-    OPENSIM_PORTABLE_HINSTANCE library = LoadOpenSimLibrary(aLibraryName, true);
+    LoadOpenSimLibrary(aLibraryName, true);
 }
 
 OSIMCOMMON_API bool

--- a/OpenSim/Common/osimCommonDLL.cpp
+++ b/OpenSim/Common/osimCommonDLL.cpp
@@ -76,7 +76,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
     return TRUE;
 }
-#elif defined(__linux__)
+#else
 static void __attribute__((constructor)) Shared_Object_Constructor()
 {
    Plugin_Attach();

--- a/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
+++ b/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
@@ -126,7 +126,6 @@ void CMCActuatorSubsystemRep::setSpeedTrajectories(FunctionSet *aSet) {
   {
      /* set generalized coordinates and speeds from spline sets */
     int nq = _model->getNumCoordinates();
-    int nu = _model->getNumSpeeds();
     double t;
 
     if(_holdCoordinatesConstant) {

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -205,22 +205,6 @@ double PathActuator::computeMomentArm(const SimTK::State& s, Coordinate& aCoord)
 }
 
 //------------------------------------------------------------------------------
-//                            CONNECT TO MODEL
-//------------------------------------------------------------------------------
-/**
- * Perform some setup functions that happen after the
- * object has been deserialized or copied.
- *
- * @param aModel OpenSim model containing this PathActuator.
- */
-void PathActuator::extendFinalizeFromProperties()
-{
-    GeometryPath &path = updGeometryPath();
-
-    Super::extendFinalizeFromProperties();
-}
-
-//------------------------------------------------------------------------------
 //                            REALIZE DYNAMICS
 //------------------------------------------------------------------------------
 // See if anyone has an opinion about the path color and change it if so.

--- a/OpenSim/Simulation/Model/PathActuator.cpp
+++ b/OpenSim/Simulation/Model/PathActuator.cpp
@@ -143,8 +143,7 @@ void PathActuator::addNewPathPoint(
          PhysicalFrame& aBody, 
          const SimTK::Vec3& aPositionOnBody) {
     // Create new PathPoint already appended to the PathPointSet for the path
-    AbstractPathPoint* newPathPoint = updGeometryPath()
-        .appendNewPathPoint(proposedName, aBody, aPositionOnBody);
+    updGeometryPath().appendNewPathPoint(proposedName, aBody, aPositionOnBody);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -136,8 +136,6 @@ protected:
     virtual SimTK::Vec3 computePathColor(const SimTK::State& state) const;
 
     /** Extension of parent class method; derived classes may extend further. **/
-    void extendFinalizeFromProperties() override;
-    /** Extension of parent class method; derived classes may extend further. **/
     void extendRealizeDynamics(const SimTK::State& state) const override;
 
 private:

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -121,11 +121,6 @@ namespace {
             vec.push_back(strings[i]);
         return vec;
     }
-    template <>
-    std::vector<std::string> createVector(
-            const std::vector<std::string>& strings) {
-        return strings;
-    }
 }
 
 TimeSeriesTable StatesTrajectory::exportToTable(const Model& model,

--- a/OpenSim/Simulation/osimSimulationDLL.cpp
+++ b/OpenSim/Simulation/osimSimulationDLL.cpp
@@ -83,7 +83,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
     return TRUE;
 }
-#elif defined(__linux__)
+#else
 static void __attribute__((constructor)) Shared_Object_Constructor()
 {
    Plugin_Attach();

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -245,12 +245,6 @@ bool MarkerPlacer::processModel(Model* aModel,
     */
     TimeSeriesTableVec3 staticPoseTable{aPathToSubject + _markerFileName};
     const auto& timeCol = staticPoseTable.getIndependentColumn();
-    auto numRowsInRange = std::count_if(timeCol.cbegin(),
-                                        timeCol.cend(),
-                                        [&] (const double& val) {
-                                            return val >= _timeRange[0] &&
-                                                   val <= _timeRange[1];
-                                        });
 
     // Users often set a time range that purposely exceeds the range of
     // their data with the mindset that all their data will be used.

--- a/OpenSim/Tools/osimToolsDLL.cpp
+++ b/OpenSim/Tools/osimToolsDLL.cpp
@@ -79,7 +79,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
 
     return TRUE;
 }
-#elif defined(__linux__)
+#else
 static void __attribute__((constructor)) Shared_Object_Constructor()
 {
    Plugin_Attach();


### PR DESCRIPTION
### Brief summary of changes

I've removed variables and functions that are unused. Clang was generating warnings for these unused symbols.

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...these changes do not alter the API or its semantics.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
