### PR TITLE
[Doxygen] Include link to documentation for MetabolicMuscleParameter classes

### DIFF
--- a/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.h
@@ -475,6 +475,14 @@ private:
 //==============================================================================
 //          Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameter
 //==============================================================================
+
+/**
+ * Documentation for this class has been provided with the documentation for the
+ * Bhargava2004MuscleMetabolicsProbe class.
+ *
+ * @see Bhargava2004MuscleMetabolicsProbe
+ */
+
 class OSIMSIMULATION_API 
     Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameter 
     : public Object  

--- a/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
@@ -458,6 +458,14 @@ public:
 //==============================================================================
 //          Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter
 //==============================================================================
+
+/**
+ * Documentation for this class has been provided with the documentation for the
+ * Umberger2010MuscleMetabolicsProbe class.
+ *
+ * @see Umberger2010MuscleMetabolicsProbe
+ */
+
 class OSIMSIMULATION_API 
     Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter 
     : public Object  


### PR DESCRIPTION
Fixes issue communicated by Adrian Lai.

### Brief summary of changes
Adds links from the `{Umberger2010|Bhargava2004}MuscleMetabolicsProbe_MetabolicMuscleParameter` pages to the `{Umberger2010|Bhargava2004}MuscleMetabolicsProbe` pages, where details about the properties of the former are provided. It is preferable to keep all {Umberger2010|Bhargava2004} metabolics probe documentation on one page, and it seems reasonable to direct users to the main metabolics probe pages since each `..._MetabolicMuscleParameter` class is used exclusively by its namesake.

### Testing I've completed
Built doxygen locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
