### PR TITLE
Solve bugs in IK and JR tools

### DIFF
--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -512,16 +512,15 @@ record(const SimTK::State& s)
 
     _model->updMultibodySystem().realize(s_analysis, s.getSystemStage());
     if(_useForceStorage){
-
-        const Set<Actuator> *actuatorSet = &_model->getActuators();
-        int nA = actuatorSet->getSize();
+        const auto& actuatorSet = _model->getActuators();
+        int nA = actuatorSet.getSize();
         Array<double> forces(0,nA);
         _storeActuation->getDataAtTime(s.getTime(),nA,forces);
         int storageIndex = -1;
         for(int actuatorIndex=0;actuatorIndex<nA;actuatorIndex++)
         {
             //Actuator* act = dynamic_cast<Actuator*>(&_forceSet->get(actuatorIndex));
-            std::string actuatorName = actuatorSet->get(actuatorIndex).getName();
+            std::string actuatorName = actuatorSet.get(actuatorIndex).getName();
             storageIndex = _storeActuation->getStateIndex(actuatorName, 0);
             if(storageIndex == -1){
                 cout << "The actuator, " << actuatorName << ", was not found in the forces file." << endl;

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -274,10 +274,10 @@ bool InverseKinematicsTool::run()
         IO::chDir(directoryOfSetupFile);
 
         // Define reporter for output
-        Kinematics kinematicsReporter;
-        kinematicsReporter.setRecordAccelerations(false);
-        kinematicsReporter.setInDegrees(true);
-        _model->addAnalysis(&kinematicsReporter);
+        Kinematics* kinematicsReporter = new Kinematics();
+        kinematicsReporter->setRecordAccelerations(false);
+        kinematicsReporter->setInDegrees(true);
+        _model->addAnalysis(kinematicsReporter);
 
         cout<<"Running tool "<<getName()<<".\n";
 
@@ -304,7 +304,7 @@ bool InverseKinematicsTool::run()
         ikSolver.setAccuracy(_accuracy);
         s.updTime() = start_time;
         ikSolver.assemble(s);
-        kinematicsReporter.begin(s);
+        kinematicsReporter->begin(s);
 
         const clock_t start = clock();
         double dt = 1.0/markersReference.getSamplingFrequency();
@@ -362,17 +362,17 @@ bool InverseKinematicsTool::run()
 
             }
 
-            kinematicsReporter.step(s, i);
+            kinematicsReporter->step(s, i);
             analysisSet.step(s, i);
         }
 
         // Do the maneuver to change then restore working directory 
         // so that output files are saved to same folder as setup file.
         if (_outputMotionFileName!= "" && _outputMotionFileName!="Unassigned"){
-            kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
+            kinematicsReporter->getPositionStorage()->print(_outputMotionFileName);
         }
         // Once done, remove the analysis we added
-        _model->removeAnalysis(&kinematicsReporter);
+        _model->removeAnalysis(kinematicsReporter);
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);


### PR DESCRIPTION
Fixes issue #<issue_number>

### Brief summary of changes

Fix two bugs presented in the tools.  

Bug 1: When InverseKinematicsTool finishes the Kinematics analysis is deleted, which caused a segmentation fault. The problem was that the Kinematics analysis was allocated on the stack. I am surprised that this was working in the previous versions. It is possible that I detected this error because I am working on archlinux which fetches the newest versions of packages (e.g. clang, etc.).

Bug 2: When JointReaction is performed and the muscle forces are applied I was getting segmentation fault in python (#2076). I tried to investigate this error through c++ so I can detect the cause, and it turn out that it was not a python problem. The analyze tool wasn't working either both on Linux and Windows. It turns out that the cast 

`const ScalarActuator* act = dynamic_cast<const ScalarActuator*>(&actuatorSet[actuatorIndex]);`

in the following lines failed because we had 

`const Set<Actuator>* actuatorSet = &_model->getActuators();`

and when I changed to 

` const auto& actuatorSet = _model->getActuators();`

In theory it is the same but for some reason I was getting the error. Now I am able to perform the JR analysis. 

### Testing I've completed

I have scripts where I have automated the execution of IK, ID, SO, JRA. They worked with v3.3 but when I migrated to v4.0 I had problems with IK and JRA. 

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
