### PR TITLE
Wrap Rotation_::setRotationFromTwoAxes().

### DIFF
--- a/Bindings/Java/Matlab/tests/testSimbody.m
+++ b/Bindings/Java/Matlab/tests/testSimbody.m
@@ -43,3 +43,9 @@ for i = 0:residual.size()-1
     assert(abs(residual.get(i)) < 1e-10);
 end
 
+% Test Rotation.
+% --------------
+rot = Rotation()
+rot.setRotationFromTwoAxes(UnitVec3(1, 0, 0), CoordinateAxis(0), ...
+                           Vec3(0, 1, 0), CoordinateAxis(1));
+

--- a/Bindings/SWIGSimTK/Rotation.h
+++ b/Bindings/SWIGSimTK/Rotation.h
@@ -196,7 +196,6 @@ public:
     /// Calculate R_AB by knowing one of B's unit vector expressed in A.
     /// Note: The other vectors are perpendicular (but somewhat arbitrarily so).
     //@{
-#ifndef SWIG
     Rotation_( const UnitVec3& uvec, const CoordinateAxis axis )  { setRotationFromOneAxis(uvec,axis); }
     /* SimTK_SimTKCOMMON_EXPORT */ Rotation_&  setRotationFromOneAxis( const UnitVec3& uvec, const CoordinateAxis axis );
     //@}
@@ -210,7 +209,6 @@ public:
     //@{
     Rotation_( const UnitVec3& uveci, const CoordinateAxis& axisi, const Vec3& vecjApprox, const CoordinateAxis& axisjApprox )  { setRotationFromTwoAxes(uveci,axisi,vecjApprox,axisjApprox); }
     /* SimTK_SimTKCOMMON_EXPORT */ Rotation_&  setRotationFromTwoAxes( const UnitVec3& uveci, const CoordinateAxis& axisi, const Vec3& vecjApprox, const CoordinateAxis& axisjApprox );
-#endif
     //@}
 
     // Converts rotation matrix to one or two or three orientation angles.


### PR DESCRIPTION
Fixes #1958.

### Brief summary of changes

Wrapped Rotation_::setRotationFromTwoAxes().

### Testing I've completed

Added a MATLAB test case and ran it locally.

### CHANGELOG.md (choose one)

- no need to update because...this is minor