### PR TITLE
Output reporting analysis

### DIFF
--- a/Applications/Analyze/test/Tug_of_War_Setup_Analyze.xml
+++ b/Applications/Analyze/test/Tug_of_War_Setup_Analyze.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<OpenSimDocument Version="30000">
+<OpenSimDocument Version="30516">
 	<AnalyzeTool name="Tug_of_War_Millard_Iso">
 		<!--Name of the .osim file used to construct a model.-->
 		<model_file>Tug_of_War_Millard_Iso.osim</model_file>
@@ -29,7 +29,7 @@
 		<AnalysisSet name="Analyses">
 			<objects>
 				<ForceReporter name="ForceReporter">
-					<!--Flag (true or false) specifying whether whether on. True by default.-->
+					<!--Flag (true or false) specifying whether on. True by default.-->
 					<on>true</on>
 					<!--Start time.-->
 					<start_time>0</start_time>
@@ -42,18 +42,31 @@
 					<!--Flag indicating whether to include forces due to constraints.-->
 					<include_constraint_forces>false</include_constraint_forces>
 				</ForceReporter>
+				<OutputReporter name="OutputReporter">
+					<!--The names of Outputs to be reported. To select specific Component Outputs, provide its path name. For example, 'slider/tx/value' is an Output for the value of a Coordinate 'tx' belonging to the Joint 'slider'.-->
+					<output_paths>LeftMuscle/fiber_length LeftMuscle/tendon_force com_position LeftMuscle/active_force_length_multiplier ground_block/reaction_on_child</output_paths>
+					<!--Flag (true or false) specifying whether on. True by default.-->
+					<on>true</on>
+					<!--Start time.-->
+					<start_time>-Inf</start_time>
+					<!--End time.-->
+					<end_time>Inf</end_time>
+					<!--Specifies how often to store results during a simulation. More specifically, the interval (a positive integer) specifies how many successful integration steps should be taken before results are recorded again.-->
+					<step_interval>1</step_interval>
+					<!--Flag (true or false) indicating whether the results are in degrees or not.-->
+					<in_degrees>true</in_degrees>
+				</OutputReporter>
 			</objects>
 			<groups />
 		</AnalysisSet>
 		<!--Controller objects in the model.-->
 		<ControllerSet name="Controllers">
-			<objects>
-			</objects>
+			<objects />
 			<groups />
 		</ControllerSet>
 		<!--XML file (.xml) containing the forces applied to the model as ExternalLoads.-->
 		<external_loads_file />
-		<!--Storage file (.sto) containing the time history of states for the model. This file often contains multiple rows of data, each row being a time-stamped array of states. The first column contains the time.  The rest of the columns contain the states in the order appropriate for the model. In a storage file, unlike a motion file (.mot), non-uniform time spacing is allowed.  If the user-specified initial time for a simulation does not correspond exactly to one of the time stamps in this file, inerpolation is NOT used because it is sometimes necessary to an exact set of states for analyses.  Instead, the closest earlier set of states is used.-->
+		<!--Storage file (.sto) containing the time history of states for the model. This file often contains multiple rows of data, each row being a time-stamped array of states. The first column contains the time.  The rest of the columns contain the states in the order appropriate for the model. In a storage file, unlike a motion file (.mot), non-uniform time spacing is allowed.  If the user-specified initial time for a simulation does not correspond exactly to one of the time stamps in this file, interpolation is NOT used because it is sometimes necessary to use an exact set of states for analyses.  Instead, the closest earlier set of states is used.-->
 		<states_file />
 		<!--Motion file (.mot) or storage file (.sto) containing the time history of the generalized coordinates for the model. These can be specified in place of the states file.-->
 		<coordinates_file>Tug_of_War_ConstantVelocity.sto</coordinates_file>

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -142,7 +142,7 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
     TimeSeriesTable_<double> outputs_table =
         STOFileAdapter_<double>::
         read("Analyze_Tug_of_War/Tug_of_War_Millard_Iso_Outputs.sto");
