### PR TITLE
Scaletool binding fixes

### DIFF
--- a/Bindings/Java/swig/java_actuators.i
+++ b/Bindings/Java/swig/java_actuators.i
@@ -60,11 +60,12 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 %rename OpenSim::ModelScaler::addScale private_addScale;
 
 %typemap(javacode) OpenSim::ModelScaler %{
-    addScale(Scale scale){
+    public void addScale(Scale scale){
         scale.markAdopted();
         private_addScale(scale);
     }
-    addMeasurement(Measurement meas){
+
+    public void addMeasurement(Measurement meas){
         meas.markAdopted();
         private_addMeasurement(meas);
     }

--- a/Bindings/Java/swig/java_actuators.i
+++ b/Bindings/Java/swig/java_actuators.i
@@ -53,3 +53,19 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 %include <Bindings/Java/OpenSimJNI/OpenSimContext.h>
 
 %include <Bindings/Java/OpenSimJNI/Hooks/SimtkLogCallback.h>
+
+// When used from GUI or matlab ModelScaler takes ownership on these calls, 
+// communicate that fact to the interpreter to avoid Garbage Collection issues
+%rename OpenSim::ModelScaler::addMeasurement private_addMeasurement;
+%rename OpenSim::ModelScaler::addScale private_addScale;
+
+%typemap(javacode) OpenSim::ModelScaler %{
+    addScale(Scale scale){
+        scale.markAdopted();
+        private_addScale(scale);
+    }
+    addMeasurement(Measurement meas){
+        meas.markAdopted();
+        private_addMeasurement(meas);
+    }
+%}

--- a/Bindings/Java/swig/java_actuators.i
+++ b/Bindings/Java/swig/java_actuators.i
@@ -47,15 +47,12 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
 
 %include <Bindings/actuators.i>
 %include <Bindings/analyses.i>
-%include <Bindings/tools.i>
-%include <OpenSim/Utilities/simmFileWriterDLL/SimmFileWriter.h>
-
-%include <Bindings/Java/OpenSimJNI/OpenSimContext.h>
-
-%include <Bindings/Java/OpenSimJNI/Hooks/SimtkLogCallback.h>
-
+        
 // When used from GUI or matlab ModelScaler takes ownership on these calls, 
 // communicate that fact to the interpreter to avoid Garbage Collection issues
+%javamethodmodifiers OpenSim::ModelScaler::addMeasurement "private";
+%javamethodmodifiers OpenSim::ModelScaler::addScale "private";
+
 %rename OpenSim::ModelScaler::addMeasurement private_addMeasurement;
 %rename OpenSim::ModelScaler::addScale private_addScale;
 
@@ -70,3 +67,11 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
         private_addMeasurement(meas);
     }
 %}
+
+%include <Bindings/tools.i>
+%include <OpenSim/Utilities/simmFileWriterDLL/SimmFileWriter.h>
+
+%include <Bindings/Java/OpenSimJNI/OpenSimContext.h>
+
+%include <Bindings/Java/OpenSimJNI/Hooks/SimtkLogCallback.h>
+

--- a/Bindings/Java/tests/TestBasics.java
+++ b/Bindings/Java/tests/TestBasics.java
@@ -91,12 +91,18 @@ class TestBasics {
     public static void testToyReflexController() {
         ToyReflexController controller = new ToyReflexController();
     }
-        
+      
+    public static void testScaleToolUtils() {
+       ModelScaler ms = new ModelScaler();
+       Scale s = new Scale();
+       ms.addScale(s);
+    }  
   public static void main(String[] args) {
       testBasics();
       testMuscleList();
       testToyReflexController();
-      
+      testScaleToolUtils();
+
       System.out.println("Test finished!");
       // TODO to cause test to fail: System.exit(-1);
   }

--- a/Bindings/Python/swig/python_tools.i
+++ b/Bindings/Python/swig/python_tools.i
@@ -44,14 +44,6 @@ using namespace SimTK;
     }
 }
 
-%pythonappend OpenSim::ModelScaler::addScale %{
-    aScale._markAdopted()
-%}
-
-%pythonappend OpenSim::ModelScaler::addMeasurement %{
-    aMeasurement._markAdopted()
-%}
-
 // Typemaps
 // ========
 // None.
@@ -62,6 +54,13 @@ using namespace SimTK;
 %include <Bindings/preliminaries.i>
 %include <Bindings/tools.i>
 
+%pythonappend OpenSim::ModelScaler::addScale %{
+    args[1]._markAdopted()
+%}
+
+%pythonappend OpenSim::ModelScaler::addMeasurement %{
+    args[1]._markAdopted()
+%}
 
 // Memory management
 // =================

--- a/Bindings/Python/swig/python_tools.i
+++ b/Bindings/Python/swig/python_tools.i
@@ -44,6 +44,14 @@ using namespace SimTK;
     }
 }
 
+%pythonappend OpenSim::ModelScaler::addScale %{
+    aScale._markAdopted()
+%}
+
+%pythonappend OpenSim::ModelScaler::addMeasurement %{
+    aMeasurement._markAdopted()
+%}
+
 // Typemaps
 // ========
 // None.

--- a/Bindings/Python/swig/python_tools.i
+++ b/Bindings/Python/swig/python_tools.i
@@ -49,18 +49,17 @@ using namespace SimTK;
 // None.
 
 
+%pythonappend OpenSim::ModelScaler::addScale %{
+    aScale._markAdopted()
+%}
+
+%pythonappend OpenSim::ModelScaler::addMeasurement %{
+    aMeasurement._markAdopted()
+%}
 // Include all the OpenSim code.
 // =============================
 %include <Bindings/preliminaries.i>
 %include <Bindings/tools.i>
-
-%pythonappend OpenSim::ModelScaler::addScale %{
-    args[1]._markAdopted()
-%}
-
-%pythonappend OpenSim::ModelScaler::addMeasurement %{
-    args[1]._markAdopted()
-%}
 
 // Memory management
 // =================


### PR DESCRIPTION
Fixes issue # Scale GUI crash due to upstream memory management mixup (BodyScale is double deleted)

### Brief summary of changes
API calls that change ownership are indicated in SWIG interface files

### Testing I've completed
These are bug fixes regardless of GUI code, testing will happen when opensim-core and gui are integrated.

### Looking for feedback on.
Where to add corresponding code for python wrapping, then we can add a python test case

### CHANGELOG.md (choose one)

- no need to update because it's a bug fix


The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
