### PR TITLE
 Update PointKinematics to use PhysicalFrame instead of Body

### DIFF
--- a/OpenSim/Analyses/PointKinematics.cpp
+++ b/OpenSim/Analyses/PointKinematics.cpp
@@ -308,7 +308,7 @@ setModel(Model& aModel)
     Analysis::setModel(aModel);
 
     // Map name to index
-    _body = &aModel.updBodySet().get(_bodyName);
+    _body = &aModel.getComponent<PhysicalFrame>(_bodyName);
     if (aModel.updBodySet().contains(_relativeToBodyName))
         _relativeToBody = &aModel.updBodySet().get(_relativeToBodyName);
 
@@ -343,8 +343,7 @@ setBodyPoint(const std::string& aBody, const SimTK::Vec3& aPoint)
  *
  * @param aBody Body ID
  */
-void PointKinematics::
-setBody(Body* aBody)
+void PointKinematics::setBody(const PhysicalFrame* aBody)
 {
     // CHECK
     if (aBody==NULL) {
@@ -358,8 +357,7 @@ setBody(Body* aBody)
     _bodyName = _body->getName();
     cout<<"PointKinematics.setBody: set body to "<<_bodyName<<endl;
 }
-void PointKinematics::
-setRelativeToBody(Body* aBody)
+void PointKinematics::setRelativeToBody(const PhysicalFrame* aBody)
 {
     // CHECK
     if (aBody==NULL) {
@@ -380,12 +378,12 @@ setRelativeToBody(Body* aBody)
  *
  * @return Body pointer
  */
-Body* PointKinematics::getBody()
+const PhysicalFrame* PointKinematics::getBody() const
 {
     return(_body);
 }
 
-Body* PointKinematics::getRelativeToBody()
+const PhysicalFrame* PointKinematics::getRelativeToBody() const
 {
     return(_relativeToBody);
 }

--- a/OpenSim/Analyses/PointKinematics.h
+++ b/OpenSim/Analyses/PointKinematics.h
@@ -45,7 +45,7 @@ const int PointKinematicsBUFFER_LENGTH = 2048;
 //=============================================================================
 namespace OpenSim { 
 
-class Body;
+class PhysicalFrame;
 class Model;
 class Storage;
 
@@ -68,8 +68,8 @@ public:
 private:
     //char _buffer[PointKinematicsBUFFER_LENGTH];
     //char _tmp[PointKinematicsBUFFER_LENGTH];
-    Body *_body;
-    Body *_relativeToBody;
+    const PhysicalFrame *_body;
+    const PhysicalFrame *_relativeToBody;
 protected:
     // Properties
     PropertyStr _bodyNameProp;
@@ -121,10 +121,10 @@ public:
     //--------------------------------------------------------------------------
     // BODY
     void setBodyPoint(const std::string& aBody, const SimTK::Vec3& aPoint);
-    void setBody(Body* aBody);
-    void setRelativeToBody(Body* aBody);
-    Body* getBody();
-    Body* getRelativeToBody();
+    void setBody(const PhysicalFrame* aBody);
+    void setRelativeToBody(const PhysicalFrame* aBody);
+    const PhysicalFrame* getBody() const;
+    const PhysicalFrame* getRelativeToBody() const;
     // POINT
     void setPoint(const SimTK::Vec3& aPoint);
     void getPoint(SimTK::Vec3& rPoint);


### PR DESCRIPTION
Fixes issue #1854

### Brief summary of changes
*ground* is an invalid `Body` name and could not be found in the `Model`'s `BodySet`, which gives rise to the ` ArrayPtrs.get(aName): No object with name ground` error reported in #1854.  Now use `getComponent<PhysicalFrame>()` to locate the frame to which we can attach a station for the `PointKinematics` analysis.

### Testing I've completed
- `PointKinematics` analysis runs with `ground` 
- using an illegal name it throws now with a more reasonable message:
```
Component 'arm26' could not find 'voodoo' of type PhysicalFrame. Make sure a component exists at this path and that it is of the correct type.
        In file G:\OpenSimGit\opensim-core\OpenSim/Common/Component.h:711
        In function 'getComponent'
```

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because there is not change to the API


The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
