### PR TITLE
Avoid unnecessary exception in DelimFileAdapter

### DIFF
--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -541,13 +541,11 @@ DelimFileAdapter<T>::extendWrite(const InputTables& absTables,
     std::ofstream out_stream{fileName};
 
     // First line of the stream is the header.
-    try {
+    if (table->getTableMetaData().hasKey("header")) {
         out_stream << table->
                       getTableMetaData().
                       getValueForKey("header").
                       template getValue<std::string>() << "\n";
-    } catch(KeyNotFound&) {
-        // No operation. Continue with other keys in table metadata.
     }
     // Write rest of the key-value pairs and end the header.
     for(const auto& key : table->getTableMetaDataKeys()) {


### PR DESCRIPTION
### Brief summary of changes

Using a debugger with OpenSim, with a breakpoint on any thrown exceptions, is very helpful. However, when our code uses exceptions to perform routine non-error tasks, then debugging gets more difficult (the debugger stops at all these unimportant exceptions).

This PR avoids the use of an exception for simply checking if a key exists.

### Testing I've completed

- continuous integration.

### CHANGELOG.md (choose one)

- no need to update because...this is internal.