### PR TITLE
Delay TransformAxis check for Function when Coordinates present

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
@@ -105,9 +105,6 @@ void SpatialTransform::connectToJoint(CustomJoint& owningJoint)
     for(int i=0; i < NumTransformAxes; ++i) {
         TransformAxis& transform = updTransformAxis(i);
 
-        // Ask the transform axis to connect itself to the joint too.
-        transform.connectToJoint(*((Joint*)(&owningJoint)));
-
         // check if it has a function
         if(!transform.hasFunction()){
             // does it have a coordinate?
@@ -118,6 +115,9 @@ void SpatialTransform::connectToJoint(CustomJoint& owningJoint)
             else
                 transform.setFunction(new Constant());
         }
+
+        // Ask the transform axis to connect itself to the joint.
+        transform.connectToJoint(*((Joint*)(&owningJoint)));
     }
 }
 


### PR DESCRIPTION
Fixes issue #2050

A check that we added in 4.0  was causing models with a `SpatialTransform` `TransformAxis` without an associated `Function` to fail . This was causing the failure  to load in #2050.

### Brief summary of changes
In 92d3de2d017b26f236e9c292e7a6980ba2440740 we added a check that a `TransformAxis` with `Coordinate`s must have an associated `Function`. This check was happening before the `SpatialTransform` had the opportunity to supply functions in the case that functions where unspecified, which was the case in model version 10600 and earlier. It loads in 3.3 because the check was not there and the functions are correctly set afterwards. Fix was simply to delay the check until after the `SpatialTransform` has a chance to add them. 

### Testing I've completed
Verified that model in #2050 loads.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a big fix.


