### PR TITLE
Allow Joints to own PhysicalOffsetFrames only, not just any PhysicalFrame

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -267,8 +267,8 @@ bool Joint::isCoordinateUsed(const Coordinate& aCoordinate) const
 void Joint::scale(const ScaleSet& scaleSet)
 {
     // Scale the parent and/or child Frame, but only if owned by the Joint. The
-    // Joint owns Frames that appear in the Joint's "frames" list property,
-    // which can occur only if the Frame is a PhysicalOffsetFrame.
+    // Joint owns Frames that appear in the Joint's "frames" list property
+    // (which can occur only if the Frame is a PhysicalOffsetFrame).
     auto findIndexInFramesList = [&](const PhysicalFrame& frame) -> int
     {
         const PhysicalOffsetFrame* pof =
@@ -283,7 +283,7 @@ void Joint::scale(const ScaleSet& scaleSet)
     if (parentIndex < 0 && childIndex < 0)  // No scaling to do.
         return;
 
-    // If either parent or child is owned by the Joint, search the scaleSet once
+    // If parent and/or child is owned by the Joint, search the scaleSet *once*
     // to find the associated scale factors.
     const std::string& parentName = getParentFrame().findBaseFrame().getName();
     const std::string& childName  =  getChildFrame().findBaseFrame().getName();
@@ -313,11 +313,9 @@ void Joint::scale(const ScaleSet& scaleSet)
 
     // Scale the PhysicalOffsetFrames owned by this Joint.
     if (parentIndex >= 0)
-        updComponent<PhysicalOffsetFrame>(
-            upd_frames(parentIndex).getAbsolutePathName()).scale(parentFactors);
+        upd_frames(parentIndex).scale(parentFactors);
     if (childIndex >= 0)
-        updComponent<PhysicalOffsetFrame>(
-            upd_frames(childIndex).getAbsolutePathName()).scale(childFactors);
+        upd_frames(childIndex).scale(childFactors);
 }
 
 const SimTK::MobilizedBodyIndex Joint::

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -269,9 +269,8 @@ void Joint::scale(const ScaleSet& scaleSet)
     auto scaleOffsetFrameIfOwned = [&](const PhysicalFrame& frame) -> void {
         // If the frame is owned and immediate subcomponent of this Joint then
         // scale it. Otherwise, let the immediate owner of the frame decide.
-        if (auto* offset = findComponent<PhysicalOffsetFrame>(frame.getName())
-            && (&(offset->getOwner()) == this))
-        {
+        auto* offset = findComponent<PhysicalOffsetFrame>(frame.getName());
+        if (offset && (&(offset->getOwner()) == this)) {
             // find the scale factors associated with the base PhysicalFrame
             // of this offset frame
             const string& baseFrameName = offset->findBaseFrame().getName();

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -267,9 +267,10 @@ bool Joint::isCoordinateUsed(const Coordinate& aCoordinate) const
 void Joint::scale(const ScaleSet& scaleSet)
 {
     auto scaleOffsetFrameIfOwned = [&](const PhysicalFrame& frame) -> void {
-        // If the frame is owned by this Joint then scale it.
-        // Otherwise let the owner of the frame decide.
-        if (auto* offset = findComponent<PhysicalOffsetFrame>(frame.getName()))
+        // If the frame is owned and immediate subcomponent of this Joint then
+        // scale it. Otherwise, let the immediate owner of the frame decide.
+        if (auto* offset = findComponent<PhysicalOffsetFrame>(frame.getName())
+            && (&(offset->getOwner()) == this))
         {
             // find the scale factors associated with the base PhysicalFrame
             // of this offset frame

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -24,6 +24,7 @@
  * -------------------------------------------------------------------------- */
 // INCLUDE
 #include <OpenSim/Simulation/Model/ModelComponent.h>
+#include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Simulation/SimbodyEngine/Body.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 #include <simbody/internal/MobilizedBody.h>
@@ -102,12 +103,12 @@ public:
         "List containing the generalized coordinates (q's) that parameterize "
         "this joint.");
 
-    OpenSim_DECLARE_LIST_PROPERTY(frames, PhysicalFrame,
-        "Physical frames owned by the Joint that are used to satisfy the Joint's "
-        "parent and child frame connections. For examples, PhysicalOffsetFrames "
+    OpenSim_DECLARE_LIST_PROPERTY(frames, PhysicalOffsetFrame,
+        "Physical offset frames owned by the Joint that are used to satisfy "
+        "the Joint's parent and child frame connections. PhysicalOffsetFrames "
         "are often used to offset the connection from a Body's origin to another "
         "location of interest (e.g. the joint center). That offset can be added "
-        "to the Joint. When the joint is delete so are the Frames in this list.");
+        "to the Joint. When the joint is deleted so are the Frames in this list.");
 
 //==============================================================================
 // SOCKETS


### PR DESCRIPTION
Fixes issue #1913

### Brief summary of changes
Changed definition of Joint's `frames` list property and updated `Joint::scale()` method accordingly. Also improved `scale()` method to search through the ScaleSet for parent/child scale factors only when necessary.

### Testing I've completed
Ran testScale.

### Looking for feedback on...

### CHANGELOG.md (choose one)
This PR fixes a bug that did not exist in 3.3.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.