### PR TITLE
removed Model::replaceMarkerSet()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Converting from v3.x to v4.0
 `Millard2012EquilibriumMuscle::computeFiberEquilibrium(SimTK::State&, bool useZeroVelocity)`
 where fiber-velocity can be estimated from the state or assumed to be zero if the flag is *true*.
 - `Millard2012EquilibriumMuscle::computeInitialFiberEquilibrium(SimTK::State&)` invokes `computeFiberEquilibrium()` with `useZeroVelocity = true` to maintain its previous behavior.
+- `Model::replaceMarkerSet()` was removed. (PR #1938) Please use `Model::updMarkerSet()` to edit the model's MarkerSet instead.
 
 Composing a Component from other components
 -------------------------------------------

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1691,31 +1691,6 @@ void Model::writeMarkerFile(const string& aFileName)
     upd_MarkerSet().print(aFileName);
 }
 
-//_____________________________________________________________________________
-/**
- * Replace all markers in the model with the ones in the passed-in marker set.
- *
- * @param aMarkerSet The new marker set to copy.
- * @return Number of markers that were successfully added to the model.
- */
-int Model::replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet)
-{
-    int i, numAdded = 0;
-
-    // First remove all existing markers from the model.
-    upd_MarkerSet().clearAndDestroy();
-
-    // Now add the markers from aMarkerSet whose body names match bodies in the engine.
-    for (i = 0; i < aMarkerSet.getSize(); i++)
-    {
-        Marker* marker = aMarkerSet[i].clone();
-        upd_MarkerSet().adoptAndAppend(marker);
-        ++numAdded;
-    }
-
-    cout << "Replaced marker set in model " << getName() << endl;
-    return numAdded;
-}
 
 //_____________________________________________________________________________
 void Model::updateMarkerSet(MarkerSet& newMarkerSet)

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -889,7 +889,7 @@ public:
     //--------------------------------------------------------------------------
     MarkerSet& updMarkerSet() { return upd_MarkerSet(); }
     const MarkerSet& getMarkerSet() const { return get_MarkerSet(); }
-    int replaceMarkerSet(const SimTK::State& s, const MarkerSet& aMarkerSet);
+
     void writeMarkerFile(const std::string& aFileName);
 
     /**


### PR DESCRIPTION
Fixes issue #1780 (point 1)

### Brief summary of changes
Eliminated `Model::replaceMarkerSet()` from the API. 

### Testing I've completed
None.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
