### PR TITLE
[appveyor] Build doxygen.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,8 @@ init:
   # The CMake variable JAVA_HOME tells CMake where to look for Java.
   - SET JAVA_HOME=%JAVA_DIR%
   - SET PATH=%JAVA_HOME%\bin;%PATH%
+  # Detect if we are on the master branch; if so, we will deploy binaries.
+  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
 
 nuget:
   account_feed: true
@@ -111,9 +113,9 @@ test_script:
 
   ## Build doxygen (now that tests pass).
   # http://help.appveyor.com/discussions/problems/863-doxygen-installed-via-chocolatey-not-found
-  - choco install doxygen.portable --yes
-  - cmake .
-  - cmake --build . --target doxygen --config Release
+  - IF DEFINED DISTR choco install doxygen.portable --yes
+  - IF DEFINED DISTR cmake .
+  - IF DEFINED DISTR cmake --build . --target doxygen --config Release
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   
@@ -127,8 +129,6 @@ test_script:
 after_test:
   - cd %APPVEYOR_BUILD_FOLDER% 
   - ## On master branch, create NuGet package for OpenSim.
-  - # Detect if we are on the master branch.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   - # Create and upload NuGet package.
   - IF DEFINED DISTR nuget pack .opensim-core.nuspec -Properties "packageIdSuffix=%NUGET_PACKAGE_ID_SUFFIX%" -BasePath %OPENSIM_INSTALL_DIR%
   - IF DEFINED DISTR appveyor PushArtifact opensim-core%NUGET_PACKAGE_ID_SUFFIX%.0.0.0.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,6 +109,11 @@ test_script:
   ## Run tests.
   - ctest --parallel 4 --build-config Release --output-on-failure #--exclude-regex "%OPENSIM_TESTS_TO_EXCLUDE%"
 
+  ## Build doxygen (now that tests pass).
+  # http://help.appveyor.com/discussions/problems/863-doxygen-installed-via-chocolatey-not-found
+  - choco install doxygen.portable --yes
+  - cmake .
+  - cmake --build . --target doxygen --config Release
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   
@@ -120,7 +125,7 @@ test_script:
   - "%PYTHON_DIR%\\Scripts\\nosetests -v" #--exclude=%PYTHON_TESTS_TO_EXCLUDE%"
 
 after_test:
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - cd %APPVEYOR_BUILD_FOLDER% 
   - ## On master branch, create NuGet package for OpenSim.
   - # Detect if we are on the master branch.
   - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,6 +116,7 @@ test_script:
   - IF DEFINED DISTR choco install doxygen.portable --yes
   - IF DEFINED DISTR cmake .
   - IF DEFINED DISTR cmake --build . --target doxygen --config Release
+  
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   


### PR DESCRIPTION
This PR builds doxygen on AppVeyor so that the binaries we upload to AppVeyor contain doxygen. This is to prepare us for when we start using AppVeyor/Travis to automatically build our public releases.