### PR TITLE
Return a const reference to scale factors rather than a copy of the Vec3

### DIFF
--- a/OpenSim/Simulation/Model/Frame.cpp
+++ b/OpenSim/Simulation/Model/Frame.cpp
@@ -199,8 +199,8 @@ void Frame::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
         return;
 
     // Get scale factors (if an entry for the base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, *this);
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, *this);
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     scaleAttachedGeometry(scaleFactors);

--- a/OpenSim/Simulation/Model/ModelComponent.cpp
+++ b/OpenSim/Simulation/Model/ModelComponent.cpp
@@ -137,7 +137,10 @@ void ModelComponent::scale(const SimTK::State& s, const ScaleSet& scaleSet)
 void ModelComponent::postScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {   extendPostScale(s, scaleSet); }
 
-SimTK::Vec3 ModelComponent::
+// (static) Returned by getScaleFactors() if scale factors not found.
+const SimTK::Vec3 ModelComponent::InvalidScaleFactors = SimTK::Vec3(0);
+
+const SimTK::Vec3& ModelComponent::
 getScaleFactors(const ScaleSet& scaleSet, const Frame& frame) const
 {
     const std::string& baseFrameName = frame.findBaseFrame().getName();
@@ -147,7 +150,7 @@ getScaleFactors(const ScaleSet& scaleSet, const Frame& frame) const
             return scaleSet[i].getScaleFactors();
 
     // No scale factors found for the base Body.
-    return SimTK::Vec3(SimTK::NaN);
+    return InvalidScaleFactors;
 }
 
 } // end of namespace OpenSim

--- a/OpenSim/Simulation/Model/ModelComponent.h
+++ b/OpenSim/Simulation/Model/ModelComponent.h
@@ -139,10 +139,14 @@ public:
     void postScale(const SimTK::State& s, const ScaleSet& scaleSet);
 
     /** Get the scale factors corresponding to the base OpenSim::Body of the
-        specified Frame. Returns SimTK::Vec3(SimTK::NaN) if the ScaleSet does
-        not contain scale factors for the base Body. */
-    SimTK::Vec3 getScaleFactors(const ScaleSet& scaleSet,
-                                const Frame& frame) const;
+        specified Frame. Returns ModelComponent::InvalidScaleFactors if the
+        ScaleSet does not contain scale factors for the base Body. */
+    const SimTK::Vec3& getScaleFactors(const ScaleSet& scaleSet,
+                                       const Frame& frame) const;
+
+    /** Returned by getScaleFactors() if the ScaleSet does not contain scale
+        factors for the base Body associated with the specified Frame. */
+    static const SimTK::Vec3 InvalidScaleFactors;
 
 protected:
     /** Perform any computations that must occur before ModelComponent::scale()

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -317,8 +317,8 @@ extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     if (!_xCoordinate.empty()) {

--- a/OpenSim/Simulation/Model/OffsetFrame.h
+++ b/OpenSim/Simulation/Model/OffsetFrame.h
@@ -323,9 +323,9 @@ extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const SimTK::Vec3 scaleFactors =
+    const SimTK::Vec3& scaleFactors =
         this->getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     upd_translation() = get_translation().elementwiseMultiply(scaleFactors);

--- a/OpenSim/Simulation/Model/PathPoint.cpp
+++ b/OpenSim/Simulation/Model/PathPoint.cpp
@@ -96,8 +96,8 @@ void PathPoint::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     // Note: Currently, PathPoint and its Station subcomponent both have a

--- a/OpenSim/Simulation/Model/Station.cpp
+++ b/OpenSim/Simulation/Model/Station.cpp
@@ -115,8 +115,8 @@ void Station::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     upd_location() = get_location().elementwiseMultiply(scaleFactors);

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -195,8 +195,8 @@ void Body::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for this Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, *this);
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, *this);
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     upd_mass_center() = get_mass_center().elementwiseMultiply(scaleFactors);
@@ -327,8 +327,8 @@ void Body::scaleInertialProperties(const SimTK::Vec3& scaleFactors, bool scaleMa
 void Body::scaleInertialProperties(const ScaleSet& scaleSet, bool scaleMass)
 {
     // Get scale factors (if an entry for this Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, *this);
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, *this);
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     scaleInertialProperties(scaleFactors, scaleMass);

--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
@@ -253,9 +253,9 @@ extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
 
     // Get scale factors (if there exists an entry for the base Body of the
     // Joint's parent Frame).
-    const Vec3 scaleFactors =
+    const Vec3& scaleFactors =
         getScaleFactors(scaleSet, depCoordinate.getJoint().getParentFrame());
-    if (scaleFactors.isNaN())
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     // Constraint scale factor. Assume uniform scaling unless proven otherwise.

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -130,8 +130,8 @@ void CustomJoint::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     //TODO: Need to scale transforms appropriately, given an arbitrary axis.

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -108,8 +108,8 @@ extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     //TODO: Need to scale transforms appropriately, given an arbitrary axis.

--- a/OpenSim/Simulation/Wrap/WrapCylinder.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinder.cpp
@@ -85,8 +85,8 @@ void WrapCylinder::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     // _pose.x() holds the ellipsoid's X-axis expressed in the body's reference

--- a/OpenSim/Simulation/Wrap/WrapEllipsoid.cpp
+++ b/OpenSim/Simulation/Wrap/WrapEllipsoid.cpp
@@ -144,8 +144,8 @@ void WrapEllipsoid::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     // _pose.x() holds the ellipsoid's X-axis expressed in the body's reference

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -87,8 +87,8 @@ void WrapObject::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     upd_translation() = get_translation().elementwiseMultiply(scaleFactors);

--- a/OpenSim/Simulation/Wrap/WrapSphere.cpp
+++ b/OpenSim/Simulation/Wrap/WrapSphere.cpp
@@ -134,8 +134,8 @@ void WrapSphere::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     _radius *= (scaleFactors.sum() / 3.);

--- a/OpenSim/Simulation/Wrap/WrapTorus.cpp
+++ b/OpenSim/Simulation/Wrap/WrapTorus.cpp
@@ -120,8 +120,8 @@ void WrapTorus::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
     Super::extendScale(s, scaleSet);
 
     // Get scale factors (if an entry for the Frame's base Body exists).
-    const Vec3 scaleFactors = getScaleFactors(scaleSet, getFrame());
-    if (scaleFactors.isNaN())
+    const Vec3& scaleFactors = getScaleFactors(scaleSet, getFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
         return;
 
     // _pose.x() holds the torus's X-axis expressed in the body's reference


### PR DESCRIPTION
Fixes issue #1998.

### Brief summary of changes
Changed return of `ModelComponent::getScaleFactors()` from `Vec3` to `const Vec3&` to avoid making a copy of the `Vec3`.

### Testing I've completed
Tests pass locally.

### Looking for feedback on...
@aseth1 suggested (in #1998 via #1994) to make the static const a *private* data member, but then I wouldn't be able to check `if (scaleFactors == InvalidScaleFactors)` in the derived classes (unless they're friends, which doesn't seem like the proper design). I've made the static const a public member because `getScaleFactors()` is public (and, presumably, anyone who can call `getScaleFactors()` would want to use `InvalidScaleFactors` to check the return). Question: should `getScaleFactors()` and `InvalidScaleFactors` be protected instead?

### CHANGELOG.md (choose one)
- no need to update because... internal cleanup from aisle #1994.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
