### PR TITLE
Specify correct time for IK of the static pose

### DIFF
--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -261,7 +261,7 @@ bool MarkerPlacer::processModel(Model* aModel,
                                                    _timeRange[1]);
     for(size_t r = staticPoseTable.getNumRows() - 1; r > 0; --r)
         staticPoseTable.removeRowAtIndex(r);
-    staticPoseTable.setRow(_timeRange[0], avgRow);
+    staticPoseTable.appendRow(_timeRange[0], avgRow);
     
     OPENSIM_THROW_IF(!staticPoseTable.hasTableMetaDataKey("Units"),
                      Exception,

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -259,7 +259,7 @@ bool MarkerPlacer::processModel(Model* aModel,
 
     const auto avgRow = staticPoseTable.averageRow(_timeRange[0],
                                                    _timeRange[1]);
-    for(size_t r = staticPoseTable.getNumRows() - 1; r >= 0; --r)
+    for(size_t r = staticPoseTable.getNumRows(); r-- > 0; )
         staticPoseTable.removeRowAtIndex(r);
     staticPoseTable.appendRow(_timeRange[0], avgRow);
     

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -261,7 +261,7 @@ bool MarkerPlacer::processModel(Model* aModel,
                                                    _timeRange[1]);
     for(size_t r = staticPoseTable.getNumRows() - 1; r > 0; --r)
         staticPoseTable.removeRowAtIndex(r);
-    staticPoseTable.updRowAtIndex(0) = avgRow;
+    staticPoseTable.setRow(_timeRange[0], avgRow);
     
     OPENSIM_THROW_IF(!staticPoseTable.hasTableMetaDataKey("Units"),
                      Exception,
@@ -294,6 +294,7 @@ bool MarkerPlacer::processModel(Model* aModel,
 
     // Construct the system and get the working state when done changing the model
     SimTK::State& s = aModel->initSystem();
+    s.updTime() = _timeRange[0];
     
     // Create references and WeightSets needed to initialize InverseKinemaicsSolver
     Set<MarkerWeight> markerWeightSet;

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -259,7 +259,7 @@ bool MarkerPlacer::processModel(Model* aModel,
 
     const auto avgRow = staticPoseTable.averageRow(_timeRange[0],
                                                    _timeRange[1]);
-    for(size_t r = staticPoseTable.getNumRows() - 1; r > 0; --r)
+    for(size_t r = staticPoseTable.getNumRows() - 1; r >= 0; --r)
         staticPoseTable.removeRowAtIndex(r);
     staticPoseTable.appendRow(_timeRange[0], avgRow);
     


### PR DESCRIPTION
Fixes issue #2201

### Brief summary of changes
As of 4.0 time coherence is enforced by `TimeSeriesTable` and we throw if the time requested is out of range.  In #2201 the range of data to compute the average frame was 1 to 1.01s but IK was being solved for time = 0, and the `TimeSeriesTable` or marker data correctly throws. 

### Testing I've completed
Example in #2021 runs correctly and tests pass locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because. this is a bug fix.