### PR TITLE
Fix IKTool reporting to use size of markerErrors returned from IKSolver

### DIFF
--- a/OpenSim/Simulation/InverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/InverseKinematicsSolver.cpp
@@ -77,6 +77,11 @@ InverseKinematicsSolver::InverseKinematicsSolver(const Model &model, MarkersRefe
 
 }
 
+int InverseKinematicsSolver::getNumMarkersInUse() const
+{
+    return _markerAssemblyCondition->getNumMarkers();
+}
+
 /* Change the weighting of a marker to take effect when assemble or track is called next. 
    Update a marker's weight by name. */
 void InverseKinematicsSolver::updateMarkerWeight(const std::string &markerName, double value)

--- a/OpenSim/Simulation/InverseKinematicsSolver.h
+++ b/OpenSim/Simulation/InverseKinematicsSolver.h
@@ -93,6 +93,13 @@ public:
         to track a desired trajectory of coordinate values. */
     //virtual void track(SimTK::State &s);
 
+    /** Return the number of markers used to solve for model coordinates.
+        It is a count of the number of markers in the intersection of 
+        the reference markers and model markers.
+        This number is guaranteed not to change after assemble() is called
+        (i.e. during subsequent calls to track()).*/
+    int getNumMarkersInUse() const;
+
     /** Change the weighting of a marker, given the marker's name. Takes effect
         when assemble() or track() is called next. */
     void updateMarkerWeight(const std::string &markerName, double value);

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -561,7 +561,7 @@ void testNumberOfMarkersMismatch()
 
         auto namesIter = usedMarkerNames.begin();
         for (int j = 0; j < nme; ++j) {
-            auto& markerName = ikSolver.getMarkerNameForIndex(j);
+            const auto& markerName = ikSolver.getMarkerNameForIndex(j);
             cout << " " << markerName << " error = " << markerErrors[j];
 
             SimTK_ASSERT_ALWAYS( *namesIter++ != "unused",

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -51,9 +51,10 @@ Model* constructPendulumWithMarkers();
 // randomly select the noise to be added at each frame.
 TimeSeriesTable_<SimTK::Vec3>
 generateMarkerDataFromModelAndStates(const Model& model,
-                                     const StatesTrajectory& states,
-                                     double noiseRadius = 0, 
-                                     bool constantOffset = false);
+                        const StatesTrajectory& states,
+                        const SimTK::RowVector_<SimTK::Vec3>& biases,
+                        double noiseRadius = 0, 
+                        bool constantOffset = false);
 
 // Verify that accuracy improves the number of decimals points to which
 // the solver solution (coordinates) can be trusted as it is tightened.
@@ -65,9 +66,16 @@ void testUpdateMarkerWeights();
 // weights and marker error is being reduced as its weighting increases.
 void testTrackWithUpdateMarkerWeights();
 
+// Verify that solver does not confuse/mismanage markers when reference
+// has more markers than the model.
+// the solver solution (coordinates) can be trusted as it is tightened.
+void testNumberOfMarkersMismatch();
+
 int main()
 {
     SimTK::Array_<std::string> failures;
+
+    testNumberOfMarkersMismatch();
 
     try { testMarkersReference(); }
     catch (const std::exception& e) {
@@ -199,8 +207,9 @@ void testAccuracy()
     StatesTrajectory states;
     states.append(state);
 
+    SimTK::RowVector_<SimTK::Vec3> biases(3, SimTK::Vec3(0));
     MarkersReference
-        markersRef(generateMarkerDataFromModelAndStates(*pendulum, states));
+        markersRef(generateMarkerDataFromModelAndStates(*pendulum, states, biases));
     markersRef.setDefaultWeight(1.0);
 
     // Reset the initial coordinate value
@@ -298,9 +307,10 @@ void testUpdateMarkerWeights()
     StatesTrajectory states;
     states.append(state);
 
+    SimTK::RowVector_<SimTK::Vec3> biases(3, SimTK::Vec3(0));
     MarkersReference
         markersRef(generateMarkerDataFromModelAndStates(*pendulum,
-                                                        states,
+                                                        states, biases,
                                                         0.02));
     auto& markerNames = markersRef.getNames();
 
@@ -406,9 +416,10 @@ void testTrackWithUpdateMarkerWeights()
         states.append(state);
     } 
 
+    SimTK::RowVector_<SimTK::Vec3> biases(3, SimTK::Vec3(0));
     MarkersReference
         markersRef(generateMarkerDataFromModelAndStates(*pendulum,
-                                                        states,
+                                                        states, biases,
                                                         0.02,
                                                         true));
     auto& markerNames = markersRef.getNames();
@@ -459,6 +470,114 @@ void testTrackWithUpdateMarkerWeights()
     }
 }
 
