### PR TITLE
Name stateStorage used by AnalyzeTool so it doesn't end up named UNKNOWN

### DIFF
--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -371,7 +371,7 @@ loadStatesFromFile(SimTK::State& s)
         cout<<"\nLoading states from file "<<_statesFileName<<"."<<endl;
         Storage temp(_statesFileName);
         _statesStore = new Storage();
-        _statesStore->setName("standardized_"+temp.getName()); // Name appears in GUI
+        _statesStore->setName("states"); // Name appears in GUI
         _model->formStateStorage(temp, *_statesStore, true);
     } else {
         if(!_coordinatesFileNameProp.isValidFileName()) 

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -371,6 +371,7 @@ loadStatesFromFile(SimTK::State& s)
         cout<<"\nLoading states from file "<<_statesFileName<<"."<<endl;
         Storage temp(_statesFileName);
         _statesStore = new Storage();
+        _statesStore->setName("states"); // Name appears in GUI
         _model->formStateStorage(temp, *_statesStore, true);
     } else {
         if(!_coordinatesFileNameProp.isValidFileName()) 

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -371,7 +371,7 @@ loadStatesFromFile(SimTK::State& s)
         cout<<"\nLoading states from file "<<_statesFileName<<"."<<endl;
         Storage temp(_statesFileName);
         _statesStore = new Storage();
-        _statesStore->setName("states"); // Name appears in GUI
+        _statesStore->setName("standardized_"+temp.getName()); // Name appears in GUI
         _model->formStateStorage(temp, *_statesStore, true);
     } else {
         if(!_coordinatesFileNameProp.isValidFileName()) 


### PR DESCRIPTION
Fixes issue # opensim-gui/issues/594

### Brief summary of changes
AnalyzeTool internally creates a stateStorage that is loaded by the GUI when user runs the tool. The storage is never given a name. Added a call to name it "states".

### Testing I've completed
Followed instructions in issue and the loaded motion after AnalyzeTool run is now called "states"

### Looking for feedback on...
Is there a better/more meaningful name? Variety of tools and analyses produce "states".

### CHANGELOG.md (choose one)

- no need to update because, the name of the displayed Storage  is  likely never documented.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
