### PR TITLE
Reorder component properties in Model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_install:
   ## Avoid bug on OSX (https://github.com/travis-ci/travis-ci/issues/6307)
   # This prevents the build from failing with:
   # `/Users/travis/build.sh: line 109: shell_session_update: command not found`
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
+  # - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
   
   # Avoid "Homebrew must be run under Ruby 2.3!"
   # https://github.com/PowerShell/PowerShell/issues/5062

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -152,9 +152,6 @@ public:
     "at locations measured to five significant digits while the model lacks dofs "
     "to change stance width, in which case it cannot achieve 1e-9 accuracy." );
 
-    OpenSim_DECLARE_PROPERTY(ground, Ground,
-        "The model's ground reference frame.");
-
     OpenSim_DECLARE_PROPERTY(gravity,SimTK::Vec3,
         "Acceleration due to gravity, expressed in ground.");
 
@@ -169,33 +166,36 @@ public:
 
     OpenSim_DECLARE_PROPERTY(force_units,std::string,
         "Units for all forces.");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ControllerSet, 
-        "Controllers that provide the control inputs for Actuators.");  
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ConstraintSet,
-        "Constraints in the model.");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ForceSet,
-        "Forces in the model (includes Actuators).");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(MarkerSet,
-        "Markers in the model.");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ContactGeometrySet,
-        "Geometry to be used in contact forces.");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ComponentSet,
-        "Additional components in the model.");
-
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ProbeSet,
-        "Probes in the model.");
-
+    
+    OpenSim_DECLARE_PROPERTY(ground, Ground,
+        "The model's ground reference frame.");
+    
     OpenSim_DECLARE_UNNAMED_PROPERTY(BodySet,
         "List of bodies that make up this model.");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(JointSet,
         "List of joints that connect the bodies.");
+    
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ConstraintSet,
+        "Constraints in the model.");
+    
+    OpenSim_DECLARE_UNNAMED_PROPERTY(MarkerSet,
+        "Markers in the model.");
+    
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ForceSet,
+        "Forces in the model (includes Actuators).");
+
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ControllerSet, 
+        "Controllers that provide the control inputs for Actuators.");  
+
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ContactGeometrySet,
+        "Geometry to be used in contact forces.");
+    
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ProbeSet,
+        "Probes in the model.");
+
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ComponentSet,
+        "Additional components in the model.");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(ModelVisualPreferences,
         "Visual preferences for this model.");

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -140,7 +140,19 @@ OpenSim_OBJECT_NONTEMPLATE_DEFS(Model, ModelComponent);
 public:
 //==============================================================================
 // PROPERTIES
-//==============================================================================
+//==============================================================================    
+    OpenSim_DECLARE_PROPERTY(credits, std::string,
+        "Credits (e.g., model author names) associated with the model.");
+
+    OpenSim_DECLARE_PROPERTY(publications, std::string,
+        "Publications and references associated with the model.");
+
+    OpenSim_DECLARE_PROPERTY(length_units, std::string,
+        "Units for all lengths.");
+
+    OpenSim_DECLARE_PROPERTY(force_units, std::string,
+        "Units for all forces.");
+        
     OpenSim_DECLARE_PROPERTY(assembly_accuracy, double,
     "Specify how accurate the resulting configuration of a model assembly "
     "should be. This translates to the number of significant digits in the "
@@ -152,20 +164,8 @@ public:
     "at locations measured to five significant digits while the model lacks dofs "
     "to change stance width, in which case it cannot achieve 1e-9 accuracy." );
 
-    OpenSim_DECLARE_PROPERTY(gravity,SimTK::Vec3,
+    OpenSim_DECLARE_PROPERTY(gravity, SimTK::Vec3,
         "Acceleration due to gravity, expressed in ground.");
-
-    OpenSim_DECLARE_PROPERTY(credits,std::string,
-        "Credits (e.g., model author names) associated with the model.");
-
-    OpenSim_DECLARE_PROPERTY(publications,std::string,
-        "Publications and references associated with the model.");
-
-    OpenSim_DECLARE_PROPERTY(length_units,std::string,
-        "Units for all lengths.");
-
-    OpenSim_DECLARE_PROPERTY(force_units,std::string,
-        "Units for all forces.");
     
     OpenSim_DECLARE_PROPERTY(ground, Ground,
         "The model's ground reference frame.");


### PR DESCRIPTION
Fixes #1763.

### Brief summary of changes

This PR introduces a more logical ordering of component properties in Model. With this PR, the XML tags `<gravity>`, etc. will come before `<Ground>`.

### Testing I've completed

- None; relying on CI.

### Looking for feedback on...

- Do you like this ordering?

### CHANGELOG.md (choose one)

- no need to update because...this does not alter the API.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
