### PR TITLE
[WIP] Add analysis clone assign cases

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -30,11 +30,13 @@
 #include <OpenSim/Analyses/OutputReporter.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Auxiliary/auxiliaryTestMuscleFunctions.h>
+#include <OpenSim/Analyses/osimAnalyses.h>
 
 using namespace OpenSim;
 using namespace std;
 
 void testTutorialOne();
+void testAnalyses();
 
 // Test different default activations are respected when activation
 // states are not provided.
@@ -43,6 +45,11 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct);
 int main()
 {
     SimTK::Array_<std::string> failures;
+
+    try { testAnalyses(); }
+    catch (const std::exception& e) {
+        cout << e.what() << endl; failures.push_back("testAnalyses");
+    }
 
     try { testTutorialOne(); }
     catch (const std::exception& e) {
@@ -78,6 +85,46 @@ int main()
     cout << "Done" << endl;
     return 0;
 }
+
+
+void testAnalyses() {
+
+    Kinematics* temp = new Kinematics();
+
+    // Get all the Analyses
+    AnalysisSet availableAnalyses;
+    AnalysisSet::getAvailableAnalyses(availableAnalyses);
+
+    const std::string original{ "original" };
+    const std::string modified{ "modified" };
+    
+
+    for (int i = 0; i < availableAnalyses.getSize(); ++i) {
+        Analysis* analysis = &availableAnalyses.get(i);
+        cout << "Testing clone and assignment of "
+            << analysis->getConcreteClassName() << "." << endl;
+
+        randomize(analysis);
+        analysis->setName(original);
+        Analysis* clone = analysis->clone();
+
+        // perform an edit on the original
+        analysis->setName(modified);
+
+        // restore analysis to its unedited state
+        analysis->assign( *clone );
+
+        ASSERT(*analysis == *clone); 
+
+        delete clone;
+
+        ASSERT(analysis->getName() == original);
+
+        cout << "PASSED clone and assignment for  "
+            << analysis->getConcreteClassName() << "." << endl;
+    }
+}
+
 
 void testTutorialOne() {
     AnalyzeTool analyze1("PlotterTool.xml");

--- a/Bindings/Java/tests/TestBasics.java
+++ b/Bindings/Java/tests/TestBasics.java
@@ -99,12 +99,33 @@ class TestBasics {
        ModelScaler ms = new ModelScaler();
        Scale s = new Scale();
        ms.addScale(s);
-    }  
+    } 
+
+    public static void testAnalyses() {
+        // Get all the Analyses
+        AnalysisSet availableAnalyses = new AnalysisSet();
+        AnalysisSet.getAvailableAnalyses(availableAnalyses);
+
+        for (int i = 0; i < availableAnalyses.getSize(); ++i) {
+            Analysis analysis = availableAnalyses.get(i);
+
+            OpenSimObject clone = analysis.clone();
+
+            // restore analysis to its unedited state
+            analysis.assign( clone );
+
+            System.out.println(analysis.dump());
+            System.out.println(clone.dump()); 
+        }
+}
+
+
   public static void main(String[] args) {
       testBasics();
       testMuscleList();
       testToyReflexController();
       testScaleToolUtils();
+      testAnalyses();
 
       System.out.println("Test finished!");
       // TODO to cause test to fail: System.exit(-1);


### PR DESCRIPTION
Targets conjectured cause of issue [GUI #524](https://github.com/opensim-org/opensim-gui/issues/524)

### Brief summary of changes
Added cases for cloning and assigning each concrete `Analysis` registered in OpenSim.

### Testing I've completed
Both C++ and Java tests pass on Windows 10, but the behavior in the GUI is intermittent on Windows and fatal on Mac, so we expect Travis CI to fail.

### Looking for feedback on...
@aymanhab how does this differ from the code you use when editting Analyses? We can beef up the Java test to mirror your call sequence until we force the failure.

### CHANGELOG.md (choose one)
- no need to update because this is for a bug fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2116)
<!-- Reviewable:end -->
