### PR TITLE
Avoid clang warnings in PropertyObj (hidden override).

### DIFF
--- a/OpenSim/Common/PropertyDblVec.h
+++ b/OpenSim/Common/PropertyDblVec.h
@@ -115,6 +115,9 @@ public:
     void setValue(const SimTK::Vec<M> &aVec) { 
         SimTK::Vec<M>::updAs(&_dblvec[0])=aVec; 
     }
+    // This helps avoid the -Woverloaded-virtual warning with Clang (the method
+    // above otherwise hides the virtual setValue() methods in the base class).
+    using Property_Deprecated::setValue;
     /** set value of this property from an array of doubles of equal or greater length */
     void setValue(const Array<double> &anArray) override {
         assert(anArray.getSize() >= M);

--- a/OpenSim/Common/PropertyObjArray.h
+++ b/OpenSim/Common/PropertyObjArray.h
@@ -134,6 +134,9 @@ public:
 
     // Other members (not in Property base class)
     void setValue(const ArrayPtrs<T> &aArray) { _array = aArray; }
+    // This helps avoid the -Woverloaded-virtual warning with Clang (the method
+    // above otherwise hides the virtual setValue() methods in the base class).
+    using Property_Deprecated::setValue;
     ArrayPtrs<T>& getValueObjArray() { return _array; }
 #ifndef SWIG
     const ArrayPtrs<T>& getValueObjArray() const { return _array; }


### PR DESCRIPTION
### Brief summary of changes

This PR gets rid of two clang warnings related to overloaded functions hiding similar functions from the base class. I added `using Property_Deprecated::setValue;` lines that make the functions from the base class available in the derived class.

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...these changes are very minor (adding two likely-unused functions to the API).

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
