### PR TITLE
Fix InverseKinematicsTool to respect user time range

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -246,6 +246,46 @@ public:
         *this = std::move(*table);
     }
 
+    /** Get index of row whose time is nearest/closest to the given value.
+
+    \param time Value to search for.
+    \param restrictToTimeRange  When true -- Exception is thrown if the given
+                                value is out-of-range of the time column.
+                                When false -- If the given value is less than or
+                                equal to the first value in the time column, the
+                                row returned is the first row. If the given value
+                                is greater than or equal to the last value in the
+                                time column, the row returned is the last row.
+                                This operation only returns existing rows and
+                                does not perform any interpolation. Defaults to
+                                'true'.
+
+    \throws TimeOutOfRange If the given value is out-of-range of time column.
+    \throws EmptyTable If the table is empty.                                 */
+    size_t getNearestRowIndexForTime(const double time,
+                                     const bool restrictToTimeRange = true) const {
+        using DT = DataTable_<double, ETY>;
+        const auto& timeCol = DT::getIndependentColumn();
+        OPENSIM_THROW_IF(timeCol.size() == 0,
+            EmptyTable);
+        const SimTK::Real eps = SimTK::SignificantReal;
+        OPENSIM_THROW_IF(restrictToTimeRange &&
+            ((time < timeCol.front() - eps) ||
+            (time > timeCol.back() + eps)),
+            TimeOutOfRange,
+            time, timeCol.front(), timeCol.back());
+
+        auto iter = std::lower_bound(timeCol.begin(), timeCol.end(), time);
+        if (iter == timeCol.end())
+            return timeCol.size() - 1;
+        if (iter == timeCol.begin())
+            return 0;
+        if ((*iter - time) <= (time - *std::prev(iter)))
+            return std::distance(timeCol.begin(), iter);
+        else
+            return std::distance(timeCol.begin(), std::prev(iter));
+    }
+
     /** Get row whose time column is nearest/closest to the given value. 
 
     \param time Value to search for. 
@@ -266,26 +306,8 @@ public:
     getNearestRow(const double& time,
                   const bool restrictToTimeRange = true) const {
         using DT = DataTable_<double, ETY>;
-        const auto& timeCol = DT::getIndependentColumn();
-        OPENSIM_THROW_IF(timeCol.size() == 0,
-                         EmptyTable);
-        const SimTK::Real eps = SimTK::SignificantReal;
-        OPENSIM_THROW_IF(restrictToTimeRange &&
-                         ( (time < timeCol.front()-eps) ||
-                           (time > timeCol.back()+eps) ),
-                         TimeOutOfRange,
-                         time, timeCol.front(), timeCol.back());
-
-        auto iter = std::lower_bound(timeCol.begin(), timeCol.end(), time);
-        if(iter == timeCol.end())
-            return DT::getRowAtIndex(timeCol.size() - 1);
-        if(iter == timeCol.begin())
-            return DT::getRowAtIndex(0);
-        if((*iter - time) <= (time - *std::prev(iter)))
-            return DT::getRowAtIndex(std::distance(timeCol.begin(), iter));
-        else
-            return DT::getRowAtIndex(std::distance(timeCol.begin(),
-                                                   std::prev(iter)));
+        return DT::getRowAtIndex( 
+            getNearestRowIndexForTime(time, restrictToTimeRange) );
     }
 
     /** Get writable reference to row whose time column is nearest/closest to 
@@ -309,24 +331,8 @@ public:
     updNearestRow(const double& time,
                   const bool restrictToTimeRange = true) {
         using DT = DataTable_<double, ETY>;
-        const auto& timeCol = DT::getIndependentColumn();
-        OPENSIM_THROW_IF(timeCol.size() == 0,
-                         EmptyTable);
-        OPENSIM_THROW_IF(restrictToTimeRange &&
-                         time < timeCol.front() || time > timeCol.back(),
-                         TimeOutOfRange,
-                         time, timeCol.front(), timeCol.back());
-
-        auto iter = std::lower_bound(timeCol.begin(), timeCol.end(), time);
-        if(iter == timeCol.end())
-            return DT::updRowAtIndex(timeCol.size() - 1);
-        if(iter == timeCol.begin())
-            return DT::updRowAtIndex(0);
-        if((*iter - time) <= (time - *std::prev(iter)))
-            return DT::updRowAtIndex(std::distance(timeCol.begin(), iter));
-        else
-            return DT::updRowAtIndex(std::distance(timeCol.begin(),
-                                                   std::prev(iter)));
+        return DT::updRowAtIndex(
+            getNearestRowIndexForTime(time, restrictToTimeRange));
     }
 
     /** Compute the average row in the time range (inclusive) given. This

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -30,7 +30,6 @@ provide an in-memory container for data access and manipulation.              */
 
 #include "OpenSim/Common/DataTable.h"
 
