### PR TITLE
Make testCommandLineInterface pass with VS141.

### DIFF
--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -293,7 +293,7 @@ void testRunTool() {
     testCommand("run-tool", EXIT_FAILURE,
             StartsWith("Arguments did not match expected patterns"));
     testCommand("run-tool putes.xml", EXIT_FAILURE,
-            StartsWith("SimTK Exception thrown at Xml.cpp"));
+            StartsWith("SimTK Exception thrown at"));
     // We use print-xml to create a setup file that we can try to run.
     // (We are not really trying to test print-xml right now.)
     testCommand("print-xml cmc testruntool_cmc_setup.xml", EXIT_SUCCESS,


### PR DESCRIPTION
### Brief summary of changes

AppVeyor builds have been failing when using Visual Studio 2017, because the capitalization in an exception message changed (`Xml.cpp` -> `xml.cpp`). This PR updates the relevant test by removing the check for `Xml.cpp` from the test.

### Testing I've completed

1. Ran testCommandLineInterface locally on Windows using Visual Studio 2017 (VS141).