### PR TITLE
[Dynamic Walking] Script to optimize jump height of hopper

### DIFF
--- a/Bindings/Java/Matlab/Hopper_Device/.gitignore
+++ b/Bindings/Java/Matlab/Hopper_Device/.gitignore
@@ -3,3 +3,4 @@ hopper_results.csv
 *.asv
 *.mat
 *.sto
+*.dat

--- a/Bindings/Java/Matlab/Hopper_Device/BuildInteractiveHopperSolution.m
+++ b/Bindings/Java/Matlab/Hopper_Device/BuildInteractiveHopperSolution.m
@@ -42,7 +42,7 @@ defaultIsActivePropMyo = false;
 defaultActiveParameter = 50;
 defaultDeviceControl = [0.0 2.5 5.0;
                         0.0 0.75 0.0];
-defaultPrintSubcomponentAndOutputInfo = true;
+defaultPrintModelInfo = true;
 
 % Create optional values for input parser                   
 addOptional(p,'muscle',defaultMuscle)
@@ -55,7 +55,7 @@ addOptional(p,'activePatellaWrap',defaultActivePatellaWrap)
 addOptional(p,'isActivePropMyo',defaultIsActivePropMyo)
 addOptional(p,'activeParameter',defaultActiveParameter)
 addOptional(p,'deviceControl',defaultDeviceControl)
-addOptional(p,'printSubcomponentAndOutputInfo',defaultPrintSubcomponentAndOutputInfo)
+addOptional(p,'printModelInfo',defaultPrintModelInfo)
 
 % Parse inputs
 parse(p,varargin{:});
@@ -63,6 +63,25 @@ parse(p,varargin{:});
 % Retrieve inputs and/or default values
 muscle = p.Results.muscle;
 muscleExcitation = p.Results.muscleExcitation;
+% Check that muscle excitation nodes lie within proper bounds
+if any(muscleExcitation(1,:) < 0) || any(muscleExcitation(1,:) > 5)
+   error('Muscle excitation nodes must lie within the time interval [0,5].')
+end
+if any(muscleExcitation(2,:) < 0) || any(muscleExcitation(2,:) > 1)
+   error('Muscle excitation nodes must have values within the interval [0,1].')
+end
+if (muscleExcitation(1,1) ~= 0) && (muscleExcitation(2,1) ~= 0)
+    fprintf('First muscle excitation node must lie at (0,0). Adding node...');
+    muscleExcitation = [0 muscleExcitation(1,:);
+                        0 muscleExcitation(2,:)];
+end
+if muscleExcitation(1,end) ~= 5
+    fprintf(['Zero-order hold being applied to final muscle excitation ' ...
+             'node to end of 5 second hop cycle (value: %f)'], ...
+             muscleExcitation(2,end));
+    muscleExcitation = [muscleExcitation(1,:) 5;
+                        muscleExcitation(2,:) muscleExcitation(2,end)];
+end
 addPassiveDevice = p.Results.addPassiveDevice;
 passivePatellaWrap = p.Results.passivePatellaWrap;
 passiveParameter = p.Results.passiveParameter;
@@ -71,7 +90,28 @@ activePatellaWrap = p.Results.activePatellaWrap;
 isActivePropMyo = p.Results.isActivePropMyo;
 activeParameter = p.Results.activeParameter;
 deviceControl = p.Results.deviceControl;
