### PR TITLE
In FileAdapter::readFile(), support v1.0 STO files.

### DIFF
--- a/OpenSim/Common/STOFileAdapter.cpp
+++ b/OpenSim/Common/STOFileAdapter.cpp
@@ -58,8 +58,10 @@ createSTOFileAdapterForReading(const std::string& fileName) {
             }
         }
     }
-
-    OPENSIM_THROW(STODataTypeNotFound);
+    // The file does not seem to have a DataType field, and is therefore likely
+    // a version 1.0 STO file. These files only supported double as the column
+    // data type; try to read the file with type double.
+    return std::make_shared<STOFileAdapter_<double>>();
 }
 
 std::shared_ptr<DataAdapter>

--- a/OpenSim/Common/STOFileAdapter.h
+++ b/OpenSim/Common/STOFileAdapter.h
@@ -40,18 +40,6 @@ public:
     }
 };
 
-class STODataTypeNotFound : public Exception {
-public:
-    STODataTypeNotFound(const std::string& file,
-                        size_t line,
-                        const std::string& func) :
-        Exception(file, line, func) {
-        std::string msg = "DataType not specified in the header.";
-
-        addMessage(msg);
-    }
-};
-
 /** STOFileAdapter is a DelimFileAdapter that presets the delimiters 
 appropriately for STO files. The format of the file is as follows:
 \code

--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -271,6 +271,16 @@ int main() {
     SimTK_TEST_MUST_THROW_EXC(STOFileAdapter::read(emptyFileName), FileIsEmpty);
     std::remove(emptyFileName.c_str());
 
+    std::cout << "Testing reading STO version 1.0 using "
+              << "FileAdapter::readFile()." << std::endl;
+    // There was a bug where the FileAdapter::readFile() could not handle
+    // version-1.0 STO files because the "DataType" metadata was required to
+    // determine the template argument for STOFileAdapter (Issue #1725).
+    // This test ensures that bug is fixed (test.sto is version 1.0).
+    auto outputTables = FileAdapter::readFile("test.sto");
+    SimTK_TEST(outputTables["table"]->getNumRows() == 2);
+    SimTK_TEST(outputTables["table"]->getNumColumns() == 2);
+
     std::cout << "\nAll tests passed!" << std::endl;
 
     return 0;


### PR DESCRIPTION
Fixes #1725 

### Brief summary of changes

I modified the way `FileAdapter::readFile()` determines which file adapter to use so that version-1.0 STO files are supported. Previously, only version-2.0 files were supported.

### Testing I've completed

Added a test case. I ensured that the test case failed before I introduced the fix.

### CHANGELOG.md (choose one)

- no need to update because...data adapters are new to 4.0

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
