### PR TITLE
Fix set<Conectee>Name() methods to only set the connectee_name property

### DIFF
--- a/Applications/Scale/test/testScale.cpp
+++ b/Applications/Scale/test/testScale.cpp
@@ -55,7 +55,7 @@ int main()
         scaleModelWithLigament();
     }
     catch (const std::exception& e) {
-        cerr << e.what() << endl;
+        cout << e.what() << endl;
         return 1;
     }
     cout << "Done" << endl;

--- a/Bindings/Python/tests/test_sockets_inputs_outputs.py
+++ b/Bindings/Python/tests/test_sockets_inputs_outputs.py
@@ -211,8 +211,8 @@ class TestInputsOutputs(unittest.TestCase):
         s = m.initSystem()
 
         # Access and iterate through AbstractInputs, using names.
-        expectedLabels = ['/model_/pin/pin_coord_0|value', 'spd',
-                          '/model_/source|column:col1', 'second_col']
+        expectedLabels = ['/model/pin/pin_coord_0|value', 'spd',
+                          '/model/source|column:col1', 'second_col']
         i = 0
         for name in rep.getInputNames():
             # Actually, there is only one input, which we connected to 4

--- a/OpenSim/Actuators/BodyActuator.cpp
+++ b/OpenSim/Actuators/BodyActuator.cpp
@@ -60,7 +60,7 @@ BodyActuator::BodyActuator(const Body& body,
     setAuthors("Soha Pouya, Michael Sherman");
     constructProperties();
 
-    updSocket<Body>("body").setConnecteeName(body.getName());
+    connectSocket_body(body);
 
     set_point(point); // origin
     set_point_is_global(pointIsGlobal);

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -73,17 +73,9 @@ void Marker::constructProperties()
     constructProperty_fixed(false);
 }
 
-//_____________________________________________________________________________
-/**
- * Set the 'frame name' field, which is used when the marker is added to
- * an existing model.
- *
- * @param  name of frame
- */
-void Marker::setFrameName(const string& name)
+void Marker::setParentFrameName(const string& name)
 {
-    const auto& refFrame = getModel().getComponent<PhysicalFrame>(name);
-    setParentFrame(refFrame);
+    updSocket<PhysicalFrame>("parent_frame").setConnecteeName(name);
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -90,48 +90,27 @@ const string& Marker::getParentFrameName() const
 }
 
 
-//_____________________________________________________________________________
-/**
- * Change the PhysicalFrame that this marker is attached to. It assumes that the frame is
- * already set, so that extendConnectToModel() needs to be called to update 
- * dependent information.
- *
- * @param aFrame Reference to the PhysicalFrame.
- */
-void Marker::changeFrame(const OpenSim::PhysicalFrame& aPhysicalFrame)
+void Marker::changeFrame(const PhysicalFrame& parentFrame)
 {
-
-    if (aPhysicalFrame == getParentFrame())
+    if (parentFrame == getParentFrame())
         return;
 
-    setParentFrameName(aPhysicalFrame.getName());
-
-    extendConnectToModel(updModel());
+    setParentFrame(parentFrame);
 }
 