-printSubcomponentAndOutputInfo = p.Results.printSubcomponentAndOutputInfo;
+% Check that device control nodes lie within proper bounds
+if addActiveDevice && ~isActivePropMyo
+    if any(deviceControl(1,:) < 0) || any(deviceControl(1,:) > 5)
+        error('Device control nodes must lie within the time interval [0,5].')
+    end
+    if any(deviceControl(2,:) < 0) || any(deviceControl(2,:) > 1)
+        error('Device control nodes must have values within the interval [0,1].')
+    end
+    if deviceControl(1,1) ~= 0
+        fprintf('First device control node must lie at (0,0). Adding node...');
+        deviceControl = [0 deviceControl(1,:);
+                         0 deviceControl(2,:)];
+    end
+    if deviceControl(1,end) ~= 5
+        fprintf(['Zero-order hold being applied to final device control ' ...
+                 'node to end of 5 second hop cycle (value: %f)'], ...
+                  deviceControl(2,end));
+        deviceControl = [deviceControl(1,:) 5;
+                         deviceControl(2,:) deviceControl(2,end)];
+    end
+end
+printModelInfo = p.Results.printModelInfo;
 
 import org.opensim.modeling.*;
 
@@ -116,7 +156,7 @@ hopper = BuildHopper('excitation',muscleExcitation, ...
                      'maxIsometricForce', maxIsometricForce, ...
                      'optimalFiberLength', optimalFiberLength, ...
                      'tendonSlackLength', tendonSlackLength);
-if printSubcomponentAndOutputInfo
+if printModelInfo
     hopper.printSubcomponentInfo();
 end
 
@@ -160,7 +200,7 @@ for d = 1:length(devices)
     % the hopper's subcomponents, and locate the two subcomponents named
     % 'deviceAttach'.
     device = devices{d};
-    if printSubcomponentAndOutputInfo
+    if printModelInfo
         device.printSubcomponentInfo();
     end
     
@@ -199,7 +239,7 @@ for d = 1:length(devices)
     
     % Print the names of the outputs of the device's PathActuator and
     % ToyPropMyoController subcomponents.
-    if strcmp(deviceNames{d},'device_active') && printSubcomponentAndOutputInfo
+    if strcmp(deviceNames{d},'device_active') && printModelInfo
         device.getComponent('cableAtoBactive').printOutputInfo();
         device.getComponent('controller').printOutputInfo();
     end

--- a/Bindings/Java/Matlab/Hopper_Device/EvaluateHopper.m
+++ b/Bindings/Java/Matlab/Hopper_Device/EvaluateHopper.m
@@ -45,9 +45,8 @@ heightRep.setName('height_reporter');
 % this function by about 1.5%.
 heightRep.set_report_time_interval(0.05);
 heightRep.addToReport(...
-    hopper.getComponent('slider/yCoord').getOutput('value'), 'height');
+    hopper.getComponent('slider/yCoord').getOutput('value'), 'height'); 
 hopperCopy.addComponent(heightRep);
-
 
 % Simulate.
 % ---------

--- a/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
+++ b/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
@@ -1,7 +1,7 @@
 function [x, f] = OptimizeHopper()
 % OPTIMIZEHOPPER
-%   This function uses CMA-ES to optimize the model for hop height.
-%
+%   This function uses fmincon to optimize the model for hop height.
+
 %-----------------------------------------------------------------------%
 % The OpenSim API is a toolkit for musculoskeletal modeling and         %
 % simulation. See http://opensim.stanford.edu and the NOTICE file       %
@@ -62,14 +62,16 @@ import org.opensim.modeling.*;
 passiveParameter = 100*x(1);
 activeParameter = 100*x(2);
 
-% Construct controls from the last optimization optimization variable. This
-% variable determines the timing of turning off the active (which releases 
-% the loaded spring) and the turning on of the vastus muscle to coordinate 
-% a hop.
+% Construct controls from the last optimization variable, x(3). This
+% variable is the time when the active device is turned off (which 
+% releases the loaded spring) and the vastus muscle is turned to 
+% coordinate a hop.
+% For deviceControl and excitation, the first row contains time nodes
+% and the second row contains control values.
 deviceControl = [0.0 0.01 x(3) x(3)+0.01 5.0;
                  0.0 1.0  1.0  0.0       0.0];
