### PR TITLE
If user asks for no warning on missing states do not warn on count either

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1876,7 +1876,7 @@ void Model::formStateStorage(const Storage& originalStorage,
     Array<string> rStateNames = getStateVariableNames();
     int numStates = getNumStateVariables();
     // make sure same size, otherwise warn
-    if (originalStorage.getSmallestNumberOfStates() != rStateNames.getSize()){
+    if (originalStorage.getSmallestNumberOfStates() != rStateNames.getSize() && warnUnspecifiedStates){
         cout << "Number of columns does not match in formStateStorage. Found "
             << originalStorage.getSmallestNumberOfStates() << " Expected  " << rStateNames.getSize() << "." << endl;
     }


### PR DESCRIPTION


Fixes issue #<issue_number>

### Brief summary of changes
Move warning inside the  warn check

### Testing I've completed
Loaded motions in GUI that are not states and got no warning

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it's internal use

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
