### PR TITLE
Make ModelComponent::InvalidScaleFactors protected.

### DIFF
--- a/OpenSim/Simulation/Model/ModelComponent.h
+++ b/OpenSim/Simulation/Model/ModelComponent.h
@@ -138,6 +138,7 @@ public:
         @see extendPostScale() */
     void postScale(const SimTK::State& s, const ScaleSet& scaleSet);
 
+protected:
     /** Get the scale factors corresponding to the base OpenSim::Body of the
         specified Frame. Returns ModelComponent::InvalidScaleFactors if the
         ScaleSet does not contain scale factors for the base Body. */
@@ -148,7 +149,6 @@ public:
         factors for the base Body associated with the specified Frame. */
     static const SimTK::Vec3 InvalidScaleFactors;
 
-protected:
     /** Perform any computations that must occur before ModelComponent::scale()
         is invoked on all ModelComponents in the Model. For example, a
         GeometryPath must calculate and store its path length in the original


### PR DESCRIPTION
Fixes #2074

Related: #2006, https://github.com/opensim-org/opensim-gui/pull/503

### Brief summary of changes

- This PR makes `getScaleFactors()` and `InvalidScaleFactors` protected, as @tkuchida suggested in #2006.

### Testing I've completed

- Built Java wrapping and ensured that `InvalidScaleFactors` did not appear.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.