-excitation = [0.0 x(3) x(3)+0.01 5.0;
-              0.0 0.0  1.0       1.0];
+excitation =    [0.0      x(3) x(3)+0.01 5.0;
+                 0.0      0.0  1.0       1.0];
           
 % Build the hopper. This is the same function called after a solution is
 % is created in the InteractiveHopper GUI. The default muscle is "The

--- a/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
+++ b/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
@@ -35,7 +35,7 @@ lb = zeros(numVariables, 1);
 ub = ones(numVariables, 1);
 
 % Initial guess
-x0 = 0.5*ub;
+x0 = 0.25*ub;
 
 % Optimize!
 opts.TolFun = 0.01;
@@ -72,7 +72,8 @@ excitation = [0.0 x(3) x(3)+0.01 5.0;
               0.0 0.0  1.0       1.0];
           
 % Build the hopper. This is the same function called after a solution is
-% is created in the InteractiveHopper GUI.
+% is created in the InteractiveHopper GUI. The default muscle is "The
+% Average Joe".
 hopper = BuildInteractiveHopperSolution(...
             'muscleExcitation', excitation, ...
             'addPassiveDevice', true, ...

--- a/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
+++ b/Bindings/Java/Matlab/Hopper_Device/OptimizeHopper.m
@@ -1,0 +1,96 @@
+function [x, f] = OptimizeHopper()
+% OPTIMIZEHOPPER
+%   This function uses CMA-ES to optimize the model for hop height.
+%
+%-----------------------------------------------------------------------%
+% The OpenSim API is a toolkit for musculoskeletal modeling and         %
+% simulation. See http://opensim.stanford.edu and the NOTICE file       %
+% for more information. OpenSim is developed at Stanford University     %
+% and supported by the US National Institutes of Health (U54 GM072970,  %
+% R24 HD065690) and by DARPA through the Warrior Web program.           %
+%                                                                       %
+% Copyright (c) 2017 Stanford University and the Authors                %
+% Author(s): Carmichael Ong,  Nick Bianco                               %
+%                                                                       %
+% Licensed under the Apache License, Version 2.0 (the "License");       %
+% you may not use this file except in compliance with the License.      %
+% You may obtain a copy of the License at                               %
+% http://www.apache.org/licenses/LICENSE-2.0.                           %
+%                                                                       %
+% Unless required by applicable law or agreed to in writing, software   %
+% distributed under the License is distributed on an "AS IS" BASIS,     %
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       %
+% implied. See the License for the specific language governing          %
+% permissions and limitations under the License.                        %
+%-----------------------------------------------------------------------%
+
+% Three variables: 1) passive stiffness 
+%                  2) active max torque 
+%                  3) hop timing
+% See buildHopperFromSolution() for more details.
+numVariables = 3; 
+
+% Variable bounds
+lb = zeros(numVariables, 1);
+ub = ones(numVariables, 1);
+
+% Initial guess
+x0 = 0.5*ub;
+
+% Optimize!
+opts.TolFun = 0.01;
+[x, f] = fmincon(@objective,x0,[],[],[],[],lb,ub,[],opts);
+
+% Evaluate optimized solution
+hopper = buildHopperFromSolution(x);
+EvaluateHopper(hopper, true, true);
+
+end
+
+function hopper = buildHopperFromSolution(x)
+% BUILDHOPPERFROMSOLUTION
+%   Build the hopper with the passive device wrapped and the active device
+%   unwrapped (behind the knee). The optimization variables 'x' determine 
+%   the device properties and the timing of the hop.
+
+import org.opensim.modeling.*;
+
+% These parameters determine the stiffness in the passive device and the
+% maximum force in the active device, both on a 0-100 scale. The range of
+% values for each device correspond to the slider values in the GUI which
+% can be accessed by running InteractiveHopper.m.
+passiveParameter = 100*x(1);
+activeParameter = 100*x(2);
+
+% Construct controls from the last optimization optimization variable. This
+% variable determines the timing of turning off the active (which releases 
+% the loaded spring) and the turning on of the vastus muscle to coordinate 
+% a hop.
+deviceControl = [0.0 0.01 x(3) x(3)+0.01 5.0;
+                 0.0 1.0  1.0  0.0       0.0];
+excitation = [0.0 x(3) x(3)+0.01 5.0;
+              0.0 0.0  1.0       1.0];
+          
+% Build the hopper. This is the same function called after a solution is
+% is created in the InteractiveHopper GUI.
+hopper = BuildInteractiveHopperSolution(...
+            'muscleExcitation', excitation, ...
+            'addPassiveDevice', true, ...
+            'passivePatellaWrap', true, ...
+            'passiveParameter', passiveParameter, ...
+            'addActiveDevice', true, ...
+            'activePatellaWrap', false, ...
+            'activeParameter', activeParameter, ...
+            'deviceControl', deviceControl, ...
+            'isActivePropMyo', false);
+end
+
+function f = objective(x)
+
+hopper = buildHopperFromSolution(x);
+[peakHeight, ~] = EvaluateHopper(hopper, false, true);
+
+% Negate peak height for minimization
+f = -peakHeight;
+
+end

