### PR TITLE
Storage constructor accepts version 2 files without nColumns and nRows in the header

### DIFF
--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -440,7 +440,7 @@ void testUpdateFile() {
                        RE_ANY));
     testCommand("update-file x.sto y", EXIT_FAILURE, 
             std::regex("(Loading input file 'x.sto')" + RE_ANY +
-                       "(Storage: ERROR- failed to open file x.sto)" + RE_ANY));
+                       "(Storage: Failed to open file x.sto)" + RE_ANY));
 
     // Successful input.
     // =================

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -1294,7 +1294,6 @@ TimeSeriesTable Storage::exportToTable() const {
     TimeSeriesTable table{};
 
     table.addTableMetaData("header", getName());
-    table.addTableMetaData("version", std::to_string(LatestVersion));
     table.addTableMetaData("inDegrees", std::string{_inDegrees ? "yes" : "no"});
     table.addTableMetaData("nRows", std::to_string(_storage.getSize()));
     table.addTableMetaData("nColumns", std::to_string(_columnLabels.getSize()));

--- a/OpenSim/Common/Storage.h
+++ b/OpenSim/Common/Storage.h
@@ -103,7 +103,7 @@ protected:
     std::string _description;
 
     /** Storage file version as written to the file */
-    int _fileVersion;
+    int _fileVersion = -1;
     static const int LatestVersion;
 //=============================================================================
 // METHODS

--- a/OpenSim/Common/Test/testStorage.cpp
+++ b/OpenSim/Common/Test/testStorage.cpp
@@ -74,10 +74,25 @@ int main() {
         // Loading version 2 storage file with Storage class.
         auto table = st->exportToTable();
         STOFileAdapter::write(table, "testStorage_version2.sto");
-        // Now read using Storage() constructor.
-        Storage stVersion2("testStorage_version2.sto");
-        // Compare with st.
-        SimTK_TEST_EQ(table.getMatrix(), stVersion2.exportToTable().getMatrix());
+        {
+            // Now read using Storage() constructor.
+            Storage stVersion2("testStorage_version2.sto");
+            // Compare with st.
+            SimTK_TEST_EQ(table.getMatrix(),
+                    stVersion2.exportToTable().getMatrix());
+        }
+
+        // The version 2 storage file does not require nRows and nColumns
+        // metadata (Issue #2120).
+        {
+            table.removeTableMetaDataKey("nRows");
+            table.removeTableMetaDataKey("nColumns");
+            STOFileAdapter::write(table,
+                    "testStorage_version2_short_header.sto");
+            Storage stVersion2("testStorage_version2_short_header.sto");
+            SimTK_TEST_EQ(table.getMatrix(),
+                    stVersion2.exportToTable().getMatrix());
+        }
     }
     catch (const Exception& e) {
         e.print(cerr);


### PR DESCRIPTION
Fixes #2120.

### Brief summary of changes

- The Storage constructor can now read version 2 files without nColumns and nRows in the header.
- I fixed another issue where "version=1" would appear in the header for version 2 storage files.
- I removed a duplicate message about failing to parse the header.

### Testing I've completed

- Added a test case and inspected the written STO files.

### CHANGELOG.md (choose one)

- no need to update because...version 2 storage files are new to 4.0
