### PR TITLE
Fix CMC slowdown due to reassembly of model within CMCActuatorSubsystem  

### DIFF
--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -617,11 +617,11 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName, Mo
         // Form complete storage so that the kinematics match the state labels/ordering
         Storage *qStore=NULL;
         Storage *uStore=NULL;
-        aModel.getSimbodyEngine().formCompleteStorages(s, *loadKinematicsForPointTransformation,qStore,uStore);
+        aModel.getSimbodyEngine().formCompleteStorages(s, 
+            *loadKinematicsForPointTransformation,
+            qStore,
+            uStore);
         // qStore should be in radians
-        if (qStore->isInDegrees()){
-            aModel.getSimbodyEngine().convertDegreesToRadians(*qStore);
-        }
         _externalLoads.transformPointsExpressedInGroundToAppliedBodies(*qStore, _ti, _tf);
         delete qStore;
         delete uStore;

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -621,7 +621,7 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName, Mo
             *loadKinematicsForPointTransformation,
             qStore,
             uStore);
-        // qStore should be in radians
+       
         _externalLoads.transformPointsExpressedInGroundToAppliedBodies(*qStore, _ti, _tf);
         delete qStore;
         delete uStore;

--- a/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
+++ b/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
@@ -148,11 +148,16 @@ void CMCActuatorSubsystemRep::setSpeedTrajectories(FunctionSet *aSet) {
     // controls
     const CoordinateSet& coords = _model->getCoordinateSet();
     for (int i = 0; i < nq; ++i) {
-        // the last argument to setValue is a bool to enforce kinematic constraints
-        // or not. It is being set to true when we set the last coordinate value.
-        coords[i].setValue(mutableCompState, _qWork[i] + _qCorrections[i], i==(nq-1));
+        // the last argument to setValue, a bool to enforce constraints,
+        // is false since values come from a _qSet of splined desired
+        // kinematics formed from formCompleteStorages, which enforces
+        // model constraints.
+        coords[i].setValue(mutableCompState, _qWork[i] + _qCorrections[i], false);
         coords[i].setSpeedValue(mutableCompState, _uWork[i] + _uCorrections[i]);
     }
+    // projectQ is sufficient to satisfy constraints perturbed by _qCorrections
+    _model->getMultibodySystem().projectQ(mutableCompState,
+        getModel()->get_assembly_accuracy());
 
      /* copy  muscle states computed from the actuator system to the muscle states
         for the complete system  then compute forces*/

--- a/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
+++ b/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
@@ -155,19 +155,21 @@ void CMCActuatorSubsystemRep::setSpeedTrajectories(FunctionSet *aSet) {
         coords[i].setValue(mutableCompState, _qWork[i] + _qCorrections[i], false);
         coords[i].setSpeedValue(mutableCompState, _uWork[i] + _uCorrections[i]);
     }
-    // projectQ is sufficient to satisfy constraints perturbed by _qCorrections
+    // project() to satisfy constraints perturbed by _q/_uCorrections
     _model->getMultibodySystem().projectQ(mutableCompState,
-        getModel()->get_assembly_accuracy()/10);
+        getModel()->get_assembly_accuracy() / 10);
+    _model->getMultibodySystem().projectU(mutableCompState,
+        getModel()->get_assembly_accuracy() / 10);
 
-     /* copy  muscle states computed from the actuator system to the muscle states
-        for the complete system  then compute forces*/
+    /* copy  muscle states computed from the actuator system to the muscle states
+       for the complete system  then compute forces*/
     mutableCompState.updZ() = s.getZ();
     mutableCompState.updTime() = t;
 
-     _model->getMultibodySystem().realize(_completeState, SimTK::Stage::Acceleration);
+    _model->getMultibodySystem().realize(_completeState, SimTK::Stage::Acceleration);
 
-     /* copy 1st derivatives of muscle states from complete system to actuator system */ 
-     s.updZDot() = _completeState.getZDot();
+    /* copy 1st derivatives of muscle states from complete system to actuator system */ 
+    s.updZDot() = _completeState.getZDot();
 
 /*
     cout << "_qWork=" << _qWork << endl;

--- a/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
+++ b/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
@@ -157,7 +157,7 @@ void CMCActuatorSubsystemRep::setSpeedTrajectories(FunctionSet *aSet) {
     }
     // projectQ is sufficient to satisfy constraints perturbed by _qCorrections
     _model->getMultibodySystem().projectQ(mutableCompState,
-        getModel()->get_assembly_accuracy());
+        getModel()->get_assembly_accuracy()/10);
 
      /* copy  muscle states computed from the actuator system to the muscle states
         for the complete system  then compute forces*/

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -897,8 +897,7 @@ formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
     
     delete qStore;
     
