### PR TITLE
Expose Object::getDocument() as a const public method.

### DIFF
--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1241,10 +1241,15 @@ updateDefaultObjectsXMLNode(SimTK::Xml::Element& aParent)
  *
  * @return Document's filename for this object.
  */
-string Object::
-getDocumentFileName() const
+string Object::getDocumentFileName() const
 {
     return _document ? _document->getFileName() : "";
+}
+
+
+int Object::getDocumentFileVersion() const
+{ 
+    return _document ? _document->getDocumentVersion() : -1;
 }
 
 

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -563,13 +563,14 @@ protected:
     lost here. **/
     void setDocument(XMLDocument* doc) {_document=doc;}
 
-    /** Get a const pointer to the document (if any) associated with this
-    object. **/
-    const XMLDocument* getDocument() const {return _document;}
     /** Get a writable pointer to the document (if any) associated with this
     object. **/
     XMLDocument* updDocument() {return _document;}
 public:
+    /** Get a const pointer to the document (if any) associated with this
+    object. **/
+    const XMLDocument* getDocument() const { return _document; }
+
     /** If there is a document associated with this object then return the
     file name maintained by the document. Otherwise return an empty string. **/
     std::string getDocumentFileName() const;

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -563,17 +563,23 @@ protected:
     lost here. **/
     void setDocument(XMLDocument* doc) {_document=doc;}
 
+    /** Get a const pointer to the document (if any) associated with this
+    object. **/
+    const XMLDocument* getDocument() const {return _document;}
     /** Get a writable pointer to the document (if any) associated with this
     object. **/
     XMLDocument* updDocument() {return _document;}
 public:
-    /** Get a const pointer to the document (if any) associated with this
-    object. **/
-    const XMLDocument* getDocument() const { return _document; }
-
     /** If there is a document associated with this object then return the
     file name maintained by the document. Otherwise return an empty string. **/
     std::string getDocumentFileName() const;
+
+    /** If there is a document associated with this object then return its
+        version number. For example this is 30000 for OpenSim 3.x documents 
+        and is 305xx for OpenSim 4.0 beta and above. If there is no document
+        associated with the object, the method returns -1.*/
+    int getDocumentFileVersion() const;
+
     void setAllPropertiesUseDefault(bool aUseDefault);
 
     /** Write this %Object into an XML file of the given name; conventionally


### PR DESCRIPTION
Necessary to fix [GUI issue #766](https://github.com/opensim-org/opensim-gui/issues/766) 

### Brief summary of changes
Allow `Object` to provide the underling `XMLDocument` and subsequently its version.

### Testing I've completed
Existing tests pass. 

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because method was only used internally
