### PR TITLE
[WIP] Avoid repeated assembly in StatesTrajectory::createFromStatesStorage()

### DIFF
--- a/Bindings/Python/tests/test_states_trajectory.py
+++ b/Bindings/Python/tests/test_states_trajectory.py
@@ -49,7 +49,6 @@ class TestStatesTrajectory(unittest.TestCase):
     def test_modify_states(self):
         model = osim.Model(os.path.join(test_dir,
             "gait10dof18musc_subject01.osim"))
-        model.initSystem()
 
         states = osim.StatesTrajectory.createFromStatesStorage(
                 model, self.states_sto_fname)
@@ -57,6 +56,7 @@ class TestStatesTrajectory(unittest.TestCase):
         states[0].setTime(4)
         assert states[0].getTime() == 4
 
+        model.initSystem()
         self.assertNotAlmostEqual(model.getStateVariableValue(states[2],
                 "ground_pelvis/pelvis_tilt/value"), 8)
         model.setStateVariableValue(states[2],
@@ -78,7 +78,6 @@ class TestStatesTrajectory(unittest.TestCase):
         # wrapping works.
         model = osim.Model(os.path.join(test_dir,
             "gait10dof18musc_subject01.osim"))
-        model.initSystem()
         sto = osim.Storage(self.states_sto_fname)
         states = osim.StatesTrajectory.createFromStatesStorage(
                 model, sto)

--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -166,6 +166,30 @@ TimeSeriesTable StatesTrajectory::exportToTable(const Model& model,
     return table;
 }
 
+/** The map provides the index of each state variable in
+SimTK::State::getY() from its each state variable path string. */
+std::map<std::string, int> createSystemYIndices(const Model& model) {
+    std::map<std::string, int> sysYIndices;
+    auto s = model.getWorkingState();
+    const auto svNames = model.getStateVariableNames();
+    s.updY() = 0;
+    for (int iy = 0; iy < s.getNY(); ++iy) {
+        s.updY()[iy] = SimTK::NaN;
+        const auto svValues = model.getStateVariableValues(s);
+        for (int isv = 0; isv < svNames.size(); ++isv) {
+            if (SimTK::isNaN(svValues[isv])) {
+                sysYIndices[svNames[isv]] = iy;
+                s.updY()[iy] = 0;
+                break;
+            }
+        }
+    }
+    SimTK_ASSERT2_ALWAYS(svNames.size() == sysYIndices.size(),
+        "Expected to find %i state indices but found %i.", svNames.size(),
+        sysYIndices.size());
+    return sysYIndices;
+}
+
 StatesTrajectory StatesTrajectory::createFromStatesStorage(
         const Model& model,
         const Storage& sto,
@@ -209,6 +233,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
     // Check if states are missing from the Storage.
     // ---------------------------------------------
     const auto& modelStateNames = localModel.getStateVariableNames();
+    const auto sysYIndices = createSystemYIndices(localModel);
     std::vector<std::string> missingColumnNames;
     // Also, assemble the indices of the states that we will actually set in the
     // trajectory.
@@ -219,7 +244,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
         if (stateIndex == -1) {
             missingColumnNames.push_back(modelStateNames[is]);
         } else {
-            statesToFillUp[stateIndex] = is;
+            statesToFillUp[stateIndex] = sysYIndices.at(modelStateNames[is]);
         }
     }
     OPENSIM_THROW_IF(!allowMissingColumns && !missingColumnNames.empty(),
@@ -254,9 +279,8 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
     // Working memory for Storage.
     SimTK::Vector dependentValues(numDependentColumns);
 
-    // Working memory for State. Initialize to default so that missing
-    // columns end up as NaN.
-    SimTK::Vector statesValues(modelStateNames.getSize(), SimTK::NaN);
+    // Initialize so that missing columns end up as NaN.
+    state.updY().setToNaN();
 
     // Loop through all rows of the Storage.
     for (int itime = 0; itime < sto.getSize(); ++itime) {
@@ -269,10 +293,10 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
 
         // Fill up current State with the data for the current time.
         for (const auto& kv : statesToFillUp) {
-            // 'first': index for Storage; 'second': index for Model.
-            statesValues[kv.second] = dependentValues[kv.first];
+            // 'first': index for Storage; 'second': index for SimTK State.
+            state.updY()[kv.second] = dependentValues[kv.first];
         }
-        localModel.setStateVariableValues(state, statesValues);
+        localModel.assemble(state);
 
         // Make a copy of the edited state and put it in the trajectory.
         states.append(state);

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -411,8 +411,9 @@ public:
      * variable values, but not discrete state variable values, modeling
      * option values, etc. Also, keep in mind that states Storage files usually
      * do not contain the state values to full precision, and thus cannot
-     * exactly reproduce results from the initial state trajectory; constraints
-     * may not be satisfied, etc.
+     * exactly reproduce results from the initial state trajectory. Lastly,
+     * this function modifies each state to obey any constraints in the model
+     * (by calling Model::assemble()).
      *
      * The states in the resulting trajectory will be realized to
      * SimTK::Stage::Instance. You should not use the resulting trajectory with

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -439,21 +439,15 @@ public:
      *      ignored.
      *
      * #### Usage
-     * You must have called Model::initSystem() on your model before calling
-     * this function.
      * Here is how you might use this function in python:
      * @code{.py}
      * import opensim
      * model = opensim.Model("subject01.osim")
-     * model.initSystem()
      * sto = opensim.Storage("subject01_states.sto")
      * states = opensim.StatesTrajectory.createFromStatesStorage(model, sto)
      * print(states[0].getTime())
      * print(model.getStateVariableValue(states[0], "knee/flexion/value"))
      * @endcode
-     * 
-     * @throws ModelHasNoSystem Thrown if you have not yet called initSystem()
-     *      on the model.
      * 
      * @throws MissingColumnsInStatesStorage See the description of the
      *      `allowMissingColumns` argument.

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -179,13 +179,14 @@ void testFromStatesStorageGivesCorrectStates() {
 
     Storage sto(statesStoFname);
 
-    // This will fail because we have not yet called initSystem() on the model.
-    SimTK_TEST_MUST_THROW_EXC(
-            StatesTrajectory::createFromStatesStorage(model, sto),
-            OpenSim::ModelHasNoSystem);
-
-    model.initSystem();
+    // It's important that we have not yet initialized the model,
+    // since `createFromStatesStorage()` should be able to work with such a
+    // model.
     auto states = StatesTrajectory::createFromStatesStorage(model, sto);
+
+    // However, we eventually *do* need to call initSystem() to make use of the
+    // trajectory with the model.
+    model.initSystem();
 
     // Test that the states are correct, and also that the iterator works.
     // -------------------------------------------------------------------
@@ -399,7 +400,6 @@ void testFromStatesStorageInconsistentModel(const std::string &stoFilepath) {
 void testFromStatesStorageUniqueColumnLabels() {
 
     Model model("gait2354_simbody.osim");
-    model.initSystem();
     Storage sto(statesStoFname);
     
     // Edit column labels so that they are not unique.
@@ -439,8 +439,8 @@ void testFromStatesStoragePre40CorrectStates() {
     Storage sto(pre40StoFname);
     // So the test doesn't take so long.
     sto.resampleLinear(0.01);
-    model.initSystem();
     auto states = StatesTrajectory::createFromStatesStorage(model, sto);
+    model.initSystem();
 
     // Test that the states are correct.
     // ---------------------------------

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -147,7 +147,7 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        332fd91cc6c17d4fbc1a2b1d41757f814174c8b6
+              TAG        fd5c03115038a7398ed5ac04169f801a2aa737f2
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION
### Brief summary of changes

This PR avoids repeatedly assembling the states (via `Coordinate::setValue()`) within `StatesTrajectory::createFromStatesStorage()`. The repeated assemblies were causing `createFromStatesStorage()` to take many minutes to run for the Rajagopal 2016 model (with 2 coordinate coupler constraints), and this PR fixes this performance issue.

### Testing I've completed

Ran ctests.

### Looking for feedback on...

 There are multiple options for how we can avoid assembling repeatedly, which I discussed with @tkuchida this week. This is related to #1884 (this PR is a workaround for #1884).

1. Have `Coordinate::CoordinateStateVariable::setValue()` pass `false` for the `enforceConstraints` parameter of `Coordinate::setValue()`. We would edit the documentation of `Component::setStateVariableValues()` to say that users must call `model.assemble()`, etc. on their own to enforce the constraints.
2. Have `Component::setStateVariableValues()` take a `enforceConstraints` parameter, and enforce the constraints only after setting all state variable values. This could be achieved by giving `Component` a virtual function that `Model` would implement by calling `assemble()`. I don't really like this idea. How is a generic component supposed to know how to enforce constraints?
3. Permit users to have a way to set state variable values without using `Component::setStateVariableValues()`. That is, help users use `State::updY()` directly. Then users can call `assemble()` on their own. I see 2 options:

    1. provide a method that gives the names of the state variables in the order of `State::getY()`.
    2. Implement `Component::StateVariable::getSystemYIndex()` and expose these global indices to users, perhaps via `Component::getSystemYIndices()` (similar to `Component::getStateVariableNames()`).

(I've copied these options to #1884.)

In this PR, I've chosen to go with 3(i). I think we should do 3(i) regardless of how we solve #1884. I also like option 1.

I don't actually want to merge this PR yet. Rather, I want to discuss the options and to get opinions about my implementation of `createSystemYIndices()`. If we like `createSystemYIndices()`, then I would want to move it to `Model`.

### CHANGELOG.md (choose one)

- no need to update because...StatesTrajectory is new to 4.0.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.