+
+void testNumberOfMarkersMismatch()
+{
+    cout << 
+        "\ntestInverseKinematicsSolver::testNumberOfMarkersMismatch()"
+        << endl;
+
+    std::unique_ptr<Model> pendulum{ constructPendulumWithMarkers() };
+    Coordinate& coord = pendulum->getCoordinateSet()[0];
+
+    SimTK::State state = pendulum->initSystem();
+    StatesTrajectory states;
+
+    // sample time
+    double dt = 0.1;
+    int N = 11;
+    for (int i = 0; i < N; ++i) {
+        state.updTime() = i*dt;
+        coord.setValue(state, i*dt*SimTK::Pi / 3);
+        states.append(state);
+    }
+
+    double err = 0.05;
+    SimTK::RowVector_<SimTK::Vec3> biases(3, SimTK::Vec3(0));
+    // bias m0
+    biases[0] += SimTK::Vec3(0, err, 0);
+    cout << "biases: " << biases << endl;
+
+    auto markerTable = generateMarkerDataFromModelAndStates(*pendulum,
+                        states,
+                        biases,
+                        0.0,
+                        true);
+
+    SimTK::Vector_<SimTK::Vec3> unusedCol(N, SimTK::Vec3(0.987654321));
+
+    auto usedMarkerNames = markerTable.getColumnLabels();
+
+    // add an unused marker to the marker data
+    markerTable.appendColumn("unused", unusedCol);
+
+    cout << "Before:\n" << markerTable << endl;
+    
+    // re-order "observed" marker data
+    SimTK::Matrix_<SimTK::Vec3> dataGutsCopy = markerTable.getMatrix();
+    int last = dataGutsCopy.ncol() - 1;
+    // swap first and last columns 
+    markerTable.updMatrix()(0) = dataGutsCopy(last);
+    markerTable.updMatrix()(last) = dataGutsCopy(0);
+    auto columnNames = markerTable.getColumnLabels();
+    markerTable.setColumnLabel(0, columnNames[last]);
+    markerTable.setColumnLabel(last, columnNames[0]);
+    columnNames = markerTable.getColumnLabels();
+
+    // Inject NaN in "observations" of "mR" marker data
+    for (int i = 4; i < 7; ++i) {
+        markerTable.updMatrix()(i, 1) = SimTK::NaN;
+    }
+
+    cout << "After reorder and NaN injections:\n" << markerTable << endl;
+
+    MarkersReference markersRef(markerTable);
+    int nm = markersRef.getNumRefs();
+    auto& markerNames = markersRef.getNames();
+    cout << markerNames << endl;
+
+    SimTK::Array_<CoordinateReference> coordRefs;
+    // Reset the initial coordinate value
+    coord.setValue(state, 0.0);
+    InverseKinematicsSolver ikSolver(*pendulum, markersRef, coordRefs);
+    double tol = 1e-4;
+    ikSolver.setAccuracy(tol);
+    ikSolver.assemble(state);
+
+    SimTK::Array_<double> markerErrors(nm);
+    for (unsigned i = 0; i < markersRef.getNumFrames(); ++i) {
+        state.updTime() = i*dt;
+        ikSolver.track(state);
+
+        //get the marker errors
+        ikSolver.computeCurrentMarkerErrors(markerErrors);
+
+        int nme = markerErrors.size();
+        cout << "time: " << state.getTime() << " |";
+
+        auto namesIter = usedMarkerNames.begin();
+        for (int j = 0; j < nme; ++j) {
+            auto& markerName = ikSolver.getMarkerNameForIndex(j);
+            cout << " " << markerName << " error = " << markerErrors[j];
+
+            SimTK_ASSERT_ALWAYS( *namesIter++ != "unused",
+                "InverseKinematicsSolver failed to ignore "
+                "unused marker reference (observation).");
+            
+            if (markerName == "m0") {// marker we biased shoulder the error
+                SimTK_ASSERT_ALWAYS(abs(markerErrors[j]-err) <= tol,
+                    "InverseKinematicsSolver mangled marker oder.");
+            }
+            else { // other markers should be minimally affected
+                SimTK_ASSERT_ALWAYS(markerErrors[j] <= tol,
+                    "InverseKinematicsSolver mangled marker oder.");
+            }
+        }
+        cout << endl;
+    }
+}
+
+
 Model* constructPendulumWithMarkers()
 {
     Model* pendulum = new Model();
@@ -503,6 +622,7 @@ Model* constructPendulumWithMarkers()
 TimeSeriesTable_<SimTK::Vec3>
 generateMarkerDataFromModelAndStates(const Model& model,
                                      const StatesTrajectory& states,
+                                     const SimTK::RowVector_<SimTK::Vec3>& biases,
                                      double noiseRadius,
                                      bool constantOffset) {
     // use a fixed seed so that we can reproduce and debug failures.
@@ -513,8 +633,10 @@ generateMarkerDataFromModelAndStates(const Model& model,
     
     auto* markerReporter = new TableReporterVec3();
     
-    auto markers = m->getComponentList<Marker>();
-    for (const auto& marker : markers) {
+    auto markers = m->updComponentList<Marker>();
+    int cnt = 0;
+    for (auto& marker : markers) {
+        marker.set_location(marker.get_location() + biases[cnt++]);
         markerReporter->addToReport(
                 marker.getOutput("location"), marker.getName());
     }

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -482,7 +482,7 @@ void testNumberOfMarkersMismatch()
         << endl;
 
     std::unique_ptr<Model> pendulum{ constructPendulumWithMarkers() };
-    Coordinate& coord = pendulum->getCoordinateSet()[0];
+    const Coordinate& coord = pendulum->getCoordinateSet()[0];
 
     SimTK::State state = pendulum->initSystem();
     StatesTrajectory states;
@@ -560,7 +560,7 @@ void testNumberOfMarkersMismatch()
 
         int nme = markerErrors.size();
 
-        SimTK_ASSERT_ALWAYS(nme = nm,
+        SimTK_ASSERT_ALWAYS(nme == nm,
             "InverseKinematicsSolver failed to account "
             "for unused marker reference (observation).");
 
@@ -574,7 +574,7 @@ void testNumberOfMarkersMismatch()
                 "InverseKinematicsSolver failed to ignore "
                 "unused marker reference (observation).");
             
-            if (markerName == "m0") {// marker we biased shoulder the error
+            if (markerName == "m0") {//should see error on biased marker
                 SimTK_ASSERT_ALWAYS(abs(markerErrors[j]-err) <= tol,
                     "InverseKinematicsSolver mangled marker order.");
             }

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -536,7 +536,7 @@ void testNumberOfMarkersMismatch()
     cout << "After reorder and NaN injections:\n" << markerTable << endl;
 
     MarkersReference markersRef(markerTable);
-    int nm = markersRef.getNumRefs();
+    int nmr = markersRef.getNumRefs();
     auto& markerNames = markersRef.getNames();
     cout << markerNames << endl;
 
@@ -548,6 +548,8 @@ void testNumberOfMarkersMismatch()
     ikSolver.setAccuracy(tol);
     ikSolver.assemble(state);
 
+    int nm = ikSolver.getNumMarkersInUse();
+
     SimTK::Array_<double> markerErrors(nm);
     for (unsigned i = 0; i < markersRef.getNumFrames(); ++i) {
         state.updTime() = i*dt;
@@ -557,8 +559,12 @@ void testNumberOfMarkersMismatch()
         ikSolver.computeCurrentMarkerErrors(markerErrors);
 
         int nme = markerErrors.size();
-        cout << "time: " << state.getTime() << " |";
 
+        SimTK_ASSERT_ALWAYS(nme = nm,
+            "InverseKinematicsSolver failed to account "
+            "for unused marker reference (observation).");
+
+        cout << "time: " << state.getTime() << " |";
         auto namesIter = usedMarkerNames.begin();
         for (int j = 0; j < nme; ++j) {
             const auto& markerName = ikSolver.getMarkerNameForIndex(j);

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -67,15 +67,13 @@ void testUpdateMarkerWeights();
 void testTrackWithUpdateMarkerWeights();
 
 // Verify that solver does not confuse/mismanage markers when reference
-// has more markers than the model.
-// the solver solution (coordinates) can be trusted as it is tightened.
+// has more markers than the model, order is changed or marker reference
+// includes intervals with NaNs (no observation)
 void testNumberOfMarkersMismatch();
 
 int main()
 {
     SimTK::Array_<std::string> failures;
-
-    testNumberOfMarkersMismatch();
 
     try { testMarkersReference(); }
     catch (const std::exception& e) {
@@ -95,6 +93,12 @@ int main()
     catch (const std::exception& e) {
         cout << e.what() << endl;
         failures.push_back("testTrackWithUpdateMarkerWeights");
+    }
+
+    try { testNumberOfMarkersMismatch(); }
+    catch (const std::exception& e) {
+        cout << e.what() << endl;
+        failures.push_back("testNumberOfMarkersMismatch");
     }
 
     if (!failures.empty()) {

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -570,11 +570,11 @@ void testNumberOfMarkersMismatch()
             
             if (markerName == "m0") {// marker we biased shoulder the error
                 SimTK_ASSERT_ALWAYS(abs(markerErrors[j]-err) <= tol,
-                    "InverseKinematicsSolver mangled marker oder.");
+                    "InverseKinematicsSolver mangled marker order.");
             }
             else { // other markers should be minimally affected
                 SimTK_ASSERT_ALWAYS(markerErrors[j] <= tol,
-                    "InverseKinematicsSolver mangled marker oder.");
+                    "InverseKinematicsSolver mangled marker order.");
             }
         }
         cout << endl;

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -69,8 +69,11 @@ int main()
 {
     SimTK::Array_<std::string> failures;
 
-    testMarkersReference();
-
+    try { testMarkersReference(); }
+    catch (const std::exception& e) {
+        cout << e.what() << endl;
+        failures.push_back("testMarkersReference");
+    }
     try { testAccuracy(); }
     catch (const std::exception& e) {
         cout << e.what() << endl; failures.push_back("testAccuracy");

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -310,7 +310,7 @@ bool InverseKinematicsTool::run()
         int Nframes = int((final_time-start_time)/dt)+1;
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.begin(s);
-        // number of markers
+        // max number of markers
         int nm = markersReference.getNumRefs();
         SimTK::Array_<double> squaredMarkerErrors(nm, 0.0);
         SimTK::Array_<Vec3> markerLocations(nm, Vec3(0));
@@ -329,6 +329,10 @@ bool InverseKinematicsTool::run()
                 int worst = -1;
 
                 ikSolver.computeCurrentSquaredMarkerErrors(squaredMarkerErrors);
+                // if a marker is not present in the model or its reference value 
+                // is NaN it is not included. Therefore, size of the errors can
+                // vary from frame to frame.
+                nm = squaredMarkerErrors.size();
                 for(int j=0; j<nm; ++j){
                     totalSquaredMarkerError += squaredMarkerErrors[j];
                     if(squaredMarkerErrors[j] > maxSquaredMarkerError){
@@ -337,7 +341,7 @@ bool InverseKinematicsTool::run()
                     }
                 }
 
-                double rms = sqrt(totalSquaredMarkerError / nm);
+                double rms = nm > 0 ? sqrt(totalSquaredMarkerError / nm) : 0;
                 markerErrors.set(0, totalSquaredMarkerError); 
                 markerErrors.set(1, rms);
                 markerErrors.set(2, sqrt(maxSquaredMarkerError));

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -310,8 +310,10 @@ bool InverseKinematicsTool::run()
         int Nframes = int((final_time-start_time)/dt)+1;
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.begin(s);
-        // max number of markers
-        int nm = markersReference.getNumRefs();
+        // Get the actual number of markers the Solver is using, which
+        // can be fewer than the number of references if there isn't a
+        // corresponding model marker for each reference.
+        int nm = ikSolver.getNumMarkersInUse();
         SimTK::Array_<double> squaredMarkerErrors(nm, 0.0);
         SimTK::Array_<Vec3> markerLocations(nm, Vec3(0));
         
@@ -329,10 +331,6 @@ bool InverseKinematicsTool::run()
                 int worst = -1;
 
                 ikSolver.computeCurrentSquaredMarkerErrors(squaredMarkerErrors);
-                // if a marker is not present in the model or its reference value 
-                // is NaN it is not included. Therefore, size of the errors can
-                // vary from frame to frame.
-                nm = squaredMarkerErrors.size();
                 for(int j=0; j<nm; ++j){
                     totalSquaredMarkerError += squaredMarkerErrors[j];
                     if(squaredMarkerErrors[j] > maxSquaredMarkerError){

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -262,12 +262,12 @@ bool InverseKinematicsTool::run()
             modelFromFile = false;
 
         // although newly loaded model will be finalized
-        // there is no gaurantee that the _model has not been edited/modified
+        // there is no guarantee that the _model has not been edited/modified
         _model->finalizeFromProperties();
         _model->printBasicInfo();
 
-        // Do the maneuver to change then restore working directory 
-        // so that the parsing code behaves properly if called from a different directory.
+        // Do the maneuver to change then restore working directory so that the
+        // parsing code behaves properly if called from a different directory.
         string saveWorkingDirectory = IO::getCwd();
         string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
         IO::chDir(directoryOfSetupFile);
@@ -283,7 +283,7 @@ bool InverseKinematicsTool::run()
         // Get the trial name to label data written to files
         string trialName = getName();
 
-        // Initialize the model's underlying computational system and get its default state.
+        // Initialize the model's underlying system and get its default state.
         SimTK::State& s = _model->initSystem();
 
         //Convert old Tasks to references for assembly and tracking
@@ -292,14 +292,19 @@ bool InverseKinematicsTool::run()
         // populate the references according to the setting of this Tool
         populateReferences(markersReference, coordinateReferences);
 
-        // Determine the start time, if the provided time range is not specified then use time from marker reference
-        // also adjust the time range for the tool if the provided range exceeds that of the marker data
+        // Determine the start time, if the provided time range is not 
+        // specified then use time from marker reference.
+        // Adjust the time range for the tool if the provided range exceeds
+        // that of the marker data.
         SimTK::Vec2 markersValidTimRange = markersReference.getValidTimeRange();
-        double start_time = (markersValidTimRange[0] > _timeRange[0]) ? markersValidTimRange[0] : _timeRange[0];
-        double final_time = (markersValidTimRange[1] < _timeRange[1]) ? markersValidTimRange[1] : _timeRange[1];
+        double start_time = (markersValidTimRange[0] > _timeRange[0]) ?
+            markersValidTimRange[0] : _timeRange[0];
+        double final_time = (markersValidTimRange[1] < _timeRange[1]) ?
+            markersValidTimRange[1] : _timeRange[1];
 
         // create the solver given the input data
-        InverseKinematicsSolver ikSolver(*_model, markersReference, coordinateReferences, _constraintWeight);
+        InverseKinematicsSolver ikSolver(*_model, markersReference,
+            coordinateReferences, _constraintWeight);
         ikSolver.setAccuracy(_accuracy);
         s.updTime() = start_time;
         ikSolver.assemble(s);
@@ -317,8 +322,10 @@ bool InverseKinematicsTool::run()
         SimTK::Array_<double> squaredMarkerErrors(nm, 0.0);
         SimTK::Array_<Vec3> markerLocations(nm, Vec3(0));
         
-        Storage *modelMarkerLocations = _reportMarkerLocations ? new Storage(Nframes, "ModelMarkerLocations") : NULL;
-        Storage *modelMarkerErrors = _reportErrors ? new Storage(Nframes, "ModelMarkerErrors") : NULL;
+        Storage *modelMarkerLocations = _reportMarkerLocations ?
+            new Storage(Nframes, "ModelMarkerLocations") : nullptr;
+        Storage *modelMarkerErrors = _reportErrors ? 
+            new Storage(Nframes, "ModelMarkerErrors") : nullptr;
 
         for (int i = 0; i < Nframes; i++) {
             s.updTime() = start_time + i*dt;
@@ -345,10 +352,11 @@ bool InverseKinematicsTool::run()
                 markerErrors.set(2, sqrt(maxSquaredMarkerError));
                 modelMarkerErrors->append(s.getTime(), 3, &markerErrors[0]);
 
-                cout << "Frame " << i << " (t=" << s.getTime() << "):\t";
-                cout << "total squared error = " << totalSquaredMarkerError;
-                cout << ", marker error: RMS=" << rms;
-                cout << ", max=" << sqrt(maxSquaredMarkerError) << " (" << ikSolver.getMarkerNameForIndex(worst) << ")" << endl;
+                cout << "Frame " << i << " (t=" << s.getTime() << "):\t"
+                    << "total squared error = " << totalSquaredMarkerError
+                    << ", marker error: RMS=" << rms << ", max="
+                    << sqrt(maxSquaredMarkerError) << " (" 
+                    << ikSolver.getMarkerNameForIndex(worst) << ")" << endl;
             }
 
             if(_reportMarkerLocations){
@@ -372,7 +380,7 @@ bool InverseKinematicsTool::run()
         if (_outputMotionFileName!= "" && _outputMotionFileName!="Unassigned"){
             kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
         }
-        // Once done, remove the analysis we added, don't delete as it was allocated on stack
+        // Remove the analysis we added, don't delete as it was allocated on stack
         _model->removeAnalysis(&kinematicsReporter, false);
 
         if (modelMarkerErrors) {
@@ -387,7 +395,8 @@ bool InverseKinematicsTool::run()
 
             IO::makeDir(getResultsDir());
             string errorFileName = trialName + "_ik_marker_errors";
-            Storage::printResult(modelMarkerErrors, errorFileName, getResultsDir(), -1, ".sto");
+            Storage::printResult(modelMarkerErrors, errorFileName,
+                                 getResultsDir(), -1, ".sto");
 
             delete modelMarkerErrors;
         }
@@ -407,7 +416,8 @@ bool InverseKinematicsTool::run()
     
             IO::makeDir(getResultsDir());
             string markerFileName = trialName + "_ik_model_marker_locations";
-            Storage::printResult(modelMarkerLocations, markerFileName, getResultsDir(), -1, ".sto");
+            Storage::printResult(modelMarkerLocations, markerFileName,
+                                 getResultsDir(), -1, ".sto");
 
             delete modelMarkerLocations;
         }
@@ -416,11 +426,13 @@ bool InverseKinematicsTool::run()
 
         success = true;
 
-        cout << "InverseKinematicsTool completed " << Nframes-1 << " frames in " <<(double)(clock()-start)/CLOCKS_PER_SEC << "s\n" <<endl;
+        cout << "InverseKinematicsTool completed " << Nframes-1 << " frames in "
+            <<(double)(clock()-start)/CLOCKS_PER_SEC << "s\n" <<endl;
     }
     catch (const std::exception& ex) {
         std::cout << "InverseKinematicsTool Failed: " << ex.what() << std::endl;
-        throw (Exception("InverseKinematicsTool Failed, please see messages window for details..."));
+        throw (Exception("InverseKinematicsTool Failed, "
+            "please see messages window for details..."));
     }
 
     if (modelFromFile) delete _model;


### PR DESCRIPTION
Fixes issue #2052 

### Brief summary of changes
Use the size of the vector of marker errors returned by the `InverseKinematicsSolver` and do not assume it is the number of references in the `MarkersReference`. In fact, the number is not necessarily fixed, since a marker is ignored if its reference value is NaN.

### Testing I've completed
Changes have no impact on existing tests. They still pass.

### Looking for feedback on...
Would like @chrisdembia to apply fix on the case he reported.

### CHANGELOG.md (choose one)
- no need to update because this is an internal bug fix

