### PR TITLE
Fix correction controller with GUI use case

### DIFF
--- a/Applications/Forward/test/subject01_Setup_Forward_Controller.xml
+++ b/Applications/Forward/test/subject01_Setup_Forward_Controller.xml
@@ -60,8 +60,8 @@
 					    indicates the controller will controll all the acuators in the model-->
 					<actuator_list> </actuator_list>
 					<!--Flag (true or false) indicating whether or not the controller is
-					    enabled (ON) should-->
-					<enable_controller> true </enable_controller>
+					    disabled.-->
+					<isDisabled> false </isDisabled>
 					<!--XML file containing the controls for the controlSet.-->
 					<controls_file> subject01_walk1_controls.xml </controls_file>
 				</ControlSetController>
@@ -70,12 +70,12 @@
 					    indicates the controller will controll all the acuators in the model-->
 					<actuator_list> </actuator_list>
 					<!--Flag (true or false) indicating whether or not the controller is
-					    enabled (ON) should-->
-					<enable_controller> true </enable_controller>
+					    disabled.-->
+					<isDisabled> false </isDisabled>
 					<!--Gain for position errors-->
-					<kp>     25.00000000 </kp>
+					<kp>    16.00000000 </kp>
 					<!--Gain for velocity errors-->
-					<kv>      10.00000000 </kv>
+					<kv>     8.00000000 </kv>
 				</CorrectionController>
 			</objects>
 			<groups/>

--- a/Applications/Forward/test/testForward.cpp
+++ b/Applications/Forward/test/testForward.cpp
@@ -33,69 +33,34 @@
 using namespace OpenSim;
 using namespace std;
 
-void testPendulum();    // test manager/integration process
-void testPendulumExternalLoad(); // test application of external loads point in pendulum
-void testPendulumExternalLoadWithPointInGround(); // test application of external loads point in ground
-void testArm26();       // now add computation of controls and generation of muscle forces
-void testGait2354();    // controlled muscles and ground reactions forces 
-void testGait2354WithController(); // included additional controller
-void testGait2354WithControllerGUI(); // implements steps GUI takes to provide a model
+void testPendulum();
+void testPendulumExternalLoad();
+void testPendulumExternalLoadWithPointInGround(); 
+void testArm26();
+void testGait2354();
+void testGait2354WithController();
+void testGait2354WithControllerGUI();
+
+
 int main() {
     Object::renameType("Thelen2003Muscle", "Thelen2003Muscle_Deprecated");
 
-    SimTK::Array_<std::string> failures;
-
-    // test manager/integration process
-    try { testPendulum(); cout << "\nPendulum test PASSED " << endl; }  
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testPendulum"); }
-    
-    // test application of external loads
-    try { testPendulumExternalLoad(); 
-        cout << "\nPendulum with external load test PASSED " << endl; }
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testPendulumExternalLoad"); }
-    
-    // test application of external loads
-    try { testPendulumExternalLoadWithPointInGround(); 
-        cout << "\nPendulum with external load and point in ground PASSED " << endl; }
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testPendulumExternalLoadWithPointInGround"); }
-    
-    // now add computation of controls and generation of muscle forces
-    try { testArm26(); 
-        cout << "\narm26 test PASSED " << endl; }
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testArm26"); }
-        
-    // include applied ground reactions forces 
-    try { testGait2354(); 
-        cout << "\ngait2354 test PASSED " << endl; }
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testGait2354"); }
-
-    // finally include a controller
-    try { testGait2354WithController(); 
-        cout << "\ngait2354 with correction controller test PASSED " << endl; }
-    catch (const std::exception& e)
-        { cout << e.what() <<endl; failures.push_back("testGait2354WithController"); }  
-
-    try {
-        testGait2354WithControllerGUI();
-        cout << "\nGUI run gait2354 with correction controller test PASSED " << endl;
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testGait2354WithControllerGUI");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-    return 0;
+    SimTK_START_TEST("testForward");
+        // test manager/integration process
+        SimTK_SUBTEST(testPendulum);
+        // test application of external loads point in pendulum
+        SimTK_SUBTEST(testPendulumExternalLoad);
+        // test application of external loads with point moving in ground
+        SimTK_SUBTEST(testPendulumExternalLoadWithPointInGround);
+        // now add computation of controls and generation of muscle forces
+        SimTK_SUBTEST(testArm26);
+        // controlled muscles and ground reactions forces
+        SimTK_SUBTEST(testGait2354);
+        // included additional controller
+        SimTK_SUBTEST(testGait2354WithController);
+        // implements steps GUI takes to provide a model
+        SimTK_SUBTEST(testGait2354WithControllerGUI);
+    SimTK_END_TEST();
 }
 
 void testPendulum() {


### PR DESCRIPTION
Fixes issue #<52164>

### Brief summary of changes
GUI use case was replicate in testForward. Repeated `CorrectionController::extendConnectToModel()` calls were incorrectly adding in *corrector* actuators. The reason being they were expecting actuators in the model `ForceSet`, but actuators but `CorrectionController` owns the actuators it adds and includes them as subcomponents so that deleting the `CorrectionController` will take its actuators with it. The fix was to use `model.getComponentList<CoordinateActuator> to also find the subcomponents of `CorrectionController` should they exist (e.g. previous calls to `connectToModel`).

Also snuck in changes to eliminate unnecessary dynamic_cast in `computeControls` and cleaned  up `testForward`.

### Testing I've completed
Included a test case that emulates the GUI call sequence, which initially reproduced the bug. 
Verified that it produces identical results to the command line solution.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix, with no API changes.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
