### PR TITLE
Kinematics reporter used internally by InverseKinematicsTool should n…

### DIFF
--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -372,7 +372,7 @@ bool InverseKinematicsTool::run()
             kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
         }
         // Once done, remove the analysis we added
-        _model->removeAnalysis(&kinematicsReporter);
+        _model->removeAnalysis(&kinematicsReporter, false);
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -371,7 +371,7 @@ bool InverseKinematicsTool::run()
         if (_outputMotionFileName!= "" && _outputMotionFileName!="Unassigned"){
             kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
         }
-        // Once done, remove the analysis we added
+        // Once done, remove the analysis we added, don't delete as it was allocated on stack
         _model->removeAnalysis(&kinematicsReporter, false);
 
         if (modelMarkerErrors) {


### PR DESCRIPTION
…ot be deleted (will go out of scope)

Fixes issue https://github.com/opensim-org/opensim-gui/issues/421

### Brief summary of changes
Analysis created on the stack shouldn't be deleted as it will be deleted again when goes out of scope.
### Testing I've completed
Ran Scale followed by IK or IK standalone in the GUI

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
