### PR TITLE
Exception message shows file name, not full path.

### DIFF
--- a/OpenSim/Common/Exception.cpp
+++ b/OpenSim/Common/Exception.cpp
@@ -66,11 +66,21 @@ exception()
 //#endif
 }
 
+namespace {
+/// Grab the last element of a file path.
+std::string findFileName(const std::string& filepath) {
+    // Based on a similar function from Simbody.
+    std::string::size_type pos = filepath.find_last_of("/\\");
+    if (pos + 1 >= filepath.size()) pos = 0;
+    return filepath.substr(pos + 1);
+}
+} // namespace
+
 Exception::Exception(const std::string& file,
                      size_t line,
                      const std::string& func) {
-    addMessage("\tIn file " + file + ":" + std::to_string(line) + "\n" +
-               "\tIn function '" + func + "'");
+    addMessage("\tThrown at " + findFileName(file) + ":" +
+            std::to_string(line) + " in " + func + "().");
 }
 
 Exception::Exception(const std::string& file,
@@ -89,7 +99,7 @@ Exception::Exception(const std::string& file,
     std::string className = obj.getConcreteClassName();
     std::string objName = obj.getName();
     if (objName.empty()) objName = "<no-name>";
-    addMessage("\tIn object '" + objName + "' of type " + className + ".");
+    addMessage("\tIn Object '" + objName + "' of type " + className + ".");
 }
 
 Exception::Exception(const std::string& file,


### PR DESCRIPTION
Fixes #1984 

### Brief summary of changes

- Adds a small function to pull off the filename from a path (I wanted to use @carmichaelong's Path class but it's abstract).
- Uses the function to only show the filename (not the full path) in the exception message.

**After**:
```
Socket 'childFoo' not connected.
     In object 'Bar' of type Bar.
     In file /Users/chris/repos/opensim/16/opensim-core/OpenSim/Common/Component.h:856
     In function 'getConnectee'
```

**Before**:
```
Socket 'childFoo' not connected.
     In Object 'Bar' of type Bar.
     Thrown at Component.h:856 in getConnectee().
```

### Testing I've completed

- Ran testComponentInterface and inspected the new exception message format.

### Looking for feedback on...

- Do we think this format is an improvement?

### CHANGELOG.md (choose one)

- no need to update because...minor change