### PR TITLE
Write scale results to folder with setupfile

### DIFF
--- a/OpenSim/Common/PropertyStr.h
+++ b/OpenSim/Common/PropertyStr.h
@@ -95,7 +95,7 @@ public:
     void clearValue() { _value = getDefaultStr(); setValueIsDefault(true); }
     static const std::string& getDefaultStr();
 
-    bool isValidFileName() { return _value!="" && _value!=getDefaultStr(); }
+    bool isValidFileName() const { return _value!="" && _value!=getDefaultStr(); }
 
 //=============================================================================
 };  // END of class PropertyStr

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -391,19 +391,19 @@ bool MarkerPlacer::processModel(Model* aModel,
     //_outputStorage->print("statesReporterOutputWithMarkers.sto");
 
     if(_printResultFiles) {
-        if (!_outputModelFileNameProp.getValueIsDefault())
+        if (!_outputModelFileNameProp.isValidFileName())
         {
             aModel->print(aPathToSubject + _outputModelFileName);
             cout << "Wrote model file " << _outputModelFileName << " from model " << aModel->getName() << endl;
         }
 
-        if (!_outputMarkerFileNameProp.getValueIsDefault())
+        if (!_outputMarkerFileNameProp.isValidFileName())
         {
             aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
             cout << "Wrote marker file " << _outputMarkerFileName << " from model " << aModel->getName() << endl;
         }
         
-        if (!_outputMotionFileNameProp.getValueIsDefault())
+        if ( _outputMotionFileNameProp.isValidFileName())
         {
             _outputStorage->print(aPathToSubject + _outputMotionFileName, 
                 "w", "File generated from solving marker data for model "+aModel->getName());

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -37,6 +37,7 @@
 #include "IKCoordinateTask.h"
 #include "IKTaskSet.h"
 #include <OpenSim/Analyses/StatesReporter.h>
+#include <OpenSim/Common/IO.h>
 //=============================================================================
 // STATICS
 //=============================================================================
@@ -391,6 +392,9 @@ bool MarkerPlacer::processModel(Model* aModel,
     //_outputStorage->print("statesReporterOutputWithMarkers.sto");
 
     if(_printResultFiles) {
+        std::string savedCwd = IO::getCwd();
+        IO::chDir(aPathToSubject);
+
         if (_outputModelFileNameProp.isValidFileName()) {
             aModel->print(aPathToSubject + _outputModelFileName);
             cout << "Wrote model file " << _outputModelFileName <<
@@ -408,6 +412,7 @@ bool MarkerPlacer::processModel(Model* aModel,
                 "w", "File generated from solving marker data for model "
                 + aModel->getName());
         }
+        IO::chDir(savedCwd);
     }
 
     return true;

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -395,22 +395,29 @@ bool MarkerPlacer::processModel(Model* aModel,
         std::string savedCwd = IO::getCwd();
         IO::chDir(aPathToSubject);
 
-        if (_outputModelFileNameProp.isValidFileName()) {
-            aModel->print(aPathToSubject + _outputModelFileName);
-            cout << "Wrote model file " << _outputModelFileName <<
-                " from model " << aModel->getName() << endl;
-        }
+        try { // writing can throw an exception
+            if (_outputModelFileNameProp.isValidFileName()) {
+                aModel->print(aPathToSubject + _outputModelFileName);
+                cout << "Wrote model file " << _outputModelFileName <<
+                    " from model " << aModel->getName() << endl;
+            }
 
-        if (_outputMarkerFileNameProp.isValidFileName()) {
-            aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
-            cout << "Wrote marker file " << _outputMarkerFileName <<
-                " from model " << aModel->getName() << endl;
-        }
-        
-        if ( _outputMotionFileNameProp.isValidFileName()) {
-            _outputStorage->print(aPathToSubject + _outputMotionFileName, 
-                "w", "File generated from solving marker data for model "
-                + aModel->getName());
+            if (_outputMarkerFileNameProp.isValidFileName()) {
+                aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
+                cout << "Wrote marker file " << _outputMarkerFileName <<
+                    " from model " << aModel->getName() << endl;
+            }
+
+            if (_outputMotionFileNameProp.isValidFileName()) {
+                _outputStorage->print(aPathToSubject + _outputMotionFileName,
+                    "w", "File generated from solving marker data for model "
+                    + aModel->getName());
+            }
+        } // catch the exception so we can reset the working directory
+        catch (std::exception& ex) {
+            IO::chDir(savedCwd);
+            // now re-throw in context of ModelPlacer
+            OPENSIM_THROW_FRMOBJ(Exception, ex.what());
         }
         IO::chDir(savedCwd);
     }

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -391,22 +391,22 @@ bool MarkerPlacer::processModel(Model* aModel,
     //_outputStorage->print("statesReporterOutputWithMarkers.sto");
 
     if(_printResultFiles) {
-        if (!_outputModelFileNameProp.isValidFileName())
-        {
+        if (_outputModelFileNameProp.isValidFileName()) {
             aModel->print(aPathToSubject + _outputModelFileName);
-            cout << "Wrote model file " << _outputModelFileName << " from model " << aModel->getName() << endl;
+            cout << "Wrote model file " << _outputModelFileName <<
+                " from model " << aModel->getName() << endl;
         }
 
-        if (!_outputMarkerFileNameProp.isValidFileName())
-        {
+        if (_outputMarkerFileNameProp.isValidFileName()) {
             aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
-            cout << "Wrote marker file " << _outputMarkerFileName << " from model " << aModel->getName() << endl;
+            cout << "Wrote marker file " << _outputMarkerFileName <<
+                " from model " << aModel->getName() << endl;
         }
         
-        if ( _outputMotionFileNameProp.isValidFileName())
-        {
+        if ( _outputMotionFileNameProp.isValidFileName()) {
             _outputStorage->print(aPathToSubject + _outputMotionFileName, 
-                "w", "File generated from solving marker data for model "+aModel->getName());
+                "w", "File generated from solving marker data for model "
+                + aModel->getName());
         }
     }
 

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -416,7 +416,6 @@ bool MarkerPlacer::processModel(Model* aModel,
         } // catch the exception so we can reset the working directory
         catch (std::exception& ex) {
             IO::chDir(savedCwd);
-            // now re-throw in context of ModelPlacer
             OPENSIM_THROW_FRMOBJ(Exception, ex.what());
         }
         IO::chDir(savedCwd);

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -311,21 +311,20 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
         /* Now scale the model. */
         aModel->scale(s, theScaleSet, aSubjectMass, _preserveMassDist);
 
-
         if(_printResultFiles) {
             std::string savedCwd = IO::getCwd();
             IO::chDir(aPathToSubject);
 
-            if (!_outputModelFileNameProp.getValueIsDefault())
-            {
+            if (_outputModelFileNameProp.isValidFileName()) {
                 if (aModel->print(_outputModelFileName))
-                    cout << "Wrote model file " << _outputModelFileName << " from model " << aModel->getName() << endl;
+                    cout << "Wrote model file " << _outputModelFileName <<
+                        " from model " << aModel->getName() << endl;
             }
 
-            if (!_outputScaleFileNameProp.getValueIsDefault())
-            {
+            if (_outputScaleFileNameProp.isValidFileName()) {
                 if (theScaleSet.print(_outputScaleFileName))
-                    cout << "Wrote scale file " << _outputScaleFileName << " for model " << aModel->getName() << endl;
+                    cout << "Wrote scale file " << _outputScaleFileName <<
+                        " for model " << aModel->getName() << endl;
             }
             IO::chDir(savedCwd);
         }

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -326,7 +326,7 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
                         cout << "Wrote scale file " << _outputScaleFileName <<
                         " for model " << aModel->getName() << endl;
                 }
-            }
+            } // catch the exception so we can reset the working directory
             catch (std::exception& ex) {
                 IO::chDir(savedCwd);
                 OPENSIM_THROW_FRMOBJ(Exception, ex.what());

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -314,23 +314,27 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
         if(_printResultFiles) {
             std::string savedCwd = IO::getCwd();
             IO::chDir(aPathToSubject);
-
-            if (_outputModelFileNameProp.isValidFileName()) {
-                if (aModel->print(_outputModelFileName))
-                    cout << "Wrote model file " << _outputModelFileName <<
+            try { // writing can throw an exception
+                if (_outputModelFileNameProp.isValidFileName()) {
+                    if (aModel->print(_outputModelFileName))
+                        cout << "Wrote model file " << _outputModelFileName <<
                         " from model " << aModel->getName() << endl;
-            }
+                }
 
-            if (_outputScaleFileNameProp.isValidFileName()) {
-                if (theScaleSet.print(_outputScaleFileName))
-                    cout << "Wrote scale file " << _outputScaleFileName <<
+                if (_outputScaleFileNameProp.isValidFileName()) {
+                    if (theScaleSet.print(_outputScaleFileName))
+                        cout << "Wrote scale file " << _outputScaleFileName <<
                         " for model " << aModel->getName() << endl;
+                }
+            }
+            catch (std::exception& ex) {
+                IO::chDir(savedCwd);
+                OPENSIM_THROW_FRMOBJ(Exception, ex.what());
             }
             IO::chDir(savedCwd);
         }
     }
-    catch (const Exception& x)
-    {
+    catch (const Exception& x) {
         x.print(cout);
         return false;
     }


### PR DESCRIPTION
Fixes issue #1957
There were two bugs addressed: 
1. "*Unassigned*" files were always being written out because the check used was inadequate. This included both `MarkerSet` and `ScaleSet` files from the `MarkerPlacer` and `ModelScaler`, respectively.

2. The `ModelScaler` updates the working directory to the location of the `ScaleTool` setup file (`ScaleTool` it calls it the `_pathToSubject`), but he `MarkerPlacer` receives the same path in its `processModel` method except it was not doing anything with it.

### Brief summary of changes
1. Employ `PropertyStr::isValidFileName()` to check for the validity of filenames. *Unassigned* fails this test so these files are not longer written out.
2. Make  `MarkerPlacer::processModel` change directory to the the setup file directory (like `ModelScaler` does) upon printing results.
 
### Testing I've completed
- verified that Unassigned files are no longer printed.
- verified that all `testScale` generated files are written to the directory with the setup file. 

### Looking for feedback on...
- verification that in the GUI files are not written to the application directory

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

