### PR TITLE
Computing marker RMS uses the number of non-NaN values

### DIFF
--- a/OpenSim/Simulation/InverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/InverseKinematicsSolver.cpp
@@ -118,6 +118,31 @@ void InverseKinematicsSolver::updateMarkerWeights(const SimTK::Array_<double> &w
         throw Exception("InverseKinematicsSolver::updateMarkerWeights: invalid size of weights.");
 }
 
+/* Get the current reference values for markers*/
+const SimTK::Vec3& InverseKinematicsSolver::getMarkerReferenceValue(int markerIndex)
+{
+    SimTK::Markers::ObservationIx oix(
+        _markerAssemblyCondition->getObservationIxForMarker(
+            SimTK::Markers::MarkerIx(markerIndex)) );
+    return _markerAssemblyCondition->getObservation(oix);
+}
+const SimTK::Vec3& InverseKinematicsSolver::getMarkerReferenceValue(const std::string &markerName)
+{
+    SimTK::Markers::ObservationIx oix(
+        _markerAssemblyCondition->getObservationIxForMarker(
+            _markerAssemblyCondition->getMarkerIx(markerName)) );
+    return _markerAssemblyCondition->getObservation(oix);
+}
+void InverseKinematicsSolver::getMarkerReferenceValues(SimTK::Array_<SimTK::Vec3> &markerRefs)
+{
+    int nm = getNumMarkersInUse();
+    markerRefs.resize(nm);
+
+    for (int i = 0; i < nm; ++i) {
+        markerRefs[i] = getMarkerReferenceValue(i);
+    }
+}
+
 /* Compute and return the spatial location of a marker in ground. */
 SimTK::Vec3 InverseKinematicsSolver::computeCurrentMarkerLocation(const std::string &markerName)
 {

--- a/OpenSim/Simulation/InverseKinematicsSolver.h
+++ b/OpenSim/Simulation/InverseKinematicsSolver.h
@@ -112,6 +112,14 @@ public:
         solver was constructed. */
     void updateMarkerWeights(const SimTK::Array_<double> &weights);
 
+    /** Get the current reference value for the marker specified by index */
+    const SimTK::Vec3& getMarkerReferenceValue(int markerIndex);
+    /** Get the current reference value for the marker specified by name */
+    const SimTK::Vec3& getMarkerReferenceValue(const std::string &markerName);
+    /** Get the current reference values for all markers in use. Missing
+        reference values at the current instant are denoted by NaN. */
+    void getMarkerReferenceValues(SimTK::Array_<SimTK::Vec3> &markerRefs);
+
     /** Compute and return a marker's spatial location in the ground frame,
         given the marker's name. */
     SimTK::Vec3 computeCurrentMarkerLocation(const std::string &markerName);

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -550,14 +550,21 @@ void testNumberOfMarkersMismatch()
 
     int nm = ikSolver.getNumMarkersInUse();
 
+    SimTK::Array_<SimTK::Vec3> markerRefs(nm);
     SimTK::Array_<double> markerErrors(nm);
+
     for (unsigned i = 0; i < markersRef.getNumFrames(); ++i) {
         state.updTime() = i*dt;
         ikSolver.track(state);
 
+        ikSolver.getMarkerReferenceValues(markerRefs);
+        int nmr = markerRefs.size();
+        SimTK_ASSERT_ALWAYS(nmr == nm,
+            "InverseKinematicsSolver number of reference values "
+            "failed to match the number of markers in use.");
+
         //get the marker errors
         ikSolver.computeCurrentMarkerErrors(markerErrors);
-
         int nme = markerErrors.size();
 
         SimTK_ASSERT_ALWAYS(nme == nm,
@@ -581,6 +588,15 @@ void testNumberOfMarkersMismatch()
             else { // other markers should be minimally affected
                 SimTK_ASSERT_ALWAYS(markerErrors[j] <= tol,
                     "InverseKinematicsSolver mangled marker order.");
+            }
+
+            if (markerRefs[j].isNaN()) {
+                SimTK_ASSERT_ALWAYS(markerName == "mR",
+                    "InverseKinematicsSolver order of marker reference "
+                    "values does not match order of markers.");
+                SimTK_ASSERT_ALWAYS(markerErrors[j] == 0,
+                    "InverseKinematicsSolver failed to assign 0 for the "
+                    "error associated with marker reference with NaN value.");
             }
         }
         cout << endl;

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -341,7 +341,7 @@ bool InverseKinematicsTool::run()
 
                 ikSolver.getMarkerReferenceValues(markerRefValues);
                 for (const Vec3& val : markerRefValues) {
-                    val.isNaN() ? ignore_cnt++ : 0;
+                    if(val.isNaN()) ignore_cnt++;
                 }
 
                 ikSolver.computeCurrentSquaredMarkerErrors(squaredMarkerErrors);

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -332,10 +332,17 @@ bool InverseKinematicsTool::run()
             ikSolver.track(s);
             
             if(_reportErrors){
-                Array<double> markerErrors(0.0, 3);
+                Array_<Vec3> markerRefValues(nm);
+                Array<double> markerErrors(0.0, nm);
                 double totalSquaredMarkerError = 0.0;
                 double maxSquaredMarkerError = 0.0;
                 int worst = -1;
+                int ignore_cnt = 0;
+
+                ikSolver.getMarkerReferenceValues(markerRefValues);
+                for (const Vec3& val : markerRefValues) {
+                    val.isNaN() ? ignore_cnt++ : 0;
+                }
 
                 ikSolver.computeCurrentSquaredMarkerErrors(squaredMarkerErrors);
                 for(int j=0; j<nm; ++j){
@@ -346,7 +353,8 @@ bool InverseKinematicsTool::run()
                     }
                 }
 
-                double rms = nm > 0 ? sqrt(totalSquaredMarkerError / nm) : 0;
+                double rms = (nm-ignore_cnt) > 0 ? 
+                    sqrt(totalSquaredMarkerError/(nm-ignore_cnt)) : NaN;
                 markerErrors.set(0, totalSquaredMarkerError); 
                 markerErrors.set(1, rms);
                 markerErrors.set(2, sqrt(maxSquaredMarkerError));


### PR DESCRIPTION
Fixes issue #2058

### Brief summary of changes
Added methods to access the marker reference values from the `InverseKinematicsSolver`.
Using this to check if any reference value is NaN when accounting for it when reporting marker RMS errors. 

### Testing I've completed
Added conditions to testInverseKinematicsSolver to check that NaN reference values are being returned and correspond to the correct marker.

There isn't an explicit test for running the IKTool with with experimental data with NaNs.

### Looking for feedback on...
 @jimmyDunne , @chrisdembia , @apoorvar perhaps you have a model and data handy for me to use as a test case?

### CHANGELOG.md (choose one)
- no need to update because this a bug fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2059)
<!-- Reviewable:end -->
