### PR TITLE
Avoid "overloaded-virtual" warning in muscle curves (using SmoothSegmentedFunctions)

### DIFF
--- a/OpenSim/Actuators/ActiveForceLengthCurve.cpp
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.cpp
@@ -170,6 +170,13 @@ double ActiveForceLengthCurve::calcDerivative(double normFiberLength,
     return m_curve.calcDerivative(normFiberLength,order);
 }
 
+double ActiveForceLengthCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 SimTK::Vec2 ActiveForceLengthCurve::getCurveDomain() const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties(),

--- a/OpenSim/Actuators/ActiveForceLengthCurve.h
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.h
@@ -221,6 +221,10 @@ public:
         normalized fiber length.
     */
     double calcDerivative(double normFiberLength, int order) const;
+    
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
 
     /** Returns a SimTK::Vec2 containing the lower (0th element) and upper (1st
     element) bounds on the domain of the curve. Outside this domain, the curve

--- a/OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.cpp
+++ b/OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.cpp
@@ -250,6 +250,13 @@ double FiberCompressiveForceCosPennationCurve::
 }
 
 double FiberCompressiveForceCosPennationCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
+double FiberCompressiveForceCosPennationCurve::
     calcIntegral(double cosPennationAngle) const
 {    
     SimTK_ASSERT(isObjectUpToDateWithProperties()==true,

--- a/OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h
+++ b/OpenSim/Actuators/FiberCompressiveForceCosPennationCurve.h
@@ -64,7 +64,9 @@ namespace OpenSim {
 
  */
 class OSIMACTUATORS_API FiberCompressiveForceCosPennationCurve : 
