### PR TITLE
Fix ContactHalfSpace decoration to lie within the contact geometry.

### DIFF
--- a/OpenSim/Simulation/Model/ContactHalfSpace.cpp
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.cpp
@@ -77,8 +77,14 @@ void ContactHalfSpace::generateDecorations(bool fixed, const ModelDisplayHints& 
     const auto& X_BF = getFrame().findTransformInBaseFrame();
     const auto& X_FP = getTransform();
     const auto X_BP = X_BF * X_FP;
-    geometry.push_back(SimTK::DecorativeBrick(Vec3{.005, 0.5, 0.5})
-        .setTransform(X_BP).setScale(1)
+    const double brickHalfThickness = 0.005;
+    geometry.push_back(
+        SimTK::DecorativeBrick(Vec3{brickHalfThickness, 0.5, 0.5})
+        // The brick is centered on the origin. To ensure the decorative
+        // geometry is within the contact geomtry, we must offset by half
+        // the thickness of the brick.
+        .setTransform(X_BP * Transform(Vec3(brickHalfThickness, 0, 0)))
+        .setScale(1)
         .setRepresentation(get_Appearance().get_representation())
         .setBodyId(getFrame().getMobilizedBodyIndex())
         .setColor(get_Appearance().get_color())

--- a/OpenSim/Simulation/Model/ContactHalfSpace.cpp
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.cpp
@@ -77,7 +77,7 @@ void ContactHalfSpace::generateDecorations(bool fixed, const ModelDisplayHints& 
     const auto& X_BF = getFrame().findTransformInBaseFrame();
     const auto& X_FP = getTransform();
     const auto X_BP = X_BF * X_FP;
-    const double brickHalfThickness = 0.005;
+    const double brickHalfThickness = 0.0005;
     geometry.push_back(
         SimTK::DecorativeBrick(Vec3{brickHalfThickness, 0.5, 0.5})
         // The brick is centered on the origin. To ensure the decorative

--- a/OpenSim/Tools/Test/testVisualization.cpp
+++ b/OpenSim/Tools/Test/testVisualization.cpp
@@ -251,9 +251,10 @@ bool testVisModelAgainstStandard(Model& model, const SimTK::Array_<DecorativeGeo
     const ModelDisplayHints& mdh = model.getDisplayHints();
     SimTK::Array_<SimTK::DecorativeGeometry> geometryToDisplay;
     model.generateDecorations(true, mdh, si, geometryToDisplay);
-    cout << geometryToDisplay.size() << endl;
+    cout << "Number of fixed geometries: " << geometryToDisplay.size() << endl;
     model.generateDecorations(false, mdh, si, geometryToDisplay);
-    cout << geometryToDisplay.size() << endl;
+    cout << "Number of fixed and non-fixed geometries: "
+         << geometryToDisplay.size() << endl;
     /*
     DecorativeGeometryImplementationText textFromModel;
     textFromModel.setPrintTransforms(true); // Debugging
@@ -276,6 +277,10 @@ bool testVisModelAgainstStandard(Model& model, const SimTK::Array_<DecorativeGeo
                 throw  OpenSim::Exception("failed comparing " + dgiTextFromStandard.getAsString() + "vs." + dgiTextFromModel.getAsString());
             // Compare transforms, this has to be more lenient than String comparison due to roundoff
             SimTK::Mat44 diffTransform = nextGeom->getTransform().toMat44() - geometryToDisplay[i].getTransform().toMat44();
+            // std::cout << "Transform from standard: "
+            //      << nextGeom->getTransform().toMat44() << std::endl;
+            // std::cout << "Transform from model: "
+            //      << geometryToDisplay[i].getTransform().toMat44() << std::endl;
             double norm = diffTransform.norm();
             SimTK_TEST_EQ(norm, 0.)
              ++i;
@@ -436,7 +441,7 @@ void populate_contactModelPrimitives(SimTK::Array_<DecorativeGeometry>& stdPrimi
         DecorativeBrick({ 0.005,0.5,0.5 }).setBodyId(0).setColor(SimTK::Cyan)
         .setIndexOnBody(-1).setOpacity(0.7).setScale(1)
         .setRepresentation(SimTK::DecorativeGeometry::DrawSurface)
-        .setTransform(transform));
+        .setTransform(transform * Transform(Vec3(0.005, 0, 0))));
 
 }
 

--- a/OpenSim/Tools/Test/testVisualization.cpp
+++ b/OpenSim/Tools/Test/testVisualization.cpp
@@ -438,10 +438,10 @@ void populate_contactModelPrimitives(SimTK::Array_<DecorativeGeometry>& stdPrimi
     SimTK::Transform transform;
     transform.updR().setRotationFromAngleAboutZ(.5);
     stdPrimitives.push_back(
-        DecorativeBrick({ 0.005,0.5,0.5 }).setBodyId(0).setColor(SimTK::Cyan)
+        DecorativeBrick({ 0.0005,0.5,0.5 }).setBodyId(0).setColor(SimTK::Cyan)
         .setIndexOnBody(-1).setOpacity(0.7).setScale(1)
         .setRepresentation(SimTK::DecorativeGeometry::DrawSurface)
-        .setTransform(transform * Transform(Vec3(0.005, 0, 0))));
+        .setTransform(transform * Transform(Vec3(0.0005, 0, 0))));
 
 }
 


### PR DESCRIPTION
Fixes #2211

### Brief summary of changes

- This PR fixes the transform for `ContactHalfSpace` so that the half-space's decorative geometry does not protrode outside of the contact geometry (half in, half out).

### Testing I've completed

- I temporarily turned the visualizer on in `testContactGeometry` and ensured that the entire `DecorativeBrick` for the `ContactHalfSpace` appeared below ground.
- I ran and fixed `testVisualization` (this test initially failed after I changed `ContactHalfSpace.cpp`).

### CHANGELOG.md (choose one)

- no need to update because...our current way of displaying `ContactHalfSpace` was not in any previous release.