### PR TITLE
Preparing for the removal of pthreads from Simbody

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: cpp
 
 # Use container-based infrastructure to allow caching (for ccache).
 sudo: false
+
+# For thread_local support on macOS.
+osx_image: xcode8
     
 matrix:
   include:

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -27,6 +27,7 @@
 #include "OpenSim/Common/IO.h"
 #include "XMLDocument.h"
 #include <unordered_map>
+#include <set>
 
 using namespace SimTK;
 


### PR DESCRIPTION
### Brief summary of changes

- Soon, pthreads will be removed from Simbody. To allow OpenSim to continue working with Simbody once pthreads is removed, we must introduce the changes in this PR.
  - Travis must use Xcode 8 (or greater) for C++11 `thread_local` support.
  - We must add `#include <set>` in Component.cpp.

### Testing I've completed

- Ran ctest locally.

### CHANGELOG.md (choose one)

- no need to update because...this is mostly an internal change.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
