### PR TITLE
Fix crash in ExternalForce when force_expressed_in_body is unspecified.

### DIFF
--- a/OpenSim/Simulation/Model/ExternalForce.h
+++ b/OpenSim/Simulation/Model/ExternalForce.h
@@ -62,7 +62,7 @@ public:
         "Name of the body the force is applied to.");
     OpenSim_DECLARE_PROPERTY(force_expressed_in_body, std::string,
         "Name of the body the force is expressed in (default is ground).");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(point_expressed_in_body, std::string,
+    OpenSim_DECLARE_PROPERTY(point_expressed_in_body, std::string,
         "Name of the body the point is expressed in (default is ground).");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(force_identifier, std::string,
         "Identifier (string) to locate the force to be applied in the data source.");
@@ -88,13 +88,21 @@ public:
     /**
      * Convenience Constructor of an ExternalForce. 
      * 
-     * @param dataSource        a storage containing the pertinent force data through time
-     * @param forceIdentifier   string used to access the force data in the dataSource
-     * @param pointIdentifier   string used to access the point of application of the force in dataSource
-     * @param torqueIdentifier  string used to access the force data in the dataSource
-     * @param appliedToBodyName         string used to specify the body to which the force is applied
-     * @param forceExpressedInBodyName  string used to define in which body the force is expressed
-     * @param pointExpressedInBodyName  string used to define the body in which the point is expressed
+     * @param dataSource        
+     *      a storage containing the pertinent force data through time
+     * @param forceIdentifier
+     *      string used to access the force data in the dataSource
+     * @param pointIdentifier
+     *      string used to access the point of application of the force in
+     *      dataSource
+     * @param torqueIdentifier
+     *      string used to access the force data in the dataSource
+     * @param appliedToBodyName
+     *      string used to specify the body to which the force is applied
+     * @param forceExpressedInBodyName
+     *      string used to define in which body the force is expressed
+     * @param pointExpressedInBodyName
+     *      string used to define the body in which the point is expressed
      */
     ExternalForce(const Storage& dataSource, 
                   const std::string& forceIdentifier="force", 
@@ -107,9 +115,6 @@ public:
 
     // Uses default (compiler-generated) destructor, copy constructor, copy 
     // assignment operator.
-
-    // Copy properties from XML into member variables
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
 
     // ACCESS METHODS
     /**
@@ -208,6 +213,8 @@ public:
 
 
 protected:
+
+    void extendFinalizeFromProperties() override;
 
     /**  ModelComponent interface */ 
     void extendConnectToModel(Model& model) override;

--- a/OpenSim/Tools/Test/testExternalLoads.cpp
+++ b/OpenSim/Tools/Test/testExternalLoads.cpp
@@ -29,18 +29,14 @@ using namespace OpenSim;
 using namespace std;
 
 void testExternalLoad();
+void testExternalLoadDefaultProperties();
 
 int main()
 {
-    try {
-        testExternalLoad();
-    }
-    catch (const Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
+    SimTK_START_TEST("testExternalLoads");
+        SimTK_SUBTEST(testExternalLoad);
+        SimTK_SUBTEST(testExternalLoadDefaultProperties);
+    SimTK_END_TEST();
 }
 
 
@@ -265,4 +261,60 @@ void testExternalLoad()
 
     // kinematics should match to within integ accuracy
     ASSERT_EQUAL(0.0, norm_err, integ_accuracy);
+}
+
+// Ensure the default values for the ExternalForce properties work as expected.
+void testExternalLoadDefaultProperties() {
+    using namespace SimTK;
+
+    Model model("Pendulum.osim");
+
+    auto& pendulum = model.getBodySet().get(model.getNumBodies()-1);
+    string pendBodyName = pendulum.getName();
+    Vec3 comInB = pendulum.getMassCenter();
+
+    Storage forceStore;
+    addLoadToStorage(forceStore,  pendulum.getMass()*model.getGravity(),
+            comInB, Vec3(0, 0, 0));
+    forceStore.setName("test_external_load_default_properties.sto");
+    forceStore.print(forceStore.getName());
+
+    ExternalForce* xf = new ExternalForce();
+    xf->setName("grav");
+    xf->setDataSource(forceStore);
+    SimTK_TEST(!xf->appliesForce());
+    SimTK_TEST(!xf->specifiesPoint());
+    SimTK_TEST(!xf->appliesTorque());
+    xf->set_force_identifier("force");
+    SimTK_TEST(xf->appliesForce());
+    xf->set_point_identifier("point");
+    SimTK_TEST(xf->specifiesPoint());
+    xf->set_torque_identifier("torque");
+    SimTK_TEST(xf->appliesTorque());
+    SimTK_TEST(xf->getAppliedToBodyName() == "");
+    xf->set_applied_to_body(pendBodyName);
+    SimTK_TEST(xf->getPointExpressedInBodyName() == "ground");
+    xf->set_point_expressed_in_body(pendBodyName);
+    SimTK_TEST(xf->getForceExpressedInBodyName() == "ground");
+    // Leave force_expressed_in_body as default ("ground").
+    ExternalLoads* extLoads = new ExternalLoads(model);
+    extLoads->adoptAndAppend(xf);
+
+    extLoads->print("testExternalLoadDefaultProperties_ExternalLoads.xml");
+
+    for(int i=0; i<extLoads->getSize(); i++)
+        model.addForce(&(*extLoads)[i]);
+    
+    // Ensure that, even when force_expressed_in_body is unspecified, no issues
+    // occur when initializing ExternalForce.
+    model.initSystem();
+
+    // ExternalForce throws an exception if it can't find the applied_to_body.
+    xf->set_applied_to_body("");
+    SimTK_TEST_MUST_THROW_EXC(model.initSystem(), OpenSim::Exception);
+    xf->set_applied_to_body(pendBodyName);
+
+    // If force_expressed_in_body can't be found, it's set to ground; no error.
+    xf->set_force_expressed_in_body("nonexistant");
+    model.initSystem();
 }

--- a/OpenSim/Tools/Test/testExternalLoads.cpp
+++ b/OpenSim/Tools/Test/testExternalLoads.cpp
@@ -315,6 +315,6 @@ void testExternalLoadDefaultProperties() {
     xf->set_applied_to_body(pendBodyName);
 
     // If force_expressed_in_body can't be found, it's set to ground; no error.
-    xf->set_force_expressed_in_body("nonexistant");
+    xf->set_force_expressed_in_body("nonexistent");
     model.initSystem();
 }


### PR DESCRIPTION
Fixes #2110

### Brief summary of changes

This PR fixes an issue with `ExternalForce` where, if the `force_expressed_in_body`  property is not set, the `_forceExpressedInBody` pointer is set to `Model`, causing a crash (because `Model` is not of type `PhysicalFrame`, and CMC was calling `getTransformInGround()` on `Model`). The cause was this line:

```cpp
_forceExpressedInBody = static_cast<const PhysicalFrame*>(&_model->getComponent(forceExpressedInBodyName));
```

The call `getComponent(forceExpressedInBodyName)`, with `forceExpressedInBodName==“”`, returned a pointer to the model, and `static_cast` doesn’t check type.

In this PR, I removed the static cast and added a test case to ensure that `force_expressed_in_body` is `”ground”` by default, as the documentation states. I made various related changes as well.

I wasn’t able to reproduce the exact same “Bus error: 10” error in #2110, but the crash I fixed occurred at the same part of RRA as #2110, and until other evidence surfaces, I think it’s safe to say this PR fixes #2110.
### Testing I've completed

- Added a test case.
- Ran RRA on Sam Hamner's data (see #2110) and the crash I was getting no longer occurred.

### CHANGELOG.md (choose one)

- no need to update because...minor fix.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
