### PR TITLE
[travis] Ignore more tests in debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,7 +158,7 @@ before_install:
   # Initialize environment variable.
   - export TESTS_TO_EXCLUDE="unmatched" # This is just for the regex.
   ## If we are building in debug, there are some tests to ignore.
-  - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testOptimizationExample|testCMCGait10dof18musc|testCMCWithControlConstraintsRunningModel"; fi
+  - if [ "$BTYPE" = "Debug" ]; then export TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE|testOptimizationExample|testCMCGait10dof18musc|testCMCWithControlConstraintsRunningModel|testContactGeometry|testForward|testCMCArm26_Millard"; fi
   
   ## Set compiler flags.
   - export CXX_FLAGS="-Werror " # -Wno-tautological-undefined-compare -Wno-undefined-bool-conversion"


### PR DESCRIPTION
The following tests have been timing out in Travis' Debug build, so I think we should ignore them for now so that the green checkmark is meaningful.

- testContactGeometry
- testForward
- testCMCArm26_Millard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/1956)
<!-- Reviewable:end -->
