### PR TITLE
[travis] No longer use nose to run Python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -266,8 +266,8 @@ script:
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/sdk/Python; fi
   # Run the python tests, verbosely.
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then sudo /usr/bin/easy_install nose; fi
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then /usr/bin/python -m nose -v; fi
+  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then sudo /usr/bin/easy_install nose2; fi
+  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then /usr/bin/python -m nose2 -v; fi
   - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "linux" ]]; then nosetests -v; fi
     
   ## Set up ssh for sourceforge.

--- a/.travis.yml
+++ b/.travis.yml
@@ -266,7 +266,7 @@ script:
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/sdk/Python; fi
   # Run the python tests, verbosely.
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then sudo /usr/bin/easy_install nose2; fi
+  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then sudo pip install nose2; fi
   - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then /usr/bin/python -m nose2 -v; fi
   - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "linux" ]]; then nosetests -v; fi
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,6 @@ addons:
       - valgrind
       # To build doxygen documentation.
       # TOO OLD; see below. - doxygen
-      # To run the python tests.
-      - python-nose
   # To avoid being prompted when ssh'ing into sourceforge.
   ssh_known_hosts:
       # For uploading doxygen.
@@ -266,9 +264,7 @@ script:
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/sdk/Python; fi
   # Run the python tests, verbosely.
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then sudo pip install nose2; fi
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "osx" ]]; then /usr/bin/python -m nose2 -v; fi
-  - if [[ "$WRAP" = "on" && "$TRAVIS_OS_NAME" = "linux" ]]; then nosetests -v; fi
+  - if [ "$WRAP" = "on" ]; then /usr/bin/python -m unittest discover --start-directory opensim/tests --verbose; fi
     
   ## Set up ssh for sourceforge.
   - if [[ "$DEPLOY" = "yes" || ("$DOXY" = "on" && "$TRAVIS_OS_NAME" = "linux" && "$TRAVIS_PULL_REQUEST" != "false") ]]; then PREP_SOURCEFORGE_SSH=0; else PREP_SOURCEFORGE_SSH=1; fi


### PR DESCRIPTION
### Brief summary of changes

- This PR removes `nose` from Travis. We were using the nose library to run python tests but we have had trouble downloading nose on Mac and we can easily do without nose.

### Testing I've completed

- Ran Travis CI tests.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...CI does not need to documented in the changelog.

Thanks @tkuchida for starting this fix.