### PR TITLE
[WIP] Throw Exception if results directory cannot be created or file cannot be written

### DIFF
--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -429,8 +429,9 @@ void simulateMuscle(
 
     //An analysis only writes to a dir that exists, so create here.
     if(printResults){
-        IO::makeDir("testMuscleResults");
-        muscleAnalysis->printResults(actuatorType, "testMuscleResults");
+        const std::string dirName = "testMuscleResults";
+        OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory, dirName);
+        muscleAnalysis->printResults(actuatorType, dirName);
     }
 
     double muscleWork = muscWorkProbe->getProbeOutputs(si)(0);

--- a/OpenSim/Common/FileAdapter.h
+++ b/OpenSim/Common/FileAdapter.h
@@ -70,6 +70,19 @@ public:
     }
 };
 
+class UnableToCreateDirectory : public IOError {
+public:
+    UnableToCreateDirectory(const std::string& file,
+                            size_t line,
+                            const std::string& func,
+                            const std::string& directory) :
+        IOError(file, line, func) {
+        std::string msg = "Unable to create directory '" + directory + "'.";
+
+        addMessage(msg);
+    }
+};
+
 class FileExtensionNotFound : public InvalidArgument {
 public:
     FileExtensionNotFound(const std::string& file,

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2741,7 +2741,9 @@ print(const string &aFileName,const string &aMode, const string& aComment) const
 {
     // OPEN THE FILE
     FILE *fp = IO::OpenFile(aFileName,aMode);
-    if(fp==NULL) return(false);
+    OPENSIM_THROW_IF(fp==NULL, Exception,
+        "Storage: Failed to open file '" + aFileName + "' for writing.\n"
+        + "Verify that the destination directory is writable.");
 
     // WRITE THE HEADER
     int n=0,nTotal=0;
@@ -2819,7 +2821,9 @@ print(const string &aFileName,double aDT,const string &aMode) const
     if (_fp!= NULL) fclose(_fp);
     // OPEN THE FILE
     FILE *fp = IO::OpenFile(aFileName,aMode);
-    if(fp==NULL) return(-1);
+    OPENSIM_THROW_IF(fp==NULL, Exception,
+        "Storage: Failed to open file '" + aFileName + "' for writing.\n"
+        + "Verify that the destination directory is writable.");
 
     // HOW MANY TIME STEPS?
     double ti = getFirstTime();

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -240,8 +240,10 @@ int main()
                                       "tugOfWar_fatigue_forces.sto");
 
         // Save the muscle analysis results
-        IO::makeDir("MuscleAnalysisResults");
-        muscAnalysis->printResults("fatigue", "MuscleAnalysisResults");
+        const std::string dirName = "MuscleAnalysisResults";
+        IO::makeDir(dirName);
+        OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory, dirName);
+        muscAnalysis->printResults("fatigue", dirName);
 
         // Save the OpenSim model to a file
         osimModel.print("tugOfWar_fatigue_model.osim");

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -548,7 +548,10 @@ printResults(const string &aBaseName,const string &aDir,double aDT,
                  const string &aExtension)
 {
     cout<<"Printing results of investigation "<<getName()<<" to "<<aDir<<"."<<endl;
-    IO::makeDir(aDir);
+    if (!aDir.empty()) {
+        IO::makeDir(aDir);
+        OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory, aDir);
+    }
     _model->updAnalysisSet().printResults(aBaseName,aDir,aDT,aExtension);
 }
 

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -824,7 +824,13 @@ bool CMCTool::run()
     cmcActSubsystem.setCompleteState( s );
 
     // Set output file names so that files are flushed regularly in case we fail
-    IO::makeDir(getResultsDir());   // Create directory for output in case it doesn't exist
+    // Create directory for output in case it doesn't exist
+    if (!getResultsDir().empty()) {
+        IO::makeDir(getResultsDir());
+        OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                         getResultsDir());
+    }
+
     manager.getStateStorage().setOutputFileName(getResultsDir() + "/" + getName() + "_states.sto");
     try {
         manager.initialize(s);

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -406,7 +406,12 @@ bool InverseDynamicsTool::run()
         genForceResults.setColumnLabels(labels);
         genForceResults.setName("Inverse Dynamics Generalized Forces");
 
-        IO::makeDir(getResultsDir());
+        if (!getResultsDir().empty()) {
+            IO::makeDir(getResultsDir());
+            OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                             getResultsDir());
+        }
+
         Storage::printResult(&genForceResults, _outputGenForceFileName, getResultsDir(), -1, ".sto");
         IO::chDir(saveWorkingDirectory);
 
@@ -415,7 +420,12 @@ bool InverseDynamicsTool::run()
             bodyForcesResults.setColumnLabels(body_force_labels);
             bodyForcesResults.setName("Inverse Dynamics Body Forces at Specified Joints");
 
-            IO::makeDir(getResultsDir());
+            if (!getResultsDir().empty()) {
+                IO::makeDir(getResultsDir());
+                OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                                 getResultsDir());
+            }
+
             Storage::printResult(&bodyForcesResults, _outputBodyForcesAtJointsFileName, getResultsDir(), -1, ".sto");
             IO::chDir(saveWorkingDirectory);
         }

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -425,7 +425,11 @@ bool InverseKinematicsTool::run()
             modelMarkerErrors->setColumnLabels(labels);
             modelMarkerErrors->setName("Model Marker Errors from IK");
 
-            IO::makeDir(getResultsDir());
+            if (!getResultsDir().empty()) {
+                IO::makeDir(getResultsDir());
+                OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                                 getResultsDir());
+            }
             string errorFileName = trialName + "_ik_marker_errors";
             Storage::printResult(modelMarkerErrors, errorFileName,
                                  getResultsDir(), -1, ".sto");
@@ -445,8 +449,13 @@ bool InverseKinematicsTool::run()
             }
             modelMarkerLocations->setColumnLabels(labels);
             modelMarkerLocations->setName("Model Marker Locations from IK");
-    
-            IO::makeDir(getResultsDir());
+
+            if (!getResultsDir().empty()) {
+                IO::makeDir(getResultsDir());
+                OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                                 getResultsDir());
+            }
+
             string markerFileName = trialName + "_ik_model_marker_locations";
             Storage::printResult(modelMarkerLocations, markerFileName,
                                  getResultsDir(), -1, ".sto");

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -809,7 +809,13 @@ bool RRATool::run()
     cmcActSubsystem.setCompleteState( s );
 
     // Set output file names so that files are flushed regularly in case we fail
-    IO::makeDir(getResultsDir());   // Create directory for output in case it doesn't exist
+    // Create directory for output in case it doesn't exist
+    if (!getResultsDir().empty()) {
+        IO::makeDir(getResultsDir());
+        OPENSIM_THROW_IF(errno == ENOENT, UnableToCreateDirectory,
+                         getResultsDir());
+    }
+
     manager.getStateStorage().setOutputFileName(getResultsDir() + "/" + getName() + "_states.sto");
     try {
         manager.initialize(s);


### PR DESCRIPTION
Fixes #2181.

### Brief summary of changes
- Catch [`errno == ENOENT`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr) if results directory cannot be created.
- Throw Exception from Storage if file cannot be opened for writing.

### Testing I've completed
Ran example setup file that attempted to write results to `C:\Program Files`:
<pre>
InverseKinematicsTool Failed: Storage: Failed to open file 'C:\Program Files/ik_marker_errors.sto' for writing.
Verify that the destination directory is writable.
        Thrown at Storage.cpp:2746 in print().
</pre>

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because... bug fix.
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2188)
<!-- Reviewable:end -->
