### PR TITLE
Storage constructor can read version 2 STO files

### DIFF
--- a/OpenSim/Analyses/ForceReporter.h
+++ b/OpenSim/Analyses/ForceReporter.h
@@ -104,7 +104,7 @@ public:
     
     /** Get forces table.                                                     */
     TimeSeriesTable getForcesTable() const {
-        return _forceStore.getAsTimeSeriesTable();
+        return _forceStore.exportToTable();
     }
 
     // MODEL

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -1268,7 +1268,7 @@ Storage::getColumnIndicesForIdentifier(const std::string& identifier) const
     return found;
 }
 
-TimeSeriesTable Storage::getAsTimeSeriesTable() const {
+TimeSeriesTable Storage::exportToTable() const {
     TimeSeriesTable table{};
 
     table.addTableMetaData("header", getName());

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -36,9 +36,26 @@
 #include "SimTKcommon.h"
 #include "GCVSpline.h"
 #include "StateVector.h"
+#include "STOFileAdapter.h"
+#include "TimeSeriesTable.h"
 
 using namespace OpenSim;
 using namespace std;
+
+void convertTableToStorage(const TimeSeriesTable& table, Storage& sto) {
+    sto.purge();
+    OpenSim::Array<std::string> labels("", (int)table.getNumColumns() + 1);
+    labels[0] = "time";
+    for (int i = 0; i < (int)table.getNumColumns(); ++i) {
+        labels[i + 1] = table.getColumnLabel(i);
+    }
+    sto.setColumnLabels(labels);
+    const auto& times = table.getIndependentColumn();
+    for (unsigned i_time = 0; i_time < table.getNumRows(); ++i_time) {
+        auto rowView = table.getRowAtIndex(i_time);
+        sto.append(times[i_time], SimTK::Vector(rowView.transpose()));
+    }
+}            
 
 
 //============================================================================
@@ -130,9 +147,14 @@ Storage::Storage(const string &aFileName, bool readHeadersOnly) :
     // Motion files from SIMM are in degrees
     if (_fileVersion < 1 && (0 == aFileName.compare (aFileName.length() - 4, 4, ".mot"))) _inDegrees = true;
     if (_fileVersion < 1) cout << ".. assuming rotations in " << (_inDegrees?"Degrees.":"Radians.") << endl;
-    if(_fileVersion > 1)
-      throw Exception{"Error: File version (" + std::to_string(_fileVersion) +
-                      ") not supported. Use STOFileAdapter instead."};
+    if(_fileVersion > 1) {
+        OPENSIM_THROW_IF(readHeadersOnly, Exception, 
+                "Cannot read headers only if STO version is greater than 1.");
+        TimeSeriesTable table = STOFileAdapter::read(aFileName);
+        convertTableToStorage(table, *this);
+        return;
+    }
+
     // IGNORE blank lines after header -- treat \r and \n as end of line chars
     while(fp->good()) {
         int c = fp->peek();

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -195,7 +195,8 @@ public:
     int getDataColumn(const std::string& columnName,double *&rData) const;
     void getDataColumn(const std::string& columnName, Array<double>& data, double startTime=0.0) override;
 
-    /** Convert to a TimeSeriesTable (new in 4.0).                            */
+    /** Convert to a TimeSeriesTable. This may be useful if you need to use
+    parts of the API that require a TimeSeriesTable instead of a Storage. */
     TimeSeriesTable exportToTable() const;
 
 #ifndef SWIG

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -191,8 +191,8 @@ public:
     int getDataColumn(const std::string& columnName,double *&rData) const;
     void getDataColumn(const std::string& columnName, Array<double>& data, double startTime=0.0) override;
 
-    /** Get a TimeSeriesTable out of the Storage.                             */
-    TimeSeriesTable getAsTimeSeriesTable() const;
+    /** Convert to a TimeSeriesTable (new in 4.0).                            */
+    TimeSeriesTable exportToTable() const;
 
 #ifndef SWIG
     /** A data block, like a vector for a force, point, etc... will span multiple "columns"

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -112,6 +112,10 @@ public:
     // make this constructor explicit so you don't get implicit casting of int to Storage
     explicit Storage(int aCapacity=Storage_DEFAULT_CAPACITY,
         const std::string &aName="UNKNOWN");
+    /** Load a STO file.
+    <b>Version 2 STO files</b>: This constructor can read version 1 and version 2
+    STO files. However, most metadata from a version 2 STO file will not be
+    preserved. Use STOFileAdapter and TimeSeriesTable instead, if possible. */
     Storage(const std::string &aFileName, bool readHeadersOnly=false) SWIG_DECLARE_EXCEPTION;
     Storage(const Storage &aStorage,bool aCopyData=true);
     Storage(const Storage &aStorage,int aStateIndex,int aN,

--- a/OpenSim/Common/Test/testStorage.cpp
+++ b/OpenSim/Common/Test/testStorage.cpp
@@ -34,7 +34,7 @@ int main() {
         //checkRunDirFile << "Run from here:\n\n";
         //checkRunDirFile.close();
         string stdLabels[] = {"time", "v1", "v2"};
-        Storage* st = new Storage("test.sto");
+        std::unique_ptr<Storage> st(new Storage("test.sto"));
         // time[\t]v1[\t]v2
         // 1.[\t]   10.0[Space]20
         // 2.[\t\t] 20.0[\t]40
@@ -71,7 +71,13 @@ int main() {
         diff = st->compareColumn(st2, stdLabels[2], 0.);
         ASSERT(fabs(diff) < 1E-7);
 
-        delete st;
+        // Loading version 2 storage file with Storage class.
+        auto table = st->exportToTable();
+        STOFileAdapter::write(table, "testStorage_version2.sto");
+        // Now read using Storage() constructor.
+        Storage stVersion2("testStorage_version2.sto");
+        // Compare with st.
+        SimTK_TEST_EQ(table.getMatrix(), stVersion2.exportToTable().getMatrix());
     }
     catch (const Exception& e) {
         e.print(cerr);

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -569,7 +569,7 @@ getStateStorage() const
 }
 
 TimeSeriesTable Manager::getStatesTable() const {
-    return getStateStorage().getAsTimeSeriesTable();
+    return getStateStorage().exportToTable();
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/ControllerSet.cpp
+++ b/OpenSim/Simulation/Model/ControllerSet.cpp
@@ -157,7 +157,7 @@ void ControllerSet::printControlStorage( const string& fileName)  const
 }
 
 TimeSeriesTable ControllerSet::getControlTable() const {
-    return _controlStore->getAsTimeSeriesTable();
+    return _controlStore->exportToTable();
 }
 
 void ControllerSet::setActuators( Set<Actuator>& as) 


### PR DESCRIPTION
Fixes #1983 

### Brief summary of changes

- Allow Storage to read version 2 storage files, as we agreed in a dev meeting a while ago.
- Renamed `Storage::getTimeSeriesTable()` to `Storage::exportToTable()`.

### Testing I've completed

- Added test case to `testStorage`.

### Looking for feedback on...

@jimmyDunne can you test this locally with the inverse dynamics tool and a version 2 storage file?

### CHANGELOG.md (choose one)

- no need to update because...version 2 storage files are new in 4.0.
