### PR TITLE
Make clamping of Coordinates invoked only if enforceConstraints is true

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -317,7 +317,7 @@ double Coordinate::getValue(const SimTK::State& s) const
  */
 void Coordinate::setValue(SimTK::State& s, double aValue , bool enforceConstraints) const
 {
-    // If the coordinate is clamped, pull aValue into range, only if enforceConstraints
+    // If enforceConstraints is true and coordinate is clamped, clamp aValue into range
     if (enforceConstraints && getClamped(s)) {
         if (aValue < get_range(0))
             aValue = get_range(0);

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -317,8 +317,8 @@ double Coordinate::getValue(const SimTK::State& s) const
  */
 void Coordinate::setValue(SimTK::State& s, double aValue , bool enforceConstraints) const
 {
-    // If the coordinate is clamped, pull aValue into range.
-    if (getClamped(s)) {
+    // If the coordinate is clamped, pull aValue into range, only if enforceConstraints
+    if (enforceConstraints && getClamped(s)) {
         if (aValue < get_range(0))
             aValue = get_range(0);
         else if (aValue > get_range(1))

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -141,6 +141,9 @@ public:
         Model::assemble(state) once all Coordinate values have been set.
         Alternatively, use Model::setStateVariableValues() to set all coordinate
         values and their speeds at once followed by Model::assemble(state).
+      
+        The provided value will be clamped to the coordinate's range if
+        the coordinate is clamped and enforceConstraints is true.
         */
     void setValue(SimTK::State& s, double aValue, bool enforceContraints=true) const;
 


### PR DESCRIPTION

Fixes issue #540 of gui
https://github.com/opensim-org/opensim-gui/issues/540
### Brief summary of changes
Moved the block to enforce Coordinate clamp range so it is executed only when enforceConstraints is true
### Testing I've completed
GUI playback doesn't enforce clamping on bouncing block model of GUI issue above
### Looking for feedback on...
If documentation needs update?

### CHANGELOG.md (choose one)

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
