### PR TITLE
[cmake] OpenSimConfig.cmake: Simbody is required

### DIFF
--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -67,7 +67,7 @@ set(@CMAKE_PROJECT_NAME@_JAR_FILE
 # ------------
 if (@OPENSIM_COPY_DEPENDENCIES@) # OPENSIM_COPY_DEPENDENCIES
     # Find the copy of Simbody within the OpenSim installation.
-    find_package(Simbody @SIMBODY_VERSION_TO_USE@
+    find_package(Simbody @SIMBODY_VERSION_TO_USE@ REQUIRED
         PATHS "@PACKAGE_OPENSIM_INSTALL_SIMBODYDIR@" NO_MODULE NO_DEFAULT_PATH)
 else()
     # Find the correct version anywhere on the machine.


### PR DESCRIPTION
Mark Simbody as a required package in OpenSimConfig.cmake.

