### PR TITLE
Change Manager interface to prevent "reinitializing"

### DIFF
--- a/Bindings/Java/Matlab/Dynamic_Walker_Example/RunForwardSimulation.m
+++ b/Bindings/Java/Matlab/Dynamic_Walker_Example/RunForwardSimulation.m
@@ -37,9 +37,9 @@ state = model.initSystem();
 % Run a fwd simulation using the manager
 state = model.initSystem();
 manager = Manager(model);
-manager.setInitialTime(0);
-manager.setFinalTime(2);
-manager.integrate(state);
+state.setTime(0);
+manager.initialize(state);
+state = manager.integrate(2);
 
 % Get the states table from the manager and print the results.
 sTable = manager.getStatesTable();

--- a/Bindings/Java/Matlab/Hopper_Device/Simulate.m
+++ b/Bindings/Java/Matlab/Hopper_Device/Simulate.m
@@ -106,7 +106,8 @@ while true
     % Simulate.
     state = State(initState);
     manager = Manager(model);
-    manager.integrate(state, 5.0);
+    manager.initialize(state);
+    state = manager.integrate(5.0);
     simulatedAtLeastOnce = true;
 
     % If there is no visualizer, only simulate once.

--- a/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
+++ b/Bindings/Java/Matlab/examples/wiringInputsAndOutputsWithTableReporter.m
@@ -83,9 +83,9 @@ end
 
 % Simulate the model.
 manager = Manager(deserializedModel);
-manager.setInitialTime(0);
-manager.setFinalTime(1.0);
-manager.integrate(state);
+state.setTime(0);
+manager.initialize(state);
+state = manager.integrate(1.0);
 
 % Now that the simulation is done, get the table from the TableReporter and
 % write it to a file.

