### PR TITLE
Deploy CI on beta branch 4.0dev_nov2017

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -311,7 +311,8 @@ deploy:
   skip_cleanup: true
   script: rsync --archive --compress --verbose ~/to_deploy/$ZIPNAME opensim-bot@frs.sourceforge.net:/home/frs/project/myosin/opensim-core/
   on:
-    branch: master 
+    # TODO temporarily deply on beta branch so GUI doesn't depend directly on master.
+    branch: 4.0beta_nov2017 
     # Upload for both linux (once) and OSX. Might need to modify the condition
     # if we change the build matrix.
     condition: "$DEPLOY = yes"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,8 @@ init:
   - SET JAVA_HOME=%JAVA_DIR%
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # Detect if we are on the master branch; if so, we will deploy binaries.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  # TODO temporarily deploy on beta branch, to help with GUI build.
+  - IF %APPVEYOR_REPO_BRANCH% EQU 4.0beta_nov2017 IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
 
 nuget:
   account_feed: true


### PR DESCRIPTION
This PR causes CI to only deploy on the branch `4.0dev_nov2017` instead of `master`. 

@aymanhab after this PR is merged to master, you'll need to merge it into `4.0dev_nov2017` yourself. You can use a GitHub PR to do that, if you want.

I've already created the `4.0dev_nov2017` branch.