### PR TITLE
Prevent repeated throws from subcomponents when invalid Muscle properties are set

### DIFF
--- a/OpenSim/Actuators/ClutchedPathSpring.cpp
+++ b/OpenSim/Actuators/ClutchedPathSpring.cpp
@@ -128,17 +128,21 @@ void ClutchedPathSpring::setInitialStretch(double stretch0)
 
      OPENSIM_THROW_IF_FRMOBJ(
          (SimTK::isNaN(get_stiffness()) || get_stiffness() < 0),
-         InvalidPropertyValue, getProperty_stiffness().getName());
+         InvalidPropertyValue, getProperty_stiffness().getName(),
+         "Stiffness cannot be less than zero");
      OPENSIM_THROW_IF_FRMOBJ(
          (SimTK::isNaN(get_dissipation()) || get_dissipation() < 0),
-         InvalidPropertyValue, getProperty_dissipation().getName());
+         InvalidPropertyValue, getProperty_dissipation().getName(),
+         "Dissipation cannot be less than zero");
      OPENSIM_THROW_IF_FRMOBJ(
          (SimTK::isNaN(get_relaxation_time_constant()) || get_relaxation_time_constant() < 0),
          InvalidPropertyValue, 
-         getProperty_relaxation_time_constant().getName());
+         getProperty_relaxation_time_constant().getName(),
+         "Relaxation time constant cannot be less than zero");
      OPENSIM_THROW_IF_FRMOBJ(
          (SimTK::isNaN(get_initial_stretch()) || get_initial_stretch() < 0),
-         InvalidPropertyValue, getProperty_initial_stretch().getName());
+         InvalidPropertyValue, getProperty_initial_stretch().getName(),
+         "Initial stretch cannot be less than zero");
  }
 
 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -164,7 +164,7 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     penMdl.set_maximum_pennation_angle(get_maximum_pennation_angle());
     try {
         penMdl.finalizeFromProperties();
-    } catch (const InvalidPropertyValue& ex) {
+    } catch (const InvalidPropertyValue&) {
         penMdl = *penMdlCopy;
         throw;
     }
@@ -180,7 +180,7 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
         actMdl.set_minimum_activation(get_minimum_activation());
         try {
             actMdl.finalizeFromProperties();
-        } catch (const InvalidPropertyValue& ex) {
+        } catch (const InvalidPropertyValue&) {
             actMdl = *actMdlCopy;
             throw;
         }

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -125,9 +125,9 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
             InvalidPropertyValue, getProperty_minimum_activation().getName(),
             "Minimum activation cannot be less than zero");
 
-        OPENSIM_THROW_IF_FRMOBJ(getMinControl() < 0.0,
+        OPENSIM_THROW_IF_FRMOBJ(getMinControl() < get_minimum_activation(),
             InvalidPropertyValue, getProperty_min_control().getName(),
-            "Minimum control cannot be less than zero");
+            "Minimum control cannot be less than minimum activation");
 
         set_minimum_activation(clamp(0, get_minimum_activation(), 1));
         falCurve.setMinValue(0.0);

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -107,10 +107,12 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     if(!get_ignore_tendon_compliance() && !use_fiber_damping) {
         // Compliant tendon with no damping.
         OPENSIM_THROW_IF_FRMOBJ(get_minimum_activation() < 0.01,
-            InvalidPropertyValue, getProperty_minimum_activation().getName());
+            InvalidPropertyValue, getProperty_minimum_activation().getName(),
+            "Minimum activation cannot be less than 0.01");
 
         OPENSIM_THROW_IF_FRMOBJ(getMinControl() < get_minimum_activation(),
-            InvalidPropertyValue, getProperty_min_control().getName());
+            InvalidPropertyValue, getProperty_min_control().getName(),
+            "Minimum control cannot be less than minimum activation");
 
         if (falCurve.getMinValue() < 0.1)
             falCurve.setMinValue(0.1);
