### PR TITLE
Fix clang's "hidden override" warning for ForceSet::set.

### DIFF
--- a/OpenSim/Simulation/Model/ForceSet.cpp
+++ b/OpenSim/Simulation/Model/ForceSet.cpp
@@ -258,7 +258,7 @@ bool ForceSet::append(ForceSet &aForceSet, bool aAllowDuplicateNames)
 //_____________________________________________________________________________
 /**
  * Set the actuator at an index.  A copy of the specified actuator is NOT made.
- * The actuator previously set a the index is removed (and deleted).
+ * The actuator previously set at the index is removed (and deleted).
  *
  * This method overrides the method in Set<Force> so that several
  * internal variables of the actuator set can be updated.
@@ -268,9 +268,10 @@ bool ForceSet::append(ForceSet &aForceSet, bool aAllowDuplicateNames)
  * @param aActuator Pointer to the actuator to be set.
  * @return True if successful; false otherwise.
  */
-bool ForceSet::set(int aIndex,Force *aActuator)
+bool ForceSet::set(int aIndex,Force *aActuator, bool preserveGroups)
 {
-    bool success = ModelComponentSet<Force>::set(aIndex,aActuator);
+    bool success = ModelComponentSet<Force>::set(aIndex, aActuator,
+                                                 preserveGroups);
 
     if(success) {
         updateActuators();

--- a/OpenSim/Simulation/Model/ForceSet.h
+++ b/OpenSim/Simulation/Model/ForceSet.h
@@ -99,7 +99,19 @@ public:
     bool append(Force &aForce);
 #endif
     bool append(ForceSet &aForceSet, bool aAllowDuplicateNames=false);
-    bool set(int aIndex, Force *aForce);
+    /** Set the force at an index.  A copy of the specified actuator is NOT
+    * made. The force previously set at the index is removed (and deleted).
+    *
+    * @internal This method overrides the method in ModelComponentSet<Force> so 
+    * that several internal variables of the set can be updated.
+    *
+    * @param aIndex Array index where the actuator is to be stored.  aIndex
+    * should be in the range 0 <= aIndex <= getSize();
+    * @param aForce Pointer to the actuator to be set.
+    * @param preserveGroups If true, the new object will be added to the groups
+    * that the object it replaces belonged to.
+    * @return True if successful; false otherwise. */
+    bool set(int aIndex, Force *aForce, bool preserveGroups = false) override;
     bool insert(int aIndex, Force *aObject) override;
 
     // subsets 


### PR DESCRIPTION
### Brief summary of changes

Get rid of a warning from clang about `ForceSet::set()` hiding a virtual function from the base class. I fixed the issue by giving `set()` the same signature as from the base class. 

I ensured to preserve the same default value for `preserveGroups` as is used in the base class, so that users' existing code won't be affected by this change.

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...this is a minor change that changes the API in a very minimal way.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
