### PR TITLE
add get/set method for markerFileName in MarkerPlacer()

### DIFF
--- a/OpenSim/Tools/MarkerPlacer.h
+++ b/OpenSim/Tools/MarkerPlacer.h
@@ -162,7 +162,7 @@ public:
         _coordinateFileNameProp.setValueIsDefault(false);
     }
 
-    const std::string getMarkerFileName() const {return _markerFileName; }
+    const std::string& getMarkerFileName() const {return _markerFileName; }
     void setMarkerFileName( const std::string& aMarkerFileName)
     {
         _markerFileName=aMarkerFileName;

--- a/OpenSim/Tools/MarkerPlacer.h
+++ b/OpenSim/Tools/MarkerPlacer.h
@@ -161,7 +161,14 @@ public:
         _coordinateFileName = aCoordinateFileName;
         _coordinateFileNameProp.setValueIsDefault(false);
     }
-    
+
+    const std::string getMarkerFileName() const {return _markerFileName; }
+    void setMarkerFileName( const std::string& aMarkerFileName)
+    {
+        _markerFileName=aMarkerFileName;
+        _markerFileNameProp.setValueIsDefault(false);
+    }
+
     double getMaxMarkerMovement() const { return _maxMarkerMovement; }
     void setMaxMarkerMovement(double aMaxMarkerMovement)
     {


### PR DESCRIPTION
### Fixes issue 
MarkerPlacer() does not have set and get methods for the Marker FIle Name. To edit the markerFileName property in Matlab, you would have to use the property editor. Since this property has to be constantly updated for each new subject, I have added get/set method for it. 

### Brief summary of changes
Added get/set method in MarkerPlacer.h

### Testing I've completed
Local ctests pass. I have built and tested in Matlab and can confirm it works correctly there. 

### Looking for feedback on...
This is a minor change so I expect it to be approved quickly. Once one person gives me a 👍 , I will merge it. 

### CHANGELOG.md (choose one)
This wasn't available in 3.3 either so may be useful to add to doc's

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
