### PR TITLE
[swig] Avoid multiple definitions for DataTable_::clone().

### DIFF
--- a/Bindings/Python/tests/test_DataTable.py
+++ b/Bindings/Python/tests/test_DataTable.py
@@ -5,6 +5,27 @@ import os, unittest
 import opensim as osim
 
 class TestDataTable(unittest.TestCase):
+    def test_clone(self):
+        # Make sure the clone() method works (we have to implement this in a
+        # SWIG interface file).
+        dt = osim.DataTable()
+        c = dt.clone()
+        assert c
+        dt = osim.DataTableVec3()
+        c = dt.clone()
+        assert c
+        dt = osim.DataTableUnitVec3()
+        c = dt.clone()
+        assert c
+        dt = osim.DataTableQuaternion()
+        c = dt.clone()
+        assert c
+        dt = osim.DataTableVec6()
+        c = dt.clone()
+        assert c
+        dt = osim.DataTableSpatialVec()
+        c = dt.clone()
+        assert c
     def test_vector_rowvector(self):
         print()
         print('Test transpose RowVector to Vector.')

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -180,15 +180,15 @@ namespace OpenSim {
 %ignore OpenSim::DataTable_::DataTable_(const DataTable_<double, double>&,
                                         const std::vector<std::string>&);
 %ignore OpenSim::DataTable_<double, double>::flatten;
-%extend OpenSim::DataTable_ {
-    OpenSim::DataTable_<ETX, ETY>* clone() const {
-        return new OpenSim::DataTable_<ETX, ETY>{*$self};
-    }
-}
 // A version of SWIG between 3.0.6 and 3.0.12 broke the ability to extend class
 // templates with more than 1 template parameter, so we must enumerate the
 // possible template arguments (not necesary for TimeSeriesTable's clone; that
 // template has only 1 param.).
+//%extend OpenSim::DataTable_ {
+//    OpenSim::DataTable_<ETX, ETY>* clone() const {
+//        return new OpenSim::DataTable_<ETX, ETY>{*$self};
+//    }
+//}
 %define DATATABLE_CLONE(ETX, ETY)
 %extend OpenSim::DataTable_<ETX, ETY> {
     OpenSim::DataTable_<ETX, ETY>* clone() const {


### PR DESCRIPTION
Fixes issue #1806.

### Brief summary of changes

No longer define `DataTable_::clone()` multiple times.

### Testing I've completed

Added python tests and they pass.

We still need to check AppVeyor's output to make sure the warnings are gone.

### CHANGELOG.md (choose one)

- no need to update because...this is internal