### PR TITLE
Add McKibbenActuator to SWIG wrapping definitions

### DIFF
--- a/Bindings/OpenSimHeaders_actuators.h
+++ b/Bindings/OpenSimHeaders_actuators.h
@@ -13,5 +13,6 @@
 #include <OpenSim/Actuators/SpringGeneralizedForce.h>
 #include <OpenSim/Actuators/RigidTendonMuscle.h>
 #include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>
+#include <OpenSim/Actuators/McKibbenActuator.h>
 
 #endif // OPENSIM_OPENSIM_HEADERS_ACTUATORS_H_

--- a/Bindings/actuators.i
+++ b/Bindings/actuators.i
@@ -8,5 +8,5 @@
 %include <OpenSim/Actuators/ClutchedPathSpring.h>
 %include <OpenSim/Actuators/SpringGeneralizedForce.h>
 %include <OpenSim/Actuators/RigidTendonMuscle.h>
-
 %include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>
+%include <OpenSim/Actuators/McKibbenActuator.h>


### PR DESCRIPTION
Fixes issue #1812

### Brief summary of changes
Add SWIG bindings for `McKibbenActuator`

### Testing I've completed
- verified that instance can be created and its properties set in MATLAB

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because no change to API

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