-    public Function {OpenSim_DECLARE_CONCRETE_OBJECT(
+    public Function {
+    
+    OpenSim_DECLARE_CONCRETE_OBJECT(
                                 FiberCompressiveForceCosPennationCurve, 
                                 Function);
 
@@ -327,6 +329,10 @@ public:
     */
     double calcDerivative(double cosPennationAngle, int order) const;
 
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
+
     /**     
     @param cosPennationAngle
                 The cosine of the pennation angle
@@ -440,8 +446,8 @@ private:
     double m_stiffnessAtPerpendicularInUse;
     double m_curvinessInUse;
     bool  m_isFittedCurveBeingUsed;
-    };
+};
 
-    }
+}
 
 #endif //OPENSIM_FiberCompressiveForceCosPennationCurve_h__

--- a/OpenSim/Actuators/FiberCompressiveForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberCompressiveForceLengthCurve.cpp
@@ -253,6 +253,13 @@ double FiberCompressiveForceLengthCurve::
     return m_curve.calcDerivative(aNormLength,order);
 }
 
+double FiberCompressiveForceLengthCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 SimTK::Vec2 FiberCompressiveForceLengthCurve::getCurveDomain() const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties()==true,

--- a/OpenSim/Actuators/FiberCompressiveForceLengthCurve.h
+++ b/OpenSim/Actuators/FiberCompressiveForceLengthCurve.h
@@ -268,6 +268,10 @@ public:
     */
     double calcDerivative(double aNormLength, int order) const;
 
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
+
     /**     
     @param aNormLength
                 Here aNormLength = l/l0, where l is the length 

--- a/OpenSim/Actuators/FiberForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberForceLengthCurve.cpp
@@ -231,6 +231,13 @@ double FiberForceLengthCurve::calcDerivative(double normFiberLength,
     return m_curve.calcDerivative(normFiberLength,order);
 }
 
+double FiberForceLengthCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 double FiberForceLengthCurve::calcIntegral(double normFiberLength) const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties(),

--- a/OpenSim/Actuators/FiberForceLengthCurve.h
+++ b/OpenSim/Actuators/FiberForceLengthCurve.h
@@ -290,6 +290,11 @@ public:
         normalized fiber length.
     */
     double calcDerivative(double normFiberLength, int order) const;
+    
+
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
 
     /** Calculates the normalized area under the curve. Since it is expensive to
     construct, the curve is built only when necessary.

--- a/OpenSim/Actuators/ForceVelocityCurve.cpp
+++ b/OpenSim/Actuators/ForceVelocityCurve.cpp
@@ -188,6 +188,13 @@ double ForceVelocityCurve::calcDerivative(double normFiberVelocity,
     return m_curve.calcDerivative(normFiberVelocity,order);
 }
 
+double ForceVelocityCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 SimTK::Vec2 ForceVelocityCurve::getCurveDomain() const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties(),

--- a/OpenSim/Actuators/ForceVelocityCurve.h
+++ b/OpenSim/Actuators/ForceVelocityCurve.h
@@ -316,6 +316,11 @@ public:
         normalized fiber velocity.
     */
     double calcDerivative(double normFiberVelocity, int order) const;
+    
+
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
 
     /** Returns a SimTK::Vec2 containing the lower (0th element) and upper (1st
     element) bounds on the domain of the curve. Outside this domain, the curve

--- a/OpenSim/Actuators/ForceVelocityInverseCurve.cpp
+++ b/OpenSim/Actuators/ForceVelocityInverseCurve.cpp
@@ -193,6 +193,13 @@ calcDerivative(double aForceVelocityMultiplier, int order) const
     return m_curve.calcDerivative(aForceVelocityMultiplier,order);
 }
 
+double ForceVelocityInverseCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 SimTK::Vec2 ForceVelocityInverseCurve::getCurveDomain() const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties(),

--- a/OpenSim/Actuators/ForceVelocityInverseCurve.h
+++ b/OpenSim/Actuators/ForceVelocityInverseCurve.h
@@ -284,6 +284,10 @@ public:
         force-velocity multiplier.
     */
     double calcDerivative(double aForceVelocityMultiplier, int order) const;
+    
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
 
     /** Returns a SimTK::Vec2 containing the lower (0th element) and upper (1st
     element) bounds on the domain of the curve. Outside this domain, the curve

--- a/OpenSim/Actuators/TendonForceLengthCurve.cpp
+++ b/OpenSim/Actuators/TendonForceLengthCurve.cpp
@@ -235,6 +235,13 @@ double TendonForceLengthCurve::calcDerivative(double aNormLength,
     return m_curve.calcDerivative(aNormLength,order);
 }
 
+double TendonForceLengthCurve::
+    calcDerivative(const std::vector<int>& derivComponents,
+                   const SimTK::Vector& x) const
+{
+    return m_curve.calcDerivative(derivComponents, x);
+}
+
 double TendonForceLengthCurve::calcIntegral(double aNormLength) const
 {
     SimTK_ASSERT(isObjectUpToDateWithProperties(),

--- a/OpenSim/Actuators/TendonForceLengthCurve.h
+++ b/OpenSim/Actuators/TendonForceLengthCurve.h
@@ -274,6 +274,10 @@ public:
         normalized tendon length.
     */
     double calcDerivative(double aNormLength, int order) const;
+    
+    /// If possible, use the simpler overload above.
+    double calcDerivative(const std::vector<int>& derivComponents,
+                          const SimTK::Vector& x) const override;
 
     /** Calculates the normalized area under the curve. Since it is expensive to
     construct, the curve is built only when necessary.

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -122,9 +122,15 @@ namespace OpenSim {
        */
        double calcDerivative(double x, int order) const;       
 
-       
+       /// Allow the more general calcDerivative from the base class to be used.
+       // This helps avoid the -Woverloaded-virtual warning with Clang.
+       // We could have also put this `using` line in ActiveForceLengthCurve,
+       // etc., but that would be inconsistent with how the
+       // SmoothSegmentedFunction is used (e.g., calcValue() delegates to the
+       // internal `m_value`).
+       using Function_<double>::calcDerivative;
 
-     
+
        /**This will return the value of the integral of this objects curve 
        evaluated at x. 
        


### PR DESCRIPTION
### Brief summary of changes

Some of the muscle curves have their own signature for `calcDerivative()`, but this hides the virtual function `calcDerivative()` from the base `Function` class. This means that calling `Function::calcDerivative()` on a function whose derived type is, for example, `ActiveForceLengthCurve`, may not do what's intended (not using the same `SimTK::Function` as is used by `calcValue()`, etc.).

This PR implements the virtual `calcDerivative()` from the base class, and defines it in a way that is consistent with the definitions for `calcValue()`, etc.

### Testing I've completed

Ran API tests.

### CHANGELOG.md (choose one)

- no need to update because...this PR has a minimal effect on the API.
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
