### PR TITLE
Do not test c3d reading if WITH_BTK=off.

### DIFF
--- a/OpenSim/Common/Test/testStorage.cpp
+++ b/OpenSim/Common/Test/testStorage.cpp
@@ -113,9 +113,11 @@ int main() {
         // Verify the loading of marker data (14 markers) from .trc into a Storage
         SimTK_SUBTEST2(testStorageLoadingFromFile, "TRCFileWithNANs.trc", 43);
 
-        // Verify the loading of forces from .c3d into a Storage. Includes 2
-        // force-plates with force, point, moment vectors (Vec3 flattened)
-        SimTK_SUBTEST2(testStorageLoadingFromFile, "walking2.c3d", 3*6+1);
+        #ifdef WITH_BTK
+            // Verify the loading of forces from .c3d into a Storage. Includes 2
+            // force-plates with force, point, moment vectors (Vec3 flattened)
+            SimTK_SUBTEST2(testStorageLoadingFromFile, "walking2.c3d", 3*6+1);
+        #endif
 
         SimTK_SUBTEST(testStorageLegacy);
     SimTK_END_TEST();


### PR DESCRIPTION
### Brief summary of changes

- Do not test reading a c3d file if `WITH_BTK` is off. Without this change, `testStorage` fails if `WITH_BTK=off`.

### Testing I've completed

- Locally built and ran `testStorage` with both `WITH_BTK` as `off` and `on`, and ensured that when `WITH_BTK=on`, the c3d file is tested.

### CHANGELOG.md (choose one)

- no need to update because this only affects a test case.
