### PR TITLE
Prevent repeated throws from subcomponents when invalid properties are set

### DIFF
--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -156,6 +156,12 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     penMdl.set_optimal_fiber_length(getOptimalFiberLength());
     penMdl.set_pennation_angle_at_optimal(getPennationAngleAtOptimalFiberLength());
     penMdl.set_maximum_pennation_angle(get_maximum_pennation_angle());
+    try {
+        penMdl.finalizeFromProperties();
+    } catch (const SimTK::Exception::Base& ex) {
+        penMdl.setDefaultProperties(); //avoid throwing again
+        OPENSIM_THROW(Exception, ex.getMessage());
+    }
 
     // Set properties of activation dynamics model subcomponent. Values of
     // activation_time_constant, deactivation_time_constant, and
@@ -167,14 +173,18 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
         actMdl.set_activation_time_constant(get_activation_time_constant());
         actMdl.set_deactivation_time_constant(get_deactivation_time_constant());
         actMdl.set_minimum_activation(get_minimum_activation());
+        try {
+            actMdl.finalizeFromProperties();
+        } catch (const SimTK::Exception::Base& ex) {
+            actMdl.setDefaultProperties(); //avoid throwing again
+            OPENSIM_THROW(Exception, ex.getMessage());
+        }
     }
 
     // Compute and store values that are used for clamping the fiber length.
     const double minActiveFiberLength = falCurve.getMinActiveFiberLength()
                                         * getOptimalFiberLength();
-    // Must update the pennation model's internal data members before requesting
-    // the minimum fiber length.
-    penMdl.finalizeFromProperties();
+    // The pennation model's internal data members are updated above.
     const double minPennatedFiberLength = penMdl.getMinimumFiberLength();
     m_minimumFiberLength = max(SimTK::SignificantReal,
         max(minActiveFiberLength, minPennatedFiberLength));

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -65,6 +65,13 @@ void MuscleFirstOrderActivationDynamicModel::constructProperties()
     constructProperty_minimum_activation(0.01);
 }
 
+void MuscleFirstOrderActivationDynamicModel::setDefaultProperties()
+{
+    set_activation_time_constant(0.010);
+    set_deactivation_time_constant(0.040);
+    set_minimum_activation(0.01);
+}
+
 //==============================================================================
 // SERVICES
 //==============================================================================

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.h
@@ -118,6 +118,11 @@ protected:
 private:
     void setNull();
     void constructProperties();
+    void setDefaultProperties();
+
+    // These classes are friends because they call setDefaultProperties().
+    friend class Thelen2003Muscle;
+    friend class Millard2012EquilibriumMuscle;
 
 };
 

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -42,6 +42,13 @@ void MuscleFixedWidthPennationModel::constructProperties()
     constructProperty_maximum_pennation_angle(acos(0.1));
 }
 
+void MuscleFixedWidthPennationModel::setDefaultProperties()
+{
+    set_optimal_fiber_length(1.0);
+    set_pennation_angle_at_optimal(0.0);
+    set_maximum_pennation_angle(acos(0.1));
+}
+
 MuscleFixedWidthPennationModel::MuscleFixedWidthPennationModel()
 {
     setNull();

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.h
@@ -327,6 +327,7 @@ protected:
 private:
     void setNull();
     void constructProperties();
+    void setDefaultProperties();
 
     double m_parallelogramHeight;
     double m_maximumSinPennation;
@@ -337,7 +338,8 @@ private:
     // singularity as the fiber length approaches zero.
     double clampFiberLength(double fiberLength) const;
 
-    // These classes are friends because they call clampFiberLength().
+    // These classes are friends because they call clampFiberLength() and
+    // setDefaultProperties().
     friend class Thelen2003Muscle;
     friend class Millard2012EquilibriumMuscle;
     friend class Millard2012AccelerationMuscle;

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -785,6 +785,52 @@ void testThelen2003Muscle()
         ASSERT_THROW( MuscleCannotEquilibrate,
                       muscle->computeInitialFiberEquilibrium(state) );
     }
