### PR TITLE
Make Model::formStateStorage throw if input is in degrees

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1940,8 +1940,8 @@ void Model::formStateStorage(const Storage& originalStorage,
     }
 
     OPENSIM_THROW_IF_FRMOBJ(originalStorage.isInDegrees(), Exception,
-        "Input Storage must be in internal units (meters, radians). \n"
-        "Please convert Storage to internal units first.");
+        "Input Storage must have values for Coordinates in meters or radians (not degrees).\n"
+        "Please convert input Storage to meters and/or degrees first.");
 
     // when the state value is not found in the storage use its default value in the State
     SimTK::Vector defaultStateValues = getStateVariableValues(getWorkingState());

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1939,6 +1939,10 @@ void Model::formStateStorage(const Storage& originalStorage,
             << originalStorage.getSmallestNumberOfStates() << " Expected  " << rStateNames.getSize() << "." << endl;
     }
 
+    OPENSIM_THROW_IF_FRMOBJ(originalStorage.isInDegrees(), Exception,
+        "Input Storage must be in internal units (meters, radians). \n"
+        "Please convert Storage to internal units first.");
+
     // when the state value is not found in the storage use its default value in the State
     SimTK::Vector defaultStateValues = getStateVariableValues(getWorkingState());
 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -401,7 +401,7 @@ public:
      * a state is unspecified in the originalStorage. If warnUnspecifiedStates is
      * true then a warning is printed that includes the default value used for
      * the state value unspecified in originalStorage. The input originalStorage 
-     * must be in internal units for coordinate values (m, rad) and their speeds
+     * must be in meters or radians for Coordinate values and their speeds
      * (m/s, rad/s) otherwise an Exception is thrown.
      */
     void formStateStorage(const Storage& originalStorage, 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -400,7 +400,9 @@ public:
      * with values populated from originalStorage. Use the default state value if
      * a state is unspecified in the originalStorage. If warnUnspecifiedStates is
      * true then a warning is printed that includes the default value used for
-     * the state value unspecified in originalStorage.
+     * the state value unspecified in originalStorage. The input originalStorage 
+     * must be in internal units for coordinate values (m, rad) and their speeds
+     * (m/s, rad/s) otherwise an Exception is thrown.
      */
     void formStateStorage(const Storage& originalStorage, 
                           Storage& statesStorage,


### PR DESCRIPTION
Fixes issue #1924

### Brief summary of changes
Added an exception and comments to enforce and document that input to `Model::formStateStorage()` must be in internal units (i.e.  not in degrees).

### Testing I've completed
All tests pass locally, 

### Looking for feedback on...
None. 

### CHANGELOG.md (choose one)
- no need to update because no change to the API

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
