### PR TITLE
Update comment in hopper example

### DIFF
--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -70,7 +70,7 @@ namespace OpenSim {
 
 // Forward declarations for methods used below.
 Model buildHopper(bool showVisualizer);    //defined in buildHopperModel.cpp
-Model buildTestbed(bool showVisualizer);   //defined in helperMethods.h
+Model buildTestbed(bool showVisualizer);   //defined in buildTestbedModel.cpp
 Device* buildDevice();  //defined in buildDevice.cpp
 
 

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -86,7 +86,7 @@ namespace OpenSim {
 
 // Forward declarations for methods used below.
 Model buildHopper(bool showVisualizer);    //defined in buildHopperModel.cpp
-Model buildTestbed(bool showVisualizer);   //defined in helperMethods.h
+Model buildTestbed(bool showVisualizer);   //defined in buildTestbedModel.cpp
 Device* buildDevice();  //defined in buildDevice.cpp
 
 


### PR DESCRIPTION
Removed comment referring to file that no longer exists.