### PR TITLE
Avoid doxygen "Illegal command n" warning.

### DIFF
--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -888,7 +888,7 @@ private:
     /** This socket was generated with the                               */ \
     /** #OpenSim_DECLARE_SOCKET macro;                                   */ \
     /** see AbstractSocket for more information.                         */ \
-    /** @socketmethods connectSocket_##cname##()                         */ \
+    /** @see connectSocket_##cname##()                                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -962,7 +962,7 @@ private:
     /** In an XML file, you can set this socket's connectee name         */ \
     /** via the <b>\<socket_##cname##_connectee_name\></b> element.      */ \
     /** See AbstractSocket for more information.                         */ \
-    /** @socketmethods connectsocket_##cname##()                         */ \
+    /** @see connectsocket_##cname##()                                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1051,7 +1051,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     /** This input was generated with the                                */ \
     /** #OpenSim_DECLARE_INPUT macro;                                    */ \
     /** see AbstractInput for more information.                          */ \
-    /** @inputmethods connectInput_##iname##()                           */ \
+    /** @see connectInput_##iname##()                                    */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
@@ -1112,7 +1112,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     /** This input was generated with the                                */ \
     /** #OpenSim_DECLARE_LIST_INPUT macro;                               */ \
     /** see AbstractInput for more information.                          */ \
-    /** @inputmethods connectInput_##iname##()                           */ \
+    /** @see connectInput_##iname##()                                    */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1227,7 +1227,7 @@ A data member is also created but is intended for internal use only:
     /** This property was generated with                                 */ \
     /** the #OpenSim_DECLARE_PROPERTY macro;                             */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##()           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
     /** @}                                                               */ \
@@ -1265,7 +1265,7 @@ initialized with an object of type T.
     /** This property was generated with the                             */ \
     /** #OpenSim_DECLARE_UNNAMED_PROPERTY macro;                         */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##T##(), upd_##T##(), set_##T##()               */ \
+    /** @see get_##T##(), upd_##T##(), set_##T##()                       */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, T)                                        \
     /** @}                                                               */ \
@@ -1274,7 +1274,7 @@ initialized with an object of type T.
     /** Get the value of the <b> %##T </b> property.                     */ \
     const T& get_##T() const                                                \
     {   return this->getProperty_##T().getValue(); }                        \
-    /** Get a writable reference to the <b> %##T </b> property.         */ \
+    /** Get a writable reference to the <b> %##T </b> property.          */ \
     T& upd_##T()                                                            \
     {   return this->updProperty_##T().updValue(); }                        \
     /** %Set the value of the <b> %##T </b> property.                    */ \
@@ -1307,7 +1307,7 @@ value of type T.
     /** This property was generated with                                 */ \
     /** the #OpenSim_DECLARE_OPTIONAL_PROPERTY macro;                    */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##()           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
     /** @}                                                               */ \
@@ -1316,7 +1316,7 @@ value of type T.
     /** Get the value of the <b> pname </b> property.                    */ \
     const T& get_##pname() const                                            \
     {   return this->getProperty_##pname().getValue(); }                    \
-    /** Get a writable reference to the <b> pname </b> property.        */ \
+    /** Get a writable reference to the <b> pname </b> property.         */ \
     T& upd_##pname()                                                        \
     {   return this->updProperty_##pname().updValue(); }                    \
     /** %Set the value of the <b> pname </b> property.                   */ \
@@ -1343,7 +1343,7 @@ supports a %size() method and operator[] element selection.
     /** This property holds a \a list of objects, and was generated with */ \
     /** the #OpenSim_DECLARE_LIST_PROPERTY macro;                        */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##(),  */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##(),          */ \
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
@@ -1376,7 +1376,7 @@ method and operator[] element selection.
     /** and was generated with                                           */ \
     /** the #OpenSim_DECLARE_LIST_PROPERTY_SIZE macro;                   */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##()   */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##()           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
     /** @}                                                               */ \
@@ -1403,7 +1403,7 @@ selection.
     /** and was generated with                                           */ \
     /** the #OpenSim_DECLARE_LIST_PROPERTY_ATLEAST macro;                */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##(),  */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##(),          */ \
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
@@ -1431,7 +1431,7 @@ method and operator[] element selection.
     /** and was generated with                                           */ \
     /** the #OpenSim_DECLARE_LIST_PROPERTY_ATMOST macro;                 */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##(),  */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##(),          */ \
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \
@@ -1465,7 +1465,7 @@ OpenSim_DECLARE_PROPERTY_ATMOST() rather than this macro.
     /** and was generated with                                           */ \
     /** the #OpenSim_DECLARE_LIST_PROPERTY_RANGE macro;                  */ \
     /** see Property to learn about the property system.                 */ \
-    /** @propmethods get_##pname##(), upd_##pname##(), set_##pname##(),  */ \
+    /** @see get_##pname##(), upd_##pname##(), set_##pname##(),          */ \
     /**     append_##pname##()                                           */ \
     /* This macro below is explained above.                              */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, pname)                                    \

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -204,9 +204,7 @@ TAB_SIZE               = 4
 # will result in a user-defined paragraph with heading "Side Effects:".
 # You can put \n's in the value part of an alias to insert newlines.
 
-ALIASES = "propmethods=\par Methods related to this property\n"               \
-          "inputmethods=\par Methods related to this input\n"                 \
-          "socketmethods=\par Methods related to this socket\n"
+ALIASES = 
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding


### PR DESCRIPTION
Fixes #2085 

### Brief summary of changes

- Remove custom aliases that were causing doxygen warnings.

### Testing I've completed

- Generated doxygen and ensured the doxygen output retains its original functionality:

![screen shot 2018-02-14 at 10 34 24 am](https://user-images.githubusercontent.com/846001/36221343-a692e8ac-1172-11e8-8335-7a763b5011ce.png)
