### PR TITLE
Support increasing InteractiveHopper font size.

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/InteractiveHopper.m
+++ b/Bindings/Java/Matlab/Hopper_Device/InteractiveHopper.m
@@ -84,6 +84,10 @@ handles = InteractiveHopperSettings(handles,'load','setDefaults',true);
 handles.muscleExcitationDefault.Value = handles.muscleExcitation.Value;
 handles.deviceControlDefault.Value = handles.deviceControl.Value;
 
+% Increase font size used in GUI elements. Useful if presenting on a Mac.
+% set(findall(handles.interactive_hopper, '-property', 'fontsize'), ...
+%         'fontsize', 16);
+
 % Label control axes
 axes(handles.control_axes)
 resetControlAxes()


### PR DESCRIPTION
This PR adds a comment to `InteractiveHopper.m` for changing the font size of the Matlab GUI. This is useful when presenting this GUI from a Mac, as the default font size is very small.

Thanks to @nickbianco for discovering this method for changing font size.