### PR TITLE
Do not search OPENSIM_HOME to find simbody-visualizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,8 @@ programmatically in MATLAB or python.
   its properties are updated during scaling. (PR #1994)
 - The source code for the "From the Ground Up: Building a Passive Dynamic
   Walker Example" was added to this repository.
+- OpenSim no longer looks for the simbody-visualizer using the environment
+  variable `OPENSIM_HOME`.
 
 Documentation
 --------------

--- a/OpenSim/Simulation/Model/ModelVisualizer.cpp
+++ b/OpenSim/Simulation/Model/ModelVisualizer.cpp
@@ -227,19 +227,11 @@ void ModelVisualizer::addDirToGeometrySearchPaths(const std::string& dir) {
 void ModelVisualizer::createVisualizer() {
     _model.updMatterSubsystem().setShowDefaultGeometry(false);
 
-    // Allocate a Simbody Visualizer. If environment variable
-    // OPENSIM_HOME is set, add its bin subdirectory to the search path
-    // for the SimbodyVisualizer executable. The search will go as 
+    // Allocate a Simbody Visualizer. The search will go as 
     // follows: first look in the same directory as the currently-
-    // executing executable; then look in the $OPENSIM_HOME/bin 
-    // directory, then look at all the paths in the environment
+    // executing executable; then look at all the paths in the environment
     // variable PATH, then look in various default Simbody places.
     Array_<String> searchPath;
-    if (SimTK::Pathname::environmentVariableExists("OPENSIM_HOME")) {
-        searchPath.push_back( 
-            SimTK::Pathname::getEnvironmentVariable("OPENSIM_HOME")
-            + "/bin");
-    }
     if (SimTK::Pathname::environmentVariableExists("PATH")) {
         const auto& path = SimTK::Pathname::getEnvironmentVariable("PATH");
         std::string buffer{};


### PR DESCRIPTION
### Brief summary of changes

In 3.3, the OpenSim installer set the OPENSIM_HOME environment variable
and this was used on Windows to find the simbody-visualizer executable.

In 4.0, OpenSim's installer no longer sets the OPENSIM_HOME environment
variable, which means that this environment variable may point to a
pre-existing OpenSim installation. If OpenSim searches OPENSIM_HOME for
simbody-visualizer, then it's likely that OpenSim 4.0 will find an
incompatible simbody-visualizer from 3.3.

To avoid the above issue, this PR causes OpenSim to no longer search OPENSIM_HOME for simbody-visualizer.

### Testing I've completed

This change was used in the Dynamic Walking competition.

### CHANGELOG.md (choose one)

- updated.

