### PR TITLE
[travis] Use an older xcode image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ language: cpp
 sudo: false
 
 # For thread_local support on macOS, we require xcode8 or greater.
-# Before 2018, xcode7 was the default. Now that xcode8.3 is the default,
-# we no longer need to specify an osx_image.
+# 20180801 Travis-CI changed the default image to xcode9.4, which
+#          broke our build.
+#          https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce
 # https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
-# osx_image: xcode8
+osx_image: xcode8.3
     
 matrix:
   include:


### PR DESCRIPTION
### Brief summary of changes

[Yesterday, Travis-CI updated their OSX image](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce), causing our builds to fail:

> make[2]: *** No rule to make target `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Accelerate.framework', needed by `libosimCommon.dylib'.  Stop.

This PR specifies that we want to use an older OSX image.

It would be great if we can review this as part of the current spring, so that we can continue testing.

### Testing I've completed

Waiting for CI.

### CHANGELOG.md (choose one)

- no need to update because...not user-facing.