### PR TITLE
Add method that sets the location of PathPoint

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -237,6 +237,11 @@ void OpenSimContext::setLocation(PathPoint& mp, int i, double d) {
     recreateSystemKeepStage();
 }
 
+void OpenSimContext::setLocation(PathPoint& mp, const SimTK::Vec3& newLocation) {
+    mp.setLocation(newLocation);
+    recreateSystemKeepStage();
+}
+
 void OpenSimContext::setEndPoint(PathWrap& mw, int newEndPt) {
     mw.setEndPoint(*_configState, newEndPt );
     recreateSystemKeepStage();

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -153,6 +153,8 @@ public:
     void setRangeMax(ConditionalPathPoint& via, double d);
     bool replacePathPoint(GeometryPath& p, AbstractPathPoint& mp, AbstractPathPoint& newPoint);
     void setLocation(PathPoint& mp, int i, double d);
+
+    void setLocation(PathPoint& mp, const SimTK::Vec3& newLocation);
     void setEndPoint(PathWrap& mw, int newEndPt);
     void addPathPoint(GeometryPath& p, int menuChoice, PhysicalFrame& body);
     bool deletePathPoint(GeometryPath& p, int menuChoice);


### PR DESCRIPTION
This exercises the recreate system functionality so that full path recomputation and cache update is done. Similar method exists for modifying coordinates one by one as done in Path edit dialog.

Fixes issue  https://github.com/opensim-org/opensim-gui/issues/816

### Brief summary of changes
Added method that sets the location of PathPoint and recreate the system thus updating cache entry for GeometryPath.

### Testing I've completed
Along with GUI side f the fix, moving points on a muscle with wrapping and performing undo work correctly.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because this is a bug fix.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
