### PR TITLE
OutputReporter uniquely names TableReporters to eliminate duplicate name warnings

### DIFF
--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -45,8 +45,11 @@ int OutputReporter::begin(const SimTK::State& s)
     _pvtModel.reset(_model->clone());
 
     _tableReporterDouble = new TableReporter_<double>();
+    _tableReporterDouble->setName("ReporterDouble");
     _tableReporterVec3 = new TableReporter_<SimTK::Vec3>();
+    _tableReporterVec3->setName("ReporterVec3");
     _tableReporterSpatialVec = new TableReporter_<SimTK::SpatialVec>();
+    _tableReporterSpatialVec->setName("ReporterSpatialVec");
 
     _pvtModel->addComponent(_tableReporterDouble.get());
     _pvtModel->addComponent(_tableReporterVec3.get());


### PR DESCRIPTION
Fixes the issue of getting unhelpful warnings about duplicate named Reporters called "reporter", seen by @jenhicks and @jimmyDunne, when multiple reporter types are necessary for different `Output` types. 

### Brief summary of changes
Give the different `TableReporter_` unique names  according to their type.

### Testing I've completed
The warning was being written in `testOutputReporter` and it is no longer present.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a big fix


