### PR TITLE
Call initSystem after adding WrapObject to a GeometryPath.

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -292,6 +292,9 @@ void OpenSimContext::setStartPoint(PathWrap& mw, int newStartPt) {
 
 void OpenSimContext::addPathWrap(GeometryPath& p, WrapObject& awo) {
     p.addPathWrap( awo );
+    // Adding WrapObject to a GeometryPath requires initSystem similar to other Path edit operations
+    recreateSystemKeepStage();
+    p.updateGeometry(*_configState);
     return;
 }
 


### PR DESCRIPTION
Fixes https://github.com/opensim-org/opensim-gui/issues/845

### Brief summary of changes
Path edits require a call to initSystem which was not done for this specific call (while done for other Path editing support functionality. Added the call.

### Testing I've completed
I was able to remove/add-back PathWrap to BRA muscle in Arm26 model and got no exception and Path rendering updated accordingly.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it is a bugfix

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
