### PR TITLE
Catch exception for binary vtp.

### DIFF
--- a/OpenSim/Tests/VisualizeModel/CMakeLists.txt
+++ b/OpenSim/Tests/VisualizeModel/CMakeLists.txt
@@ -3,7 +3,7 @@ set(VISUALIZE_MODEL visualizeModel)
 
 add_executable(${VISUALIZE_MODEL} VisualizeModel.cpp)
 
-target_link_libraries(${VISUALIZE_MODEL} osimTools)
+target_link_libraries(${VISUALIZE_MODEL} osimAnalyses)
 
 set_target_properties(${VISUALIZE_MODEL}        
        PROPERTIES        

--- a/OpenSim/Tests/VisualizeModel/VisualizeModel.cpp
+++ b/OpenSim/Tests/VisualizeModel/VisualizeModel.cpp
@@ -30,7 +30,8 @@
 
 //==============================================================================
 //==============================================================================
-#include <OpenSim/OpenSim.h>
+#include <OpenSim/Common/IO.h>
+#include <OpenSim/Simulation/Model/Model.h>
 
 using namespace OpenSim;
 using namespace SimTK;


### PR DESCRIPTION
Addresses part of #1729 

### Brief summary of changes

- Catch the exception that is thrown if a VTP file is binary, and print the exception message:

```
Visualizer couldn't open hat_ribs_scap.vtp because:
SimTK Exception thrown at PolygonalMesh.cpp:411:
  Error detected by Simbody method PolygonalMesh::loadVtpFile(): Attempt to load a VTK PolyData (.vtp) file from file name '/Users/chris/repos/opensim32/1/install/Geometry/hat_ribs_scap.vtp' failed with message:
  SimTK Exception thrown at PolygonalMesh.cpp:340:
  Error detected by Simbody method PolygonalMesh::loadVtpFile(): Only format="ascii" is supported for .vtpfile DataArray elements, got format="appended" for Points DataArray.
  (Required condition 'pointData.getRequiredAttributeValue("format") == "ascii"' was not met.)

  (Required condition '!"failed"' was not met.)
```

- I made sure to add the check when visualizing, *not* in `extendFinalizeFromProperties()`, to avoid slowing down `initSystem()`.

### Testing I've completed

- Used the handy `visualizeModel` exectuable to load a model that pointed to a binary VTP file, and ensured the model initially did not visualize, and that with these changes, the model visualized and an error message was printed. 

### Looking for feedback on...

@aymanhab can you test this in the GUI?

Do we have any advice to give to users about how to convert binary VTP files to other formats?

### CHANGELOG.md (choose one)

- no need to update because...we never supported binary VTP files in opensim-core; we just handle the error silently now.

