### PR TITLE
Generate decorations does not realize to stage

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -480,6 +480,12 @@ public:
     obtain ground- and body-fixed geometry (with \a fixed=\c true), and then 
     once per frame (with \a fixed=\c false) to generate on-the-fly geometry such
     as rubber band lines, force arrows, labels, or debugging aids.
+
+    Please note, that the state passed to generateDecorations is only guaranteed
+    to be realized to Stage::Position. If your component can visualize quantities
+    realized and Velocity, Dynamics or Acceleration stages, then you must check
+    that the required stage has been realized before using requesting realized
+    values.
   
     If you override this method, be sure to invoke the base class method first, 
     using code like this:
@@ -493,6 +499,14 @@ public:
         // invoke parent class method
         Super::generateDecorations(fixed,hints,state,appendToThis); 
         // ... your code goes here
+        // can render velocity dependent quanities if stage is Velocity or higher
+        if(state.getSystemStage() >= Stage::Velocity) {
+            // draw velocity vector for model COM
+        }
+        // can render computed forces if stage is Dynamics or higher
+        if(state.getSystemStage() >= Stage::Dynamics) {
+            // change the length of a force arrow based on the force in N
+        }
     }
     @endcode
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -481,7 +481,7 @@ public:
     once per frame (with \a fixed=\c false) to generate on-the-fly geometry such
     as rubber band lines, force arrows, labels, or debugging aids.
 
-    Please note, that their is a precondition that the state passed in to
+    Please note that there is a precondition that the state passed in to
     generateDecorations be realized to Stage::Position. If your component can
     visualize quantities realized at Velocity, Dynamics or Acceleration stages,
     then you must check that the stage has been realized before using/requesting

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -483,9 +483,11 @@ public:
 
     Please note, that the state passed to generateDecorations is only guaranteed
     to be realized to Stage::Position. If your component can visualize quantities
-    realized and Velocity, Dynamics or Acceleration stages, then you must check
-    that the required stage has been realized before using requesting realized
-    values.
+    realized at Velocity, Dynamics or Acceleration stages, then you must check
+    that the stage has been realized before using/requesting stage dependent
+    values. It is forbidden to realize the model to a higher stage within 
+    generateDecorations, because this can trigger costly side-effects such as
+    evaluating all model forces even when performing a purely kinematic study.
   
     If you override this method, be sure to invoke the base class method first, 
     using code like this:

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -481,14 +481,15 @@ public:
     once per frame (with \a fixed=\c false) to generate on-the-fly geometry such
     as rubber band lines, force arrows, labels, or debugging aids.
 
-    Please note, that the state passed to generateDecorations is only guaranteed
-    to be realized to Stage::Position. If your component can visualize quantities
-    realized at Velocity, Dynamics or Acceleration stages, then you must check
-    that the stage has been realized before using/requesting stage dependent
-    values. It is forbidden to realize the model to a higher stage within 
-    generateDecorations, because this can trigger costly side-effects such as
-    evaluating all model forces even when performing a purely kinematic study.
-  
+    Please note, that their is a precondition that the state passed in to
+    generateDecorations be realized to Stage::Position. If your component can
+    visualize quantities realized at Velocity, Dynamics or Acceleration stages,
+    then you must check that the stage has been realized before using/requesting
+    stage dependent values. It is forbidden to realize the model to a higher
+    stage within generateDecorations, because this can trigger costly side-
+    effects such as evaluating all model forces even when performing a purely
+    kinematic study.
+
     If you override this method, be sure to invoke the base class method first, 
     using code like this:
     @code

--- a/OpenSim/Simulation/Model/ExpressionBasedBushingForce.cpp
+++ b/OpenSim/Simulation/Model/ExpressionBasedBushingForce.cpp
@@ -376,8 +376,9 @@ void ExpressionBasedBushingForce::generateDecorations
         geometryArray.push_back(decorativeFrame1);
         geometryArray.push_back(decorativeFrame2);
 
-        // if the model is moving, calculate and draw the bushing forces.
-        if(!fixed){
+        // if the model is moving and the state is adequately realized,
+        // calculate and draw the bushing forces.
+        if(!fixed && (s.getSystemStage() >= Stage::Dynamics)){
             SpatialVec F_GM(Vec3(0.0), Vec3(0.0));
             SpatialVec F_GF(Vec3(0.0), Vec3(0.0));
 

--- a/OpenSim/Simulation/Model/FunctionBasedBushingForce.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedBushingForce.cpp
@@ -226,8 +226,8 @@ OpenSim::Array<double> FunctionBasedBushingForce::
  * Implement generateDecorations to make visuals to represent the spring.
  */
 
-void FunctionBasedBushingForce::generateDecorations
-       (bool                                        fixed, 
+void FunctionBasedBushingForce::generateDecorations(
+        bool                                        fixed, 
         const ModelDisplayHints&                    hints,
         const SimTK::State&                         s,
         SimTK::Array_<SimTK::DecorativeGeometry>&   geometryArray) const
@@ -264,8 +264,9 @@ void FunctionBasedBushingForce::generateDecorations
         geometryArray.push_back(decorativeFrame1);
         geometryArray.push_back(decorativeFrame2);
 
-        // if the model is moving, calculate and draw the bushing forces.
-        if(!fixed){
+        // if the model is moving and the state is adequately realized,
+        // calculate and draw the bushing forces.
+        if (!fixed && (s.getSystemStage() >= Stage::Dynamics)) {
             SpatialVec F_GM(Vec3(0.0), Vec3(0.0));
             SpatialVec F_GF(Vec3(0.0), Vec3(0.0));
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -117,10 +117,6 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 {        
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
-    
-    // Ensure that the state has been realized to Stage::Dynamics to give
-    // clients of this path a chance to calculate meaningful color information.
-    getModel().realizeDynamics(state);
 
     const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
 

--- a/OpenSim/Tools/Test/testVisualization.cpp
+++ b/OpenSim/Tools/Test/testVisualization.cpp
@@ -169,6 +169,10 @@ void testVisModel(Model& model, const std::string standard_filename)
     if (visualDebug) 
         model.setUseVisualizer(true);
     SimTK::State& si = model.initSystem();
+
+    // Compute muscle dynamics to evaluate Muscle color
+    model.realizeDynamics(si);
+    
     if (visualDebug) 
         model.getVisualizer().show(si);
     ModelDisplayHints mdh; 


### PR DESCRIPTION
Fixes issue #2230 and related to https://github.com/opensim-org/opensim-gui/issues/427

### Brief summary of changes
Removed calls to `realizeDynamics()` within `generateDecorations()`. Documented the additional rule for implementing `generateDecorations` for custom user components that there must be a check that the required stage has been achieved before trying to draw stage dependent quantities beyond `Position`

### Testing I've completed
Build the GUI can could load the model. It does not display the forces. Verified that the forces are still drawn in the API visualizer during forward simulation.

### Looking for feedback on...
Does anyone foresee any unnecessary limitation by imposing this "no realizing" rule on user overrides of `generateDecorations`? I think it is much safer and avoids side-effects like attempting to compute forces during IK.

### CHANGELOG.md (choose one)
- no need to update because because this is a bug fix.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