--- a/Bindings/Java/tests/CMakeLists.txt
+++ b/Bindings/Java/tests/CMakeLists.txt
@@ -86,6 +86,8 @@ macro(OpenSimAddJavaTest TESTNAME)
                  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/TestVisualization")
     file(COPY "${OPENSIM_SHARED_TEST_FILES_DIR}/gait10dof18musc_subject01.osim"
                  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/TestEditProperties")
+    file(COPY "${OPENSIM_SHARED_TEST_FILES_DIR}/gait10dof18musc_subject01.osim"
+                 DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/TestEditMarkers")
     if(WIN32)
         # On Windows, CMake cannot use RPATH to hard code the location of libraries
         # in the binary directory (DLL's don't have RPATH), so we must set PATH to
@@ -132,6 +134,7 @@ OpenSimAddJavaTest(TestVisualization)
 OpenSimAddJavaTest(TestEditProperties)
 OpenSimAddJavaTest(TestTables)
 OpenSimAddJavaTest(TestModelBuilding)
+OpenSimAddJavaTest(TestEditMarkers)
 if(WITH_BTK)
     OpenSimAddJavaTest(TestC3DFileAdapter)
 endif()

--- a/Bindings/Java/tests/TestEditMarkers.java
+++ b/Bindings/Java/tests/TestEditMarkers.java
@@ -1,0 +1,65 @@
+import org.opensim.modeling.*;
+import java.io.IOException;
+import static java.nio.file.StandardOpenOption.*;
+import java.nio.file.*;
+
+class TestEditMarkers {
+  public static void main(String[] args) {
+    try {
+        // GUI model loading
+        Model model = new Model("gait10dof18musc_subject01.osim");
+        OpenSimContext context=null;
+        context = new OpenSimContext(model.initSystem(), model);
+        MarkerSet markerset = model.getMarkerSet();
+        // The following code exercises the Marker->Add New  functionality
+        Vec3 offset = new Vec3(0.11, 0.22, 0.33);
+        Body body = model.getBodySet().get(0);
+        String newMarkerName = "newMarker";
+        Marker newMarker = new Marker();
+        newMarker.setName(newMarkerName);
+        newMarker.set_location(offset);
+        newMarker.setParentFrameName(body.getName());
+        context.cacheModelAndState();
+        model.addMarker(newMarker);
+        try {
+            context.restoreStateFromCachedModel();
+        } catch (IOException ex) {
+            System.exit(1);
+        }
+        // This exercises Marker -> delete
+        context.cacheModelAndState();
+        
+        Marker findMarker = markerset.get(newMarkerName);
+        assert (findMarker != null);
+        markerset.remove(findMarker);
+        try {
+            context.restoreStateFromCachedModel();
+        } catch (IOException ex) {
+            System.exit(1);
+        }
+		// Exercise saveToFile
+        markerset.print("savedMarkers.xml");
+        // Now create a new MarkerSet from the file
+        MarkerSet newMarkerSet = new MarkerSet(model, "savedMarkers.xml");
+        Marker newMarkerRenamed = newMarkerSet.get(0);
+        String addedMarkerName = newMarkerRenamed.getName()+"_renamed";
+        newMarkerRenamed.setName(addedMarkerName);
+        context.cacheModelAndState();
+        markerset.adoptAndAppend(newMarkerRenamed);
+        try {
+            context.restoreStateFromCachedModel();
+        } catch (IOException ex) {
+            System.exit(1);
+        }
+        Marker findMarkerAdded = markerset.get(addedMarkerName);
+        assert(findMarkerAdded != null);
+        System.exit(0);
+    }
+    catch(IOException ex){
+        System.out.println("Failed to load model or in initSystem");
+        System.exit(-1);
+    }
+    // TODO to cause test to fail: System.exit(-1);
+  }
+
+}

--- a/Bindings/Java/tests/TestReporter.java
+++ b/Bindings/Java/tests/TestReporter.java
@@ -143,9 +143,9 @@ class TestReporter {
             
             State state = model.initSystem();
             Manager manager = new Manager(model);
-            manager.setInitialTime(0);
-            manager.setFinalTime(n);
-            manager.integrate(state);
+            state.setTime(0);
+            manager.initialize(state);
+            state = manager.integrate(n);
 
             TimeSeriesTable table = tableReporter.getTable();
             stoAdapter.write(table, "pendulum_coordinates.sto");

--- a/Bindings/Python/examples/build_simple_arm_model.py
+++ b/Bindings/Python/examples/build_simple_arm_model.py
@@ -159,9 +159,9 @@ arm.equilibrateMuscles(state)
 # ---------------------------------------------------------------------------
 
 manager = osim.Manager(arm)
-manager.setInitialTime(0)
-manager.setFinalTime(10.0)
-manager.integrate(state)
+state.setTime(0)
+manager.initialize(state)
+state = manager.integrate(10.0)
 
 # ---------------------------------------------------------------------------
 # Print/save model file

--- a/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
+++ b/Bindings/Python/examples/wiring_inputs_and_outputs_with_TableReporter.py
@@ -83,9 +83,9 @@ for i in range(reporter.getInput('inputs').getNumConnectees()):
 
 # Simulate the model.
 manager = osim.Manager(deserialized_model)
-manager.setInitialTime(0)
-manager.setFinalTime(1.0)
-manager.integrate(state)
+state.setTime(0)
+manager.initialize(state)
+state = manager.integrate(1.0)
 
 # Now that the simulation is done, get the table from the TableReporter and
 # write it to a file.

--- a/Bindings/Python/tests/test_basics.py
+++ b/Bindings/Python/tests/test_basics.py
@@ -73,9 +73,9 @@ class TestBasics(unittest.TestCase):
         state = model.initSystem()
 
         manager = osim.Manager(model)
-        manager.setInitialTime(0)
-        manager.setFinalTime(0.00001)
-        manager.integrate(state)
+        state.setTime(0);
+        manager.initialize(state);
+        state = manager.integrate(0.00001)
 
     def test_WrapObject(self):
         # Make sure the WrapObjects are accessible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,15 +57,18 @@ Converting from v3.x to v4.0
   compatibility, a joint's parent and child PhysicalFrames are swapped when
   opening a Model if the `reverse` element is set to `true`.
 - The `Manager::integrate(SimTK::State&)` call is deprecated and replaced by
-  `Manager::integrate(SimTK::State&, double)`. Here is a before-after example
-  (see the documentation in the `Manager` class for more details):
+  `Manager::integrate(double)`. You must also now call 
+  `Manager::initialize(SimTK::State&)` before integrating. Here is a 
+   before-after example (see the documentation in the `Manager` class 
+   for more details):
   - Before:
-	- manager.setInitialTime(0.0);
-	- manager.setFinalTime(1.0);
-	- manager.integrate(state);
+    - manager.setInitialTime(0.0);
+    - manager.setFinalTime(1.0);
+    - manager.integrate(state);
   - After:
     - state.setTime(0.0);
-	- manager.integrate(state, 1.0);
+    - manager.initialize(state);
+    - manager.integrate(1.0);
 
 - `Muscle::equilibrate(SimTK::State&)` has been removed from the Muscle interface in order to reduce the number and variety of muscle equilibrium methods. `Actuator::computeEquilibrium(SimTK::State&)` is overridden by Muscle and invokes pure virtual `Muscle::computeInitialFiberEquilibrium(SimTK::State&)`.
 - `Millard2012EquilibriumMuscle::computeFiberEquilibriumAtZeroVelocity(SimTK::State&)` and `computeInitialFiberEquilibrium(SimTK::State&)` were combined into a single method:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,18 +58,24 @@ Converting from v3.x to v4.0
   opening a Model if the `reverse` element is set to `true`.
 - The `Manager::integrate(SimTK::State&)` call is deprecated and replaced by
   `Manager::integrate(double)`. You must also now call 
-  `Manager::initialize(SimTK::State&)` before integrating. Here is a 
+  `Manager::initialize(SimTK::State&)` before integrating or pass the
+  initialization state into a convenience constructor. Here is a 
    before-after example (see the documentation in the `Manager` class 
    for more details):
   - Before:
+    - Manager manager(model);
     - manager.setInitialTime(0.0);
     - manager.setFinalTime(1.0);
     - manager.integrate(state);
   - After:
+    - Manager manager(model);
     - state.setTime(0.0);
     - manager.initialize(state);
     - manager.integrate(1.0);
-
+  - After (using a convenience constructor):
+    - state.setTime(0.0);
+    - Manager manager(model, state);
+    - manager.integrate(1.0);
 - `Muscle::equilibrate(SimTK::State&)` has been removed from the Muscle interface in order to reduce the number and variety of muscle equilibrium methods. `Actuator::computeEquilibrium(SimTK::State&)` is overridden by Muscle and invokes pure virtual `Muscle::computeInitialFiberEquilibrium(SimTK::State&)`.
 - `Millard2012EquilibriumMuscle::computeFiberEquilibriumAtZeroVelocity(SimTK::State&)` and `computeInitialFiberEquilibrium(SimTK::State&)` were combined into a single method:
 `Millard2012EquilibriumMuscle::computeFiberEquilibrium(SimTK::State&, bool useZeroVelocity)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Bug Fixes
 - Fixed a bug where MuscleAnalysis was producing empty moment arm files. We now avoid creating empty Moment and MomentArm storage files when `_computeMoments` is False. (PR #324)
 - Fixed bug causing the muscle equilibrium solve routine in both Thelen2003Muscle and Millard2012EquilibriumMuscle to fail to converge and erroneously return the minimum fiber length. The fix added a proper reduction in step-size when errors increase and limiting the fiber-length to its minimum. (PR #1728)
 - Fixed a bug where Models with Bodies and Joints (and other component types) with the same name were loaded without error. Duplicately named Bodies were simply being ignored and only the first Body of that name in the BodySet was being used, for example, to connect a Body to its parent via its Joint, or to affix path points to its respective Body. Now, duplicate names are flagged and renamed so they are uniquely identified. (PR #1887)
+- Fixed bug and speed issue with `model.setStateVariableValues()` caused by enforcing constraints after each coordinate value was being set (PR #1911). Removing the automatic enforcement of constraints makes setting all state values much faster, but also requires calling `model.assemble()` afterwards. Enforcing constraints after setting each coordinate value individually was also incorrect, since it neglected the effect of other coordinate changes have on the current coordinate. All coordinate values must be set before enforcing constraints.
 
 
 New Classes

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -147,9 +147,10 @@ void testMcKibbenActuator()
     integrator.setAccuracy(1e-7);
     Manager manager(*model, integrator);
     si.setTime(0.0);
+    manager.initialize(si);
 
     for (int i = 1; i <= nsteps; i++){
-        manager.integrate(si, dt*i);
+        si = manager.integrate(dt*i);
         model->getMultibodySystem().realize(si, Stage::Velocity);
         Vec3 pos = ball->findStationLocationInGround(si, Vec3(0));
 
@@ -309,9 +310,10 @@ void testTorqueActuator()
     Manager manager(*model,  integrator);
 
     state.setTime(0.0);
+    manager.initialize(state);
 
     double final_t = 1.00;
-    manager.integrate(state, final_t);
+    state = manager.integrate(final_t);
 
     model->computeStateVariableDerivatives(state);
 
@@ -454,9 +456,10 @@ void testClutchedPathSpring()
     manager.setWriteToStorage(true);
 
     state.setTime(0.0);
+    manager.initialize(state);
 
     double final_t = 4.99999;
-    manager.integrate(state, final_t);
+    state = manager.integrate(final_t);
 
     // tension is dynamics dependent because controls must be computed
     model->getMultibodySystem().realize(state, Stage::Dynamics);
@@ -477,7 +480,7 @@ void testClutchedPathSpring()
 
     // unclamp and continue integrating
     final_t = 5.99999;
-    manager.integrate(state, final_t);
+    state = manager.integrate(final_t);
 
     // tension is dynamics dependent because controls must be computed
     model->getMultibodySystem().realize(state, Stage::Dynamics);
@@ -491,7 +494,7 @@ void testClutchedPathSpring()
 
     // spring is reclamped at 7s so keep integrating
     final_t = 10.0;
-    manager.integrate(state, final_t);
+    state = manager.integrate(final_t);
 
     // tension is dynamics dependent because controls must be computed
     model->getMultibodySystem().realize(state, Stage::Dynamics);
@@ -683,8 +686,9 @@ void testBodyActuator()
     Manager manager(*model, integrator);
 
     state1.setTime(0.0);
+    manager.initialize(state1);
     double final_t = 1.00;
-    manager.integrate(state1, final_t);
+    state1 = manager.integrate(final_t);
 
     // ----------------- Test Copying the model -------------------
     // Before exiting lets see if copying the actuator works
@@ -909,8 +913,9 @@ void testActuatorsCombination()
     Manager manager(*model, integrator);
 
     state2.setTime(0.0);
+    manager.initialize(state2);
     double final_t = 1.00;
-    manager.integrate(state2, final_t);
+    state2 = manager.integrate(final_t);
 
 
     std::cout << " ********** Test Actuator Combination time = ********** " <<

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -389,12 +389,13 @@ void simulateMuscle(
 
     // Integrate from initial time to final time
     si.setTime(initialTime);
+    manager.initialize(si);
     cout<<"\nIntegrating from " << initialTime<< " to " << finalTime << endl;
 
     // Start timing the simulation
     const clock_t start = clock();
     // simulate
-    manager.integrate(si, finalTime);
+    manager.integrate(finalTime);
 
     // how long did it take?
     double comp_time = (double)(clock()-start)/CLOCKS_PER_SEC;

--- a/OpenSim/Analyses/Actuation.cpp
+++ b/OpenSim/Analyses/Actuation.cpp
@@ -413,7 +413,7 @@ record(const SimTK::State& s)
 * @return -1 on error, 0 otherwise.
 */
 int Actuation::
-begin(SimTK::State& s)
+begin(const SimTK::State& s)
 {
     if (!proceed()) return(0);
 
@@ -486,8 +486,7 @@ step(const SimTK::State& s, int stepNumber)
 *
 * @return -1 on error, 0 otherwise.
 */
-int Actuation::
-end(SimTK::State& s)
+int Actuation::end(const SimTK::State& s)
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Analyses/Actuation.h
+++ b/OpenSim/Analyses/Actuation.h
@@ -110,11 +110,11 @@ class Storage;
         //--------------------------------------------------------------------------
 
         int
-            begin(SimTK::State& s) override;
+            begin(const SimTK::State& s) override;
         int
             step(const SimTK::State& s, int setNumber) override;
         int
-            end(SimTK::State& s) override;
+            end(const SimTK::State& s) override;
     protected:
         virtual int
             record(const SimTK::State& s);

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -604,7 +604,7 @@ record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int BodyKinematics::
-begin(SimTK::State& s )
+begin(const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
@@ -662,7 +662,7 @@ step(const SimTK::State& s, int stepNumber)
  * @return -1 on error, 0 otherwise.
  */
 int BodyKinematics::
-end(SimTK::State& s )
+end(const SimTK::State&s )
 {
     if(!proceed()) return(0);
 

--- a/OpenSim/Analyses/BodyKinematics.h
+++ b/OpenSim/Analyses/BodyKinematics.h
@@ -117,11 +117,11 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/ForceReporter.cpp
+++ b/OpenSim/Analyses/ForceReporter.cpp
@@ -303,8 +303,7 @@ int ForceReporter::record(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int ForceReporter::
-begin(SimTK::State& s)
+int ForceReporter::begin(const SimTK::State& s)
 {
     if(!proceed()) return(0);
 
@@ -338,8 +337,7 @@ begin(SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int ForceReporter::
-step(const SimTK::State& s, int stepNumber )
+int ForceReporter::step(const SimTK::State& s, int stepNumber )
 {
     if(!proceed( stepNumber )) return(0);
 
@@ -361,8 +359,7 @@ step(const SimTK::State& s, int stepNumber )
  *
  * @return -1 on error, 0 otherwise.
  */
-int ForceReporter::
-end(SimTK::State& s )
+int ForceReporter::end(const SimTK::State& s )
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Analyses/ForceReporter.h
+++ b/OpenSim/Analyses/ForceReporter.h
@@ -115,9 +115,9 @@ public:
     //--------------------------------------------------------------------------
     void includeConstraintForces(bool flag) {_includeConstraintForces = flag;}
 
-    int begin(SimTK::State& s ) override;
+    int begin(const SimTK::State& s ) override;
     int step(const SimTK::State& s, int setNumber ) override;
-    int end(SimTK::State& s ) override;
+    int end(const SimTK::State& s ) override;
 
 protected:
     virtual int

--- a/OpenSim/Analyses/InducedAccelerations.cpp
+++ b/OpenSim/Analyses/InducedAccelerations.cpp
@@ -848,7 +848,7 @@ void InducedAccelerations::initialize(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int InducedAccelerations::begin(SimTK::State &s)
+int InducedAccelerations::begin(const SimTK::State &s)
 {
     if(!proceed()) return(0);
 
@@ -900,7 +900,7 @@ int InducedAccelerations::step(const SimTK::State &s, int stepNumber)
  *
  * @return -1 on error, 0 otherwise.
  */
-int InducedAccelerations::end(SimTK::State &s)
+int InducedAccelerations::end(const SimTK::State &s)
 {
     if(!proceed()) return(0);
 

--- a/OpenSim/Analyses/InducedAccelerations.h
+++ b/OpenSim/Analyses/InducedAccelerations.h
@@ -190,9 +190,9 @@ public:
     // INTEGRATION
     //-------------------------------------------------------------------------
     virtual void initialize(const SimTK::State& s); 
-    int begin( SimTK::State& s) override;
+    int begin( const SimTK::State& s) override;
     int step( const SimTK::State& s, int stepNumber) override;
-    int end( SimTK::State& s) override;
+    int end( const SimTK::State& s) override;
 
     //-------------------------------------------------------------------------
     // IO

--- a/OpenSim/Analyses/InverseDynamics.cpp
+++ b/OpenSim/Analyses/InverseDynamics.cpp
@@ -396,8 +396,7 @@ record(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int InverseDynamics::
-begin(SimTK::State& s )
+int InverseDynamics::begin(const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
@@ -420,8 +419,6 @@ begin(SimTK::State& s )
     delete _modelWorkingCopy;
     _modelWorkingCopy = _model->clone();
     _modelWorkingCopy->updAnalysisSet().setSize(0);
-    //_modelWorkingCopy = _model->clone();
-    //_modelWorkingCopy = new Model(*_model);
 
     // Replace model force set with only generalized forces
     if(_model) {
@@ -551,13 +548,13 @@ step(const SimTK::State& s, int stepNumber )
  * @return -1 on error, 0 otherwise.
  */
 int InverseDynamics::
-end(SimTK::State& s )
+end(const SimTK::State&s )
 {
     if(!proceed()) return(0);
 
     record(s);
 
-    _model->overrideAllActuators( s, false );
+    _model->overrideAllActuators(*const_cast<SimTK::State*>(&s), false );
 
     return(0);
 }

--- a/OpenSim/Analyses/InverseDynamics.h
+++ b/OpenSim/Analyses/InverseDynamics.h
@@ -118,11 +118,11 @@ public:
     //--------------------------------------------------------------------------
 #ifndef SWIG
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -607,7 +607,7 @@ record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int JointReaction::
-begin(SimTK::State& s)
+begin(const SimTK::State& s)
 {
     if(!proceed()) return(0);
     // Read forces file here rather than during initialization
@@ -654,7 +654,7 @@ step( const SimTK::State& s, int stepNumber)
  * @return -1 on error, 0 otherwise.
  */
 int JointReaction::
-end(SimTK::State& s)
+end(const SimTK::State&s)
 {
     if(!proceed()) return(0);
 

--- a/OpenSim/Analyses/JointReaction.h
+++ b/OpenSim/Analyses/JointReaction.h
@@ -185,11 +185,11 @@ public:
     // INTEGRATION
     //----------------------------------------------------------------------
     int
-        begin( SimTK::State& s ) override;
+        begin( const SimTK::State& s ) override;
     int
         step( const SimTK::State& s, int setNumber ) override;
     int
-        end( SimTK::State& s ) override;
+        end( const SimTK::State& s ) override;
 
 
     //-------------------------------------------------------------------------

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -400,7 +400,7 @@ int Kinematics::record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int Kinematics::
-begin( SimTK::State& s )
+begin( const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
@@ -467,7 +467,7 @@ step(const SimTK::State& s, int stepNumber )
  * @return -1 on error, 0 otherwise.
  */
 int Kinematics::
-end( SimTK::State& s )
+end( const SimTK::State& s )
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Analyses/Kinematics.h
+++ b/OpenSim/Analyses/Kinematics.h
@@ -101,11 +101,11 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/MuscleAnalysis.cpp
+++ b/OpenSim/Analyses/MuscleAnalysis.cpp
@@ -682,7 +682,7 @@ int MuscleAnalysis::record(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int MuscleAnalysis::begin(SimTK::State& s )
+int MuscleAnalysis::begin(const SimTK::State&s )
 {
     if(!proceed()) return 0;
 
@@ -753,7 +753,7 @@ int MuscleAnalysis::step(const SimTK::State& s, int stepNumber )
  *
  * @return -1 on error, 0 otherwise.
  */
-int MuscleAnalysis::end(SimTK::State& s )
+int MuscleAnalysis::end(const SimTK::State& s )
 {
     if (!proceed()) return 0;
     record(s);

--- a/OpenSim/Analyses/MuscleAnalysis.h
+++ b/OpenSim/Analyses/MuscleAnalysis.h
@@ -225,11 +225,11 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
     int
-        begin( SimTK::State& s ) override;
+        begin( const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end( SimTK::State& s ) override;
+        end( const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/PointKinematics.cpp
+++ b/OpenSim/Analyses/PointKinematics.cpp
@@ -563,7 +563,7 @@ record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int PointKinematics::
-begin( SimTK::State& s)
+begin( const SimTK::State& s)
 {
     if(!proceed()) return(0);
 
@@ -619,7 +619,7 @@ step(const SimTK::State& s, int stepNumber)
  * @return -1 on error, 0 otherwise.
  */
 int PointKinematics::
-end( SimTK::State& s)
+end( const SimTK::State& s)
 {
     if(!proceed()) return(0);
     record(s);

--- a/OpenSim/Analyses/PointKinematics.h
+++ b/OpenSim/Analyses/PointKinematics.h
@@ -144,12 +144,9 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
 
-    int
-        begin( SimTK::State& s) override;
-    int
-        step(const SimTK::State& s, int setNumber) override;
-    int
-        end( SimTK::State& s) override;
+    int begin(const SimTK::State& s) override;
+    int step(const SimTK::State& s, int setNumber) override;
+    int end(const SimTK::State& s) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/ProbeReporter.cpp
+++ b/OpenSim/Analyses/ProbeReporter.cpp
@@ -273,7 +273,7 @@ int ProbeReporter::record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int ProbeReporter::
-begin(SimTK::State& s)
+begin(const SimTK::State& s)
 {
     if(!proceed()) return 0;
 
@@ -330,7 +330,7 @@ step(const SimTK::State& s, int stepNumber )
  * @return -1 on error, 0 otherwise.
  */
 int ProbeReporter::
-end(SimTK::State& s )
+end(const SimTK::State&s )
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Analyses/ProbeReporter.h
+++ b/OpenSim/Analyses/ProbeReporter.h
@@ -141,11 +141,11 @@ public:
     //--------------------------------------------------------------------------
 
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/StatesReporter.cpp
+++ b/OpenSim/Analyses/StatesReporter.cpp
@@ -225,7 +225,7 @@ record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int StatesReporter::
-begin( SimTK::State& s)
+begin( const SimTK::State& s)
 {
     if(!proceed()) return(0);
     // LABELS
@@ -281,7 +281,7 @@ step(const SimTK::State& s, int stepNumber )
  * @return -1 on error, 0 otherwise.
  */
 int StatesReporter::
-end( SimTK::State& s )
+end( const SimTK::State& s )
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Analyses/StatesReporter.h
+++ b/OpenSim/Analyses/StatesReporter.h
@@ -99,11 +99,11 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Analyses/StaticOptimization.cpp
+++ b/OpenSim/Analyses/StaticOptimization.cpp
@@ -505,8 +505,7 @@ record(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int StaticOptimization::
-begin(SimTK::State& s )
+int StaticOptimization::begin(const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
@@ -634,8 +633,7 @@ begin(SimTK::State& s )
  *
  * @return -1 on error, 0 otherwise.
  */
-int StaticOptimization::
-step(const SimTK::State& s, int stepNumber )
+int StaticOptimization::step(const SimTK::State& s, int stepNumber )
 {
     if(!proceed(stepNumber)) return(0);
 
@@ -652,8 +650,7 @@ step(const SimTK::State& s, int stepNumber )
  *
  * @return -1 on error, 0 otherwise.
  */
-int StaticOptimization::
-end( SimTK::State& s )
+int StaticOptimization::end( const SimTK::State& s )
 {
     if(!proceed()) return(0);
 

--- a/OpenSim/Analyses/StaticOptimization.h
+++ b/OpenSim/Analyses/StaticOptimization.h
@@ -139,11 +139,11 @@ public:
     // ANALYSIS
     //--------------------------------------------------------------------------
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -21,6 +21,14 @@ OpenSimAddLibrary(
     )
 
 if(WIN32)
-    add_dependencies(osimCommon Simbody_CONFIG_check)
+    # On Windows only, debug libraries cannot be mixed with release
+    # libraries, and we must copy the DLLs from the dependencies
+    # into OpenSim's build directory (so that the DLLs are found
+    # when running the tests).
+    add_dependencies(osimCommon
+        Simbody_CONFIG_check Copy_Simbody_DLLs)
+    if(WITH_BTK)
+        add_dependencies(osimCommon Copy_BTK_DLLs)
+    endif()
 endif()
   

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -392,6 +392,10 @@ void Component::baseAddToSystem(SimTK::MultibodySystem& system) const
         throw Exception(msg);
     }
 
+    // Clear cached list of all related StateVariables if any from a previous
+    // System.
+    _allStateVariables.clear();
+
     // Briefly get write access to the Component to record some
     // information associated with the System; that info is const after this.
     Component* mutableThis = const_cast<Component *>(this);

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1256,9 +1256,15 @@ public:
 
     /**
      * %Set all values of the state variables allocated by this Component.
-     * Includes state variables allocated by its subcomponents.
+     * Includes state variables allocated by its subcomponents. Note, this
+     * method simply sets the values on the input State. If other conditions
+     * must be met (such as satisfying kinematic constraints for Coordinates,
+     * or fiber and tendon equilibrium for muscles) you must invoke the
+     * appropriate methods on Model (e.g. assemble() to satisfy constraints or
+     * equilibrateMuscles()) to satisfy these conditions starting from the
+     * State values provided by setStateVariableValues.
      *
-     * @param state   the State for which to get the value
+     * @param state   the State whose values are set
      * @param values  Vector of state variable values of length
      *                getNumStateVariables() in the order returned by
      *                getStateVariableNames()

--- a/OpenSim/Examples/ControllerExample/ControllerExample.cpp
+++ b/OpenSim/Examples/ControllerExample/ControllerExample.cpp
@@ -314,9 +314,10 @@ int main()
 
         // Integrate from initial time to final time.
         si.setTime(initialTime);
+        manager.initialize(si);
         std::cout << "\n\nIntegrating from " << initialTime
             << " to " << finalTime << std::endl;
-        manager.integrate(si, finalTime);
+        manager.integrate(finalTime);
 
         // Save the simulation results.
         auto controlsTable = osimModel.getControlsTable();

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -210,8 +210,9 @@ int main()
 
         // Integrate
         si.setTime(t0);
+        manager.initialize(si);
         std::cout<<"\n\nIntegrating from " << t0 << " to " << tf << std::endl;
-        manager.integrate(si, tf);
+        manager.integrate(tf);
 
         // Save results
         auto controlsTable = osimModel.getControlsTable();

--- a/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
+++ b/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
@@ -258,8 +258,9 @@ int main(int argc, char* argv[]) {
         
         
         state.setTime(0.0);
+        manager.initialize(state);
         std::cout<<"Integrating for " << sim_time << " seconds" <<std::endl;
-        manager.integrate(state, sim_time);
+        manager.integrate(sim_time);
         std::cout<<"Integration finished."<<std::endl;
         
         //////////////////////////////

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -326,8 +326,9 @@ int main()
 
         // Integrate from initial time to final time
         si.setTime(initialTime);
+        manager.initialize(si);
         cout<<"\nIntegrating from "<<initialTime<<" to "<<finalTime<<endl;
-        manager.integrate(si, finalTime);
+        manager.integrate(finalTime);
 
         //////////////////////////////
         // SAVE THE RESULTS TO FILE //

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -221,8 +221,9 @@ int main()
 
         // Integrate from initial time to final time
         si.setTime(initialTime);
+        manager.initialize(si);
         std::cout<<"\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-        manager.integrate(si, finalTime);
+        manager.integrate(finalTime);
 
         //////////////////////////////
         // SAVE THE RESULTS TO FILE //

--- a/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
+++ b/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
@@ -75,7 +75,8 @@ public:
 
         osimModel.getMultibodySystem().realize(s, Stage::Acceleration);
 
-        manager.integrate(s, finalTime);
+        manager.initialize(s);
+        s = manager.integrate(finalTime);
 
         /* Calculate the scalar quantity we want to minimize or maximize. 
         *  In this case, we’re maximizing forward velocity of the 
@@ -204,7 +205,8 @@ int main()
         // Integrate from initial time to final time.
         si.setTime(initialTime);
         osimModel.getMultibodySystem().realize(si, Stage::Acceleration);
-        manager.integrate(si, finalTime);
+        manager.initialize(si);
+        si = manager.integrate(finalTime);
 
         auto statesTable = manager.getStatesTable();
         STOFileAdapter_<double>::write(statesTable, 

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
@@ -278,8 +278,7 @@ record(const SimTK::State& s)
  *
  * @return -1 on error, 0 otherwise.
  */
-int AnalysisPlugin_Template::
-begin(SimTK::State& s)
+int AnalysisPlugin_Template::begin(const SimTK::State& s)
 {
     if(!proceed()) return(0);
 
@@ -344,7 +343,7 @@ step(const SimTK::State& s, int stepNumber)
  * @return -1 on error, 0 otherwise.
  */
 int AnalysisPlugin_Template::
-end(SimTK::State& s)
+end(const SimTK::State&s)
 {
     if(!proceed()) return(0);
 

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.h
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.h
@@ -122,9 +122,9 @@ public:
     //-------------------------------------------------------------------------
     // METHODS THAT MUST BE OVERRIDDEN
     //-------------------------------------------------------------------------
-    int begin(SimTK::State& s) override;
+    int begin(const SimTK::State& s) override;
     int step(const SimTK::State& s, int stepNumber) override;
-    int end(SimTK::State& s) override;
+    int end(const SimTK::State& s) override;
 
     //-------------------------------------------------------------------------
     // IO

--- a/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
@@ -252,7 +252,7 @@ record(const SimTK::State& s)
  * @return -1 on error, 0 otherwise.
  */
 int SymbolicExpressionReporter::
-begin( SimTK::State& s)
+begin( const SimTK::State& s)
 {
     if(!proceed()) return(0);
     // LABELS
@@ -312,7 +312,7 @@ step(const SimTK::State& s, int stepNumber )
  * @return -1 on error, 0 otherwise.
  */
 int SymbolicExpressionReporter::
-end( SimTK::State& s )
+end( const SimTK::State& s )
 {
     if (!proceed()) return 0;
 

--- a/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.h
+++ b/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.h
@@ -108,11 +108,11 @@ public:
     //--------------------------------------------------------------------------
 #ifndef SWIG
     int
-        begin(SimTK::State& s ) override;
+        begin(const SimTK::State& s ) override;
     int
         step(const SimTK::State& s, int setNumber ) override;
     int
-        end(SimTK::State& s ) override;
+        end(const SimTK::State& s ) override;
 protected:
     virtual int
         record(const SimTK::State& s );

--- a/OpenSim/Examples/checkEnvironment/checkEnvironment.cpp
+++ b/OpenSim/Examples/checkEnvironment/checkEnvironment.cpp
@@ -238,8 +238,9 @@ int main()
 
         // Integrate from initial time to final time
         si.setTime(initialTime);
+        manager.initialize(si);
         std::cout<<"\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-        manager.integrate(si, finalTime);
+        manager.integrate(finalTime);
 
     }
     catch (const std::exception& ex)

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -51,7 +51,7 @@ std::string Manager::_displayName = "Simulator";
 // CONSTRUCTOR(S)
 //=============================================================================
 Manager::Manager(Model& model) 
-        : Manager(model,  true)
+        : Manager(model, true)
 {
     _defaultInteg.reset(
             new SimTK::RungeKuttaMersonIntegrator(_model->getMultibodySystem()));
@@ -59,8 +59,22 @@ Manager::Manager(Model& model)
 }
 
 Manager::Manager(Model& model, SimTK::Integrator& integ)
-        : Manager(model, true) {
+        : Manager(model, true) 
+{
     setIntegrator(integ);
+}
+
+Manager::Manager(Model& model, const SimTK::State& state)
+        : Manager(model) 
+{
+    initialize(state);
+}
+
+Manager::Manager(Model& model, const SimTK::State& state, 
+    SimTK::Integrator& integ)
+    : Manager(model, integ) 
+{
+    initialize(state);
 }
 
 // Private constructor to handle common tasks of the two constructors above.
@@ -95,8 +109,6 @@ void Manager::
 setNull()
 {
     _sessionName = "";
-    _ti = 0.0;
-    _tf = 1.0;
     _halt = false;
     _specifiedDT = false;
     _constantDT = false;
@@ -479,7 +491,7 @@ resetTimeAndDTArrays(double aTime)
  * Sets the model  and initializes other entities that depend on it
  */
 void Manager::
-setModel(Model& aModel)
+setModel(Model& model)
 {
     if(_model != nullptr){
         // May need to issue a warning here that model was already set to avoid a leak.
@@ -491,7 +503,7 @@ setModel(Model& aModel)
         OPENSIM_THROW(Exception, msg);
     }
 
-    _model = &aModel;
+    _model = &model;
 
     // STORAGE
     constructStorage();
@@ -528,54 +540,6 @@ setIntegrator(SimTK::Integrator& integrator)
     _integ = &integrator;
     // If we had been using the _defaultInteg, we no longer need it.
     _defaultInteg.reset();
-}
-
-//-----------------------------------------------------------------------------
-// INITIAL AND FINAL TIME
-//-----------------------------------------------------------------------------
-//_____________________________________________________________________________
-/**
- * Set the initial time of the simulation.
- *
- * @param aTI Initial time.
- */
-void Manager::
-setInitialTime(double aTI)
-{
-    _ti = aTI;
-}
-//_____________________________________________________________________________
-/**
- * Get the initial time of the simulation.
- *
- * @return Initial time.
- */
-double Manager::
-getInitialTime() const
-{
-    return(_ti);
-}
-//_____________________________________________________________________________
-/**
- * Set the final time of the simulation.
- *
- * @param aTF Final time.
- */
-void Manager::
-setFinalTime(double aTF)
-{
-    _tf = aTF;
-}
-//_____________________________________________________________________________
-/**
- * Get the final time of the simulation.
- *
- * @return Final time.
- */
-double Manager::
-getFinalTime() const
-{
-    return(_tf);
 }
 
 

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -625,8 +625,7 @@ hasStateStorage() const
 // INTEGRATION
 //-----------------------------------------------------------------------------
 
-SimTK::State Manager::
-integrate(double finalTime)
+const SimTK::State& Manager::integrate(double finalTime)
 {
     int step = 0; // for AnalysisSet::step()
 
@@ -640,7 +639,7 @@ integrate(double finalTime)
     clearHalt();
 
     // CHECK SPECIFIED DT STEPPING
-    SimTK::State s = _integ->getState();
+    const SimTK::State& s = _integ->getState();
     double initialTime = s.getTime();
     if (_specifiedDT) {
         if (_tArray.getSize() <= 0) {
@@ -737,12 +736,11 @@ integrate(double finalTime)
     clearHalt();
 
     return getState();
-
 }
 
-SimTK::State Manager::getState()
+const SimTK::State& Manager::getState() const
 {
-    return _integ->getState();
+    return _timeStepper->getState();
 }
 
 //_____________________________________________________________________________
@@ -768,7 +766,7 @@ double Manager::getFixedStepSize(int tArrayStep) const {
  * 
  * @param s system state before integration
  */
-void Manager::initializeStorageAndAnalyses(SimTK::State& s)
+void Manager::initializeStorageAndAnalyses(const SimTK::State& s)
 {
     if( _writeToStorage && _performAnalyses ) { 
 
@@ -800,7 +798,7 @@ void Manager::initializeStorageAndAnalyses(SimTK::State& s)
 /**
 * set and initialize a SimTK::TimeStepper
 */
-void Manager::initialize(SimTK::State& s)
+void Manager::initialize(const SimTK::State& s)
 {
     if (!_integ) {
         throw Exception("Manager::initialize(): "

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -594,7 +594,7 @@ const SimTK::State& Manager::integrate(double finalTime)
     int step = 0; // for AnalysisSet::step()
 
     if (_timeStepper == nullptr) {
-        throw Exception("Manager::integrate(): Manager has not be "
+        throw Exception("Manager::integrate(): Manager has not been "
             "initialized. Call Manager::initialize() first.");
     }
 

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -58,8 +58,8 @@ class ControllerSet;
  * In order to prevent an inconsistency between the Integrator and TimeStepper,
  * we only create a TimeStepper once, specifically when we call
  * initialize(SimTK::State&). To ensure this, the Manager will throw
- * an exception if initialize(SimTK::State&) is called more than once. Note 
- * that editing the SimTK::State after calling  initialize(SimTK::State&) 
+ * an exception if initialize(SimTK::State&) is called more than once. Note
+ * that editing the SimTK::State after calling initialize(SimTK::State&)
  * will not affect the simulation.
  *
  * Note that this interface means that you cannot "reinitialize" a Manager.
@@ -189,11 +189,11 @@ public:
     DEPRECATED_14("Get the state's time using SimTK::State::getTime().")
     double getInitialTime() const;
     /** <b>(Deprecated)</b> Integrate to a specified finalTime using 
-        Manager::integrate(SimTK::State&, double). */
+        Manager::integrate(double). */
     DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
     void setFinalTime(double aTF);
     /** <b>(Deprecated)</b> Integrate to a specified finalTime using
-        Manager::integrate(SimTK::State&, double). */
+        Manager::integrate(double). */
     DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
     double getFinalTime() const;
     // SPECIFIED TIME STEP
@@ -260,14 +260,16 @@ public:
     * }
     * @endcode
     *
-    * Example: Integrate from time = 0s to time = 10s, updating the
-    *          state at 2s increments
+    * Example: Integrate from time = 0s to time = 10s, updating the state
+    *          (e.g., the model's first coordinate value) every 2s
     * @code
     * dTime = 2.0;
     * finalTime = 10.0;
     * int n = int(round(finalTime/dTime));
+    * state.setTime(0.0);
     * manager.initialize(state);
     * for (int i = 0; i < n; ++i) {
+    *     model.getCoordinateSet().get(0).setValue(state, 0.1*i);
     *     Manager manager(model);
     *     state.setTime(i*dTime);
     *     manager.initialize(state);

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -227,7 +227,7 @@ public:
     * here will not affect the simulation. Calling this function multiple 
     * times with the same Manager will trigger an Exception.
     */
-    void initialize(SimTK::State& s);
+    void initialize(const SimTK::State& s);
     
     /**
     * Integrate the equations of motion for the specified model, given the current
@@ -276,9 +276,9 @@ public:
     * @endcode
     *
     */
-    SimTK::State integrate(double finalTime);
+    const SimTK::State& integrate(double finalTime);
 
-    SimTK::State getState();
+    const SimTK::State& getState() const;
     
     double getFixedStepSize(int tArrayStep) const;
 
@@ -303,7 +303,7 @@ private:
     Manager(Model& aModel, bool dummyVar);
 
     // Helper functions during initialization of integration
-    void initializeStorageAndAnalyses(SimTK::State& s);
+    void initializeStorageAndAnalyses(const SimTK::State& s);
     void initializeTimeStepper(const SimTK::State& s);
 
     // Helper functions for Manager::integrate()

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -56,15 +56,15 @@ class ControllerSet;
  * using setIntegrator().
  * 
  * In order to prevent an inconsistency between the Integrator and TimeStepper,
- * we only create a TimeStepper once, specifically at the first call to
- * integrate(SimTK::State&, double). To ensure this, the Manager will throw 
- * an exception if setModel() or setIntegrator() is called after 
- * integrate(SimTK::State&, double) has been called at least once.
+ * we only create a TimeStepper once, specifically when we call
+ * initialize(SimTK::State&). To ensure this, the Manager will throw
+ * an exception if initialize(SimTK::State&) is called more than once. Note 
+ * that editing the SimTK::State after calling  initialize(SimTK::State&) 
+ * will not affect the simulation.
  *
- * Since the call to integrate(SimTK::State&, double) takes the state as an 
- * argument, it is up to the caller to ensure that the state is a legal state 
- * if the same Manager is used to integrate again. Integrating a different 
- * state for some new arbitrary system has undefined behavior.
+ * Note that this interface means that you cannot "reinitialize" a Manager.
+ * If you make changes to the SimTK::State, a new Manager must be created
+ * before integrating again.
  */
 class OSIMSIMULATION_API Manager
 {
@@ -76,7 +76,7 @@ private:
     /** Simulation session name. */
     std::string _sessionName;
     /** Model for which the simulation is performed. */
-    Model *_model;
+    SimTK::ReferencePtr<Model> _model;
 
     /** Integrator. */
     // This is the actual integrator that is used when integrate() is called.
@@ -137,12 +137,12 @@ private:
 public:
     /** This constructor cannot be used in MATLAB/Python, since the
      * SimTK::Integrator%s are not exposed in those languages. */
-    Manager(Model&, SimTK::Integrator&);
+    Manager(Model& model, SimTK::Integrator& integ);
     /** Constructor that takes a model only and internally uses a
      * SimTK::RungeKuttaMersonIntegrator with default settings (accuracy,
      * constraint tolerance, etc.). MATLAB/Python users must use this
      * constructor. */
-    Manager(Model& aModel);
+    Manager(Model& model);
     /** <b>(Deprecated)</b> A Constructor that does not take a model or
      * controllerSet. This constructor also does not set an integrator; you
      * must call setIntegrator() on your own. You should use one of the other
@@ -190,11 +190,11 @@ public:
     double getInitialTime() const;
     /** <b>(Deprecated)</b> Integrate to a specified finalTime using 
         Manager::integrate(SimTK::State&, double). */
-    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(SimTK::State&, double).")
+    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
     void setFinalTime(double aTF);
     /** <b>(Deprecated)</b> Integrate to a specified finalTime using
         Manager::integrate(SimTK::State&, double). */
-    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(SimTK::State&, double).")
+    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
     double getFinalTime() const;
     // SPECIFIED TIME STEP
     void setUseSpecifiedDT(bool aTrueFalse);
@@ -221,17 +221,31 @@ public:
     // EXECUTION
     //--------------------------------------------------------------------------
     /**
+    * Initializes the Manager by creating and initializing the underlying 
+    * SimTK::TimeStepper. This must be called before calling 
+    * Manager::integrate() Subsequent changes to the State object passed in 
+    * here will not affect the simulation. Calling this function multiple 
+    * times with the same Manager will trigger an Exception.
+    */
+    void initialize(SimTK::State& s);
+    
+    /**
     * Integrate the equations of motion for the specified model, given the current
-    * state (at which the integration will start) and a finalTime. Make sure to
-    * use SimTK::state::setTime(double) to specify a starting time before calling
-    * this function.
+    * state (at which the integration will start) and a finalTime. You must call
+    * Manager::initialize(SimTK::State&) before calling this function.
+    *
+    * If you must update states or controls in a loop, you must recreate the 
+    * manager within the loop (such discontinuous changes are considered "events"
+    * and cannot be handled during integration of the otherwise continuous system).
+    * The proper way to handle this situation is to create a SimTK::EventHandler.
     *
     * Example: Integrating from time = 1s to time = 2s
     * @code
     * SimTK::State state = model.initSystem();
     * Manager manager(model);
     * state.setTime(1.0);
-    * manager.integrate(state, 2.0);
+    * manager.initialize(state);
+    * state = manager.integrate(2.0);
     * @endcode
     *
     * Example: Integrate from time = 0s to time = 10s, in 2s increments
@@ -240,17 +254,32 @@ public:
     * finalTime = 10.0;
     * int n = int(round(finalTime/dTime));
     * state.setTime(0.0);
+    * manager.initialize(state);
     * for (int i = 1; i <= n; ++i) {
-    *     manager.integrate(state, i*dTime);
+    *     state = manager.integrate(i*dTime);
+    * }
+    * @endcode
+    *
+    * Example: Integrate from time = 0s to time = 10s, updating the
+    *          state at 2s increments
+    * @code
+    * dTime = 2.0;
+    * finalTime = 10.0;
+    * int n = int(round(finalTime/dTime));
+    * manager.initialize(state);
+    * for (int i = 0; i < n; ++i) {
+    *     Manager manager(model);
+    *     state.setTime(i*dTime);
+    *     manager.initialize(state);
+    *     state = manager.integrate((i+1)*dTime);
     * }
     * @endcode
     *
     */
-    bool integrate(SimTK::State& s, double finalTime);
-    /** <b>(Deprecated)</b> Integrate to a specified finalTime using
-        Manager::integrate(SimTK::State&, double). */
-    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(SimTK::State&, double).")
-    bool integrate(SimTK::State& s);
+    SimTK::State integrate(double finalTime);
+
+    SimTK::State getState();
+    
     double getFixedStepSize(int tArrayStep) const;
 
     // STATE STORAGE

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -91,11 +91,6 @@ private:
     /** TimeStepper */
     std::unique_ptr<SimTK::TimeStepper> _timeStepper;
 
-    /** Initial time of the simulation. */
-    double _ti;
-    /** Final time of the simulation. */
-    double _tf;
-    
     /** Storage for the states. */
     std::unique_ptr<Storage> _stateStore;
 
@@ -143,10 +138,15 @@ public:
      * constraint tolerance, etc.). MATLAB/Python users must use this
      * constructor. */
     Manager(Model& model);
+    /** Convenience constructor for creating and initializing a Manager. */
+    Manager(Model& model, const SimTK::State& state);
+    /** Convenience constructor for creating and initializing a Manager with
+      * a specified integrator. */
+    Manager(Model& model, const SimTK::State& state, SimTK::Integrator& integ);
     /** <b>(Deprecated)</b> A Constructor that does not take a model or
      * controllerSet. This constructor also does not set an integrator; you
      * must call setIntegrator() on your own. You should use one of the other
-     * two constructors. */
+     * constructors. */
     DEPRECATED_14("There will be no replacement for this constructor.")
     Manager();
 
@@ -163,7 +163,7 @@ private:
     //--------------------------------------------------------------------------
 public:
     void setSessionName(const std::string &name);
-    void setModel(Model& aModel);
+    void setModel(Model& model);
     const std::string& getSessionName() const;
     const std::string& toString() const;
 
@@ -179,23 +179,6 @@ public:
      */
     void setIntegrator(SimTK::Integrator&);
 
-    // Initial and final times
-    /** <b>(Deprecated)</b> Set the state's time using 
-        SimTK::State::setTime(double). */
-    DEPRECATED_14("Set the state's time using SimTK::State::setTime(double).")
-    void setInitialTime(double aTI);
-    /** <b>(Deprecated)</b> Get the state's time using 
-        SimTK::State::getTime(). */
-    DEPRECATED_14("Get the state's time using SimTK::State::getTime().")
-    double getInitialTime() const;
-    /** <b>(Deprecated)</b> Integrate to a specified finalTime using 
-        Manager::integrate(double). */
-    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
-    void setFinalTime(double aTF);
-    /** <b>(Deprecated)</b> Integrate to a specified finalTime using
-        Manager::integrate(double). */
-    DEPRECATED_14("Integrate to a specified finalTime using Manager::integrate(double).")
-    double getFinalTime() const;
     // SPECIFIED TIME STEP
     void setUseSpecifiedDT(bool aTrueFalse);
     bool getUseSpecifiedDT() const;
@@ -248,6 +231,15 @@ public:
     * state = manager.integrate(2.0);
     * @endcode
     *
+    * Example: Integrating from time = 1s to time = 2s using the
+    *          convenience constructor
+    * @code
+    * SimTK::State state = model.initSystem();
+    * state.setTime(1.0);
+    * Manager manager(model, state);
+    * state = manager.integrate(2.0);
+    * @endcode
+    *
     * Example: Integrate from time = 0s to time = 10s, in 2s increments
     * @code
     * dTime = 2.0;
@@ -267,7 +259,6 @@ public:
     * finalTime = 10.0;
     * int n = int(round(finalTime/dTime));
     * state.setTime(0.0);
-    * manager.initialize(state);
     * for (int i = 0; i < n; ++i) {
     *     model.getCoordinateSet().get(0).setValue(state, 0.1*i);
     *     Manager manager(model);
@@ -280,6 +271,8 @@ public:
     */
     const SimTK::State& integrate(double finalTime);
 
+    /** Get the current State from the Integrator associated with this 
+    Manager. */
     const SimTK::State& getState() const;
     
     double getFixedStepSize(int tArrayStep) const;
@@ -302,7 +295,7 @@ public:
 private:
 
     // Handles common tasks of some of the other constructors.
-    Manager(Model& aModel, bool dummyVar);
+    Manager(Model& model, bool dummyVar);
 
     // Helper functions during initialization of integration
     void initializeStorageAndAnalyses(const SimTK::State& s);

--- a/OpenSim/Simulation/Model/Analysis.cpp
+++ b/OpenSim/Simulation/Model/Analysis.cpp
@@ -484,8 +484,7 @@ getEndTime() const
  *
  * @return -1 on error, 0 otherwise.
  */
-int Analysis::
-begin( SimTK::State& s )
+int Analysis::begin(const SimTK::State& s )
 {
     //printf("Analysis.begin: %s.\n",getName());
     return (0);
@@ -518,8 +517,7 @@ step( const SimTK::State& s, int stepNumber )
  *
  * @return -1 on error, 0 otherwise.
  */
-int Analysis::
-end( SimTK::State& s )
+int Analysis::end(const SimTK::State& s )
 {
     //printf("Analysis.end: %s.\n",getName());
     return(0);

--- a/OpenSim/Simulation/Model/Analysis.h
+++ b/OpenSim/Simulation/Model/Analysis.h
@@ -143,12 +143,9 @@ public:
     Analysis& operator=(const Analysis &aAnalysis);
 #endif
 
-   virtual int
-        begin( SimTK::State& s);
-    virtual int
-        step( const SimTK::State& s, int stepNumber);
-    virtual int
-        end( SimTK::State& s);
+    virtual int begin(const SimTK::State& s);
+    virtual int step( const SimTK::State& s, int stepNumber);
+    virtual int end( const SimTK::State& s);
 
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/AnalysisSet.cpp
+++ b/OpenSim/Simulation/Model/AnalysisSet.cpp
@@ -196,8 +196,7 @@ getOn() const
  *
  * @param s Current state 
  */
-void AnalysisSet::
-begin(SimTK::State& s )
+void AnalysisSet::begin(const SimTK::State& s )
 {
     int i;
     for(i=0;i<getSize();i++) {
@@ -230,8 +229,7 @@ step( const SimTK::State& s, int stepNumber )
  *
  * @param s Current state 
  */
-void AnalysisSet::
-end(SimTK::State& s)
+void AnalysisSet:: end(const SimTK::State& s)
 {
     int i;
     for(i=0;i<getSize();i++) {

--- a/OpenSim/Simulation/Model/AnalysisSet.h
+++ b/OpenSim/Simulation/Model/AnalysisSet.h
@@ -96,12 +96,9 @@ public:
     //--------------------------------------------------------------------------
     // CALLBACKS
     //--------------------------------------------------------------------------
-    virtual void
-        begin(SimTK::State& s );
-    virtual void
-        step(const SimTK::State& s, int stepNumber );
-    virtual void
-        end(SimTK::State& s );
+    void begin(const SimTK::State& s );
+    void step(const SimTK::State& s, int stepNumber );
+    void end(const SimTK::State& s );
 
     //--------------------------------------------------------------------------
     // RESULTS

--- a/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
@@ -475,6 +475,14 @@ private:
 //==============================================================================
 //          Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameter
 //==============================================================================
+
+/**
+ * Documentation for this class has been provided with the documentation for the
+ * Bhargava2004MuscleMetabolicsProbe class.
+ *
+ * @see Bhargava2004MuscleMetabolicsProbe
+ */
+
 class OSIMSIMULATION_API 
     Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameter 
     : public Object  

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -386,7 +386,7 @@ void TwoFrameLinker<C, F>::scaleFrames(const ScaleSet& scaleSet)
     SimTK::Vec3 frame1Factors(1.0);
     SimTK::Vec3 frame2Factors(1.0);
 
-    // Find the factors associated with the PhysicalFrames this Joint connects
+    // Find the factors associated with the PhysicalFrames this Component connects
     const std::string& base1Name = this->getFrame1().findBaseFrame().getName();
     const std::string& base2Name = this->getFrame2().findBaseFrame().getName();
     // Get scale factors
@@ -406,7 +406,7 @@ void TwoFrameLinker<C, F>::scaleFrames(const ScaleSet& scaleSet)
             break;
     }
 
-    // if the frame is owned by this Joint scale it,
+    // if the frame is owned by this Component scale it,
     // otherwise let the owner of the frame decide.
     int found = getProperty_frames().findIndex(getFrame1());
     if (found >= 0) {

--- a/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
@@ -458,6 +458,14 @@ public:
 //==============================================================================
 //          Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter
 //==============================================================================
+
+/**
+ * Documentation for this class has been provided with the documentation for the
+ * Umberger2010MuscleMetabolicsProbe class.
+ *
+ * @see Umberger2010MuscleMetabolicsProbe
+ */
+
 class OSIMSIMULATION_API 
     Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter 
     : public Object  

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -623,7 +623,7 @@ double Coordinate::CoordinateStateVariable::
 void Coordinate::CoordinateStateVariable::
     setValue(SimTK::State& state, double value) const
 {
-    ((Coordinate *)&getOwner())->setValue(state, value);
+    ((Coordinate *)&getOwner())->setValue(state, value, false);
 }
 
 double Coordinate::CoordinateStateVariable::

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -132,11 +132,17 @@ public:
 
     /** get the value of the Coordinate from the state */
     double getValue(const SimTK::State& s) const;
-    /** set the value of the Coordinate on to the state.
-        optional flag to enforce the constraints immediately, which may 
-        adjust its value in the state. Use getValue(s) to see if/how the
-        value was adjusted to satisfy the kinematic constraints. */
-    void setValue(SimTK::State& s, double aValue, bool aEnforceContraints=true) const;
+    /** Set the value of the Coordinate on to the state.
+        Optional flag to enforce the constraints immediately (true by default),
+        which can adjust all coordinate values in the state to satisfy model
+        constraints. Use getValue(s) to see if/how the value was adjusted to
+        satisfy the kinematic constraints. If setting multiple Coordinate values
+        consecutively, e.g. in a loop, set the flag to false and then call
+        Model::assemble(state) once all Coordinate values have been set.
+        Alternatively, use Model::setStateVariableValues() to set all coordinate
+        values and their speeds at once followed by Model::assemble(state).
+        */
+    void setValue(SimTK::State& s, double aValue, bool enforceContraints=true) const;
 
     /** get the speed value of the Coordinate from the state */
     double getSpeedValue(const SimTK::State& s) const;

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -216,7 +216,8 @@ void integrateOpenSimModel(Model *osimModel, SimTK::State &osim_state)
     // the range of times over which the controls are available.
     //Control *control;
     osim_state.setTime(0.0);
-    manager.integrate(osim_state, duration);
+    manager.initialize(osim_state);
+    osim_state = manager.integrate(duration);
 }
 
 void compareSimulationStates(SimTK::Vector q_sb, SimTK::Vector u_sb,
@@ -549,8 +550,9 @@ void testCoordinateLocking()
 
     // Integrate from initial time to final time
     si2.setTime(0.0);
+    manager.initialize(si2);
     cout<<"\n\nIntegrating from "<<si2.getTime()<<" to "<<duration<<std::endl;
-    manager.integrate(si2, duration);
+    si2 = manager.integrate(duration);
 
     // Print out the final position and velocity states
     Vector qf = si2.getQ();

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -381,6 +381,7 @@ void integrateOpenSimModel(Model *osimModel, SimTK::State &osim_state)
     // the range of times over which the controls are available.
     //Control *control;
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     // Integrate
     /*const SimbodyMatterSubsystem& matter2 = */osimModel->getMultibodySystem().getMatterSubsystem();
@@ -389,7 +390,7 @@ void integrateOpenSimModel(Model *osimModel, SimTK::State &osim_state)
     //cout << osim_state.getQ()<<endl;
     //cout << "\n\nOpenSim Integration 0.0 to " << duration << endl;
 
-    manager.integrate(osim_state, duration);
+    osim_state = manager.integrate(duration);
 }
 
 void compareSimulationStates(const SimTK::Vector &q_sb, const SimTK::Vector &u_sb, const SimTK::Vector &q_osim, const SimTK::Vector &u_osim, string errorMessagePrefix = "")

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -84,7 +84,8 @@ inline SimTK::State simulate(Model& model,
         SimTK::RungeKuttaMersonIntegrator integrator(model.getSystem());
         Manager manager(model, integrator);
         state.setTime(0.0);
-        manager.integrate(state, finalTime);
+        manager.initialize(state);
+        manager.integrate(finalTime);
 
         // Save the states to a storage file (if requested).
         if (saveStatesFile) {

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -225,9 +225,10 @@ void testAssembleModelWithConstraints(string modelFile)
     integrator.setAccuracy(accuracy);
     Manager manager(model, integrator);
     state.setTime(0.0);
+    manager.initialize(state);
 
     // Simulate forward in time
-    manager.integrate(state, 0.05);
+    state = manager.integrate(0.05);
     model.getMultibodySystem().realize(state, SimTK::Stage::Velocity);
 
     Vector positionErr = state.getQErr();

--- a/OpenSim/Simulation/Test/testContactGeometry.cpp
+++ b/OpenSim/Simulation/Test/testContactGeometry.cpp
@@ -191,10 +191,11 @@ int testBouncingBall(bool useMesh, const std::string mesh_filename)
     integrator.setAccuracy(integ_accuracy);
     Manager manager(*osimModel, integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     for (unsigned int i = 0; i < duration/interval; ++i)
     {
-        manager.integrate(osim_state, (i + 1)*interval);
+        osim_state = manager.integrate((i + 1)*interval);
         double time = osim_state.getTime();
 
         osimModel->getMultibodySystem().realize(osim_state, Stage::Acceleration);
@@ -327,7 +328,8 @@ int testBallToBallContact(bool useElasticFoundation, bool useMesh1, bool useMesh
     integrator.setMaximumStepSize(100*integ_accuracy);
     Manager manager(*osimModel, integrator);
     osim_state.setTime(0.0);
-    manager.integrate(osim_state, duration);
+    manager.initialize(osim_state);
+    osim_state = manager.integrate(duration);
 
     kin->printResults(prefix);
     reporter->printResults(prefix);
@@ -492,7 +494,8 @@ void testIntermediateFrames() {
         integrator.setAccuracy(integ_accuracy);
         Manager manager(model, integrator);
         state.setTime(0.0);
-        manager.integrate(state, 1.0);
+        manager.initialize(state);
+        state = manager.integrate(1.0);
 
         return state;
     };

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -236,9 +236,10 @@ void testExpressionBasedCoordinateForce()
     integrator.setAccuracy(1e-7);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 pos = ball.findStationLocationInGround(osim_state, Vec3(0));
         
@@ -326,9 +327,10 @@ void testExpressionBasedPointToPointForce()
     integrator.setAccuracy(1e-6);
     Manager manager(model,  integrator);
     state.setTime(0.0);
+    manager.initialize(state);
 
     double final_t = 1.0;
-    manager.integrate(state, final_t);
+    state = manager.integrate(final_t);
 
     //manager.getStateStorage().print("testExpressionBasedPointToPointForce.sto");
 
@@ -440,9 +442,10 @@ void testPathSpring()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 10.0;
-    manager.integrate(osim_state, final_t);
+    osim_state = manager.integrate(final_t);
 
     // tension should only be velocity dependent
     osimModel.getMultibodySystem().realize(osim_state, Stage::Velocity);
@@ -532,13 +535,14 @@ void testSpringMass()
     integrator.setAccuracy(1e-7);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
     double nsteps = 10;
     double dt = final_t/nsteps;
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 pos = ball.findStationLocationInGround(osim_state, Vec3(0));
         
@@ -651,13 +655,14 @@ void testBushingForce()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
     double nsteps = 10;
     double dt = final_t/nsteps;
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 pos = ball->findStationLocationInGround(osim_state, Vec3(0));
         
@@ -826,13 +831,14 @@ void testFunctionBasedBushingForce()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
     double nsteps = 10;
     double dt = final_t/nsteps;
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 pos = ball.findStationLocationInGround(osim_state, Vec3(0));
         
@@ -944,13 +950,14 @@ void testExpressionBasedBushingForceTranslational()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
     
     double final_t = 2.0;
     double nsteps = 10;
     double dt = final_t/nsteps;
     
     for(int i = 1; i <=nsteps; ++i){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 pos = ball.findStationLocationInGround(osim_state, Vec3(0));
         
@@ -1062,6 +1069,7 @@ void testExpressionBasedBushingForceRotational()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel, integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
     double nsteps = 10;
@@ -1072,7 +1080,7 @@ void testExpressionBasedBushingForceRotational()
     double omega = sqrt(stiffness / I_y);
 
     for (int i = 1; i <= nsteps; ++i) {
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
 
         // compute the current rotation about the y axis
@@ -1141,13 +1149,14 @@ void testElasticFoundation()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
 
     // start timing
     clock_t startTime = clock();
 
-    manager.integrate(osim_state, final_t);
+    osim_state = manager.integrate(final_t);
 
     // end timing
     cout << "Elastic Foundation simulation time = " << 1.e3*(clock()-startTime)/CLOCKS_PER_SEC << "ms" << endl;;
@@ -1218,13 +1227,14 @@ void testHuntCrossleyForce()
     integrator.setAccuracy(1e-6);
     Manager manager(osimModel, integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 2.0;
 
     // start timing
     clock_t startTime = clock();
 
-    manager.integrate(osim_state, final_t);
+    osim_state = manager.integrate(final_t);
 
     // end timing
     cout << "Hunt Crossley simulation time = " << 1.e3*(clock()-startTime)/CLOCKS_PER_SEC << "ms" << endl;
@@ -1359,13 +1369,14 @@ void testCoordinateLimitForce()
     integrator.setAccuracy(1e-6);
     Manager manager(*osimModel, integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 1.0;
     double nsteps = 20;
     double dt = final_t/nsteps;
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel->getMultibodySystem().realize(osim_state, Stage::Acceleration);
         
         double h = q_h.getValue(osim_state);
@@ -1502,13 +1513,14 @@ void testCoordinateLimitForceRotational()
     integrator.setAccuracy(1e-8);
     Manager manager(osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
 
     double final_t = 1.0;
     double nsteps = 20;
     double dt = final_t/nsteps;
 
     for(int i = 1; i <=nsteps; i++){
-        manager.integrate(osim_state, dt*i);
+        osim_state = manager.integrate(dt*i);
         osimModel.getMultibodySystem().realize(osim_state, Stage::Acceleration);
 
         double ediss = clf->getDissipatedEnergy(osim_state);
@@ -1595,7 +1607,8 @@ void testExternalForce()
     // Specify the initial and final times of the simulation.
     double tf = 2.0;
     s.setTime(0.0);
-    manager.integrate(s, tf);
+    manager.initialize(s);
+    s = manager.integrate(tf);
 
     manager.getStateStorage().print("external_force_test_model_states.sto");;
 
@@ -1636,7 +1649,8 @@ void testExternalForce()
     integrator2.setAccuracy(accuracy);
     Manager manager2(model, integrator2);
     s2.setTime(0.0);
-    manager2.integrate(s2, tf);
+    manager2.initialize(s2);
+    s2 = manager2.integrate(tf);
 
     // all dofs should remain constant
     for(int i=0; i<model.getCoordinateSet().getSize(); i++){
@@ -1673,7 +1687,8 @@ void testExternalForce()
     integrator3.setAccuracy(accuracy);
     Manager manager3(model, integrator3);
     s3.setTime(0.0);
-    manager3.integrate(s3, tf);
+    manager3.initialize(s3);
+    s3 = manager3.integrate(tf);
 
     // all dofs should remain constant except Y
     for(int i=0; i<model.getCoordinateSet().getSize(); i++){
@@ -1722,7 +1737,8 @@ void testExternalForce()
     integrator4.setAccuracy(accuracy);
     Manager manager4(model, integrator4);
     s4.setTime(0.0);
-    manager4.integrate(s4, tf);
+    manager4.initialize(s4);
+    s4 = manager4.integrate(tf);
 
     // all dofs should remain constant except X-translation
     for(int i=0; i<model.getCoordinateSet().getSize(); i++){

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -97,9 +97,10 @@ void testStates(const string& modelFile)
     RungeKuttaMersonIntegrator integrator(model.getMultibodySystem());
     Manager manager(model, integrator);
     state.setTime(0.0);
+    manager.initialize(state);
 
     // update state after a short simulation forward in time
-    manager.integrate(state, 0.05);
+    manager.integrate(0.05);
 
     // continuous state variables after simulation
     Vector y2 = state.getY();
@@ -122,9 +123,10 @@ void testStates(const string& modelFile)
     RungeKuttaMersonIntegrator integrator2(model.getMultibodySystem());
     Manager manager2(model, integrator);
     state2.setTime(0.0);
+    manager2.initialize(state2);
 
     // update state after a short simulation forward in time
-    manager2.integrate(state2, 0.05);
+    manager2.integrate(0.05);
 
     // get the default continuous state variables updated
     // from the state after the simulation

--- a/OpenSim/Simulation/Test/testManager.cpp
+++ b/OpenSim/Simulation/Test/testManager.cpp
@@ -280,8 +280,8 @@ void testExcitationUpdatesWithManager()
     
     for (int i = 0; i < 3; ++i)
     {
-        double initAct = 0.1 + i*0.1;
-        double excitation = 0.2 + i*0.2;
+        double initAct = 0.2 + i*0.2; // 0.2, 0.4, 0.6
+        double excitation = initAct + 0.1; // 0.3, 0.5, 0.7
         
         muscleSet.get(0).setActivation(state, initAct);
         FunctionSet& fnset = controller->upd_ControlFunctions();
@@ -299,14 +299,14 @@ void testExcitationUpdatesWithManager()
         arm.realizeDynamics(state);
         double finalAct = muscleSet.get(0).getActivation(state);
         double finalExcitation = muscleSet.get(0).getExcitation(state);
-        cout << state.getTime() << " " << excitation << " " << initAct;
+        cout << state.getTime() << " " << initAct << " " << excitation;
         cout << " " << finalAct << endl;
         // Check if excitation is correct
         SimTK_TEST_EQ(excitation, finalExcitation);
-        // If excitation is not set correctly, it will go back to the default
-        // after the first integration. We can check if this is happening by
-        // ensuring the activation is increasing on each integration.
+        // Also check if the final activation is between the initial
+        // activation and excitation
         SimTK_TEST(finalAct > initAct);
+        SimTK_TEST(finalAct < excitation);
     }
 }
 

--- a/OpenSim/Simulation/Test/testManager.cpp
+++ b/OpenSim/Simulation/Test/testManager.cpp
@@ -31,18 +31,22 @@ TimeStepper::initialize() would trigger cache validation improperly.
 //=============================================================================*/
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 
 using namespace OpenSim;
 using namespace std;
 void testStationCalcWithManager();
+void testStateChangesBetweenIntegration();
 
 int main()
 {
     SimTK::Array_<std::string> failures;
 
-    try { testStationCalcWithManager(); }
+    try { testStationCalcWithManager(); 
+          testStateChangesBetweenIntegration(); 
+    }
     catch (const std::exception& e) {
         cout << e.what() << endl;
         failures.push_back("testStationCalcWithManager");
@@ -106,16 +110,17 @@ void testStationCalcWithManager()
 
     // Hold the computed kinematics from OpenSim and Simbody
     SimTK::Vec3 lo, vo, ao, l, v, a;
-
+    
     Manager manager(pendulum, integrator);
     manager.setPerformAnalyses(false);
     manager.setWriteToStorage(false);
     state.setTime(0.0);
+    manager.initialize(state);
 
     for (int i = 1; i <= n; ++i) {
         // Reuse the same Manager to integrate a state forward repeatedly.
         // This would previously cause issues with cache validation.
-        manager.integrate(state, i*dt);
+        state = manager.integrate(i*dt);
 
         // realize to acceleration to access acceleration stage cache
         pendulum.realizeAcceleration(state);
@@ -135,4 +140,84 @@ void testStationCalcWithManager()
         SimTK_TEST_EQ(v, vo);
         SimTK_TEST_EQ(a, ao);
     }
+}
+
+void testStateChangesBetweenIntegration()
+{
+    using SimTK::Vec3;
+
+    Model model;
+    model.setName("ball");
+
+    auto ball = new Body("ball", 0.7, Vec3(0.1),
+        SimTK::Inertia::sphere(0.5));
+    model.addBody(ball);
+
+    auto freeJoint = new FreeJoint("freeJoint", model.getGround(), Vec3(0), Vec3(0),
+        *ball, Vec3(0), Vec3(0));
+    model.addJoint(freeJoint);
+
+    double g = 9.81;
+    model.setGravity(Vec3(0, -g, 0));
+
+    Station* myStation = new Station();
+    const SimTK::Vec3 point(0);
+    myStation->set_location(point);
+    myStation->setParentFrame(*ball);
+    model.addModelComponent(myStation);
+
+    SimTK::State state = model.initSystem();
+
+    //auto sliderCoord = 
+    //    freeJoint->getCoordinate(FreeJoint::Coord::TranslationY);
+    const Coordinate& sliderCoord = 
+        freeJoint->getCoordinate(FreeJoint::Coord::TranslationY);
+
+    std::vector<double> integInitTimes = {0.0, 1.0, 3.0};
+    std::vector<double> integFinalTimes = {1.0, 3.0, 6.0};
+    std::vector<double> initHeights = {0.0, 13.3, 6.5};
+    std::vector<double> initSpeeds = {0.0, 0.5, -0.5};
+    state.setTime(integInitTimes[0]);
+    int n = integFinalTimes.size();
+
+    for (int i = 0; i < n; ++i) {
+        // Set initial state for integration and check that it's correct
+        sliderCoord.setValue(state, initHeights[i]);
+        sliderCoord.setSpeedValue(state, initSpeeds[i]);
+        
+        Manager manager(model);
+        manager.initialize(state);
+        SimTK::State initState = manager.getState();
+        SimTK_TEST_EQ(initState.getTime(), integInitTimes[i]);
+        SimTK_TEST_EQ(sliderCoord.getValue(initState), initHeights[i]);
+        SimTK_TEST_EQ(sliderCoord.getSpeedValue(initState), initSpeeds[i]);
+
+        state = manager.integrate(integFinalTimes[i]);
+        model.realizeVelocity(state);
+        double duration = integFinalTimes[i] - integInitTimes[i];
+        double finalHeight = 
+            initHeights[i] + initSpeeds[i]*duration - 0.5*g*duration*duration;
+        double finalSpeed = initSpeeds[i] - g*duration;
+        double sliderHeight = sliderCoord.getValue(state);
+        double sliderSpeed = sliderCoord.getSpeedValue(state);
+        cout << "Slider: t = " << state.getTime() << ", h = " << sliderHeight
+            << ", v = " << sliderSpeed << " | Eq: t = " << integFinalTimes[i]
+            << ", h = " << finalHeight << ", v = " << finalSpeed;
+
+        SimTK_TEST_EQ(state.getTime(), integFinalTimes[i]);
+        SimTK_TEST_EQ(sliderHeight, finalHeight);
+        SimTK_TEST_EQ(sliderSpeed, finalSpeed);
+
+        // Use Simbody to get the location, velocity & acceleration in ground.
+        double stationHeight = myStation->getLocationInGround(state)[1];
+        double stationSpeed = myStation->getVelocityInGround(state)[1];
+
+        cout << " | Station: t = " << state.getTime() << ", h = " 
+            << stationHeight << ", v = " << stationSpeed << endl;
+
+        // Compare Station values from equation values
+        SimTK_TEST_EQ(stationHeight, finalHeight);
+        SimTK_TEST_EQ(stationSpeed, finalSpeed);
+    }
+
 }

--- a/OpenSim/Simulation/Test/testManager.cpp
+++ b/OpenSim/Simulation/Test/testManager.cpp
@@ -178,12 +178,13 @@ void testStateChangesBetweenIntegration()
     std::vector<double> initHeights = {0.0, 13.3, 6.5};
     std::vector<double> initSpeeds = {0.0, 0.5, -0.5};
     state.setTime(integInitTimes[0]);
-    int n = integFinalTimes.size();
+    size_t n = integFinalTimes.size();
 
-    for (int i = 0; i < n; ++i) {
+    for (size_t i = 0; i < n; ++i) {
         // Set initial state for integration and check that it's correct
         sliderCoord.setValue(state, initHeights[i]);
         sliderCoord.setSpeedValue(state, initSpeeds[i]);
+        model.realizeVelocity(state);
         
         Manager manager(model);
         manager.initialize(state);
@@ -194,6 +195,7 @@ void testStateChangesBetweenIntegration()
 
         state = manager.integrate(integFinalTimes[i]);
         model.realizeVelocity(state);
+
         double duration = integFinalTimes[i] - integInitTimes[i];
         double finalHeight = 
             initHeights[i] + initSpeeds[i]*duration - 0.5*g*duration*duration;
@@ -208,7 +210,7 @@ void testStateChangesBetweenIntegration()
         SimTK_TEST_EQ(sliderHeight, finalHeight);
         SimTK_TEST_EQ(sliderSpeed, finalSpeed);
 
-        // Use Simbody to get the location, velocity & acceleration in ground.
+        // Use Station to get the location, velocity & acceleration in ground.
         double stationHeight = myStation->getLocationInGround(state)[1];
         double stationSpeed = myStation->getVelocityInGround(state)[1];
 

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -89,7 +89,7 @@ int main() {
 
         // should not be able to "trick" the manager into integrating a model
         // given a stale but compatible state
-        ASSERT_THROW(ComponentHasNoSystem, manager.integrate(state, 1.));
+        ASSERT_THROW(ComponentHasNoSystem, manager.initialize(state));
 
         // once again, get a valid System and corresponding state
         state = model.initSystem();

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -639,11 +639,12 @@ Storage simulateModel(Model& model, double t0, double t1)
 
     Manager manager(model, integrator);
     state.setTime(t0);
+    manager.initialize(state);
 
     // Simulate.
     const clock_t tStart = clock();
     cout << "- integrating from " << t0 << " to " << t1 << "s" << endl;
-    manager.integrate(state, t1);
+    manager.integrate(t1);
     cout << "- simulation complete (" << (double)(clock()-tStart)/CLOCKS_PER_SEC
          << " seconds elapsed)" << endl;
 

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -157,9 +157,10 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
     RungeKuttaMersonIntegrator integrator(osimModel->getMultibodySystem() );
     Manager manager(*osimModel,  integrator);
     osim_state.setTime(0.0);
+    manager.initialize(osim_state);
     for (unsigned int i = 0; i < times.size(); ++i)
     {
-        manager.integrate(osim_state, times[i]);
+        osim_state = manager.integrate(times[i]);
         osimModel->getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 accel = body.findStationAccelerationInGround(osim_state, Vec3(0));
         Vec3 angularAccel = body.getAccelerationInGround(osim_state)[0];

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -549,7 +549,8 @@ void simulateMuscle(
     // Start timing the simulation
     const clock_t start = clock();
     // simulate
-    manager.integrate(si, finalTime);
+    manager.initialize(si);
+    manager.integrate(finalTime);
 
     // how long did it take?
     double comp_time = (double)(clock() - start) / CLOCKS_PER_SEC;

--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -59,7 +59,8 @@ void testConsoleReporterLabels() {
     RungeKuttaMersonIntegrator integrator(model.getSystem());
     Manager manager(model, integrator);
     state.setTime(0.0);
-    manager.integrate(state, 1.0);
+    manager.initialize(state);
+    manager.integrate(1.0);
 
     // Restore original destination for cout and display ConsoleReporter output.
     cout.rdbuf(oldBuf);
@@ -106,7 +107,8 @@ void testTableReporterLabels() {
     RungeKuttaMersonIntegrator integrator(model.getSystem());
     Manager manager(model, integrator);
     state.setTime(0.0);
-    manager.integrate(state, 1.0);
+    manager.initialize(state);
+    manager.integrate(1.0);
 
     // Check column headings for dependent variables reported by TableReporter,
     // which should be "/world/slider/sliderCoord/value" and "height".

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -167,7 +167,8 @@ void createStateStorageFile() {
     SimTK::RungeKuttaMersonIntegrator integrator(model.getSystem());
     Manager manager(model, integrator);
     initState.setTime(0.0);
-    manager.integrate(initState, 0.15);
+    manager.initialize(initState);
+    manager.integrate(0.15);
     manager.getStateStorage().print(statesStoFname);
 }
 

--- a/OpenSim/Tests/AddComponents/testAddComponents.cpp
+++ b/OpenSim/Tests/AddComponents/testAddComponents.cpp
@@ -373,8 +373,9 @@ int main()
 
         // Integrate from initial time to final time
         si.setTime(initialTime);
+        manager.initialize(si);
         cout<<"\nIntegrating from "<<initialTime<<" to "<<finalTime<<endl;
-        manager.integrate(si, finalTime);
+        manager.integrate(finalTime);
 
         //////////////////////////////
         // SAVE THE RESULTS TO FILE //

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -880,7 +880,8 @@ void simulate(Model& osimModel, State& si, double initialTime, double finalTime)
 
     const double start = SimTK::realTime();
     integrator.resetAllStatistics();
-    manager.integrate(si, finalTime);
+    manager.initialize(si);
+    manager.integrate(finalTime);
     cout << "simulation time = " << SimTK::realTime()-start
          << " seconds (wallclock time)\n" << endl;
 

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -829,7 +829,8 @@ bool CMCTool::run()
     IO::makeDir(getResultsDir());   // Create directory for output in case it doesn't exist
     manager.getStateStorage().setOutputFileName(getResultsDir() + "/" + getName() + "_states.sto");
     try {
-        manager.integrate(s, finalTime);
+        manager.initialize(s);
+        manager.integrate(finalTime);
     }
     catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results

--- a/OpenSim/Tools/ForwardTool.cpp
+++ b/OpenSim/Tools/ForwardTool.cpp
@@ -307,7 +307,8 @@ bool ForwardTool::run()
 
         cout<<"\n\nIntegrating from "<<_ti<<" to "<<_tf<<endl;
         s.setTime(_ti);
-        manager.integrate(s, _tf);
+        manager.initialize(s);
+        manager.integrate(_tf);
     } catch(const std::exception& x) {
         cout << "ForwardTool::run() caught exception \n";
         cout << x.what() << endl;

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -814,7 +814,8 @@ bool RRATool::run()
     IO::makeDir(getResultsDir());   // Create directory for output in case it doesn't exist
     manager.getStateStorage().setOutputFileName(getResultsDir() + "/" + getName() + "_states.sto");
     try {
-        manager.integrate(s, finalTime);
+        manager.initialize(s);
+        manager.integrate(finalTime);
     }
     catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -148,8 +148,9 @@ void testControlSetControllerOnBlock()
 
     // Integrate from initial time to final time
     si.setTime(initialTime);
+    manager.initialize(si);
     std::cout<<"\n\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-    manager.integrate(si, finalTime);
+    si = manager.integrate(finalTime);
 
     si.getQ().dump("Final position:");
     double x_err = fabs(coordinates[0].getValue(si) - 0.5*(controlForce[0]/blockMass)*finalTime*finalTime);
@@ -240,8 +241,9 @@ void testPrescribedControllerOnBlock(bool enabled)
 
     // Integrate from initial time to final time
     si.setTime(initialTime);
+    manager.initialize(si);
     std::cout<<"\n\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-    manager.integrate(si, finalTime);
+    si = manager.integrate(finalTime);
 
     si.getQ().dump("Final position:");
 
@@ -348,8 +350,9 @@ void testPrescribedControllerFromFile(const std::string& modelFile,
 
     // Integrate from initial time to final time
     si.setTime(initialTime);
+    manager.initialize(si);
     cout<<"\n\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-    manager.integrate(si, finalTime);
+    si = manager.integrate(finalTime);
 
     string modelName = osimModel.getName();
     // Save the simulation results
@@ -389,8 +392,9 @@ void testPrescribedControllerFromFile(const std::string& modelFile,
 
     // Integrate from initial time to final time
     s2.setTime(initialTime);
+    manager2.initialize(s2);
     cout<<"\n\nIntegrating from "<<initialTime<<" to "<<finalTime<<std::endl;
-    manager2.integrate(s2, finalTime);
+    s2 = manager2.integrate(finalTime);
 
     // Save the simulation results
     Storage states(manager2.getStateStorage());

--- a/OpenSim/Tools/Test/testExternalLoads.cpp
+++ b/OpenSim/Tools/Test/testExternalLoads.cpp
@@ -116,9 +116,10 @@ void testExternalLoad()
     integrator.setAccuracy(integ_accuracy);
     Manager manager(model, integrator);
     s.setTime(init_t);
+    manager.initialize(s);
 
     for(int i = 0; i < nsteps+1; i++){
-        manager.integrate(s, dt*i);
+        manager.integrate(dt*i);
         q_grav[i] = model.updCoordinateSet()[0].getValue(s);
     }
 
@@ -173,13 +174,14 @@ void testExternalLoad()
     integrator2.setAccuracy(integ_accuracy);
     Manager manager2(model,  integrator2);
     s2.setTime(init_t);
+    manager2.initialize(s2);
 
     // Simulate with the external force applied instead of gravity
     Vector_<double> q_xf(nsteps+1);
     Vector_<Vec3> pcom_xf(nsteps+1);
 
     for(int i = 0; i < nsteps+1; i++){
-        manager2.integrate(s2, dt*i);
+        manager2.integrate(dt*i);
         q_xf[i] = model.updCoordinateSet()[0].getValue(s2);
     }
 
@@ -246,12 +248,13 @@ void testExternalLoad()
     integrator3.setAccuracy(integ_accuracy);
     Manager manager3(model,  integrator3);
     s3.setTime(init_t);
+    manager3.initialize(s3);
 
     // Simulate with the external force applied instead of gravity
     Vector_<double> q_xf2(nsteps+1);
 
     for(int i = 0; i < nsteps+1; i++){
-        manager3.integrate(s3, dt*i);
+        manager3.integrate(dt*i);
         q_xf2[i] = model.updCoordinateSet()[0].getValue(s3);
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,10 +103,6 @@ build_script:
   - cmake %OPENSIM_SOURCE_DIR% -G"%CMAKE_GENERATOR%" -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON 
 
   # Build.
-  # Hack to avoid error MSB3191: Unable to create directory
-  # "C:\projects\opensim_build\Release\" which may result from parallel jobs
-  # trying to create this directory.
-  - mkdir %OPENSIM_BUILD_DIR%\Release
   - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet #/p:TreatWarningsAsErrors="true"
   
 test_script:

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -353,15 +353,17 @@ function(OpenSimCopyDependencyDLLsForWin DEP_NAME DEP_INSTALL_DIR)
             message(FATAL_ERROR "Zero DLLs found in directory "
                                 "${DEP_INSTALL_DIR}.")
         endif()
+        set(DEST_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
         foreach(DLL IN LISTS DLLS)
             get_filename_component(DLL_NAME ${DLL} NAME)
-            set(DEST_DIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR})
-            add_custom_command(OUTPUT ${DLL_NAME}
-                               COMMAND ${CMAKE_COMMAND} -E copy ${DLL} ${DEST_DIR}
-                               COMMENT "Copying ${DLL_NAME} to ${DEST_DIR}.")
-            list(APPEND DLL_NAMES ${DLL_NAME})
+            list(APPEND DLLS_DEST "${DEST_DIR}/${DLL_NAME}")
+            add_custom_command(OUTPUT "${DEST_DIR}/${DLL_NAME}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
+                COMMAND ${CMAKE_COMMAND} -E copy ${DLL} ${DEST_DIR}
+                DEPENDS ${DLL}
+                COMMENT "Copying DLL from ${DEP_INSTALL_DIR}/${DLL_NAME} to ${DEST_DIR}.")
         endforeach()
-        add_custom_target(Copy_${DEP_NAME}_DLLs ALL DEPENDS ${DLL_NAMES})
+        add_custom_target(Copy_${DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
         set_target_properties(Copy_${DEP_NAME}_DLLs PROPERTIES
             PROJECT_LABEL "Copy ${DEP_NAME} DLLs")
         if(OPENSIM_COPY_DEPENDENCIES)
@@ -369,7 +371,6 @@ function(OpenSimCopyDependencyDLLsForWin DEP_NAME DEP_INSTALL_DIR)
         endif()
     endif()
 endfunction()
-
 
 # Discover the file dependencies for an invocation of swig, for use with the
 # DEPENDS field of an add_custom_command().


### PR DESCRIPTION
Fixes issue #1662 

### Brief summary of changes
The focus of this PR is to prevent a user from using the same Manager for integrating a state that has been modified. To do this, I've added `Manager::initialize(state)` which mimics the initialization method of a `SimTK::TimeStepper`.

### Testing I've completed
Updated tests for change in `Manager` interface, checked that tests pass locally.


### CHANGELOG.md (choose one)
- updated to describe new interface

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