-    // Compute storage object for simulation
-    // Need to set column labels before converting rad->deg
+    // Set column labels before returning
     rQComplete->setColumnLabels(columnLabels);
     rUComplete->setColumnLabels(speedLabels);
 }

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -801,23 +801,6 @@ void SimbodyEngine::convertQuaternionsToDirectionCosines(double aQ1, double aQ2,
 //=============================================================================
 // CONFIGURATION
 //=============================================================================
-/**
- * From a potentially partial specification of the generalized coordinates,
- * form a complete storage of the generalized coordinates (q's) and
- * generalized speeds (u's).
- *
- * @param aQIn Storage containing the q's or a subset of the q's.  Rotational
- * q's should be in degrees.
- * @param rQComplete Storage containing all the q's.  If q's were not
- * in aQIn, the values are set to 0.0.  When a q is constrained, its value
- * is altered to be consistent with the constraint.  The caller is responsible
- * for deleting the memory associated with this storage.
- * @param rUComplete Storage containing all the u's.  The generalized speeds
- * are obtained by spline fitting the q's and differentiating the splines.
- * When a u is constrained, its value is altered to be consistent with the
- * constraint.  The caller is responsible for deleting the memory
- * associated with this storage.
- */
 void SimbodyEngine::
 formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
     OpenSim::Storage *&rQComplete,OpenSim::Storage *&rUComplete) const
@@ -883,7 +866,6 @@ formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
     if (aQIn.isInDegrees())
         convertDegreesToRadians(*qStore);
 
-
     // Compute generalized speeds
     GCVSplineSet tempQset(5,qStore);
     std::unique_ptr<Storage> uStore{tempQset.constructStorage(1)};
@@ -919,9 +901,6 @@ formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
     // Need to set column labels before converting rad->deg
     rQComplete->setColumnLabels(columnLabels);
     rUComplete->setColumnLabels(speedLabels);
-    // Convert back to degrees
-    convertRadiansToDegrees(*rQComplete);
-    convertRadiansToDegrees(*rUComplete);
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h
@@ -120,8 +120,26 @@ public:
     //--------------------------------------------------------------------------
     // CONSTRAINTS
     //--------------------------------------------------------------------------
-    virtual void formCompleteStorages( const SimTK::State& s, const OpenSim::Storage &aQIn,
-       OpenSim::Storage *&rQComplete,OpenSim::Storage *&rUComplete) const;
+    /**
+    * From a potentially partial specification of the generalized coordinates,
+    * form a complete storage of the generalized coordinates (q's) and
+    * generalized speeds (u's) in radians and radians/s respectively.
+    *
+    * @param aQIn Storage containing the q's or a subset of the q's.
+    * @param rQComplete Storage containing all the q's.  If q's were not
+    * in aQIn, the values are set to 0.0.  When a q is constrained, its value
+    * is altered to be consistent with the constraint.  The caller is responsible
+    * for deleting the memory associated with this storage. Units are radians.
+    * @param rUComplete Storage containing all the u's.  The generalized speeds
+    * are obtained by spline fitting the q's and differentiating the splines.
+    * When a u is constrained, its value is altered to be consistent with the
+    * constraint.  The caller is responsible for deleting the memory
+    * associated with this storage. Units are radians/s.
+    */
+    void formCompleteStorages( const SimTK::State& s, 
+        const OpenSim::Storage &aQIn,
+        OpenSim::Storage *&rQComplete,
+        OpenSim::Storage *&rUComplete) const;
 
     //--------------------------------------------------------------------------
     // EQUATIONS OF MOTION

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -390,16 +390,15 @@ loadStatesFromFile(SimTK::State& s)
 
         Storage *qStore=NULL, *uStore=NULL;
 
-        _model->getSimbodyEngine().formCompleteStorages( s, coordinatesStore,qStore,uStore);
+        // qStore and uStore returned are in radians
+        _model->getSimbodyEngine().formCompleteStorages( s, coordinatesStore,
+            qStore, uStore);
 
         if(_speedsFileName!="") {
             delete uStore;
             cout<<"\nLoading speeds from file "<<_speedsFileName<<"."<<endl;
             uStore = new Storage(_speedsFileName);
         }
