### PR TITLE
[travis] Only build debug daily, not with PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,19 @@ sudo: false
     
 matrix:
   include:
-    - if type != cron:
+    - if: type != cron
       os: linux
       compiler: clang
       env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=3 DEPLOY=yes
-    - if type != cron:
+    - if: type != cron
       os: linux
       compiler: gcc
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=no
-    - if type = cron:
+    - if: type = cron
       os: linux
       compiler: clang
       env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3 DEPLOY=no
-    - if type != cron:
+    - if: type != cron
       os: osx
       compiler: clang
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,20 @@ sudo: false
     
 matrix:
   include:
-    - os: linux
+    - if type != cron:
+      os: linux
       compiler: clang
       env: BTYPE=RelWithDebInfo WRAP=on  DOXY=on  NPROC=3 DEPLOY=yes
-    - os: linux
+    - if type != cron:
+      os: linux
       compiler: gcc
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=no
-    - os: linux
+    - if type = cron:
+      os: linux
       compiler: clang
       env: BTYPE=Debug          WRAP=off DOXY=off NPROC=3 DEPLOY=no
-    - os: osx
+    - if type != cron:
+      os: osx
       compiler: clang
       env: BTYPE=RelWithDebInfo WRAP=off DOXY=off NPROC=3 DEPLOY=yes
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ sudo: false
     
 matrix:
   include:
+    # "cron" means periodic (e.g., daily) builds. 
+    # see https://travis-ci.org/opensim-org/opensim-core/settings
+    # for our scheduled cron jobs.
     - if: type != cron
       os: linux
       compiler: clang


### PR DESCRIPTION
[skip appveyor]

Only build debug tests once a day, not with PRs. This will help us avoid all the failures we see, and help shorten the queue.