### PR TITLE
Fix bug in traversePathToComponent() for InteractiveHopper

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/BuildInteractiveHopperSolution.m
+++ b/Bindings/Java/Matlab/Hopper_Device/BuildInteractiveHopperSolution.m
@@ -164,6 +164,9 @@ for d = 1:length(devices)
         device.printSubcomponentInfo();
     end
     
+    % Add the device to the hopper model.
+    hopper.addComponent(device);
+    
     % Get the 'anchor' joints in the device, and downcast them to the
     % WeldJoint class. Get the 'deviceAttach' frames in the hopper
     % model, and downcast them to the PhysicalFrame class.
@@ -180,17 +183,14 @@ for d = 1:length(devices)
     anchorA.connectSocket_parent_frame(thighAttach);
     anchorB.connectSocket_parent_frame(shankAttach);
     
-    % Add the device to the hopper model.
-    hopper.addComponent(device);
-    
     % Configure the device to wrap over the patella.
     if patellaWrap{d} && hopper.hasComponent([deviceNames{d}])
         if strcmp(deviceNames{d},'device_passive')
             % TODO: Change to downcast from PathSpring when PathSpring is
             % working for passive device
-            cable = PathActuator.safeDownCast(device.updComponent('/cableAtoBpassive'));
+            cable = PathActuator.safeDownCast(device.updComponent('cableAtoBpassive'));
         elseif strcmp(deviceNames{d},'device_active')
-            cable = PathActuator.safeDownCast(device.updComponent('/cableAtoBactive'));
+            cable = PathActuator.safeDownCast(device.updComponent('cableAtoBactive'));
         end
         patellaPath = 'thigh/patellaFrame/patella';
         wrapObject = WrapCylinder.safeDownCast(hopper.updComponent(patellaPath));

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2305,6 +2305,9 @@ protected:
         const Component* current = this;
         if (path.isAbsolute()) {
             while (current->hasOwner()) current = &current->getOwner();
+            if (path.getNumPathLevels() == 0 ||
+                    current->getName() != path.getSubcomponentNameAtLevel(0))
+                return nullptr;
             // Skip over the root name.
             iPathEltStart = 1;
         } else {

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1114,13 +1114,16 @@ void testTraversePathToComponent() {
     SimTK_TEST(&b1->getComponent<B>("/top/a1/b2") == b2);
     SimTK_TEST(&b2->getComponent<A>("/top/a1/a2") == a2);
 
+
     // No component.
     // -------------
     // Incorrect path.
     SimTK_TEST_MUST_THROW(top.getComponent<A>("oops/a2"));
     // Wrong type.
     SimTK_TEST_MUST_THROW(top.getComponent<B>("a1/a2"));
+    SimTK_TEST_MUST_THROW(b1->getComponent("/nonexistent"));
     // Going too high up.
+    SimTK_TEST_MUST_THROW(top.getComponent<A>("/"));
     SimTK_TEST_MUST_THROW(top.getComponent<A>(".."));
     SimTK_TEST_MUST_THROW(top.getComponent<A>("../"));
     SimTK_TEST_MUST_THROW(top.getComponent<A>("../.."));

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -1119,9 +1119,9 @@ void testTraversePathToComponent() {
     // -------------
     // Incorrect path.
     SimTK_TEST_MUST_THROW(top.getComponent<A>("oops/a2"));
+    SimTK_TEST_MUST_THROW(b1->getComponent("/nonexistent"));
     // Wrong type.
     SimTK_TEST_MUST_THROW(top.getComponent<B>("a1/a2"));
-    SimTK_TEST_MUST_THROW(b1->getComponent("/nonexistent"));
     // Going too high up.
     SimTK_TEST_MUST_THROW(top.getComponent<A>("/"));
     SimTK_TEST_MUST_THROW(top.getComponent<A>(".."));


### PR DESCRIPTION
### Brief summary of changes

- This PR is an urgent fix for the InteractiveHopper example that we hope to test during the OpenSim meeting on March 27 (tomorrow). Hopefully we can review it early in the morning so we can have a build ready before lunch.
- The `addComponent` line must now come before connecting sockets (I fixed this in #2084 in multiple places but neglected to fix it for the interactive hopper files).
- I fixed the path we were providing to `updComponent()`.
- I fixed a bug where `updComponent("/foo")` would return the root model, even if it wasn't called "foo".

### Testing I've completed

- I ensured that the InteractiveHopper Matlab GUI works as expected when adding a device.