-
-        _model->getSimbodyEngine().convertDegreesToRadians(*qStore);
-        _model->getSimbodyEngine().convertDegreesToRadians(*uStore);
 
         // used to use createStatesStorageFromCoordinatesAndSpeeds(*_model, *qStore, *uStore);
         double ti = qStore->getFirstTime();
@@ -437,10 +436,8 @@ setStatesFromMotion(const SimTK::State& s, const Storage &aMotion, bool aInDegre
     }
 
     Storage *qStore=NULL, *uStore=NULL;
+    // qStore and uStore returned are in radians
     _model->getSimbodyEngine().formCompleteStorages(s,motionCopy,qStore,uStore);
-
-    _model->getSimbodyEngine().convertDegreesToRadians(*qStore);
-    _model->getSimbodyEngine().convertDegreesToRadians(*uStore);
 
     double ti = qStore->getFirstTime();
     double tf = qStore->getLastTime();

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -548,11 +548,9 @@ bool CMCTool::run()
 
     if(desiredKinFlag) {
         _model->getMultibodySystem().realize(s, Stage::Time );
-        _model->getSimbodyEngine().formCompleteStorages(s, *desiredKinStore,qStore,uStore);
-        if(qStore->isInDegrees()){
-            _model->getSimbodyEngine().convertDegreesToRadians(*qStore);
-            _model->getSimbodyEngine().convertDegreesToRadians(*uStore);
-        }
+        // qStore and uStore returned are in radians
+        _model->getSimbodyEngine().formCompleteStorages(s, *desiredKinStore,
+            qStore, uStore);
     }
 
     // Spline

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -281,11 +281,11 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName, Mo
         // Form complete storage so that the kinematics match the state labels/ordering
         Storage *qStore=NULL;
         Storage *uStore=NULL;
-        aModel.getSimbodyEngine().formCompleteStorages(s, *loadKinematicsForPointTransformation,qStore,uStore);
-        // qStore should be in radians
-        if (qStore->isInDegrees()){
-            aModel.getSimbodyEngine().convertDegreesToRadians(*qStore);
-        }
+        // qStore and uStore returned are in radians
+        aModel.getSimbodyEngine().formCompleteStorages(s, 
+            *loadKinematicsForPointTransformation,
+            qStore, uStore);
+
         _externalLoads.transformPointsExpressedInGroundToAppliedBodies(*qStore, _timeRange[0], _timeRange[1]);
         delete qStore;
         delete uStore;

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -514,11 +514,9 @@ bool RRATool::run()
 
     if(desiredKinFlag) {
         _model->getMultibodySystem().realize(s, Stage::Time );
-        _model->getSimbodyEngine().formCompleteStorages(s, *desiredKinStore,qStore,uStore);
-        if(qStore->isInDegrees()){
-            _model->getSimbodyEngine().convertDegreesToRadians(*qStore);
-            _model->getSimbodyEngine().convertDegreesToRadians(*uStore);
-        }
+        // qStore and uStore returned are in radians
+        _model->getSimbodyEngine().formCompleteStorages(s, *desiredKinStore,
+            qStore, uStore);
     }
 
     // Adjust COM to reduce residuals (formerly RRA pass 1) if requested


### PR DESCRIPTION
Fixes issues: #2108, #2089

### Brief summary of changes
Using `Coordinate::setValue()` in `CMCActuatorSubsystem` ensures consistency of coordinate values in the underlying state, but it was unnecessarily triggering an `assemble()` of the model to satisfy constraints. The assemble() to enforce/satisfy constraints is unnecessary since desired (target) kinematics have already been through `SimbodyEngine::formCompleteStorages()`.  The fix to speed things up is to just `projectQ()` just in case coordinates are perturbed slightly from the desired while tracking.

It was also a potential bug in 3.3 not to do a projection of the kinematics during tracking which could lead to constraint violations and in the case of the patella this could lead to different moment-arms for the quadriceps.

### Testing I've completed
Reran CMC from leg69 during swing with no reserve actuators. This fix (4.0) runs CMC in 27s and 3.3 completed in 32s. The results are also comparable, but not identical:

![cmc_40_vs_33](https://user-images.githubusercontent.com/6494122/36943217-d93d8e22-1f39-11e8-8699-3040383be54e.png)

### Looking for feedback on...
@tkuchida can you verify that running the setup file and model for leg6dof9musc that you used in 4.0 with this branch produces similar answers to 3.3 and in similar (or better) time?

@apoorvar your model has couple constraints for the patella as well. Could you check the performance and answers from CMC on your model resulting from this fix?

### CHANGELOG.md (choose one)
- no need to update because this is a  bug fix.