+
+    // Test exception handling when invalid properties are propagated to
+    // MuscleFixedWidthPennationModel and MuscleFirstOrderActivationDynamicModel
+    // subcomponents.
+    {
+        Model model;
+        auto muscle = new Thelen2003Muscle("muscle", 1., 0.5, 0.5, 0.);
+        muscle->addNewPathPoint("p1", model.updGround(), SimTK::Vec3(0));
+        muscle->addNewPathPoint("p2", model.updGround(), SimTK::Vec3(0,0,1));
+        model.addForce(muscle);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the pennation model outside
+        // its valid range.
+        muscle->setOptimalFiberLength(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setOptimalFiberLength(0.5);
+        model.finalizeFromProperties();
+
+        muscle->setPennationAngleAtOptimalFiberLength(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setPennationAngleAtOptimalFiberLength(0.);
+        model.finalizeFromProperties();
+
+        muscle->setMaximumPennationAngle(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setMaximumPennationAngle(0.);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the activation dynamics model
+        // outside its valid range.
+        muscle->setActivationTimeConstant(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setActivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setDeactivationTimeConstant(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setDeactivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setMinimumActivation(-0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setMinimumActivation(0.01);
+        model.finalizeFromProperties();
+    }
 }
 
 
@@ -849,6 +895,51 @@ void testMillard2012EquilibriumMuscle()
         muscle->computeInitialFiberEquilibrium(state);
     }
 
+    // Test exception handling when invalid properties are propagated to
+    // MuscleFixedWidthPennationModel and MuscleFirstOrderActivationDynamicModel
+    // subcomponents.
+    {
+        Model model;
+        auto muscle = new Millard2012EquilibriumMuscle("mcl", 1., 0.5, 0.5, 0.);
+        muscle->addNewPathPoint("p1", model.updGround(), SimTK::Vec3(0));
+        muscle->addNewPathPoint("p2", model.updGround(), SimTK::Vec3(0,0,1));
+        model.addForce(muscle);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the pennation model outside
+        // its valid range.
+        muscle->setOptimalFiberLength(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setOptimalFiberLength(0.5);
+        model.finalizeFromProperties();
+
+        muscle->setPennationAngleAtOptimalFiberLength(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setPennationAngleAtOptimalFiberLength(0.);
+        model.finalizeFromProperties();
+
+        muscle->set_maximum_pennation_angle(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->set_maximum_pennation_angle(0.);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the activation dynamics model
+        // outside its valid range.
+        muscle->setActivationTimeConstant(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setActivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setDeactivationTimeConstant(0.);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setDeactivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setMinimumActivation(-0.1);
+        ASSERT_THROW(Exception, model.finalizeFromProperties());
+        muscle->setMinimumActivation(0.01);
+        model.finalizeFromProperties();
+    }
 }
 
 void testMillard2012AccelerationMuscle()

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -107,19 +107,32 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     OPENSIM_THROW_IF_FRMOBJ(getMinControl() < get_minimum_activation(),
         InvalidPropertyValue, getProperty_min_control().getName());
 
-    // Set properties of subcomponents.
+    // Set properties of pennation model.
     auto& pennMdl =
         updMemberSubcomponent<MuscleFixedWidthPennationModel>(pennMdlIdx);
     pennMdl.set_optimal_fiber_length(getOptimalFiberLength());
     pennMdl.set_pennation_angle_at_optimal(
         getPennationAngleAtOptimalFiberLength());
     pennMdl.set_maximum_pennation_angle(get_maximum_pennation_angle());
+    try {
+        pennMdl.finalizeFromProperties();
+    } catch (const SimTK::Exception::Base& ex) {
+        pennMdl.setDefaultProperties(); //avoid throwing again
+        OPENSIM_THROW(Exception, ex.getMessage());
+    }
 
+    // Set properties of activation dynamics model.
     auto& actMdl =
         updMemberSubcomponent<MuscleFirstOrderActivationDynamicModel>(actMdlIdx);
     actMdl.set_activation_time_constant(get_activation_time_constant());
     actMdl.set_deactivation_time_constant(get_deactivation_time_constant());
     actMdl.set_minimum_activation(get_minimum_activation());
+    try {
+        actMdl.finalizeFromProperties();
+    } catch (const SimTK::Exception::Base& ex) {
+        actMdl.setDefaultProperties(); //avoid throwing again
+        OPENSIM_THROW(Exception, ex.getMessage());
+    }
 }
 
 //====================================================================


### PR DESCRIPTION
Fixes #2106.

### Brief summary of changes
`Thelen2003Muscle` and `Millard2012EquilibriumMuscle` now call `finalizeFromProperties()` on their subcomponents. If the subcomponent throws an Exception, the Muscle catches it and sets default properties in the subcomponent before re-throwing, which prevents the subcomponent from throwing again when its `finalizeFromProperties()` method is called directly by the MCI.

### Testing I've completed
Added tests to testMuscles; pass locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because... fixes bug in new MCI.
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
