### PR TITLE
remove MarkerSet::addMarker()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Converting from v3.x to v4.0
   If you have subclassed from Actuator, you must now subclass from ScalarActuator.
 - Methods like `Actuator::getForce` are renamed to use "Actuator" instead (e.g., `Actuator::getActuator`) (PR #209).
 - Markers are now ModelComponents (PR #188). Code is included for conversion on serialization/de-serialization.
+- MarkerSet::addMarker() was removed (PR #1898). Please use Model::addMarker() to add markers to your model.
 - `Body::getMassCenter` now returns a `Vec3` instead of taking a `Vec3` reference as an argument (commit cb0697d98).
 - The following virtual methods in ModelComponent have been moved:
   - connectToModel -> extendConnectToModel

--- a/OpenSim/Simulation/Model/MarkerSet.cpp
+++ b/OpenSim/Simulation/Model/MarkerSet.cpp
@@ -158,24 +158,3 @@ void MarkerSet::addNamePrefix(const string& prefix)
         get(i).setName(prefix + get(i).getName());
 }
 
-//_____________________________________________________________________________
-/**
- * Create a new marker and add it to the set.
- */
-Marker* MarkerSet::addMarker(const string& aName, const SimTK::Vec3& aOffset, OpenSim::PhysicalFrame& aPhysicalFrame)
-{
-    // If a marker by this name already exists, do nothing.
-    if (contains(aName))
-        return NULL;
-
-    // Create a marker and add it to the set.
-    Marker* m = new Marker();
-    m->setName(aName);
-    m->set_location(aOffset);
-    // Frame will be based on this name when marker is connected to Model.
-
-    m->setFrameName(aPhysicalFrame.getName()); 
-    aPhysicalFrame.updModel().addMarker(m);
-
-    return m;
-}

--- a/OpenSim/Simulation/Model/MarkerSet.h
+++ b/OpenSim/Simulation/Model/MarkerSet.h
@@ -73,8 +73,6 @@ public:
     void scale(const ScaleSet& aScaleSet);
     /** Add a prefix to marker names for all markers in the set**/
     void addNamePrefix(const std::string& prefix);
-    Marker* addMarker( const std::string& aName, const SimTK::Vec3& aOffset, OpenSim::PhysicalFrame& aPhysicalFrame);
-
 //=============================================================================
 };  // END of class MarkerSet
 //=============================================================================


### PR DESCRIPTION
Fixes issue #1888 

### Brief summary of changes
`MarkerSet::addMarker()` was removed. It was unused, broken and redundant (and adding confusion) with `Model.addMarker()`.

### Testing I've completed
All tests passed locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.