-
 namespace OpenSim {
 
 class InvalidTable : public Exception {
@@ -270,8 +269,10 @@ public:
         const auto& timeCol = DT::getIndependentColumn();
         OPENSIM_THROW_IF(timeCol.size() == 0,
                          EmptyTable);
+        const SimTK::Real eps = SimTK::SignificantReal;
         OPENSIM_THROW_IF(restrictToTimeRange &&
-                         time < timeCol.front() || time > timeCol.back(),
+                         ( (time < timeCol.front()-eps) ||
+                           (time > timeCol.back()+eps) ),
                          TimeOutOfRange,
                          time, timeCol.front(), timeCol.back());
 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -250,15 +250,15 @@ public:
 
     \param time Value to search for.
     \param restrictToTimeRange  When true -- Exception is thrown if the given
-                                value is out-of-range of the time column.
+                                value is out-of-range of the time column. A value
+                                within SimTK::SignifcantReal of a time column
+                                bound is considered to be equal to the bound.
                                 When false -- If the given value is less than or
                                 equal to the first value in the time column, the
-                                row returned is the first row. If the given value
-                                is greater than or equal to the last value in the
-                                time column, the row returned is the last row.
-                                This operation only returns existing rows and
-                                does not perform any interpolation. Defaults to
-                                'true'.
+                                index returned is of the first row. If the given
+                                value is greater than or equal to the last value
+                                in the time column, the index of the last row is
+                                returned. Defaults to 'true'.
 
     \throws TimeOutOfRange If the given value is out-of-range of time column.
     \throws EmptyTable If the table is empty.                                 */

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -307,9 +307,11 @@ bool InverseKinematicsTool::run()
             final_time, start_time);
 
         const auto& markersTable = markersReference.getMarkerTable();
-        const size_t start_ix = markersTable.getNearestRowIndexForTime(start_time);
-        const size_t final_ix = markersTable.getNearestRowIndexForTime(final_time);
-        const size_t Nframes = final_ix - start_ix + 1;
+        const int start_ix = int(
+            markersTable.getNearestRowIndexForTime(start_time) );
+        const int final_ix = int(
+            markersTable.getNearestRowIndexForTime(final_time) );
+        const int Nframes = final_ix - start_ix + 1;
         const auto& times = markersTable.getIndependentColumn();
 
         // create the solver given the input data
@@ -336,7 +338,7 @@ bool InverseKinematicsTool::run()
 
         const clock_t start = clock();
 
-        for (size_t i = start_ix; i <= final_ix; ++i) {
+        for (int i = start_ix; i <= final_ix; ++i) {
             s.updTime() = times[i];
             ikSolver.track(s);
             

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -312,7 +312,13 @@ bool InverseKinematicsTool::run()
 
         const clock_t start = clock();
         double dt = 1.0/markersReference.getSamplingFrequency();
-        int Nframes = int((final_time-start_time)/dt)+1;
+        int Nframes = int((final_time-start_time)/dt + SimTK::SignificantReal)+1;
+        SimTK_ASSERT1_ALWAYS(
+            isNumericallyEqual(final_time, start_time + dt*(Nframes - 1), 
+                               SimTK::SignificantReal),
+            "InverseKinematicsTool could not specify the precise final time of %f s.",
+            final_time);
+
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.begin(s);
         // Get the actual number of markers the Solver is using, which

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -144,57 +144,78 @@ void InverseKinematicsTool::setNull()
  */
 void InverseKinematicsTool::setupProperties()
 {
-    _modelFileNameProp.setComment("Name of the .osim file used to construct a model.");
+    _modelFileNameProp.setComment(
+        "Name of the model (.osim) to use for inverse kinematics.");
     _modelFileNameProp.setName("model_file");
     _propertySet.append( &_modelFileNameProp );
 
-    _constraintWeightProp.setComment("A positive scalar that is used to weight the importance of satisfying constraints."
-        "A weighting of 'Infinity' or if it is unassigned results in the constraints being strictly enforced.");
+    _constraintWeightProp.setComment(
+        "A positive scalar that weights the relative importance of satisfying "
+        "constraints. A weighting of 'Infinity' (the default) results in the "
+        "constraints being strictly enforced. Otherwise, the weighted-squared "
+        "constraint errors are appended to the cost function.");
     _constraintWeightProp.setName("constraint_weight");
     _constraintWeightProp.setValue(std::numeric_limits<SimTK::Real>::infinity());
     _propertySet.append( &_constraintWeightProp );
 
-    _accuracyProp.setComment("The accuracy of the solution in absolute terms. I.e. the number of significant"
-        "digits to which the solution can be trusted.");
+    _accuracyProp.setComment(
+        "The accuracy of the solution in absolute terms. Default is 1e-5. "
+        "It determines the number of significant digits to which the solution "
+        "can be trusted.");
     _accuracyProp.setName("accuracy");
     _accuracyProp.setValue(1e-5);
     _propertySet.append( &_accuracyProp );
 
-    _ikTaskSetProp.setComment("Markers and coordinates to be considered (tasks) and their weightings.");
+    _ikTaskSetProp.setComment(
+        "Markers and coordinates to be considered (tasks) and their weightings. "
+        "The sum of weighted-squared task errors composes the cost function.");
     _ikTaskSetProp.setName("IKTaskSet");
     _propertySet.append(&_ikTaskSetProp);
 
-    _markerFileNameProp.setComment("TRC file (.trc) containing the time history of observations of marker positions.");
+    _markerFileNameProp.setComment(
+        "TRC file (.trc) containing the time history of observations of marker "
+        "positions obtained during a motion capture experiment. Markers in this "
+        "file that have a corresponidng task and model marker are included.");
     _markerFileNameProp.setName("marker_file");
     _propertySet.append(&_markerFileNameProp);
 
-    _coordinateFileNameProp.setComment("The name of the storage (.sto or .mot) file containing coordinate observations."
-        "Coordinate values from this file are included if there is a corresponding coordinate task. ");
+    _coordinateFileNameProp.setComment(
+        "The name of the storage (.sto or .mot) file containing the time history"
+        " of coordinate observations. Coordinate values from this file are "
+        "included if there is a corresponding model coordinate and task. ");
     _coordinateFileNameProp.setName("coordinate_file");
     _propertySet.append(&_coordinateFileNameProp);
 
-    const double defaultTimeRange[] = {-std::numeric_limits<SimTK::Real>::infinity(), std::numeric_limits<SimTK::Real>::infinity()};
-    _timeRangeProp.setComment("Time range over which the inverse kinematics problem is solved.");
+    const double defaultTimeRange[] =
+        {-std::numeric_limits<SimTK::Real>::infinity(),
+          std::numeric_limits<SimTK::Real>::infinity()};
+    _timeRangeProp.setComment(
+        "The desired time range over which inverse kinematics is solved. "
+        "The closest start and final times from the provided observations "
+        "are used to specify the actual time range to be processed.");
     _timeRangeProp.setName("time_range");
     _timeRangeProp.setValue(2, defaultTimeRange);
     _timeRangeProp.setAllowableListSize(2);
     _propertySet.append(&_timeRangeProp);
 
-    _reportErrorsProp.setComment("Flag (true or false) indicating whether or not to report marker "
+    _reportErrorsProp.setComment(
+        "Flag (true or false) indicating whether or not to report marker "
         "errors from the inverse kinematics solution.");
     _reportErrorsProp.setName("report_errors");
     _reportErrorsProp.setValue(true);
     _propertySet.append(&_reportErrorsProp);
 
-    _outputMotionFileNameProp.setComment("Name of the motion file (.mot) to which the results should be written.");
+    _outputMotionFileNameProp.setComment(
+        "Name of the resulting inverse kinematics motion (.mot) file.");
     _outputMotionFileNameProp.setName("output_motion_file");
     _propertySet.append(&_outputMotionFileNameProp);
 
-    _reportMarkerLocationsProp.setComment("Flag indicating whether or not to report model marker locations in ground.");
+    _reportMarkerLocationsProp.setComment(
+        "Flag indicating whether or not to report model marker locations. "
+        "Note, model marker location are expresssed in Ground.");
     _reportMarkerLocationsProp.setName("report_marker_locations");
     _reportMarkerLocationsProp.setValue(false);
     _propertySet.append(&_reportMarkerLocationsProp);
-
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -145,7 +145,7 @@ void InverseKinematicsTool::setNull()
 void InverseKinematicsTool::setupProperties()
 {
     _modelFileNameProp.setComment(
-        "Name of the model (.osim) to use for inverse kinematics.");
+        "Name of the model file (.osim) to use for inverse kinematics.");
     _modelFileNameProp.setName("model_file");
     _propertySet.append( &_modelFileNameProp );
 
@@ -175,7 +175,7 @@ void InverseKinematicsTool::setupProperties()
     _markerFileNameProp.setComment(
         "TRC file (.trc) containing the time history of observations of marker "
         "positions obtained during a motion capture experiment. Markers in this "
-        "file that have a corresponidng task and model marker are included.");
+        "file that have a corresponding task and model marker are included.");
     _markerFileNameProp.setName("marker_file");
     _propertySet.append(&_markerFileNameProp);
 
@@ -212,7 +212,7 @@ void InverseKinematicsTool::setupProperties()
 
     _reportMarkerLocationsProp.setComment(
         "Flag indicating whether or not to report model marker locations. "
-        "Note, model marker location are expresssed in Ground.");
+        "Note, model marker locations are expressed in Ground.");
     _reportMarkerLocationsProp.setName("report_marker_locations");
     _reportMarkerLocationsProp.setValue(false);
     _propertySet.append(&_reportMarkerLocationsProp);


### PR DESCRIPTION
Fixes issue #2028

### Brief summary of changes
The last frame was intermittently being missed due to round-off error. The condition for finding time frames was updated to consider +/- round off error.

### Testing I've completed
Tested on case provided by user in #2028. It now gets the last time-frame at 0.15s.
Added an assert if user final time is not achieved. 

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix.

