### PR TITLE
Dependencies: use Simbody-3.6.1 tag

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -149,7 +149,7 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        fd5c03115038a7398ed5ac04169f801a2aa737f2
+              TAG        Simbody-3.6.1
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION

### Brief summary of changes

- In preparation for the release of 4.0, I updated the superbuild should to use the `Simbody-3.6.1` tag (after releasing 4.0, we should maybe update Simbody tag/commit again).

### Testing I've completed

- I made sure that, locally, superbuild can find and checkout the `Simbody-3.6.1` tag.
- Note: the CI does not use superbuild for Simbody.

### Looking for feedback on...

- When should we merge this? I do not expect us to add anymore commits to Simbody, so I think it would be fine to merge this now.

### CHANGELOG.md (choose one)

- no need to update because...this PR is not related to a bug/feature of OpenSim.