@@ -120,10 +122,12 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
 
     } else { //singularity-free model still cannot have excitations below 0
         OPENSIM_THROW_IF_FRMOBJ(get_minimum_activation() < 0.0,
-            InvalidPropertyValue, getProperty_minimum_activation().getName());
+            InvalidPropertyValue, getProperty_minimum_activation().getName(),
+            "Minimum activation cannot be less than zero");
 
         OPENSIM_THROW_IF_FRMOBJ(getMinControl() < 0.0,
-            InvalidPropertyValue, getProperty_min_control().getName());
+            InvalidPropertyValue, getProperty_min_control().getName(),
+            "Minimum control cannot be less than zero");
 
         set_minimum_activation(clamp(0, get_minimum_activation(), 1));
         falCurve.setMinValue(0.0);

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -158,14 +158,14 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     // re-throw the exception thrown by the subcomponent.
     auto& penMdl =
         updMemberSubcomponent<MuscleFixedWidthPennationModel>(penMdlIdx);
-    MuscleFixedWidthPennationModel* penMdlCopy = penMdl.clone();
+    MuscleFixedWidthPennationModel penMdlCopy(penMdl);
     penMdl.set_optimal_fiber_length(getOptimalFiberLength());
     penMdl.set_pennation_angle_at_optimal(getPennationAngleAtOptimalFiberLength());
     penMdl.set_maximum_pennation_angle(get_maximum_pennation_angle());
     try {
         penMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue&) {
-        penMdl = *penMdlCopy;
+        penMdl = penMdlCopy;
         throw;
     }
 
@@ -174,14 +174,14 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     if (!get_ignore_activation_dynamics()) {
         auto& actMdl =
             updMemberSubcomponent<MuscleFirstOrderActivationDynamicModel>(actMdlIdx);
-        MuscleFirstOrderActivationDynamicModel* actMdlCopy = actMdl.clone();
+        MuscleFirstOrderActivationDynamicModel actMdlCopy(actMdl);
         actMdl.set_activation_time_constant(get_activation_time_constant());
         actMdl.set_deactivation_time_constant(get_deactivation_time_constant());
         actMdl.set_minimum_activation(get_minimum_activation());
         try {
             actMdl.finalizeFromProperties();
         } catch (const InvalidPropertyValue&) {
-            actMdl = *actMdlCopy;
+            actMdl = actMdlCopy;
             throw;
         }
     }

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -162,7 +162,7 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
         penMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue& ex) {
         penMdl = *penMdlCopy;
-        throw(ex);
+        throw;
     }
 
     // Propagate properties down to activation dynamics model subcomponent.
@@ -178,7 +178,7 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
             actMdl.finalizeFromProperties();
         } catch (const InvalidPropertyValue& ex) {
             actMdl = *actMdlCopy;
-            throw(ex);
+            throw;
         }
     }
 

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -97,15 +97,17 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
         " MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties";
 
     // Ensure property values are within appropriate ranges.
-    SimTK_ERRCHK1_ALWAYS(get_activation_time_constant() > SimTK::SignificantReal,
-        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Activation time constant must be greater than zero",
-        getName().c_str());
-    SimTK_ERRCHK1_ALWAYS(get_deactivation_time_constant() > SimTK::SignificantReal,
-        "MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties",
-        "%s: Deactivation time constant must be greater than zero",
-        getName().c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_minimum_activation(),
-        1.0-SimTK::SignificantReal, "minimum_activation",
-        errorLocation.c_str());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_activation_time_constant() < SimTK::SignificantReal,
+        InvalidPropertyValue,
+        getProperty_activation_time_constant().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_deactivation_time_constant() < SimTK::SignificantReal,
+        InvalidPropertyValue,
+        getProperty_deactivation_time_constant().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_minimum_activation() < 0 ||
+        get_minimum_activation() > 1.0-SimTK::SignificantReal,
+        InvalidPropertyValue,
+        getProperty_minimum_activation().getName());
 }

