### PR TITLE
[travis] Fix sourceforge certificate error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ language: cpp
 # Use container-based infrastructure to allow caching (for ccache).
 sudo: false
 
-# For thread_local support on macOS.
-osx_image: xcode8
+# For thread_local support on macOS, we require xcode8 or greater.
+# Before 2018, xcode7 was the default. Now that xcode8.3 is the default,
+# we no longer need to specify an osx_image.
+# https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+# osx_image: xcode8
     
 matrix:
   include:


### PR DESCRIPTION
This PR changes Travis CI to use the xcode8.3 image (macOS 10.12) to avoid sourceforge certificate error that is causing Mac builds to fail.
