### PR TITLE
Add accessor to MarkersReference for TimeSeriesTable retrieval.

### DIFF
--- a/OpenSim/Simulation/MarkersReference.cpp
+++ b/OpenSim/Simulation/MarkersReference.cpp
@@ -135,7 +135,7 @@ const SimTK::Array_<std::string>& MarkersReference::getNames() const {
     return _markerNames;
 }
 
-void  MarkersReference::getValues(const SimTK::State& s,
+void MarkersReference::getValues(const SimTK::State& s,
                                   SimTK::Array_<Vec3>& values) const {
     double time = s.getTime();
     const auto rowView = _markerTable.getNearestRow(time);

--- a/OpenSim/Simulation/MarkersReference.cpp
+++ b/OpenSim/Simulation/MarkersReference.cpp
@@ -162,6 +162,10 @@ void MarkersReference::getWeights(const SimTK::State &s,
     weights = _weights;
 }
 
+const TimeSeriesTable_<SimTK::Vec3>& MarkersReference::getMarkerTable() const {
+    return _markerTable;
+}
+
 void
 MarkersReference::setMarkerWeightSet(const Set<MarkerWeight>& markerWeights) {
     upd_marker_weights() = markerWeights;

--- a/OpenSim/Simulation/MarkersReference.h
+++ b/OpenSim/Simulation/MarkersReference.h
@@ -149,6 +149,8 @@ public:
         same order as names*/
     void getWeights(const SimTK::State &s,
                     SimTK::Array_<double> &weights) const override;
+    /** get the marker trajectories in a table*/
+    const TimeSeriesTable_<SimTK::Vec3>& getMarkerTable() const;
 
     //--------------------------------------------------------------------------
     // Convenience Access


### PR DESCRIPTION
Fixes issue #2004 (partially)

### Brief summary of changes
- Added an accessor to MarkersReference to retrieve the TimeSeriesTable member variable.

### Testing I've completed
- Passes standard tests.
- Working nicely for defining the marker tracking cost in the direct collocation code. 

### Looking for feedback on...
- Would it make sense to also add an writable reference accessor (i.e. `updMarkerTable`) for the purposes of utilizing future filtering/resampling functions on tables?

### CHANGELOG.md (choose one)
- no need to update because...small change to MarkersReference.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