--- a/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/MuscleFirstOrderActivationDynamicModel.cpp
@@ -100,14 +100,17 @@ void MuscleFirstOrderActivationDynamicModel::extendFinalizeFromProperties()
     OPENSIM_THROW_IF_FRMOBJ(
         get_activation_time_constant() < SimTK::SignificantReal,
         InvalidPropertyValue,
-        getProperty_activation_time_constant().getName());
+        getProperty_activation_time_constant().getName(),
+        "Activation time constant must be greater than zero");
     OPENSIM_THROW_IF_FRMOBJ(
         get_deactivation_time_constant() < SimTK::SignificantReal,
         InvalidPropertyValue,
-        getProperty_deactivation_time_constant().getName());
+        getProperty_deactivation_time_constant().getName(),
+        "Deactivation time constant must be greater than zero");
     OPENSIM_THROW_IF_FRMOBJ(
         get_minimum_activation() < 0 ||
         get_minimum_activation() > 1.0-SimTK::SignificantReal,
         InvalidPropertyValue,
-        getProperty_minimum_activation().getName());
+        getProperty_minimum_activation().getName(),
+        "Minimum activation must be in the range [0, 1)");
 }

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -88,17 +88,20 @@ void MuscleFixedWidthPennationModel::extendFinalizeFromProperties()
     OPENSIM_THROW_IF_FRMOBJ(
         get_optimal_fiber_length() <= 0,
         InvalidPropertyValue,
-        getProperty_optimal_fiber_length().getName());
+        getProperty_optimal_fiber_length().getName(),
+        "Optimal fiber length must be greater than zero");
     OPENSIM_THROW_IF_FRMOBJ(
         get_pennation_angle_at_optimal() < 0 ||
         get_pennation_angle_at_optimal() > SimTK::Pi/2.0-SimTK::SignificantReal,
         InvalidPropertyValue,
-        getProperty_pennation_angle_at_optimal().getName());
+        getProperty_pennation_angle_at_optimal().getName(),
+        "Pennation angle at optimal fiber length must be in the range [0, Pi/2)");
     OPENSIM_THROW_IF_FRMOBJ(
         get_maximum_pennation_angle() < 0 ||
         get_maximum_pennation_angle() > SimTK::Pi/2.0,
         InvalidPropertyValue,
-        getProperty_maximum_pennation_angle().getName());
+        getProperty_maximum_pennation_angle().getName(),
+        "Maximum pennation angle must be in the range [0, Pi/2]");
 
     // Compute quantities that are used often.
     m_parallelogramHeight = get_optimal_fiber_length()

--- a/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/MuscleFixedWidthPennationModel.cpp
@@ -85,15 +85,20 @@ void MuscleFixedWidthPennationModel::extendFinalizeFromProperties()
         " MuscleFixedWidthPennationModel::extendFinalizeFromProperties";
 
     // Ensure property values are within appropriate ranges.
-    SimTK_ERRCHK1_ALWAYS(get_optimal_fiber_length() > 0.0,
-        "MuscleFixedWidthPennationModel::extendFinalizeFromProperties",
-        "%s: Optimal fiber length must be greater than zero",
-        getName().c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_pennation_angle_at_optimal(),
-        SimTK::Pi/2.0-SimTK::SignificantReal, "optimal_pennation_angle",
-        errorLocation.c_str());
-    SimTK_VALUECHECK_ALWAYS(0.0, get_maximum_pennation_angle(), SimTK::Pi/2.0,
-        "maximum_pennation_angle", errorLocation.c_str());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_optimal_fiber_length() <= 0,
+        InvalidPropertyValue,
+        getProperty_optimal_fiber_length().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_pennation_angle_at_optimal() < 0 ||
+        get_pennation_angle_at_optimal() > SimTK::Pi/2.0-SimTK::SignificantReal,
+        InvalidPropertyValue,
+        getProperty_pennation_angle_at_optimal().getName());
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_maximum_pennation_angle() < 0 ||
+        get_maximum_pennation_angle() > SimTK::Pi/2.0,
+        InvalidPropertyValue,
+        getProperty_maximum_pennation_angle().getName());
 
     // Compute quantities that are used often.
     m_parallelogramHeight = get_optimal_fiber_length()

