### PR TITLE
Avoid clang warning in Lepton (tautological undefined compare).

### DIFF
--- a/Vendors/lepton/CMakeLists.txt
+++ b/Vendors/lepton/CMakeLists.txt
@@ -15,4 +15,16 @@ OpenSimAddLibrary(VENDORLIB LOWERINCLUDEDIRNAME
     INCLUDEINSTALLREL include/lepton
     )
 
-# TODO change header installation location to CMAKE_INSTALL_INCLUDEDIR/OpenSim/lepton
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    # Avoid clang's warning:
+    # ExpressionTreeNode.cpp:62:90: Reference cannot be bound to dereferenced
+    # null pointer in well-defined C++ code; comparison may be assumed to
+    # always evaluate to false.
+    set_source_files_properties("src/ExpressionTreeNode.cpp"
+        PROPERTIES COMPILE_FLAGS "-Wno-tautological-undefined-compare")
+    # This warning also occurs in ParsedExpression.cpp:49.
+    set_source_files_properties("src/ParsedExpression.cpp"
+        PROPERTIES COMPILE_FLAGS "-Wno-tautological-undefined-compare")
+    # We don't want to edit the lepton files (that would cause them to diverge
+    # from the copy in OpenMM), so we ignore these warnings via CMake settings.
+endif()


### PR DESCRIPTION
Fixes issue #897

### Brief summary of changes

This PR suppresses warnings generated by Clang. I asked Peter Eastman about this a long time ago, and it seemed he did not want us to make a change to the lepton source code. So instead, I simply avoid checking for these warnings by editing the CMakeLists files.

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...this doesn't affect users.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