--- a/Bindings/Java/Matlab/Hopper_Device/Simulate.m
+++ b/Bindings/Java/Matlab/Hopper_Device/Simulate.m
@@ -99,6 +99,11 @@ while true
             comp = model.getComponent(compIter.getAbsolutePathString());
             reporter = TableReporter.safeDownCast(comp);
             reporter.clearTable();
+        elseif ~isempty(strfind(compIter.getConcreteClassName(), ...
+                   'TableReporter__Vec3_'))
+            comp = model.getComponent(compIter.getAbsolutePathString());
+            reporterVec3 = TableReporterVec3.safeDownCast(comp);
+            reporterVec3.clearTable();  
         end
         compIter.next();
     end

--- a/Bindings/Java/Matlab/Hopper_Device/Simulate.m
+++ b/Bindings/Java/Matlab/Hopper_Device/Simulate.m
@@ -90,7 +90,7 @@ while true
     end
 
     % Clear the table for all TableReporters. Note: this does not handle
-    % TableReporters for Vec3s, etc.
+    % TableReporters for class Vector, etc.
     compList = model.getComponentsList();
     compIter = compList.begin();
     while ~compIter.equals(compList.end())

--- a/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
+++ b/Bindings/Java/Matlab/Utilities/osimTableToStruct.m
@@ -82,9 +82,10 @@ for iLabel = 0 : nLabels - 1
     % letters, digits, and underscores.
     % Remove an initial slash.
     col_label = regexprep(col_label, '^/', '');
-    % Replace '/' and '|' if they are present.
+    % Replace '/', '|', and '.' if they are present.
     col_label = strrep(col_label,'/', '_');
     col_label = strrep(col_label,'|', '_');
+    col_label = strrep(col_label,'.', '_');
     % Add the label and data to the data struct
     structdata.(col_label) = dataArray;
 end


### PR DESCRIPTION
### Brief summary of changes
This PR adds a short script to optimize the jump height of the hopper model, using pre-existing hopper functions and the Matlab `fmincon` optimizer. 

Some additional minor changes include:
-  A more succinct variable name for whether or not to print model component info.
- Error checking in `BuildInteractiveHopperSolution.m` so a user can't specify control bounds that would lie outside the control window of the GUI.
- Support for reporting Vec3's (workshop participants may want to do this).
- Ignore DAT files
- In `osimTableToStruct`, replace periods with underscores in column names. (Contact force components from a ForceReporter include periods in column names. Workshop participants may also be interested in reporting forces.)

### Testing I've completed
With `fmincon` and an initial guess of 0.25 for each variable (which have bounds [0,1]), I get a solution around 1.44 meters. This isn't as high as it could be, but the optimization is super simple and the solution looks reasonable. 

### Looking for feedback on...
Should we add anything else or try to improve the solution? (This could probably be addressed in a later PR after the trial run of the workshop.)