-//_____________________________________________________________________________
-/**
- * Change the PhysicalFrame that this marker is attached to. It assumes that the body is
- * already set, so that extendConnectToModel() needs to be called to update 
- * dependent information.
- *
- * @param s State.
- * @param aBody Reference to the PhysicalFrame.
- */
-void Marker::changeFramePreserveLocation(const SimTK::State& s, OpenSim::PhysicalFrame& aPhysicalFrame)
+void Marker::changeFramePreserveLocation(const SimTK::State& s, 
+                                         const PhysicalFrame& parentFrame)
 {
 
-    if (aPhysicalFrame == getParentFrame())
+    if (parentFrame == getParentFrame())
         return;
 
     // Preserve location means to switch bodies without changing
     // the location of the marker in the inertial reference frame.
     Vec3 newLocation;
-    newLocation = findLocationInFrame(s, aPhysicalFrame);
+    newLocation = findLocationInFrame(s, parentFrame);
     set_location(newLocation);
-
-    setParentFrameName(aPhysicalFrame.getName());
-    extendConnectToModel(aPhysicalFrame.updModel());
+    setParentFrame(parentFrame);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -82,16 +82,13 @@ void Marker::setParentFrameName(const string& name)
 /**
  * Get the 'frame name' field, which is used when the marker is added to
  * an existing model.
- *
- * @return aName frame name.
  */
-const string& Marker::getFrameName() const
-{
-    //if (_bodyNameProp.getValueIsDefault())
-    //  return NULL;
 
-    return getParentFrame().getName();
+const string& Marker::getParentFrameName() const
+{
+    return getSocket<PhysicalFrame>("parent_frame").getConnecteeName();
 }
+
 
 //_____________________________________________________________________________
 /**
@@ -107,7 +104,7 @@ void Marker::changeFrame(const OpenSim::PhysicalFrame& aPhysicalFrame)
     if (aPhysicalFrame == getParentFrame())
         return;
 
-    setFrameName(aPhysicalFrame.getName());
+    setParentFrameName(aPhysicalFrame.getName());
 
     extendConnectToModel(updModel());
 }
@@ -133,7 +130,7 @@ void Marker::changeFramePreserveLocation(const SimTK::State& s, OpenSim::Physica
     newLocation = findLocationInFrame(s, aPhysicalFrame);
     set_location(newLocation);
 
-    setFrameName(aPhysicalFrame.getName());
+    setParentFrameName(aPhysicalFrame.getName());
     extendConnectToModel(aPhysicalFrame.updModel());
 }
 

--- a/OpenSim/Simulation/Model/Marker.h
+++ b/OpenSim/Simulation/Model/Marker.h
@@ -46,9 +46,9 @@ class OSIMSIMULATION_API Marker : public Station {
 
 class Body;
 public:
-    //==============================================================================
-    // PROPERTIES
-    //==============================================================================
+//==============================================================================
+// PROPERTIES
+//==============================================================================
     OpenSim_DECLARE_PROPERTY(fixed, bool,
         "Flag (true or false) specifying whether the marker is fixed in its "
         "parent frame during the marker placement step of scaling.  If false, "
@@ -57,24 +57,25 @@ public:
 //=============================================================================
 // METHODS
 //=============================================================================
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
 public:
     Marker();
     virtual ~Marker();
 
     const std::string& getFrameName() const;
 
-    void setFrameName(const std::string& aName);
-    void changeFrame(const OpenSim::PhysicalFrame& aPhysicalFrame );
-    void changeFramePreserveLocation(const SimTK::State& s, OpenSim::PhysicalFrame& aPhysicalFrame );
+    /** Convenience method to set the 'parent_frame' Socket' connecte_name
+        and to establish the connection during finalizeConnections(). */
+    void setParentFrameName(const std::string& aName);
+    void changeFrame(const PhysicalFrame& aPhysicalFrame );
+    void changeFramePreserveLocation(const SimTK::State& s, 
+                                     PhysicalFrame& aPhysicalFrame );
     void scale(const SimTK::Vec3& aScaleFactors);
 
     /** Override of the default implementation to account for versioning. */
     void updateFromXMLNode(SimTK::Xml::Element& aNode,
         int versionNumber = -1) override;
-    void generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
 
 private:

--- a/OpenSim/Simulation/Model/Marker.h
+++ b/OpenSim/Simulation/Model/Marker.h
@@ -60,10 +60,10 @@ public:
 public:
     Marker();
     virtual ~Marker();
+    /** Convenience method to get the 'parent_frame' Socket's connectee_name */
+    const std::string& getParentFrameName() const;
 
-    const std::string& getFrameName() const;
-
-    /** Convenience method to set the 'parent_frame' Socket' connecte_name
+    /** Convenience method to set the 'parent_frame' Socket's connectee_name
         and to establish the connection during finalizeConnections(). */
     void setParentFrameName(const std::string& aName);
     void changeFrame(const PhysicalFrame& aPhysicalFrame );

--- a/OpenSim/Simulation/Model/Marker.h
+++ b/OpenSim/Simulation/Model/Marker.h
@@ -66,9 +66,14 @@ public:
     /** Convenience method to set the 'parent_frame' Socket's connectee_name
         and to establish the connection during finalizeConnections(). */
     void setParentFrameName(const std::string& aName);
-    void changeFrame(const PhysicalFrame& aPhysicalFrame );
+    /** Change the parent PhysicalFrame that this marker is attached to. */
+    void changeFrame(const PhysicalFrame& parentFrame);
+    /**  Change the parent PhysicalFrame that this marker is attached to, and 
+         use the state to compute the location in the new parent frame and set
+         its location. */
     void changeFramePreserveLocation(const SimTK::State& s, 
-                                     PhysicalFrame& aPhysicalFrame );
+                                     const PhysicalFrame& newParentFrame );
+
     void scale(const SimTK::Vec3& aScaleFactors);
 
     /** Override of the default implementation to account for versioning. */

--- a/OpenSim/Simulation/Model/MarkerSet.cpp
+++ b/OpenSim/Simulation/Model/MarkerSet.cpp
@@ -129,7 +129,7 @@ void MarkerSet::scale(const ScaleSet& scaleSet)
     for (int i = 0; i < getSize(); i++)
     {
         Marker& nextMarker = get(i);
-        const string& refFrameName = nextMarker.getFrameName();
+        const string& refFrameName = nextMarker.getParentFrameName();
         //assert(refBodyName);
         bool found = false;
         for (int j = 0; j < scaleSet.getSize() && !found; j++)
@@ -174,7 +174,7 @@ Marker* MarkerSet::addMarker(const string& aName, const SimTK::Vec3& aOffset, Op
     m->set_location(aOffset);
     // Frame will be based on this name when marker is connected to Model.
 
-    m->setFrameName(aPhysicalFrame.getName()); 
+    m->setParentFrameName(aPhysicalFrame.getName()); 
     aPhysicalFrame.updModel().addMarker(m);
 
     return m;

--- a/OpenSim/Simulation/Model/MarkerSet.cpp
+++ b/OpenSim/Simulation/Model/MarkerSet.cpp
@@ -129,8 +129,8 @@ void MarkerSet::scale(const ScaleSet& scaleSet)
     for (int i = 0; i < getSize(); i++)
     {
         Marker& nextMarker = get(i);
-        const string& refFrameName = nextMarker.getParentFrameName();
-        //assert(refBodyName);
+        const string& refFrameName = nextMarker.getParentFrame().getName();
+
         bool found = false;
         for (int j = 0; j < scaleSet.getSize() && !found; j++)
         {

--- a/OpenSim/Simulation/SimbodyEngine/PointConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/PointConstraint.cpp
@@ -65,8 +65,8 @@ PointConstraint::PointConstraint(const PhysicalFrame& body1,
     setNull();
     constructProperties();
 
-    setBody1ByName(body1.getName());
-    setBody2ByName(body2.getName());
+    connectSocket_body_1(body1);
+    connectSocket_body_2(body2);
 
     set_location_body_1(locationBody1);
     set_location_body_2(locationBody2);

--- a/OpenSim/Simulation/SimbodyEngine/PointOnLineConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/PointOnLineConstraint.cpp
@@ -69,8 +69,8 @@ PointOnLineConstraint::PointOnLineConstraint( const PhysicalFrame& lineBody,
     setNull();
     constructProperties();
 
-    setLineBodyByName(lineBody.getName());
-    setFollowerBodyByName(followerBody.getName());
+    connectSocket_line_body(lineBody);
+    connectSocket_follower_body(followerBody);
 
     set_line_direction_vec(lineDirection);
     set_point_on_line(pointOnLine);

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -1038,7 +1038,7 @@ void SimbodyEngine::scaleRotationalDofColumns(Storage &rStorage, double factor) 
 
 void SimbodyEngine::scaleRotationalDofColumns(TimeSeriesTable& table,
                                               double factor) const {
-    int ncols = table.getNumColumns();
+    size_t ncols = table.getNumColumns();
     if(ncols == 0)
         throw Exception("SimbodyEngine.scaleRotationalDofColumns: ERROR- storage has no labels, can't determine coordinate types for deg<->rad conversion",
                              __FILE__,__LINE__);


### PR DESCRIPTION
Fixes issue #1889

### Brief summary of changes
1. Make `setFrameName()` consistent with other convenience methods for `Socket` `connectee_name` property renaming. 
2. Rename  `setFrameName()` to  `setParentFrameName()` consistent with the *parent_frame* `Socket`.
3. When a reference to a dependency (`Component`)  is supplied, use `connectSocket` to connect to it.

### Testing I've completed
All tests pass locally. Checked that there are no more `set<Connectee>Name()` convenience methods that attempt to form a direct connection.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because `Socket`s and `Frame`s did not exist prior to 4.0

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
