### PR TITLE
[contributing] Allow only 1 reviewer for changes to Travis/AppVeyor scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ When you are ready to make a PR, please adhere to the following guidelines:
 
 4. Typo fixes can be merged by any member of the Development (Dev) Team.
 
-5. Updates to comments, Doxygen, compiler compatibility, or CMake files must be reviewed by at least one member of the Dev Team before being merged. The original author or the reviewer(s) may merge the pull request.
+5. Updates to comments, Doxygen, compiler compatibility, CMake files, or continuous integration files must be reviewed by at least one member of the Dev Team before being merged. The original author or the reviewer(s) may merge the pull request.
 
 6. Any other changes to the code require review by at least two members of the Dev Team. If the pull request involves adding a new class or performing a major object/algorithm refactor, one of these reviewers must be an Owner. The Owners and Dev Team are Teams within the opensim-org GitHub organization. The original author may NOT merge the pull request.
 


### PR DESCRIPTION
In the last few days I've been making lots of changes to the Travis/AppVeyor scripts. It would be great if these PRs could move a little faster. In my opinion, one review would be sufficient for these PRs. Let me know if you agree.

@aseth1 @tkuchida @aymanhab @jenhicks 
