### PR TITLE
updated cmake to run Matlab tests in opensim-build dir

### DIFF
--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -34,14 +34,12 @@ macro(OpenSimAddMatlabTest TESTNAME MFILE)
                 TEST_ARGS CONFIGURATIONS ${cfg}
                 ADDITIONAL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../Utilities"
                 NO_UNITTEST_FRAMEWORK
+                UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
                 )
-            #UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
-            set_tests_properties(Matlab_${TESTNAME}_${cfg} PROPERTIES
-                ENVIRONMENT "OPENSIM_USE_VISUALIZER=0")
-            if(WIN32)
-                # Must set PATH so that osimJavaJNI can find osimCommon, etc.
-                set_property(TEST Matlab_${TESTNAME}_${cfg} APPEND PROPERTY
-                    ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}/${cfg}")
+        if(WIN32)
+            # Must set PATH so that osimJavaJNI can find osimCommon, etc.
+            set_tests_properties(Matlab_${TESTNAME}_${cfg} PROPERTIES ENVIRONMENT
+                    "PATH=${CMAKE_BINARY_DIR}/${cfg}")
             endif()
         endforeach()
     else()
@@ -49,6 +47,8 @@ macro(OpenSimAddMatlabTest TESTNAME MFILE)
             UNITTEST_FILE "${_full_path_to_mfile}"
             ADDITIONAL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../Utilities"
             NO_UNITTEST_FRAMEWORK
+            # Necessary for custom initial working dir in MATLAB:
+            UNITTEST_PRECOMMAND "cd('${matlab_output_dir}')"
             )
         set_tests_properties(Matlab_${TESTNAME} PROPERTIES
             ENVIRONMENT "OPENSIM_USE_VISUALIZER=0")
@@ -69,13 +69,7 @@ add_custom_target(RunMatlabTests
 
 add_dependencies(RunMatlabTests JavaBindings)
 
-
-
-
-
 # Tests.
-# ------
-
 # From examples.
 OpenSimAddMatlabTest(TugOfWar ../examples/OpenSimCreateTugOfWarModel.m)
 OpenSimAddMatlabTest(wiringInputsAndOutputsWithTableReporter


### PR DESCRIPTION
Fixes issue #1829 
### Brief summary of changes
Edit a CMakte file to run tests in correct folder

### Testing I've completed
Ran ctest on my local machine. 

### Looking for feedback on...
DOes it work

### CHANGELOG.md (choose one)
- no need to update because it was a bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/1917)
<!-- Reviewable:end -->
