### PR TITLE
Visual Studio 2017:  update README, fix warnings, fix GetCompilerVersion()

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -208,11 +208,11 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
         // Verify that the current computed and AnalyzeTool reported force are
         // equivalent for the provided motion file
         cout << s.getTime() << " :: muscle-fiber-force: " << mf <<
-            " Analyze reported force: " << forces[i] << endl;
-        ASSERT_EQUAL<double>(mf, forces[i], equilTol, __FILE__, __LINE__,
+            " Analyze reported force: " << forces[int(i)] << endl;
+        ASSERT_EQUAL<double>(mf, forces[int(i)], equilTol, __FILE__, __LINE__,
             "Total fiber force failed to match reported muscle force.");
 
-        double delta = (i > 0) ? abs(forces[i]-forces[i-1]) : 0;
+        double delta = (i > 0) ? abs(forces[int(i)]-forces[int(i-1)]) : 0;
 
         SimTK_ASSERT_ALWAYS(delta < maxDelta,
             "Force trajectory has unexplained discontinuity.");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ in Python.
 
 Other Changes
 -------------
+- Support for compiling the source code with Microsoft Visual Studio 2017.
 - There is now a formal CMake mechanism for using OpenSim in your own C++
   project. See cmake/SampleCMakeLists.txt. (PR #187)
 - Substantial cleanup of the internal CMake scripts.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,7 +801,7 @@ set(OPENSIM_SYSTEM_INFO ${CMAKE_SYSTEM})
 set(OPENSIM_OS_NAME ${CMAKE_SYSTEM_NAME})
 
 if( WIN32 )
-    if (${MSVC_VERSION} GREATER 1910)
+    if (NOT (MSVC_VERSION LESS 2000))
         message(AUTHOR_WARNING "OpenSim::GetCompilerVersion() "
             "in OpenSim/version.h does not handle this newer version "
             "(v${MSVC_VERSION}) of Microsoft Visual C++. "

--- a/OpenSim/Analyses/InverseDynamics.cpp
+++ b/OpenSim/Analyses/InverseDynamics.cpp
@@ -458,7 +458,7 @@ begin(SimTK::State& s )
         for(size_t i=0u; i<coordinates.size(); ++i) {
             const Coordinate& coord = *coordinates[i];
             if(!coord.isConstrained(sWorkingCopy)) {
-                _accelerationIndices.append(i);
+                _accelerationIndices.append(static_cast<int>(i));
             }
         }
 

--- a/OpenSim/Analyses/StaticOptimizationTarget.cpp
+++ b/OpenSim/Analyses/StaticOptimizationTarget.cpp
@@ -78,7 +78,7 @@ StaticOptimizationTarget(const SimTK::State& s, Model *aModel,int aNP,int aNC, b
     for (size_t i = 0u; i < coordinates.size(); ++i) {
         const Coordinate& coord = *coordinates[i];
         if(!coord.isConstrained(s)) {
-            _accelerationIndices.append(i);
+            _accelerationIndices.append(static_cast<int>(i));
         }
     }
 }

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1517,11 +1517,11 @@ public:
         // subcomponents and to find the longest concrete class name.
         const std::string concreteClassName = this->getConcreteClassName();
         unsigned numSubcomponents = 0;
-        unsigned maxlen = concreteClassName.length();
+        size_t maxlen = concreteClassName.length();
         for (const C& thisComp : compList) {
             ++numSubcomponents;
             auto len = thisComp.getConcreteClassName().length();
-            maxlen = std::max(maxlen, static_cast<unsigned>(len));
+            maxlen = std::max(maxlen, len);
         }
 
         if (numSubcomponents == 0) {

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -797,7 +797,7 @@ public:
     SimTK::Vector_<T>. The elements are in the same order as the channels.
     */
     SimTK::Vector_<T> getVector(const SimTK::State& state) const {
-        SimTK::Vector_<T> v(_connectees.size());
+        SimTK::Vector_<T> v(static_cast<int>(_connectees.size()));
         for (unsigned ichan = 0u; ichan < _connectees.size(); ++ichan) {
             v[ichan] = _connectees[ichan]->getValue(state);
         }

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1995,8 +1995,6 @@ void testAliasesAndLabels() {
     SimTK_TEST(foo->getInput("listInput1").getLabel(1) == "thud");
 }
 
-#include <OpenSim/version.h>
-
 int main() {
 
     //Register new types for testing deserialization
@@ -2023,8 +2021,6 @@ int main() {
         writeTimeSeriesTableForInputConnecteeSerialization();
         SimTK_SUBTEST(testListInputConnecteeSerialization);
         SimTK_SUBTEST(testSingleValueInputConnecteeSerialization);
-
-    std::cout << OpenSim::GetCompilerVersion() << std::endl;
 
     SimTK_END_TEST();
 }

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1995,6 +1995,8 @@ void testAliasesAndLabels() {
     SimTK_TEST(foo->getInput("listInput1").getLabel(1) == "thud");
 }
 
+#include <OpenSim/version.h>
+
 int main() {
 
     //Register new types for testing deserialization
@@ -2021,6 +2023,8 @@ int main() {
         writeTimeSeriesTableForInputConnecteeSerialization();
         SimTK_SUBTEST(testListInputConnecteeSerialization);
         SimTK_SUBTEST(testSingleValueInputConnecteeSerialization);
+
+    std::cout << OpenSim::GetCompilerVersion() << std::endl;
 
     SimTK_END_TEST();
 }

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
@@ -219,7 +219,6 @@ int AnalysisPlugin_Template::
 record(const SimTK::State& s)
 {
     // VARIABLES
-    double dirCos[3][3];
     SimTK::Vec3 vec,angVec;
     double Mass = 0.0;
 

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -1038,7 +1038,7 @@ void SimbodyEngine::scaleRotationalDofColumns(Storage &rStorage, double factor) 
 
 void SimbodyEngine::scaleRotationalDofColumns(TimeSeriesTable& table,
                                               double factor) const {
-    int ncols = table.getNumColumns();
+    size_t ncols = table.getNumColumns();
     if(ncols == 0)
         throw Exception("SimbodyEngine.scaleRotationalDofColumns: ERROR- storage has no labels, can't determine coordinate types for deg<->rad conversion",
                              __FILE__,__LINE__);
@@ -1052,7 +1052,7 @@ void SimbodyEngine::scaleRotationalDofColumns(TimeSeriesTable& table,
     const CoordinateSet& coordinateSet = _model->getCoordinateSet();
     
     // first column is time, so skip
-    for (int i = 0; i < ncols; i++) {
+    for (size_t i = 0; i < ncols; i++) {
         const std::string& name = table.getColumnLabel(i);
         index = coordinateSet.getIndex(name);
         if (index < 0){

--- a/OpenSim/version.h
+++ b/OpenSim/version.h
@@ -68,37 +68,53 @@ namespace OpenSim {
     }
     inline std::string GetCompilerVersion() {
         std::string os = GetOSInfo();
-        std::string str;
+        std::string str = "(Unknown)";
 
         if( 0 == os.compare("Windows")) {
-            switch( atoi(GET_COMPILER_INFO) ) {
-            case 1910:
-                str = "Visual Studio 2017";
-                break;
-            case 1900:
-                str = "Visual Studio 2015";
-                break;
-            case 1800:
-                str = "Visual Studio 2013";
-                break;
-            case 1700:
-                str = "Visual Studio 2011";
-                break;
-            case 1600:
-                str = "Visual Studio 2010";
-                break;
-            case 1500:
-                str = "Visual Studio 2008";
-                break;
-            case 1400:
-                str = "Visual Studio 2005";
-                break;
-            case 1310:
-                str = "Visual Studio 2003";
-                break;
-            case 1300:
-                str = "Visual Studio 2002";
-                break;
+            const int MSVCVersion = atoi(GET_COMPILER_INFO);
+            if( MSVCVersion >= 1910 ) {
+                // With Visual Studio 2017, the versioning of the Visual C++
+                // compiler became more fine-grained, so we can no longer use
+                // a switch statement.
+                // Also, Visual Studio 2017 decouples the Visual Studio IDE
+                // from the C++ toolset (compiler), so providing the IDE year 
+                // does not indicate the compiler version (it may be possible
+                // to use the Visual Studio 2019 IDE, or whatever is next, 
+                // with the same C++ toolset that came with Visual Studio 2017.
+                // Therefore, we no longer provide the Visual Studio year.
+                // https://blogs.msdn.microsoft.com/vcblog/2016/10/05/visual-c-compiler-version/
+                // https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
+                if (1910 <= MSVCVersion && MSVCVersion < 2000) {
+                    str = "Microsoft Visual C++ 14.1";
+                }
+                str += " (MSC_VER " + std::to_string(MSVCVersion) + ")";
+            } else {
+                switch( MSVCVersion ) {
+                case 1900:
+                    str = "Visual Studio 2015";
+                    break;
+                case 1800:
+                    str = "Visual Studio 2013";
+                    break;
+                case 1700:
+                    str = "Visual Studio 2011";
+                    break;
+                case 1600:
+                    str = "Visual Studio 2010";
+                    break;
+                case 1500:
+                    str = "Visual Studio 2008";
+                    break;
+                case 1400:
+                    str = "Visual Studio 2005";
+                    break;
+                case 1310:
+                    str = "Visual Studio 2003";
+                    break;
+                case 1300:
+                    str = "Visual Studio 2002";
+                    break;
+                }
             }
         } else if( 0 == os.compare("Darwin")) {
             str = "Mac OS X :";

--- a/README.md
+++ b/README.md
@@ -164,26 +164,23 @@ On Windows using Visual Studio
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.2
 * **compiler / IDE**: Visual Studio [2015](https://www.visualstudio.com/vs/older-downloads/) or [2017](https://www.visualstudio.com/) (2017 requires CMake >= 3.9).
     * The *Community* variant is sufficient and is free for everyone.
-    * Visual Studio 2015 and 2017 do not install C++
-      support by default.
-      * 2015: During the installation you must select
+    * Visual Studio 2015 and 2017 do not install C++ support by default.
+      * **2015**: During the installation you must select
         *Custom*, and check *Programming Languages > Visual C++ > Common Tools
         for Visual C++ 2015*.
-        You can uncheck all other boxes. If Visual Studio
-        is installed without C++ support, CMake will report
+        You can uncheck all other boxes. If you have already installed
+        Visual Studio without C++ support, simply re-run the installer and
+        select *Modify*. Alternatively, go to *File > New > Project...* in
+        Visual Studio, select *Visual C++*, and click
+        *Install Visual C++ 2015 Tools for Windows Desktop*.
+      * **2017**: During the installation, select the workload
+        *Desktop Development with C++*.
+      * If Visual Studio is installed without C++ support, CMake will report
         the following errors:
-
         ```
         The C compiler identification is unknown
         The CXX compiler identification is unknown
-        ```
-
-        If you have already installed Visual Studio without C++ support, simply
-        re-run the installer and select *Modify*. Alternatively, go to
-        *File > New > Project...* in Visual Studio, select *Visual C++*, and click
-        *Install Visual C++ 2015 Tools for Windows Desktop*.
-      * 2017: During the installation, select the workload
-        *Desktop Development with C++*.
+        ```    
 * **physics engine**: Simbody >= 3.6. Two options:
     * Let OpenSim get this for you using superbuild (see below).
     * [Build on your own](
@@ -364,7 +361,9 @@ directory to your `PATH` environment variable.
 
 #### For the impatient (Windows)
 
-* Get **Visual Studio Community** [2015](https://www.visualstudio.com/vs/older-downloads/) or [2017](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
+* Get **Visual Studio Community**
+  [2015](https://www.visualstudio.com/vs/older-downloads/) or
+  [2017](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
  * 2015: Choose *Custom installation*, then choose
    *Programming Languages* -> *Visual C++*.
  * 2017: Choose the workload *Desktop Development with C++*.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ include source code for the OpenSim GUI.
 
 Simple example
 --------------
-Let's simulate a simple arm whose elbow is actuated by a muscle, using 
-the C++ interface (You can find a Python version of this example at 
+Let's simulate a simple arm whose elbow is actuated by a muscle, using
+the C++ interface (You can find a Python version of this example at
 `Bindings/Python/examples/build_simple_arm_model.py`):
 
 ```cpp
@@ -108,7 +108,7 @@ int main() {
 
     // Simulate.
     simulate(model, state, 10.0);
-    
+
     return 0;
 };
 ```
@@ -120,31 +120,36 @@ This code produces the following animation:
 and prints the following information to the console:
 ```
 [reporter]
-              |   /model_/bice|               | 
-          time| ps|fiber_force|    elbow_angle| 
---------------| --------------| --------------| 
-  0.000000e+00| 1.18096897e+00| 1.57079633e+00| 
-1.00000000e+00| 5.72750904e+01| 7.70664118e-01| 
-2.00000000e+00| 1.97284113e+01| 1.56804557e+00| 
-3.00000000e+00| 5.60904315e+01| 1.44198608e+00| 
-4.00000000e+00| 3.45483498e+01| 1.50834805e+00| 
-5.00000000e+00| 3.26037208e+01| 1.51802366e+00| 
-6.00000000e+00| 3.71360518e+01| 1.50212351e+00| 
-7.00000000e+00| 3.56985024e+01| 1.50718884e+00| 
-8.00000000e+00| 3.41860103e+01| 1.50791862e+00| 
-9.00000000e+00| 3.43416494e+01| 1.50672695e+00| 
-1.00000000e+01| 3.57847134e+01| 1.50716396e+00| 
+              |   /model_/bice|               |
+          time| ps|fiber_force|    elbow_angle|
+--------------| --------------| --------------|
+  0.000000e+00| 1.18096897e+00| 1.57079633e+00|
+1.00000000e+00| 5.72750904e+01| 7.70664118e-01|
+2.00000000e+00| 1.97284113e+01| 1.56804557e+00|
+3.00000000e+00| 5.60904315e+01| 1.44198608e+00|
+4.00000000e+00| 3.45483498e+01| 1.50834805e+00|
+5.00000000e+00| 3.26037208e+01| 1.51802366e+00|
+6.00000000e+00| 3.71360518e+01| 1.50212351e+00|
+7.00000000e+00| 3.56985024e+01| 1.50718884e+00|
+8.00000000e+00| 3.41860103e+01| 1.50791862e+00|
+9.00000000e+00| 3.43416494e+01| 1.50672695e+00|
+1.00000000e+01| 3.57847134e+01| 1.50716396e+00|
 ```
 ---
 
 Building from the source code
 -----------------------------
 
-**NOTE -- In all platforms (Windows, OSX, Linux), it is advised to build all OpenSim Dependencies (Simbody, BTK etc) with same *CMAKE_BUILD_TYPE* (Linux) / *CONFIGURATION* (MSVC/Xcode) as OpenSim. For example, if OpenSim is to be built with *CMAKE_BUILD_TYPE/CONFIGURATION* as *Debug*, Simbody, BTK and all other OpenSim dependencies also should be built with *CMAKE_BUILD_TYPE/CONFIGURATION* as *Debug*. Failing to do so *may* result in mysterious runtime errors like 'segfault' in standard c++ library implementation.**
+**NOTE**: On all platforms (Windows, OSX, Linux), you should
+build all OpenSim dependencies (Simbody, BTK, etc) with the
+same *CMAKE_BUILD_TYPE* (Linux) / *CONFIGURATION*
+(MSVC/Xcode) (e.g., Release, Debug) as OpenSim. Failing to
+do so *may* result in mysterious runtime errors like
+segfaults.
 
 We support a few ways of building OpenSim:
 
-1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient-windows). 
+1. [On Windows using Microsoft Visual Studio](#on-windows-using-visual-studio). In a rush? Use [these instructions](#for-the-impatient-windows).
 2. [On Mac OSX using Xcode](#on-mac-osx-using-xcode). Need extended instructions? Use [these instructions](#extended-instructions-for-osx).
 3. [On Ubuntu using Unix Makefiles](#on-ubuntu-using-unix-makefiles). In a rush? Use [these instructions](#for-the-impatient-ubuntu).
 
@@ -154,27 +159,31 @@ On Windows using Visual Studio
 
 #### Get the dependencies
 
-* **operating system**: Windows 7 or 8.
+* **operating system**: Windows 7, 8, or 10.
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.2
-* **compiler / IDE**: [Visual Studio 2015](https://www.visualstudio.com/).
-    * *Visual Studio Community 2015* is sufficient and is free for everyone.
-    * Visual Studio 2015 does not install C++
-      support by default. During the installation you must select
-      *Custom*, and check *Programming Languages > Visual C++ > Common Tools
-      for Visual C++ 2015*.
-      You can uncheck all other boxes. If Visual Studio is installed without C++
-      support, CMake will report the following errors:
-      
-      ```
-      The C compiler identification is unknown
-      The CXX compiler identification is unknown
-      ```
-      
-      If you have already installed Visual Studio without C++ support, simply
-      re-run the installer and select *Modify*. Alternatively, go to
-      *File > New > Project...* in Visual Studio, select *Visual C++*, and click
-      *Install Visual C++ 2015 Tools for Windows Desktop*.
+* **compiler / IDE**: Visual Studio [2015](https://www.visualstudio.com/vs/older-downloads/) or [2017](https://www.visualstudio.com/) (2017 requires CMake >= 3.9).
+    * The *Community* variant is sufficient and is free for everyone.
+    * Visual Studio 2015 and 2017 do not install C++
+      support by default.
+      * 2015: During the installation you must select
+        *Custom*, and check *Programming Languages > Visual C++ > Common Tools
+        for Visual C++ 2015*.
+        You can uncheck all other boxes. If Visual Studio
+        is installed without C++ support, CMake will report
+        the following errors:
+
+        ```
+        The C compiler identification is unknown
+        The CXX compiler identification is unknown
+        ```
+
+        If you have already installed Visual Studio without C++ support, simply
+        re-run the installer and select *Modify*. Alternatively, go to
+        *File > New > Project...* in Visual Studio, select *Visual C++*, and click
+        *Install Visual C++ 2015 Tools for Windows Desktop*.
+      * 2017: During the installation, select the workload
+        *Desktop Development with C++*.
 * **physics engine**: Simbody >= 3.6. Two options:
     * Let OpenSim get this for you using superbuild (see below).
     * [Build on your own](
@@ -229,9 +238,10 @@ On Windows using Visual Studio
    which to build dependencies. Let's say this is
    `C:/opensim-core-dependencies-build`.
 4. Click the **Configure** button.
-    1. Choose the *Visual Studio 14* generator (for Visual Studio 2015). To
-       build as 64-bit, select *Visual Studio 14 Win64*.
-    2. Click **Finish**.
+    1. Visual Studio 2015: Choose the *Visual Studio 14 2015* generator (may appear as *Visual Studio 14*).
+    2. Visual Studio 2017: Choose the *Visual Studio 15 2017* generator.
+    3. To build as 64-bit, select the generator with *Win64* in the name.
+    4. Click **Finish**.
 5. Where do you want to install OpenSim dependencies on your computer? Set this
    by changing the `CMAKE_INSTALL_PREFIX` variable. Let's say this is
    `C:/opensim-core-dependencies-install`.
@@ -249,7 +259,7 @@ On Windows using Visual Studio
         cmake --build . --config RelWithDebInfo
 
    Alternative values for `--config` in this command are:
-   
+
    * **Debug**: debugger symbols; no optimizations (more than 10x slower).
      Library names end with `_d`.
    * **Release**: no debugger symbols; optimized.
@@ -272,11 +282,11 @@ On Windows using Visual Studio
    `C:/opensim-core-build`, or some other path that is not inside your source
    directory. This is *not* where we are installing OpenSim-Core; see below.
 4. Click the **Configure** button.
-    1. Choose the *Visual Studio 14* or *Visual Studio 14 2015* generator. To
-       build as 64-bit, select *Visual Studio 14 Win64* or 
-       *Visual Studio 14 2015 Win64*. The choice between
-       32-bit/64-bit must be the same across all dependencies.
-    2. Click **Finish**.
+    1. Visual Studio 2015: Choose the *Visual Studio 14* or *Visual Studio 14 2015* generator.
+    2. Visual Studio 2017: Choose the *Visual Studio 15 2017* generator.
+    3. To build as 64-bit, select the generator with *Win64* in the name.
+       The choice between 32-bit/64-bit must be the same across all dependencies.
+    4. Click **Finish**.
 5. Where do you want to install OpenSim-Core on your computer? Set this by
    changing the `CMAKE_INSTALL_PREFIX` variable. We'll assume you set it to
    `C:/opensim-core`. If you choose a different installation location, make
@@ -293,8 +303,8 @@ On Windows using Visual Studio
            `C:/BTKCore-install`, then set this variable to
            `C:/BTKCore-install/share/btk-0.4dev`.
         3. docopt.cpp. Set the variable `docopt_DIR` to the directory
-           containing `docopt-config.cmake`. If the root directory of your 
-           docopt.cpp installation is `C:/docopt.cpp-install`, then set this 
+           containing `docopt-config.cmake`. If the root directory of your
+           docopt.cpp installation is `C:/docopt.cpp-install`, then set this
            variable to `C:/docopt.cpp-install/lib/cmake`.
 7. Set the remaining configuration options.
     * `BUILD_API_EXAMPLES` to compile C++ API examples.
@@ -354,43 +364,45 @@ directory to your `PATH` environment variable.
 
 #### For the impatient (Windows)
 
-* Get **Visual Studio Community** from [here](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
- * Choose *Custom' installation*.
- * Choose *Programming Languages* -> *Visual C++*.
+* Get **Visual Studio Community** [2015](https://www.visualstudio.com/vs/older-downloads/) or [2017](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
+ * 2015: Choose *Custom installation*, then choose
+   *Programming Languages* -> *Visual C++*.
+ * 2017: Choose the workload *Desktop Development with C++*.
 * Get **git** from [here](https://git-scm.com/downloads).
  * Choose *Use Git from the Windows Command Prompt*.
 * Get **CMake** from [here](https://cmake.org/download/).
  * Choose *Add CMake to the system PATH for all users*.
 * Get **Chocolatey** from [here](https://chocolatey.org/).
-* In **PowerShell**, *run as Administrator* --
+* In **PowerShell**, *run as Administrator*:
 
- ```powershell
- choco install python2 jdk8 swig
- ```
-* In **PowerShell** --
+  ```powershell
+  choco install python2 jdk8 swig
+  ```
+* In **PowerShell** (if using Visual Studio 2017, replace
+  *14 2015* with *15 2017*):
 
- ```powershell
-git clone https://github.com/opensim-org/opensim-core.git
-mkdir opensim_dependencies_build
-cd .\opensim_dependencies_build
-cmake ..\opensim-core\dependencies                             `
-      -G"Visual Studio 14 2015 Win64"                          `
-      -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"
-cmake --build . --config RelWithDebInfo -- /maxcpucount:8
-cd ..
-mkdir opensim_build
-cd .\opensim_build
-cmake ..\opensim-core                                              `
-      -G"Visual Studio 14 2015 Win64"                              `
-      -DCMAKE_INSTALL_PREFIX="..\opensim_install"                  `
-      -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install" `
-      -DBUILD_JAVA_WRAPPING=ON                                     `
-      -DBUILD_PYTHON_WRAPPING=ON                                   `
-      -DWITH_BTK=ON                                  
-cmake --build . --config RelWithDebInfo -- /maxcpucount:8
-ctest -C RelWithDebInfo --parallel 8
-cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
-```
+  ```powershell
+  git clone https://github.com/opensim-org/opensim-core.git
+  mkdir opensim_dependencies_build
+  cd .\opensim_dependencies_build
+  cmake ..\opensim-core\dependencies                             `
+        -G"Visual Studio 14 2015 Win64"                          `
+        -DCMAKE_INSTALL_PREFIX="..\opensim_dependencies_install"
+  cmake --build . --config RelWithDebInfo -- /maxcpucount:8
+  cd ..
+  mkdir opensim_build
+ c d .\opensim_build
+  cmake ..\opensim-core                                              `
+        -G"Visual Studio 14 2015 Win64"                              `
+        -DCMAKE_INSTALL_PREFIX="..\opensim_install"                  `
+        -DOPENSIM_DEPENDENCIES_DIR="..\opensim_dependencies_install" `
+        -DBUILD_JAVA_WRAPPING=ON                                     `
+        -DBUILD_PYTHON_WRAPPING=ON                                   `
+        -DWITH_BTK=ON                                  
+  cmake --build . --config RelWithDebInfo -- /maxcpucount:8
+  ctest --build-config RelWithDebInfo --parallel 8
+  cmake --build . --config RelWithDebInfo --target install -- /maxcpucount:8
+  ```
 
 Note: Please add `<FULL-DIR>\opensim_install\bin` to your PATH variable as per [these instructions](#set-environment-variables).  
 Example: If `opensim_install` is in `C:`, add `C:\opensim_install\bin` to your PATH.  
@@ -400,12 +412,12 @@ On Mac OSX using Xcode
 
 ### For Mac OSX 10.11 El Capitan
 Get **Xcode** from the App store. Open **Xcode** and *Agree* to license agreement. To *Agree* to to the license agreement, you may need to type in **Terminal**:
-```shell 
+```shell
 sudo xcodebuild -license
-``` 
+```
 If you already have **Xcode**, update it to 7.3, or the latest version.
 
-Then, in **Terminal**, copy and paste commands below, line by line, one at a time. Be sure the output doesn't contain errors.
+Then, in **Terminal**, copy and paste commands below, line by line, one at a time. The first line installs the Homebrew package manager; omit this line if you already have Homebrew. Be sure the output doesn't contain errors.
 ```shell
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 brew install cmake swig
@@ -436,7 +448,7 @@ ctest -j8
 
 #### Get the dependencies
 
-* **operating system**: Mac OSX 10.11 El Capitan.
+* **operating system**: Mac OSX 10.11 El Capitan or newer.
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.2
 * **compiler / IDE**: [Xcode](https://developer.apple.com/xcode/) >= 7.3 (the latest version), through
@@ -546,8 +558,8 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
            `BTKConfig.cmake`. If you installed BTK in `~/BTKCore-install`, then
            set `BTK_DIR` to `~/BTKCore-install/share/btk-0.4dev`
         3. docopt.cpp. Set the variable `docopt_DIR` to the directory
-           containing `docopt-config.cmake`. If the root directory of your 
-           docopt.cpp installation is `~/docopt.cpp-install`, then set this 
+           containing `docopt-config.cmake`. If the root directory of your
+           docopt.cpp installation is `~/docopt.cpp-install`, then set this
            variable to `~/docopt.cpp-install/lib/cmake`.
 7. Set the remaining configuration options.
     * `BUILD_API_EXAMPLES` to compile C++ API examples.
@@ -620,7 +632,7 @@ specific Ubuntu versions under 'For the impatient' below.
 
 * **cross-platform build system**:
   [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.2;
-  `cmake-gui`. 
+  `cmake-gui`.
 * **compiler**: [gcc](http://gcc.gnu.org) >= 4.9; `g++-4.9`, or
   [Clang](http://clang.llvm.org) >= 3.4; `clang-3.4`.
 * **physics engine**: Simbody >= 3.6. Two options:
@@ -732,8 +744,8 @@ And you could get all the optional dependencies via:
            `BTKConfig.cmake`. If you installed BTK in `~/BTK-install`, then set
            `BTK-DIR` to `~/BTK-install/share/btk-0.4dev`.
         3. docopt.cpp. Set the variable `docopt_DIR` to the directory
-           containing `docopt-config.cmake`. If the root directory of your 
-           docopt.cpp installation is `~/docopt.cpp-install`, then set this 
+           containing `docopt-config.cmake`. If the root directory of your
+           docopt.cpp installation is `~/docopt.cpp-install`, then set this
            variable to `~/docopt.cpp-install/lib/cmake`.
 7. Choose your build type by setting `CMAKE_BUILD_TYPE` to one of the following:
     * **Debug**: debugger symbols; no optimizations (more than 10x slower).
@@ -903,7 +915,7 @@ Note: You may need to add `<FULL-DIR>/opensim_install/bin` to your PATH variable
 Example: If opensim_install is in your home directory:
 
         $ echo 'export PATH=~/opensim_install/bin:$PATH' >> ~/.bashrc
- 
+
 
 [buildstatus_image_travis]: https://travis-ci.org/opensim-org/opensim-core.svg?branch=master
 [travisci]: https://travis-ci.org/opensim-org/opensim-core

--- a/README.md
+++ b/README.md
@@ -364,13 +364,13 @@ directory to your `PATH` environment variable.
 * Get **Visual Studio Community**
   [2015](https://www.visualstudio.com/vs/older-downloads/) or
   [2017](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx).
- * 2015: Choose *Custom installation*, then choose
-   *Programming Languages* -> *Visual C++*.
- * 2017: Choose the workload *Desktop Development with C++*.
+  * 2015: Choose *Custom installation*, then choose
+    *Programming Languages* -> *Visual C++*.
+  * 2017: Choose the workload *Desktop Development with C++*.
 * Get **git** from [here](https://git-scm.com/downloads).
- * Choose *Use Git from the Windows Command Prompt*.
+  * Choose *Use Git from the Windows Command Prompt*.
 * Get **CMake** from [here](https://cmake.org/download/).
- * Choose *Add CMake to the system PATH for all users*.
+  * Choose *Add CMake to the system PATH for all users*.
 * Get **Chocolatey** from [here](https://chocolatey.org/).
 * In **PowerShell**, *run as Administrator*:
 
@@ -390,7 +390,7 @@ directory to your `PATH` environment variable.
   cmake --build . --config RelWithDebInfo -- /maxcpucount:8
   cd ..
   mkdir opensim_build
- c d .\opensim_build
+  cd .\opensim_build
   cmake ..\opensim-core                                              `
         -G"Visual Studio 14 2015 Win64"                              `
         -DCMAKE_INSTALL_PREFIX="..\opensim_install"                  `


### PR DESCRIPTION
### Brief summary of changes

This PR announces formal support for VS 2017.

1. Update README to provide instructions for using VS 2017.
2. Fix compiler warnings generated with VS 2017.
3. Fix `OpenSim::GetCompilerVersion()` for new versioning scheme used by Microsoft.

### Testing I've completed

1. Ensured GetCompilerInfo gave the correct output for VS 2017.
2. Ensured compiler no longer generates warnings.

### CHANGELOG.md (choose one)

- updated...because OpenSim 3.3 can't be compiled with VS 2017.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
