### PR TITLE
Replace MSVC-specific _DEBUG with NDEBUG.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_install:
   ## Avoid bug on OSX (https://github.com/travis-ci/travis-ci/issues/6307)
   # This prevents the build from failing with:
   # `/Users/travis/build.sh: line 109: shell_session_update: command not found`
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
+  # - if [ "$TRAVIS_OS_NAME" = "osx" ]; then rvm get head; fi
   
   # Avoid "Homebrew must be run under Ruby 2.3!"
   # https://github.com/PowerShell/PowerShell/issues/5062

--- a/OpenSim/Common/LoadOpenSimLibrary.cpp
+++ b/OpenSim/Common/LoadOpenSimLibrary.cpp
@@ -103,7 +103,7 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
     // mode and a debug library is specified, we'll first try loading the debug library,
     // and then try loading the release library.
     bool tryDebugThenRelease = false;
-#ifdef _DEBUG
+#ifndef NDEBUG
     if(!hasDebugSuffix) {
         if(verbose) cout << "Will try loading debug library first" << endl;
         tryDebugThenRelease = true;


### PR DESCRIPTION
This PR fixes a bug that caused tests to fail on Linux in Debug: some tests were unable to load the `osimActuators` library in Debug. This was caused by use of a non-existent macro `_DEBUG` (this macro is only defined on Windows).