### PR TITLE
Make VisualizeModel also visualize a model's muscles

### DIFF
--- a/OpenSim/Tests/VisualizeModel/VisualizeModel.cpp
+++ b/OpenSim/Tests/VisualizeModel/VisualizeModel.cpp
@@ -32,6 +32,7 @@
 //==============================================================================
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Common/LoadOpenSimLibrary.h>
 
 using namespace OpenSim;
 using namespace SimTK;
@@ -42,6 +43,7 @@ using namespace std;
  */
 int main(int argc, char **argv)
 {
+    LoadOpenSimLibrary("osimActuators");
     try {
         // Create an OpenSim model and set its name
         if (argc < 2) {


### PR DESCRIPTION
In debugging another issue, I ran across `VisualizeModel` failing to visualize `Muscle`s because they were not registered objects.

### Brief summary of changes
Load `osimActuators` prior to loading the model for visualization.

### Testing I've completed
Visualized models with muscles locally.

### Looking for feedback on...
N/A

### CHANGELOG.md (choose one)
- no need to update because this is a minor bug fix