### PR TITLE
Make generated JNI files contain 4.0 specific url for documentation

### DIFF
--- a/Bindings/Java/swig/java_preliminaries.i
+++ b/Bindings/Java/swig/java_preliminaries.i
@@ -29,7 +29,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
           String javaHome = System.getProperties().getProperty("java.home");
           boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
           if (inMatlab) {
-              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim40/Scripting+with+Matlab";
           }
           
           System.out.println(msg);


### PR DESCRIPTION
Fixes issue #867 leftover

### Brief summary of changes
Auto generated files were not consistent with manually updated files in PR #902 and would be overwritten by automated builds.

### Testing I've completed
Checked that SWIG generated files match those manually changed in GUI repo.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because bugfix/internal

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
