### PR TITLE
Fix error cases with Component::findStateVariable().

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -732,17 +732,17 @@ std::string Component::getRelativePathName(const Component& wrt) const
 }
 
 const Component::StateVariable* Component::
-    findStateVariable(const std::string& name) const
+    traverseToStateVariable(const std::string& pathName) const
 {
     // Must have already called initSystem.
     OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
-    ComponentPath svPath(name);
+    ComponentPath svPath(pathName);
 
     const StateVariable* found = nullptr;
     if (svPath.getNumPathLevels() == 1) {
         // There was no slash. The state variable should be in this component.
-        auto it = _namedStateVariableInfo.find(name);
+        auto it = _namedStateVariableInfo.find(pathName);
         if (it != _namedStateVariableInfo.end()) {
             return it->second.stateVariable.get();
         }
@@ -752,7 +752,7 @@ const Component::StateVariable* Component::
         if (comp) {
             // This is the leaf of the path:
             const auto& varName = svPath.getComponentName();
-            found = comp->findStateVariable(varName);
+            found = comp->traverseToStateVariable(varName);
         }
     }
     return found;
@@ -837,7 +837,7 @@ double Component::
     OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     // find the state variable with this component or its subcomponents
-    const StateVariable* rsv = findStateVariable(name);
+    const StateVariable* rsv = traverseToStateVariable(name);
     if (rsv) {
         return rsv->getValue(s);
     }
@@ -868,7 +868,7 @@ double Component::
     } 
     else{
         // otherwise find the component that variable belongs to
-        const StateVariable* rsv = findStateVariable(name);
+        const StateVariable* rsv = traverseToStateVariable(name);
         if (rsv) {
             return rsv->getDerivative(state);
         }
@@ -892,7 +892,7 @@ void Component::
     OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
 
     // find the state variable
-    const StateVariable* rsv = findStateVariable(name);
+    const StateVariable* rsv = traverseToStateVariable(name);
 
     if(rsv){ // find required rummaging through the state variable names
             return rsv->setValue(s, value);
@@ -949,7 +949,7 @@ SimTK::Vector Component::
         _allStateVariables.resize(nsv);
         Array<std::string> names = getStateVariableNames();
         for (int i = 0; i < nsv; ++i)
-            _allStateVariables[i].reset(findStateVariable(names[i]));
+            _allStateVariables[i].reset(traverseToStateVariable(names[i]));
     }
 
     Vector stateVariableValues(nsv, SimTK::NaN);
@@ -982,7 +982,7 @@ void Component::
         _allStateVariables.resize(nsv);
         Array<std::string> names = getStateVariableNames();
         for (int i = 0; i < nsv; ++i)
-            _allStateVariables[i].reset(findStateVariable(names[i]));
+            _allStateVariables[i].reset(traverseToStateVariable(names[i]));
     }
 
     for(int i=0; i<nsv; ++i){

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2355,11 +2355,18 @@ protected:
 public:
 #ifndef SWIG // StateVariable is protected.
     /**
-     * Find a StateVariable of this Component (includes its subcomponents).
+     * Get a StateVariable anywhere in the Component tree, given a
+     * StateVariable path. The StateVariable doesn't need to be in a
+     * subcomponent of this compoonent; it could be located in a different
+     * branch of the Component tree (in such a case, the specified path might
+     * begin with "../").
+     * This returns nullptr if a StateVariable does not exist at the specified
+     * path or if the path is invalid.
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    const StateVariable* findStateVariable(const std::string& name) const;
+    const StateVariable* traverseToStateVariable(
+            const std::string& pathName) const;
 #endif
 
     /// @name Access to the owning component (advanced).

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -407,7 +407,8 @@ void testMisc() {
         SimTK::State sBlank;
         const std::string varName = "waldo"; //dummy name
 
-        ASSERT_THROW(ComponentHasNoSystem, theWorld.findStateVariable(varName));
+        ASSERT_THROW(ComponentHasNoSystem,
+                theWorld.traverseToStateVariable(varName));
         ASSERT_THROW(ComponentHasNoSystem, theWorld.getNumStateVariables());
         ASSERT_THROW(ComponentHasNoSystem, theWorld.getStateVariableNames());
         ASSERT_THROW(ComponentHasNoSystem,

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1046,6 +1046,42 @@ void testComponentPathNames()
     top.connect();
 }
 
+void testGetStateVariableValue() {
+
+    TheWorld top;
+    top.setName("top");
+    Sub* a = new Sub();
+    a->setName("a");
+    Sub* b = new Sub();
+    b->setName("b");
+
+    top.add(a);
+    a->addComponent(b);
+
+    MultibodySystem system;
+    top.buildUpSystem(system);
+    State s = system.realizeTopology();
+
+    SimTK_TEST(s.getNY() == 3);
+    s.updY()[0] = 10; // "top/internalSub/subState"
+    s.updY()[1] = 20; // "top/a/subState"
+    s.updY()[2] = 30; // "top/a/b/subState"
+
+    SimTK_TEST(top.getStateVariableValue(s, "internalSub/subState") == 10);
+    SimTK_TEST(top.getStateVariableValue(s, "a/subState") == 20);
+    SimTK_TEST(top.getStateVariableValue(s, "a/b/subState") == 30);
+    SimTK_TEST(a->getStateVariableValue(s, "subState") == 20);
+    SimTK_TEST(a->getStateVariableValue(s, "b/subState") == 30);
+    SimTK_TEST(b->getStateVariableValue(s, "subState") == 30);
+    SimTK_TEST(b->getStateVariableValue(s, "../subState") == 20);
+    SimTK_TEST(b->getStateVariableValue(s, "../../internalSub/subState") == 10);
+
+    top.getStateVariableValue(s, "a/b/subState");
+    SimTK_TEST_MUST_THROW_EXC(
+            top.getStateVariableValue(s, "typo/b/subState"),
+            OpenSim::Exception);
+}
+
 void testInputOutputConnections()
 {
     {
@@ -2069,6 +2105,7 @@ int main() {
         SimTK_SUBTEST(testListInputs);
         SimTK_SUBTEST(testListSockets);
         SimTK_SUBTEST(testComponentPathNames);
+        SimTK_SUBTEST(testGetStateVariableValue);
         SimTK_SUBTEST(testInputOutputConnections);
         SimTK_SUBTEST(testInputConnecteeNames);
         SimTK_SUBTEST(testExceptionsForConnecteeTypeMismatch);


### PR DESCRIPTION
Fixes #2082 

### Brief summary of changes

- This PR fixes the two bugs mentioned in #2082. Invalid state variable paths were silently being accepted, and sometimes the wrong state variable value could be returned.

### Testing I've completed

- Added a test case that failed without this PR. With the bug fix, the tests now pass.

### Looking for feedback on...

- Is the use of ComponentPath okay?

### CHANGELOG.md (choose one)

- no need to update because...this bug was introduced after 3.3.