-    SimTK::Vector tf_output = outputs_table.getDependentColumnAtIndex(0);
+    SimTK::Vector tf_output = outputs_table.getDependentColumnAtIndex(1);
 
     // Load input data as StatesTrajectory used to perform the Analysis
     auto statesTraj = StatesTrajectory::createFromStatesStorage(

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -27,6 +27,7 @@
 #include <OpenSim/Simulation/StatesTrajectory.h>
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 #include <OpenSim/Tools/AnalyzeTool.h>
+#include <OpenSim/Analyses/OutputReporter.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Auxiliary/auxiliaryTestMuscleFunctions.h>
 
@@ -128,6 +129,7 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
     // Test that the default activation is taken into consideration by
     // the Analysis and reflected in the AnalyzeTool solution
     muscle.set_default_activation(defaultAct);
+
     analyze.run();
 
     // Load the AnalyzTool results for the muscle's force through time
@@ -136,6 +138,11 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
         read("Analyze_Tug_of_War/Tug_of_War_Millard_Iso_ForceReporter_forces.sto");
     assert(results.getNumColumns() == 1);
     SimTK::Vector forces = results.getDependentColumnAtIndex(0);
+
+    TimeSeriesTable_<double> outputs_table =
+        STOFileAdapter_<double>::
+        read("Analyze_Tug_of_War/Tug_of_War_Millard_Iso_Outputs.sto");
+    SimTK::Vector tf_output = outputs_table.getDependentColumnAtIndex(0);
 
     // Load input data as StatesTrajectory used to perform the Analysis
     auto statesTraj = StatesTrajectory::createFromStatesStorage(
@@ -211,6 +218,12 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct) {
             " Analyze reported force: " << forces[int(i)] << endl;
         ASSERT_EQUAL<double>(mf, forces[int(i)], equilTol, __FILE__, __LINE__,
             "Total fiber force failed to match reported muscle force.");
+
+        cout << s.getTime() << " :: tendon-force: " << tf <<
+            " Analyze Output reported: " << tf_output[int(i)] << endl;
+        ASSERT_EQUAL<double>(tf, tf_output[int(i)], equilTol,
+            __FILE__, __LINE__,
+            "Output reported muscle-tendon force failed to match computed.");
 
         double delta = (i > 0) ? abs(forces[int(i)]-forces[int(i-1)]) : 0;
 

--- a/Bindings/OpenSimHeaders_analyses.h
+++ b/Bindings/OpenSimHeaders_analyses.h
@@ -16,5 +16,6 @@
 #include <OpenSim/Analyses/StatesReporter.h>
 #include <OpenSim/Analyses/InducedAccelerations.h>
 #include <OpenSim/Analyses/ProbeReporter.h>
+#include <OpenSim/Analyses/OutputReporter.h>
 
 #endif // OPENSIM_OPENSIM_HEADERS_ANALYSES_H_

--- a/Bindings/analyses.i
+++ b/Bindings/analyses.i
@@ -13,3 +13,4 @@
 %include <OpenSim/Analyses/StatesReporter.h>
 %include <OpenSim/Analyses/InducedAccelerations.h>
 %include <OpenSim/Analyses/ProbeReporter.h>
+%include <OpenSim/Analyses/OutputReporter.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ New Classes
 - The WeldConstraint and BushingForces (BushingForce, CoupledBushingForce, FunctionBasedBushingForce, and ExpressionBasedBushingForce) were similarly unified (like Joints) to handle the two Frames that these classes require to operate. A LinkTwoFrames intermediate class was introduced to house the common operations. Convenience constructors for WeldConstraint and BushingFrames were affected and now require the name of the Component as the first argument. (PR #649)
 - The new StatesTrajectory class allows users to load an exact representation of previously-computed states from a file. (PR #730)
 - Added Point as a new base class for all points, which include: Station, Marker, and PathPoints
+- Added OutputReporter as an Analysis so that users can use the existing AnalyzeTool and ForwardTool to extract Output values of interest, without modifications to the GUI. (PR #1991)
 
 Removed Classes
 ---------------

--- a/OpenSim/Analyses/CMakeLists.txt
+++ b/OpenSim/Analyses/CMakeLists.txt
@@ -8,5 +8,5 @@ OpenSimAddLibrary(
     LINKLIBS osimCommon osimSimulation osimActuators
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}
-	TESTDIRS Test
+    TESTDIRS Test
     )

--- a/OpenSim/Analyses/CMakeLists.txt
+++ b/OpenSim/Analyses/CMakeLists.txt
@@ -8,4 +8,5 @@ OpenSimAddLibrary(
     LINKLIBS osimCommon osimSimulation osimActuators
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}
+	TESTDIRS Test
     )

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -35,7 +35,7 @@ using namespace std;
 //=============================================================================
 // ANALYSIS
 //=============================================================================
-int OutputReporter::begin(SimTK::State& s)
+int OutputReporter::begin(const SimTK::State& s)
 {
     if (!proceed()) return 0;
 
@@ -102,7 +102,7 @@ int OutputReporter::step(const SimTK::State& s, int stepNumber)
     return 0;
 }
 
-int OutputReporter::end(SimTK::State& s)
+int OutputReporter::end(const SimTK::State& s)
 {
     if (!proceed()) return 0;
     _pvtModel->realizeReport(s);

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -1,0 +1,129 @@
+/* -------------------------------------------------------------------------- *
+ *                        OpenSim: OutputReporter.cpp                         *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s):                                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include "OutputReporter.h"
+#include <OpenSim/Simulation/Model/Model.h>
+
+using namespace OpenSim;
+using namespace std;
+
+//=============================================================================
+// ANALYSIS
+//=============================================================================
+int OutputReporter::begin(SimTK::State& s)
+{
+    if (!proceed()) return(0);
+
+    _model = _model->clone();
+
+    _tableReporterDouble = new TableReporter_<double>();
+    _tableReporterVec3 = new TableReporter_<SimTK::Vec3>();
+    _tableReporterSpatialVec = new TableReporter_<SimTK::SpatialVec>();
+
+    _model->addComponent(_tableReporterDouble.get());
+    _model->addComponent(_tableReporterVec3.get());
+    _model->addComponent(_tableReporterSpatialVec.get());
+
+    for (int i = 0; i < getProperty_output_paths().size(); ++i) {
+        auto outpath = ComponentPath(get_output_paths(i));
+        // assume that Outputs are for the Model
+        string compName = _model->getAbsolutePathString();
+        // if a a ComponentPath is specified then use the parent path
+        if (outpath.getNumPathLevels()) {
+            compName = outpath.getParentPathString();
+        }
+        auto outputName = outpath.getComponentName();
+
+        const Component* comp = _model;
+        if (!compName.empty())
+            comp = &_model->getComponent(compName);
+
+        auto& out = comp->getOutput(outputName);
+        if (out.getTypeName() == "double") {
+            _tableReporterDouble->addToReport(out);
+        }
+        else if (out.getTypeName() == "Vec3") {
+            _tableReporterVec3->addToReport(out);
+        }
+        else if (out.getTypeName() == "SpatialVec") {
+            _tableReporterSpatialVec->addToReport(out);
+        }
+        else {
+            cout << "Output '" << out.getPathName() << "' of type "
+                << out.getTypeName() << " is not supported by OutputReporter."
+                << "Consider adding a TableReporter_ to the Model." << endl;
+        }
+    }
+
+    _model->initSystem();
+
+    return 0;
+}
+
+int OutputReporter::step(const SimTK::State& s, int stepNumber)
+{
+    if (!proceed(stepNumber)) {
+        return 0;
+    }
+    if (_model == nullptr)
+        return -1;
+
+    _model->realizeReport(s);
+
+    return 0;
+        
+}
+
+
+int OutputReporter::printResults(const std::string& baseName,
+    const std::string& dir,  double dT, const std::string& extension)
+{
+    if (!getOn()) {
+        printf("OutputReporter.printResults: Off- not printing.\n");
+        return 0;
+    }
+
+    auto& tableD = _tableReporterDouble->getTable();
+    if (tableD.getNumColumns()) {
+        STOFileAdapter_<double>::write(tableD,
+            dir + baseName + extension);
+    }
+
+    auto& tableV3 = _tableReporterVec3->getTable();
+    if (tableV3.getNumColumns()) {
+        STOFileAdapter_<SimTK::Vec3>::write(tableV3,
+            dir + baseName + "Vec3" + extension);
+    }
+
+    auto& tableSV = _tableReporterSpatialVec->getTable();
+    if (tableSV.getNumColumns()) {
+        STOFileAdapter_<SimTK::SpatialVec>::write(tableSV,
+            dir + baseName + "SpatialVec" + extension);
+    }
+
+    return 0;
+}

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -37,7 +37,7 @@ using namespace std;
 //=============================================================================
 int OutputReporter::begin(SimTK::State& s)
 {
-    if (!proceed()) return(0);
+    if (!proceed()) return 0;
 
     _pvtModel.reset(_model->clone());
 
@@ -84,6 +84,7 @@ int OutputReporter::begin(SimTK::State& s)
     }
 
     _pvtModel->initSystem();
+    _pvtModel->realizeReport(s);
 
     return 0;
 }
@@ -99,9 +100,14 @@ int OutputReporter::step(const SimTK::State& s, int stepNumber)
     _pvtModel->realizeReport(s);
 
     return 0;
-        
 }
 
+int OutputReporter::end(SimTK::State& s)
+{
+    if (!proceed()) return 0;
+    _pvtModel->realizeReport(s);
+    return 0;
+}
 
 int OutputReporter::printResults(const std::string& baseName,
     const std::string& dir,  double dT, const std::string& extension)
@@ -117,19 +123,19 @@ int OutputReporter::printResults(const std::string& baseName,
     auto& tableD = _tableReporterDouble->getTable();
     if (tableD.getNumColumns()) {
         STOFileAdapter_<double>::write(tableD,
-            dir + baseName + extension);
+            dir + "/"+ baseName + "_Outputs" + extension);
     }
 
     auto& tableV3 = _tableReporterVec3->getTable();
     if (tableV3.getNumColumns()) {
         STOFileAdapter_<SimTK::Vec3>::write(tableV3,
-            dir + baseName + "Vec3" + extension);
+            dir + "/" + baseName + "_OutputsVec3" + extension);
     }
 
     auto& tableSV = _tableReporterSpatialVec->getTable();
     if (tableSV.getNumColumns()) {
         STOFileAdapter_<SimTK::SpatialVec>::write(tableSV,
-            dir + baseName + "SpatialVec" + extension);
+            dir + "/" + baseName + "_OutputsSpatialVec" + extension);
     }
 
     return 0;

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -27,6 +27,7 @@
 //=============================================================================
 #include "OutputReporter.h"
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Common/IO.h>
 
 using namespace OpenSim;
 using namespace std;
@@ -75,7 +76,7 @@ int OutputReporter::begin(SimTK::State& s)
         else {
             cout << "Output '" << out.getPathName() << "' of type "
                 << out.getTypeName() << " is not supported by OutputReporter."
-                << "Consider adding a TableReporter_ to the Model." << endl;
+                << " Consider adding a TableReporter_ to the Model." << endl;
         }
     }
 
@@ -106,6 +107,9 @@ int OutputReporter::printResults(const std::string& baseName,
         printf("OutputReporter.printResults: Off- not printing.\n");
         return 0;
     }
+
+    OPENSIM_THROW_IF_FRMOBJ(IO::Lowercase(extension) != ".sto",
+        Exception, "Only writing results to '.sto' format is supported.");
 
     auto& tableD = _tableReporterDouble->getTable();
     if (tableD.getNumColumns()) {

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -39,6 +39,9 @@ int OutputReporter::begin(const SimTK::State& s)
 {
     if (!proceed()) return 0;
 
+    if (_pvtModel == nullptr)
+        return -1;
+
     _pvtModel.reset(_model->clone());
 
     _tableReporterDouble = new TableReporter_<double>();
@@ -94,8 +97,6 @@ int OutputReporter::step(const SimTK::State& s, int stepNumber)
     if (!proceed(stepNumber)) {
         return 0;
     }
-    if (_pvtModel == nullptr)
-        return -1;
 
     _pvtModel->realizeReport(s);
 

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -83,9 +83,9 @@ protected:
     //--------------------------------------------------------------------------
     // ANALYSIS INTERFACE
     //--------------------------------------------------------------------------
-    int begin(SimTK::State& s) override final;
+    int begin(const SimTK::State& s) override final;
     int step(const SimTK::State& s, int setNumber) override final;
-    int end(SimTK::State& s) override final;
+    int end(const SimTK::State& s) override final;
 
     int printResults(const std::string& baseName,
         const std::string& dir = "",

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -83,8 +83,10 @@ protected:
     //--------------------------------------------------------------------------
     // ANALYSIS INTERFACE
     //--------------------------------------------------------------------------
-    int begin(SimTK::State& s) override;
-    int step(const SimTK::State& s, int setNumber) override;
+    int begin(SimTK::State& s) override final;
+    int step(const SimTK::State& s, int setNumber) override final;
+    int end(SimTK::State& s) override final;
+
     int printResults(const std::string& baseName,
         const std::string& dir = "",
         double dT = -1.0,

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -47,8 +47,13 @@ namespace OpenSim {
  * and writes TimeSeriesTables of Output values according to the names listed
  * as properties of the Analysis. OutputReporter enables the AnalyzeTool to
  * report on Outputs via the Analysis interface but backed by a TableReporter.
- * The OutputReporter currently only supports Outputs of type, double, Vec3
- * and SpatialVec.
+ * The OutputReporter currently only supports Outputs of type: double, Vec3
+ * and SpatialVec. The OutputReporter will automatically write multiple files-
+ * a file for each supported Output type: <results_file_name>.sto (as doubles),
+ * <results_file_name>Vec3.sto and <results_file_name>SpatialVec.sto.
+ *
+ * Note that the internal tables are reset at the beginning of a simulation or
+ * AnalyzeTool::run() and does not append results to previous tables.
  */
 class OSIMANALYSES_API OutputReporter : public Analysis {
 OpenSim_DECLARE_CONCRETE_OBJECT(OutputReporter, Analysis);

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -92,6 +92,8 @@ private:
     SimTK::ReferencePtr< TableReporter_<SimTK::SpatialVec> >
         _tableReporterSpatialVec;
 
+    SimTK::ResetOnCopy<std::unique_ptr<Model>> _pvtModel;
+
 //=============================================================================
 };  // END of class OutputReporter
 

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -1,0 +1,102 @@
+#ifndef OUTPUT_REPORTER_H_
+#define OUTPUT_REPORTER_H_
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim: OutputReporter.h                          *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s):                                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+
+//=============================================================================
+// INCLUDES
+//=============================================================================
+#include <OpenSim/Simulation/Model/Analysis.h>
+#include <OpenSim/Common/Reporter.h>
+#include <OpenSim/Common/STOFileAdapter.h>
+#include "osimAnalysesDLL.h"
+
+#ifdef SWIG
+    #ifdef OSIMANALYSES_API
+        #undef OSIMANALYSES_API
+        #define OSIMANALYSES_API
+    #endif
+#endif
+//=============================================================================
+//=============================================================================
+namespace OpenSim { 
+
+/**
+ * The OutputReporter Analysis is a wrapper for a TableReporter which
+ * generates TimeSeriesTables of Output values that are listed by name 
+ * as properties of this Analysis. OutputReporter enables the AnalyzeTool to
+ * report on Outputs via the Analysis interface but backed by a TableReporter.
+ * The OutputReporter currently only supports Outputs of type, double, Vec3
+ * and SpatialVec.
+ */
+class OSIMANALYSES_API OutputReporter : public Analysis {
+OpenSim_DECLARE_CONCRETE_OBJECT(OutputReporter, Analysis);
+
+public:
+OpenSim_DECLARE_LIST_PROPERTY(output_paths, std::string,
+    "The names of Outputs to be reported. To select specific Component outputs"
+    ", provide its path name");
+
+//=============================================================================
+// METHODS
+//=============================================================================
+
+    OutputReporter(Model *model = nullptr) : Analysis(model) {
+        constructProperty_output_paths();
+        setName("OutputReporter");
+    }
+    OutputReporter(const std::string& fileName) : 
+            Analysis(fileName, false) {
+        constructProperty_output_paths();
+        setName("OutputReporter");
+    }
+
+    virtual ~OutputReporter() = default;
+
+protected:
+    //--------------------------------------------------------------------------
+    // ANALYSIS INTERFACE
+    //--------------------------------------------------------------------------
+    int begin(SimTK::State& s) override;
+    int step(const SimTK::State& s, int setNumber) override;
+    int printResults(const std::string& baseName,
+        const std::string& dir = "",
+        double dT = -1.0,
+        const std::string& extension = ".sto") override;
+
+private:
+    // Keep a reference to the underlying TableReporter(s) for this Analysis
+    SimTK::ReferencePtr< TableReporter_<double> > _tableReporterDouble;
+    SimTK::ReferencePtr< TableReporter_<SimTK::Vec3> > _tableReporterVec3;
+    SimTK::ReferencePtr< TableReporter_<SimTK::SpatialVec> >
+        _tableReporterSpatialVec;
+
+//=============================================================================
+};  // END of class OutputReporter
+
+
+}; //namespace OpenSim
+
+
+#endif // #ifndef OUTPUT_REPORTER_H_

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -93,6 +93,11 @@ protected:
         const std::string& extension = ".sto") override;
 
 private:
+    // Invoke the reporting of the Outputs to the Tables
+    void report(const SimTK::State& s);
+
+    SimTK::Stage _minimumStageToRealize{};
+
     // Keep a reference to the underlying TableReporter(s) for this Analysis
     SimTK::ReferencePtr< TableReporter_<double> > _tableReporterDouble;
     SimTK::ReferencePtr< TableReporter_<SimTK::Vec3> > _tableReporterVec3;

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -43,9 +43,9 @@
 namespace OpenSim { 
 
 /**
- * The OutputReporter Analysis is a wrapper for a TableReporter which
- * generates TimeSeriesTables of Output values that are listed by name 
- * as properties of this Analysis. OutputReporter enables the AnalyzeTool to
+ * The OutputReporter Analysis is a wrapper for a TableReporter. It generates
+ * and writes TimeSeriesTables of Output values according to the names listed
+ * as properties of the Analysis. OutputReporter enables the AnalyzeTool to
  * report on Outputs via the Analysis interface but backed by a TableReporter.
  * The OutputReporter currently only supports Outputs of type, double, Vec3
  * and SpatialVec.
@@ -55,13 +55,13 @@ OpenSim_DECLARE_CONCRETE_OBJECT(OutputReporter, Analysis);
 
 public:
 OpenSim_DECLARE_LIST_PROPERTY(output_paths, std::string,
-    "The names of Outputs to be reported. To select specific Component outputs"
-    ", provide its path name");
+    "The names of Outputs to be reported. To select specific Component Outputs"
+    ", provide its path name. For example, 'slider/tx/value' is an Output for "
+    "the value of a Coordinate 'tx' belonging to the Joint 'slider'.");
 
 //=============================================================================
 // METHODS
 //=============================================================================
-
     OutputReporter(Model *model = nullptr) : Analysis(model) {
         constructProperty_output_paths();
         setName("OutputReporter");

--- a/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
+++ b/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
@@ -55,6 +55,8 @@ OSIMANALYSES_API void RegisterTypes_osimAnalyses()
     Object::registerType( InducedAccelerations() );
     Object::RegisterType( ProbeReporter() );
 
+    Object::RegisterType( OutputReporter() );
+
   } catch (const std::exception& e) {
     std::cerr 
         << "ERROR during osimAnalyses Object registration:\n"

--- a/OpenSim/Analyses/Test/CMakeLists.txt
+++ b/OpenSim/Analyses/Test/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB TEST_PROGS "test*.cpp")
+file(GLOB TEST_FILES *.osim *.xml *.sto *.mot *.obj *.vtp *.stl)
+
+OpenSimAddTests(
+    TESTPROGRAMS ${TEST_PROGS}
+    DATAFILES ${TEST_FILES}
+    LINKLIBS osimCommon osimSimulation osimAnalyses osimActuators osimLepton
+    )
+

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -253,11 +253,11 @@ void simulateMuscle(
     //==========================================================================
     // 5. Verify files were written with correct values
     //==========================================================================
-    auto tableD = STOFileAdapter::read("testOutputReporter.sto");
+    auto tableD = STOFileAdapter::read("testOutputReporter_Outputs.sto");
     auto tableV3 = STOFileAdapter_<SimTK::Vec3>::
-        read("testOutputReporterVec3.sto");
+        read("testOutputReporter_OutputsVec3.sto");
     auto tableSV = STOFileAdapter_<SimTK::SpatialVec>::
-        read("testOutputReporterSpatialVec.sto");
+        read("testOutputReporter_OutputsSpatialVec.sto");
 
     double val_t0 = tableD.getIndependentColumn()[0];
     const SimTK::Real& val_ke0 = tableD.getRowAtIndex(0)[0];

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -1,0 +1,312 @@
+/* --------------------------------------------------------------------------*
+*                      OpenSim:  testOutputReporter.cpp                      *
+* -------------------------------------------------------------------------- *
+* The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+* See http://opensim.stanford.edu and the NOTICE file for more information.  *
+* OpenSim is developed at Stanford University and supported by the US        *
+* National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+* through the Warrior Web program.                                           *
+*                                                                            *
+* Copyright (c) 2005-2017 Stanford University and the Authors                *
+* Author(s): Ajay Seth                                                       *
+*                                                                            *
+* Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+* not use this file except in compliance with the License. You may obtain a  *
+* copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+*                                                                            *
+* Unless required by applicable law or agreed to in writing, software        *
+* distributed under the License is distributed on an "AS IS" BASIS,          *
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+* See the License for the specific language governing permissions and        *
+* limitations under the License.                                             *
+* -------------------------------------------------------------------------- */
+
+#include <OpenSim/Common/osimCommon.h>
+#include <OpenSim/Common/IO.h>
+#include <OpenSim/Simulation/osimSimulation.h>
+#include <OpenSim/Actuators/osimActuators.h>
+#include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+#include <OpenSim/Analyses/OutputReporter.h>
+
+using namespace OpenSim;
+using namespace std;
+
+//==============================================================================
+static const double IntegrationAccuracy         = 1e-8;
+static const double SimulationTestTolerance     = 1e-6;
+static const double InitializationTestTolerance = 1e-8;
+static const double CorrectnessTestTolerance    = 1e-8;
+
+static const int SimulationTest         = 0;
+static const int InitializationTest     = 1;
+static const int CorrectnessTest        = 2;
+
+// MUSCLE CONSTANTS
+static const double MaxIsometricForce0 = 100.0,
+OptimalFiberLength0 = 0.1,
+TendonSlackLength0 = 0.2,
+    PennationAngle0 = 0.0;
+// PennationAngle1 = SimTK::Pi / 4;
+
+static const double Activation0 = 0.01,
+Deactivation0 = 0.4,
+ShutteDelpActivation1 = 7.6,
+ShutteDelpActivation2 = 2.5;
+
+/*
+This function completes a controlled activation, controlled stretch simulation
+of a muscle. After the simulation has completed, the results can be
+tested in a number of different ways to ensure that the muscle model is
+functioning
+
+@param aMuscle  a path actuator
+@param startX   the starting position of the muscle anchor. I have no idea
+why this value is included.
+@param act0     the initial i of the muscle
+@param motion   the forced stretch of the simulation
+@param control  the activation control signal that is applied to the muscle
+@param accuracy the desired accuracy of the integrated solution
+@param printResults print the osim model associated with this test.
+*/
+void simulateMuscle(const Muscle &aMuscle,
+                    double startX,
+                    double act0,
+                    const Function *motion,
+                    const Function *control,
+                    double integrationAccuracy,
+                    bool printResults);
+
+
+int main()
+{
+    SimTK::Array_<std::string> failures;
+
+    try {
+    Millard2012EquilibriumMuscle muscle("muscle",
+                    MaxIsometricForce0,
+                    OptimalFiberLength0,
+                    TendonSlackLength0,
+                    PennationAngle0);
+
+    muscle.setActivationTimeConstant(Activation0);
+    muscle.setDeactivationTimeConstant(Deactivation0);
+
+    double x0 = 0;
+    double act0 = 0.2;
+
+    Constant control(0.5);
+
+    Sine motion(0.1, SimTK::Pi, 0);
+
+    simulateMuscle( muscle,
+                    x0,
+                    act0,
+                    &motion,
+                    &control,
+                    IntegrationAccuracy,
+                    true);
+    }
+
+    catch (const Exception& e) {
+        e.print(cout);
+        failures.push_back("testOutputReporter");
+    }
+
+    cout << "************************************************************" << endl;
+
+    if (!failures.empty()) {
+        cout << "Done, with failure(s): " << failures << endl;
+        return 1;
+    }
+
+
+    cout << "testOutputReporter Done" << endl;
+    return 0;
+}
+
+/*==============================================================================
+Main test driver to be used on any muscle model 
+================================================================================
+*/
+void simulateMuscle(
+    const Muscle &aMuscModel,
+    double startX,
+    double act0,
+        const Function *motion,  // prescribe motion of free end of muscle
+        const Function *control, // prescribed excitation signal to the muscle
+        double integrationAccuracy,
+        bool printResults)
+{
+    string prescribed = (motion == NULL) ? "." : " with Prescribed Motion.";
+
+    cout << "\n******************************************************" << endl;
+    cout << "Test " << aMuscModel.getConcreteClassName()
+         << " Model" << prescribed << endl;
+    cout << "******************************************************" << endl;
+    using SimTK::Vec3;
+
+    //==========================================================================
+    // 0. SIMULATION SETUP: Create the block and ground
+    //==========================================================================
+
+    // Define the initial and final simulation times
+    double initialTime = 0.0;
+    double finalTime = 4.0;
+
+    //Physical properties of the model
+    double ballMass = 10;
+    double ballRadius = 0.05;
+    double anchorWidth = 0.1;
+
+    // Create an OpenSim model
+    Model model;
+
+    double optimalFiberLength = aMuscModel.getOptimalFiberLength();
+    double pennationAngle     = aMuscModel.getPennationAngleAtOptimalFiberLength();
+    double tendonSlackLength  = aMuscModel.getTendonSlackLength();
+
+    // Use a copy of the muscle model passed in to add path points later
+    PathActuator *aMuscle = aMuscModel.clone();
+
+    // Get a reference to the model's ground body
+    Ground& ground = model.updGround();
+
+    OpenSim::Body * ball = new OpenSim::Body("ball",
+        ballMass,
+        Vec3(0),
+                        ballMass*SimTK::Inertia::sphere(ballRadius));
+
+    ball->attachGeometry(new Sphere(ballRadius));
+    // ball connected  to ground via a slider along X
+    double xSinG = optimalFiberLength*cos(pennationAngle) + tendonSlackLength;
+
+    SliderJoint* slider = new SliderJoint("slider",
+        ground,
+        Vec3(anchorWidth / 2 + xSinG, 0, 0),
+        Vec3(0),
+        *ball,
+        Vec3(0),
+                        Vec3(0));
+
+    auto& sliderCoord = slider->updCoordinate();
+    sliderCoord.setName("tx");
+    sliderCoord.setDefaultValue(1.0);
+    sliderCoord.setRangeMin(0);
+    sliderCoord.setRangeMax(1.0);
+
+    if (motion != NULL){
+        sliderCoord.setPrescribedFunction(*motion);
+        sliderCoord.setDefaultIsPrescribed(true);
+    }
+    // add ball to model
+    model.addBody(ball);
+    model.addJoint(slider);
+
+
+    //==========================================================================
+    // 1. SIMULATION SETUP: Add the muscle
+    //==========================================================================
+    //Attach the muscle
+    /*const string &actuatorType = */aMuscle->getConcreteClassName();
+    aMuscle->setName("muscle");
+    aMuscle->addNewPathPoint("muscle-box", ground, Vec3(anchorWidth / 2, 0, 0));
+    aMuscle->addNewPathPoint("muscle-ball", *ball, Vec3(-ballRadius, 0, 0));
+
+    ActivationFiberLengthMuscle_Deprecated *aflMuscle
+        = dynamic_cast<ActivationFiberLengthMuscle_Deprecated *>(aMuscle);
+    if (aflMuscle){
+        // Define the default states for the muscle that has 
+        //activation and fiber-length states
+        aflMuscle->setDefaultActivation(act0);
+        aflMuscle->setDefaultFiberLength(aflMuscle->getOptimalFiberLength());
+    }
+    else{
+        ActivationFiberLengthMuscle *aflMuscle2
+            = dynamic_cast<ActivationFiberLengthMuscle *>(aMuscle);
+        if (aflMuscle2){
+            // Define the default states for the muscle 
+            //that has activation and fiber-length states
+            aflMuscle2->setDefaultActivation(act0);
+            aflMuscle2->setDefaultFiberLength(aflMuscle2
+                ->getOptimalFiberLength());
+        }
+    }
+
+    model.addForce(aMuscle);
+
+    // Create a prescribed controller that simply 
+    //applies controls as function of time
+    PrescribedController * muscleController = new PrescribedController();
+    if (control != NULL){
+        muscleController->setActuators(model.updActuators());
+        // Set the individual muscle control functions 
+        //for the prescribed muscle controller
+        muscleController->prescribeControlForActuator("muscle", control->clone());
+
+        // Add the control set controller to the model
+        model.addController(muscleController);
+    }
+
+    //==========================================================================
+    // 2. OUTPUTREPORTER SETUP: create and add the OutputReporter
+    //==========================================================================
+    OutputReporter* outputReporter = new OutputReporter(&model);
+    outputReporter->append_output_paths("kinetic_energy");
+    outputReporter->append_output_paths("slider/tx/value");
+    outputReporter->append_output_paths("ball/linear_velocity");
+    outputReporter->append_output_paths("ball/angular_acceleration");
+    outputReporter->append_output_paths("ball/acceleration");
+    outputReporter->append_output_paths("slider/reaction_on_child");
+
+    // should print a warning
+    outputReporter->append_output_paths("ball/transform");
+
+    model.addAnalysis(outputReporter);
+
+    model.finalizeFromProperties();
+    model.printBasicInfo();
+
+
+    //==========================================================================
+    // 3. SIMULATION Initialization
+    //==========================================================================
+
+    // Initialize the system and get the default state    
+    SimTK::State& si = model.initSystem();
+
+    model.getMultibodySystem().realize(si, SimTK::Stage::Dynamics);
+    model.equilibrateMuscles(si);
+
+    CoordinateSet& modelCoordinateSet = model.updCoordinateSet();
+
+    // Define non-zero (defaults are 0) states for the free joint
+    // set x-translation value
+    modelCoordinateSet[0].setValue(si, startX, true);
+
+    //==========================================================================
+    // 4. SIMULATION Integration
+    //==========================================================================
+    // Create the integrator
+    SimTK::RungeKuttaMersonIntegrator integrator(model.getMultibodySystem());
+    integrator.setAccuracy(integrationAccuracy);
+
+    // Create the manager
+    Manager manager(model, integrator);
+
+    // Integrate from initial time to final time
+    si.setTime(initialTime);
+    cout << "\nIntegrating from " << initialTime << " to " << finalTime << endl;
+
+    // Start timing the simulation
+    const clock_t start = clock();
+    // simulate
+    manager.integrate(si, finalTime);
+
+    // how long did it take?
+    double comp_time = (double)(clock() - start) / CLOCKS_PER_SEC;
+
+    //==========================================================================
+    // 4. Print the results
+    //==========================================================================
+    model.updAnalysisSet().printResults("testOutputReporter");
+}

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -233,12 +233,14 @@ void simulateMuscle(
 
     // Integrate from initial time to final time
     state.setTime(initialTime);
+    manager.initialize(state);
+
     cout << "\nIntegrating from " << initialTime << " to " << finalTime << endl;
 
     // Start timing the simulation
     const clock_t start = clock();
     // simulate
-    manager.integrate(state, finalTime);
+    state = manager.integrate(finalTime);
 
     // how long did it take?
     double comp_time = (double)(clock() - start) / CLOCKS_PER_SEC;

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -52,15 +52,11 @@ Deactivation0 = 0.4;
 /*
 This function performs a simulation of a muscle.
 @param muscle   a muscle model that satisfies the Muscle interface
-@param startX   the starting position of the muscle anchor. I have no idea
-why this value is included.
 @param act0     the initial i of the muscle
 @param accuracy the desired accuracy of the integrated solution
 @param printResults print the osim model associated with this test.
 */
 void simulateMuscle(const Muscle& muscle,
-                    double startX,
-                    double act0,
                     double integrationAccuracy,
                     bool printResults);
 
@@ -78,18 +74,12 @@ int main()
         muscle.setActivationTimeConstant(Activation0);
         muscle.setDeactivationTimeConstant(Deactivation0);
 
-        double x0 = 1.0;
-        double act0 = 0.2;
-
-
         simulateMuscle( muscle,
-                        x0,
-                        act0,
                         IntegrationAccuracy,
-                    true);
+                        true);
     }
-    catch (const Exception& e) {
-        e.print(cout);
+    catch (const std::exception& e) {
+        cout << e.what();
         failures.push_back("testOutputReporter");
     }
 
@@ -108,8 +98,6 @@ int main()
 //=============================================================================
 void simulateMuscle(
         const Muscle &muscModel,
-        double startX,
-        double act0,
         double integrationAccuracy,
         bool printResults)
 {
@@ -178,26 +166,6 @@ void simulateMuscle(
     muscle->addNewPathPoint("muscle-box", ground, Vec3(anchorWidth / 2, 0, 0));
     muscle->addNewPathPoint("muscle-ball", *ball, Vec3(-ballRadius, 0, 0));
 
-    ActivationFiberLengthMuscle_Deprecated *aflMuscle
-        = dynamic_cast<ActivationFiberLengthMuscle_Deprecated *>(muscle);
-    if (aflMuscle){
-        // Define the default states for the muscle that has 
-        //activation and fiber-length states
-        aflMuscle->setDefaultActivation(act0);
-        aflMuscle->setDefaultFiberLength(aflMuscle->getOptimalFiberLength());
-    }
-    else{
-        ActivationFiberLengthMuscle *aflMuscle2
-            = dynamic_cast<ActivationFiberLengthMuscle *>(muscle);
-        if (aflMuscle2){
-            // Define the default states for the muscle 
-            //that has activation and fiber-length states
-            aflMuscle2->setDefaultActivation(act0);
-            aflMuscle2->setDefaultFiberLength(aflMuscle2
-                ->getOptimalFiberLength());
-        }
-    }
-
     model.addForce(muscle);
 
     // Create a prescribed controller that simply 
@@ -246,7 +214,7 @@ void simulateMuscle(
 
     // Define non-zero (defaults are 0) states for the free joint
     // set x-translation value
-    modelCoordinateSet[0].setValue(state, startX, true);
+    modelCoordinateSet[0].setValue(state, 1.0, true);
 
     //==========================================================================
     // 4. SIMULATION Integration

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -50,11 +50,7 @@ static const double Activation0 = 0.01,
 Deactivation0 = 0.4;
 
 /*
-This function completes a controlled activation, controlled stretch simulation
-of a muscle. After the simulation has completed, the results can be
-tested in a number of different ways to ensure that the muscle model is
-functioning
-
+This function performs a simulation of a muscle.
 @param muscle   a muscle model that satisfies the Muscle interface
 @param startX   the starting position of the muscle anchor. I have no idea
 why this value is included.
@@ -67,7 +63,6 @@ void simulateMuscle(const Muscle& muscle,
                     double act0,
                     double integrationAccuracy,
                     bool printResults);
-
 
 int main()
 {
@@ -108,10 +103,9 @@ int main()
     return 0;
 }
 
-/*==============================================================================
-Main test driver to be used on any muscle model 
-================================================================================
-*/
+//=============================================================================
+// Main simulation driver used to generate Outputs and report them
+//=============================================================================
 void simulateMuscle(
         const Muscle &muscModel,
         double startX,
@@ -218,7 +212,6 @@ void simulateMuscle(
 
     // Add the control set controller to the model
     model.addController(muscleController);
-
 
     //==========================================================================
     // 2. OUTPUTREPORTER SETUP: create and add the OutputReporter

--- a/OpenSim/Analyses/osimAnalyses.h
+++ b/OpenSim/Analyses/osimAnalyses.h
@@ -23,6 +23,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "OutputReporter.h"
 #include "Kinematics.h"
 #include "Actuation.h"
 #include "ForceReporter.h"

--- a/OpenSim/Common/Path.h
+++ b/OpenSim/Common/Path.h
@@ -111,6 +111,9 @@ protected:
     /// the last one.
     std::vector<std::string> getParentPathVec() const
     {
+        if (!getNumPathLevels()) {
+            return std::vector<std::string>{}; 
+        }
         return getSubPathVec(0, getNumPathLevels() - 1);
     }
 

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -848,6 +848,14 @@ void Manager::finalize(SimTK::State& s )
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.end(s);
     }
+    if (_writeToStorage) {
+        SimTK::Vector stateValues = _model->getStateVariableValues(s);
+        StateVector vec;
+        vec.setStates(s.getTime(), stateValues);
+        getStateStorage().append(vec);
+        if (_model->isControlled())
+            _controllerSet->storeControls(s, getStateStorage().getSize());
+    }
 
     return;
 }

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -633,7 +633,7 @@ const SimTK::State& Manager::integrate(double finalTime)
     bool fixedStep = false;
     if (_constantDT || _specifiedDT) fixedStep = true;
 
-    auto status{ SimTK::Integrator::InvalidSuccessfulStepStatus };
+    auto status = SimTK::Integrator::InvalidSuccessfulStepStatus;
 
     if (!fixedStep) {
         _integ->setReturnEveryInternalStep(true);
@@ -680,8 +680,8 @@ const SimTK::State& Manager::integrate(double finalTime)
 
         status = _timeStepper->stepTo(stepToTime);
 
-        if (status == SimTK::Integrator::TimeHasAdvanced ||
-            status == SimTK::Integrator::ReachedScheduledEvent) {
+        if ( (status == SimTK::Integrator::TimeHasAdvanced) ||
+             (status == SimTK::Integrator::ReachedScheduledEvent) ) {
             const SimTK::State& s = _integ->getState();
             if (_performAnalyses) _model->updAnalysisSet().step(s, step);
             if (_writeToStorage) {

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -597,6 +597,11 @@ const SimTK::State& Manager::integrate(double finalTime)
             "initialized. Call Manager::initialize() first.");
     }
 
+    // Make sure that integrator is not stuck in a EndOfSimulation from
+    // a previous integrate call with the final state (last integrated).
+    const SimTK::State& s = _integ->getState();
+    _integ->initialize(s);
+
     // Set the final time on the integrator so it can signal EndOfSimulation
     _integ->setFinalTime(finalTime);
 
@@ -605,7 +610,6 @@ const SimTK::State& Manager::integrate(double finalTime)
     clearHalt();
 
     // CHECK SPECIFIED DT STEPPING
-    const SimTK::State& s = _integ->getState();
     double initialTime = s.getTime();
     if (_specifiedDT) {
         if (_tArray.getSize() <= 0) {

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -50,8 +50,7 @@ std::string Manager::_displayName = "Simulator";
 //=============================================================================
 // CONSTRUCTOR(S)
 //=============================================================================
-Manager::Manager(Model& model) 
-        : Manager(model, true)
+Manager::Manager(Model& model) : Manager(model, true)
 {
     _defaultInteg.reset(
             new SimTK::RungeKuttaMersonIntegrator(_model->getMultibodySystem()));

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -302,7 +302,7 @@ private:
     void initializeTimeStepper(const SimTK::State& s);
 
     // Helper functions for Manager::integrate()
-    void finalize(SimTK::State& s);
+    void finalize(const SimTK::State& s);
 
 //=============================================================================
 };  // END of class Manager

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -301,8 +301,9 @@ private:
     void initializeStorageAndAnalyses(const SimTK::State& s);
     void initializeTimeStepper(const SimTK::State& s);
 
-    // Helper functions for Manager::integrate()
-    void finalize(const SimTK::State& s);
+    // Helper to record state and analysis values at integration steps.
+    // step = 0 is the beginning, step = -1 used to denote the end/final step
+    void record(const SimTK::State& s, const int& step);
 
 //=============================================================================
 };  // END of class Manager

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -248,6 +248,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( ProbeSet() );
     Object::registerType( JointInternalPowerProbe() );
     Object::registerType( SystemEnergyProbe() );
+    Object::registerType( ActuatorForceProbe());
     Object::registerType( Umberger2010MuscleMetabolicsProbe() );
     Object::registerType( Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameterSet() );
     Object::registerType( Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter() );

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -211,11 +211,6 @@ void integrateOpenSimModel(Model *osimModel, SimTK::State &osim_state)
 
     Manager manager(*osimModel,  integrator);
 
-    // Specify the initial and final times of the simulation.
-    // In this case, the initial and final times are set based on
-    // the range of times over which the controls are available.
-    //Control *control;
-    osim_state.setTime(0.0);
     manager.initialize(osim_state);
     osim_state = manager.integrate(duration);
 }
@@ -309,8 +304,8 @@ void compareSimulations(SimTK::MultibodySystem &system, SimTK::State &state, Mod
     // Get the state at the end of the integration from OpenSim.
     Vector& qf = osim_state.updQ();
     Vector& uf = osim_state.updU();
-    cout<<"\nOpenSim Final q's:\n "<<qf<<endl;
-    cout<<"\nOpenSim Final u's:\n "<<uf<<endl;
+    qf.dump("\nOpenSim Final q's:");
+    uf.dump("\nOpenSim Final u's:");
 
     //==========================================================================================================
     // Compare Simulation Results
@@ -475,6 +470,12 @@ void testConstantDistanceConstraint()
 void testCoordinateLocking()
 {
     using namespace SimTK;
+
+    cout << endl;
+    cout << "==================================================================" << endl;
+    cout << " OpenSim testCoordinateLocking " << endl;
+    cout << "==================================================================" << endl;
+
 
     double fixedKneeAngle = Pi/2;
 

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -42,7 +42,6 @@
 #include <OpenSim/Simulation/Model/BodySet.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Analyses/Kinematics.h>
-#include <OpenSim/Analyses/PointKinematics.h>
 #include <OpenSim/Analyses/Actuation.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/PrescribedForce.h>

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -152,22 +152,21 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
     // Compute the force and torque at the specified times.
 
     const OpenSim::Body& body = osimModel->getBodySet().get("ball");
-
+    osim_state.setTime(0.0);
     RungeKuttaMersonIntegrator integrator(osimModel->getMultibodySystem() );
     Manager manager(*osimModel,  integrator);
-    osim_state.setTime(0.0);
+    
     for (unsigned int i = 0; i < times.size(); ++i)
     {
         manager.integrate(osim_state, times[i]);
+        ASSERT_EQUAL(osim_state.getTime(), times[i], SimTK::Eps);
+
         osimModel->getMultibodySystem().realize(osim_state, Stage::Acceleration);
         Vec3 accel = body.findStationAccelerationInGround(osim_state, Vec3(0));
         Vec3 angularAccel = body.getAccelerationInGround(osim_state)[0];
-        ASSERT_EQUAL(accelerations[i][0], accel[0], 1e-10);
-        ASSERT_EQUAL(accelerations[i][1], accel[1], 1e-10);
-        ASSERT_EQUAL(accelerations[i][2], accel[2], 1e-10);
-        ASSERT_EQUAL(angularAccelerations[i][0], angularAccel[0], 1e-10);
-        ASSERT_EQUAL(angularAccelerations[i][1], angularAccel[1], 1e-10);
-        ASSERT_EQUAL(angularAccelerations[i][2], angularAccel[2], 1e-10);
+
+        ASSERT_EQUAL(accelerations[i], accel, SimTK::Eps);
+        ASSERT_EQUAL(angularAccelerations[i], angularAccel, SimTK::Eps);
     }
 }
 


### PR DESCRIPTION
Fixes issue #1977
This PR doesn't create a separate `Tool`, but simply creates an `Analysis` that wraps the `TableReporter` Component. The `OutputReporter` Analysis creates and adds the `TableReporter`(s) according to the types of the `Outputs` that are listed in the property of the `Analysis`. 

### Brief summary of changes
Added `OutputReporter` as an `Analysis` that so that `Outputs` can be  reported on via the `ForwardTool` and `AnalzeTool` in the GUI. Only Outputs or type `double`, `SimTK::Vec3` and `SimTK::SpatialVec` are supported. This is intended to be a short term solution until the GUI adds support  for wiring Inputs and Outputs and for adding `Reporters` so we can deprecate Analyses.

### Testing I've completed
- added `OutputReporter` with various outputs of different types.
- verified that underlying tables are written to file.
- verified that values reported, written to file and reloaded correspond to model values

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because adds an Analysis,  but does affect existing Analyses.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