--- a/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFirstOrderActivationDynamicModel.cpp
@@ -63,25 +63,25 @@ int main(int argc, char* argv[])
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_activation_time_constant(0.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    InvalidPropertyValue);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_deactivation_time_constant(0.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ErrorCheck);
+                    InvalidPropertyValue);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_minimum_activation(-SimTK::SignificantReal);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ValueOutOfRange);
+                    InvalidPropertyValue);
         }
         {
             MuscleFirstOrderActivationDynamicModel actMdl;
             actMdl.set_minimum_activation(1.0);
             SimTK_TEST_MUST_THROW_EXC(actMdl.finalizeFromProperties(),
-                    SimTK::Exception::ValueOutOfRange);
+                    InvalidPropertyValue);
         }
 
         /*

--- a/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
+++ b/OpenSim/Actuators/Test/testMuscleFixedWidthPennationModel.cpp
@@ -801,32 +801,32 @@ int main(int argc, char* argv[])
             MuscleFixedWidthPennationModel mfwpm;
             mfwpm.set_optimal_fiber_length(0.0);
             SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
-                SimTK::Exception::ErrorCheck);
+                InvalidPropertyValue);
         }
         {
             MuscleFixedWidthPennationModel mfwpm;
             mfwpm.set_pennation_angle_at_optimal(-SimTK::SignificantReal);
             SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+                InvalidPropertyValue);
         }
         {
             MuscleFixedWidthPennationModel mfwpm;
             mfwpm.set_pennation_angle_at_optimal(SimTK::Pi/2.0);
             SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+                InvalidPropertyValue);
         }
         {
             MuscleFixedWidthPennationModel mfwpm;
             mfwpm.set_maximum_pennation_angle(-SimTK::SignificantReal);
             SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+                InvalidPropertyValue);
         }
         {
             MuscleFixedWidthPennationModel mfwpm;
             mfwpm.set_maximum_pennation_angle(SimTK::Pi/2.0
                                               + SimTK::SignificantReal);
             SimTK_TEST_MUST_THROW_EXC(mfwpm.finalizeFromProperties(),
-                SimTK::Exception::ValueOutOfRange);
+                InvalidPropertyValue);
         }
 
         //Unset properties

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -785,6 +785,52 @@ void testThelen2003Muscle()
         ASSERT_THROW( MuscleCannotEquilibrate,
                       muscle->computeInitialFiberEquilibrium(state) );
     }
+
+    // Test exception handling when invalid properties are propagated to
+    // MuscleFixedWidthPennationModel and MuscleFirstOrderActivationDynamicModel
+    // subcomponents.
+    {
+        Model model;
+        auto muscle = new Thelen2003Muscle("muscle", 1., 0.5, 0.5, 0.);
+        muscle->addNewPathPoint("p1", model.updGround(), SimTK::Vec3(0));
+        muscle->addNewPathPoint("p2", model.updGround(), SimTK::Vec3(0,0,1));
+        model.addForce(muscle);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the pennation model outside
+        // its valid range.
+        muscle->setOptimalFiberLength(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setOptimalFiberLength(0.5);
+        model.finalizeFromProperties();
+
+        muscle->setPennationAngleAtOptimalFiberLength(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setPennationAngleAtOptimalFiberLength(0.);
+        model.finalizeFromProperties();
+
+        muscle->setMaximumPennationAngle(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setMaximumPennationAngle(0.);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the activation dynamics model
+        // outside its valid range.
+        muscle->setActivationTimeConstant(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setActivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setDeactivationTimeConstant(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setDeactivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setMinimumActivation(-0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setMinimumActivation(0.01);
+        model.finalizeFromProperties();
+    }
 }
 
 
@@ -849,6 +895,51 @@ void testMillard2012EquilibriumMuscle()
         muscle->computeInitialFiberEquilibrium(state);
     }
 
+    // Test exception handling when invalid properties are propagated to
+    // MuscleFixedWidthPennationModel and MuscleFirstOrderActivationDynamicModel
+    // subcomponents.
+    {
+        Model model;
+        auto muscle = new Millard2012EquilibriumMuscle("mcl", 1., 0.5, 0.5, 0.);
+        muscle->addNewPathPoint("p1", model.updGround(), SimTK::Vec3(0));
+        muscle->addNewPathPoint("p2", model.updGround(), SimTK::Vec3(0,0,1));
+        model.addForce(muscle);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the pennation model outside
+        // its valid range.
+        muscle->setOptimalFiberLength(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setOptimalFiberLength(0.5);
+        model.finalizeFromProperties();
+
+        muscle->setPennationAngleAtOptimalFiberLength(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setPennationAngleAtOptimalFiberLength(0.);
+        model.finalizeFromProperties();
+
+        muscle->set_maximum_pennation_angle(SimTK::Pi/2.0 + 0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->set_maximum_pennation_angle(0.);
+        model.finalizeFromProperties();
+
+        // Set each property that is propagated to the activation dynamics model
+        // outside its valid range.
+        muscle->setActivationTimeConstant(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setActivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setDeactivationTimeConstant(0.);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setDeactivationTimeConstant(0.1);
+        model.finalizeFromProperties();
+
+        muscle->setMinimumActivation(-0.1);
+        ASSERT_THROW(InvalidPropertyValue, model.finalizeFromProperties());
+        muscle->setMinimumActivation(0.01);
+        model.finalizeFromProperties();
+    }
 }
 
 void testMillard2012AccelerationMuscle()

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -123,7 +123,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     pennMdl.set_maximum_pennation_angle(get_maximum_pennation_angle());
     try {
         pennMdl.finalizeFromProperties();
-    } catch (const InvalidPropertyValue& ex) {
+    } catch (const InvalidPropertyValue&) {
         pennMdl = *pennMdlCopy;
         throw;
     }
@@ -138,7 +138,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     actMdl.set_minimum_activation(get_minimum_activation());
     try {
         actMdl.finalizeFromProperties();
-    } catch (const InvalidPropertyValue& ex) {
+    } catch (const InvalidPropertyValue&) {
         actMdl = *actMdlCopy;
         throw;
     }

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -123,7 +123,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
         pennMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue& ex) {
         pennMdl = *pennMdlCopy;
-        throw(ex);
+        throw;
     }
 
     // Propagate properties down to activation dynamics model subcomponent.
@@ -138,7 +138,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
         actMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue& ex) {
         actMdl = *actMdlCopy;
-        throw(ex);
+        throw;
     }
 }
 

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -116,7 +116,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     // re-throw the exception thrown by the subcomponent.
     auto& pennMdl =
         updMemberSubcomponent<MuscleFixedWidthPennationModel>(pennMdlIdx);
-    MuscleFixedWidthPennationModel* pennMdlCopy = pennMdl.clone();
+    MuscleFixedWidthPennationModel pennMdlCopy(pennMdl);
     pennMdl.set_optimal_fiber_length(getOptimalFiberLength());
     pennMdl.set_pennation_angle_at_optimal(
         getPennationAngleAtOptimalFiberLength());
@@ -124,7 +124,7 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     try {
         pennMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue&) {
-        pennMdl = *pennMdlCopy;
+        pennMdl = pennMdlCopy;
         throw;
     }
 
@@ -132,14 +132,14 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
     // Handle invalid properties as above for pennation model.
     auto& actMdl =
         updMemberSubcomponent<MuscleFirstOrderActivationDynamicModel>(actMdlIdx);
-    MuscleFirstOrderActivationDynamicModel* actMdlCopy = actMdl.clone();
+    MuscleFirstOrderActivationDynamicModel actMdlCopy(actMdl);
     actMdl.set_activation_time_constant(get_activation_time_constant());
     actMdl.set_deactivation_time_constant(get_deactivation_time_constant());
     actMdl.set_minimum_activation(get_minimum_activation());
     try {
         actMdl.finalizeFromProperties();
     } catch (const InvalidPropertyValue&) {
-        actMdl = *actMdlCopy;
+        actMdl = actMdlCopy;
         throw;
     }
 }

--- a/OpenSim/Actuators/Thelen2003Muscle.cpp
+++ b/OpenSim/Actuators/Thelen2003Muscle.cpp
@@ -102,10 +102,12 @@ void Thelen2003Muscle::extendFinalizeFromProperties()
 
 
     OPENSIM_THROW_IF_FRMOBJ(get_minimum_activation() < 0.01,
-        InvalidPropertyValue, getProperty_minimum_activation().getName());
+        InvalidPropertyValue, getProperty_minimum_activation().getName(),
+        "Minimum activation cannot be less than 0.01");
 
     OPENSIM_THROW_IF_FRMOBJ(getMinControl() < get_minimum_activation(),
-        InvalidPropertyValue, getProperty_min_control().getName());
+        InvalidPropertyValue, getProperty_min_control().getName(),
+        "Minimum control cannot be less than minimum activation");
 
     // Propagate properties down to pennation model subcomponent. If any of the
     // new property values are invalid, restore the subcomponent's current

--- a/OpenSim/Simulation/Model/PathSpring.cpp
+++ b/OpenSim/Simulation/Model/PathSpring.cpp
@@ -111,13 +111,16 @@ void PathSpring::extendFinalizeFromProperties()
 
     OPENSIM_THROW_IF_FRMOBJ(
         (SimTK::isNaN(get_resting_length()) || get_resting_length() < 0),
-        InvalidPropertyValue, getProperty_resting_length().getName());
+        InvalidPropertyValue, getProperty_resting_length().getName(),
+        "Resting length cannot be less than zero");
     OPENSIM_THROW_IF_FRMOBJ(
         (SimTK::isNaN(get_stiffness()) || get_stiffness() < 0),
-        InvalidPropertyValue, getProperty_stiffness().getName());
+        InvalidPropertyValue, getProperty_stiffness().getName(),
+        "Stiffness cannot be less than zero");
     OPENSIM_THROW_IF_FRMOBJ(
         (SimTK::isNaN(get_dissipation()) || get_dissipation() < 0),
-        InvalidPropertyValue, getProperty_dissipation().getName());
+        InvalidPropertyValue, getProperty_dissipation().getName(),
+        "Dissipation cannot be less than zero");
 }
 
 

--- a/OpenSim/Simulation/Wrap/WrapCylinder.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinder.cpp
@@ -118,13 +118,11 @@ void WrapCylinder::extendFinalizeFromProperties()
     Super::extendFinalizeFromProperties();
 
     // maybe set a parent pointer, _body = aBody;
-    if (get_radius() < 0.0)
-    {
-        string errorMessage = getProperty_radius().getName()
-            + " is not specified or is negative.";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue,
-            getProperty_radius().getName(), errorMessage);
-    }
+    OPENSIM_THROW_IF_FRMOBJ(
+        get_radius() < 0,
+        InvalidPropertyValue,
+        getProperty_radius().getName(),
+        "Radius must be specified and cannot be less than zero");
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
@@ -138,13 +138,12 @@ void WrapCylinderObst::connectToModelAndBody(Model& aModel, PhysicalFrame& aBody
     Super::connectToModelAndBody(aModel, aBody);
 
     // maybe set a parent pointer, _body = aBody;
-    if (_radius < 0.0)
-    {
-        string errorMessage = _radiusProp.getName() +
-            " was either not specified, or is negative.";
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, _radiusProp.getName(),
-                             errorMessage);
-    }
+    OPENSIM_THROW_IF_FRMOBJ(
+        _radius < 0,
+        InvalidPropertyValue,
+        _radiusProp.getName(),
+        "Radius must be specified and cannot be less than zero");
+
 /*
     Cylinder* cyl = new Cylinder(_radius, _length);
     setGeometryQuadrants(cyl);

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -133,8 +133,10 @@ void WrapObject::extendFinalizeFromProperties()
         upd_quadrant() = "all";
         _wrapSign = 0;
     } else {
-        // quadrant was specified incorrectly in wrap object definition; 
-        OPENSIM_THROW_FRMOBJ(InvalidPropertyValue, getProperty_quadrant().getName());
+        OPENSIM_THROW_FRMOBJ(
+            InvalidPropertyValue,
+            getProperty_quadrant().getName(),
+            "Quadrant was specified incorrectly in definition of wrap object");
     }
 }
 


### PR DESCRIPTION
Fixes #2106. Redo of PR #2161 using different design.

### Brief summary of changes
Affects `Thelen2003Muscle` and `Millard2012EquilibriumMuscle`, each of which has two subcomponents: `MuscleFixedWidthPennationModel` and `MuscleFirstOrderActivationDynamicModel`.
- Muscles propagate their properties down to their subcomponents and call `finalizeFromProperties()` on each subcomponent; if an exception is thrown, the Muscle restores the subcomponent's properties to their previous (though now out-of-sync) values and re-throws the exception. Underlying issue noted in #2162 for post-4.0.
- Replaced property checks in subcomponents with `OPENSIM_THROW_IF_FRMOBJ` macro that throws only `InvalidPropertyValue` so that the Muscles can catch this exception (rather than potentially catching and misinterpreting a SimTK exception caught with `SimTK::Exception::Base`). Updated corresponding tests.
- Added informative messages when throwing `InvalidPropertyValue` exception.
- Fixed inconsistency in Millard2012EquilibriumMuscle property checking.

### Testing I've completed
Added tests to testMuscles. All tests pass locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because... fixes MCI-related bug.
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
