### PR TITLE
Fix bug preventing writing non-string metadata.

### DIFF
--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -542,9 +542,10 @@ DelimFileAdapter<T>::extendWrite(const InputTables& absTables,
 
     // First line of the stream is the header.
     if (table->getTableMetaData().hasKey("header")) {
-        out_stream << table->
-                      getTableMetaData().
-                      getValueForKey("header").getValueAsString() << "\n";
+        const auto& header = table->getTableMetaData().getValueForKey("header");
+        // TODO We assume the header is of type std::string.
+        // This is usually the case, but we don't enforce this anywhere.
+        out_stream << header.template getValue<std::string>() << "\n";
     }
     // Write rest of the key-value pairs and end the header.
     for(const auto& key : table->getTableMetaDataKeys()) {

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -544,17 +544,14 @@ DelimFileAdapter<T>::extendWrite(const InputTables& absTables,
     if (table->getTableMetaData().hasKey("header")) {
         out_stream << table->
                       getTableMetaData().
-                      getValueForKey("header").
-                      template getValue<std::string>() << "\n";
+                      getValueForKey("header").getValueAsString() << "\n";
     }
     // Write rest of the key-value pairs and end the header.
     for(const auto& key : table->getTableMetaDataKeys()) {
         try {
             if(key != "header")
                 out_stream << key << "=" 
-                           << table->
-                              template getTableMetaData<std::string>(key) 
-                           << "\n";
+                           << table->getTableMetaDataAsString(key) << "\n";
         } catch(const InvalidTemplateArgument&) {}
     }
     // Write name of the data-type -- vec3, vec6, etc.


### PR DESCRIPTION
### Brief summary of changes

This PR fixes a bug when writing a table that contains non-string table metadata: it doesn't get serialized. The reason is that all metadadta was assumed to be of type `std::string`.

An issue remains that when reading a table, all metadata is assumed to be `std::string`. This is harder to fix, because we do not write type information to the file.

### Testing I've completed

- Tested that this fix works with Muscollo.

### CHANGELOG.md (choose one)

- no need to update because...file adapters are new in 4.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2002)
<!-- Reviewable:end -->
