### PR TITLE
Added SpatialVec Output and Reporter access to Swig interface

### DIFF
--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -84,9 +84,6 @@ namespace OpenSim {
 %template(OutputVector) OpenSim::Output<SimTK::Vector>;
 %template(OutputSpatialVec) OpenSim::Output<SimTK::SpatialVec>;
 
-
-
-
 namespace OpenSim {
     %ignore Input::downcast(AbstractInput&); // suppress warning 509.
 }
@@ -402,6 +399,5 @@ namespace OpenSim {
 %template(TableReporterVector) OpenSim::TableReporter_<SimTK::Vector, SimTK::Real>;
 %template(ConsoleReporter) OpenSim::ConsoleReporter_<SimTK::Real>;
 %template(ConsoleReporterVec3) OpenSim::ConsoleReporter_<SimTK::Vec3>;
-
 
 %include <OpenSim/Common/GCVSplineSet.h>

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -82,6 +82,9 @@ namespace OpenSim {
 %template(OutputVec3) OpenSim::Output<SimTK::Vec3>;
 %template(OutputTransform) OpenSim::Output<SimTK::Transform>;
 %template(OutputVector) OpenSim::Output<SimTK::Vector>;
+%template(OutputSpatialVec) OpenSim::Output<SimTK::SpatialVec>;
+
+
 
 
 namespace OpenSim {
@@ -395,8 +398,10 @@ namespace OpenSim {
 %template(ReporterVector) OpenSim::Reporter<SimTK::Vector>;
 %template(TableReporter) OpenSim::TableReporter_<SimTK::Real>;
 %template(TableReporterVec3) OpenSim::TableReporter_<SimTK::Vec3>;
+%template(TableReporterSpatialVec) OpenSim::TableReporter_<SimTK::SpatialVec>;
 %template(TableReporterVector) OpenSim::TableReporter_<SimTK::Vector, SimTK::Real>;
 %template(ConsoleReporter) OpenSim::ConsoleReporter_<SimTK::Real>;
 %template(ConsoleReporterVec3) OpenSim::ConsoleReporter_<SimTK::Vec3>;
+
 
 %include <OpenSim/Common/GCVSplineSet.h>


### PR DESCRIPTION
Fixes issue #<issue_number>
#2029 

### Brief summary of changes
Added SpatialVec access for outputs and reporters

### Testing I've completed
Run local tests and confirmed that access is available


