### PR TITLE
Model::formStateStorage() return value: are all coordinate values specified?

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1952,11 +1952,6 @@ bool Model::formStateStorage(const Storage& originalStorage,
     rStateNames.insert(0, "time");
     statesStorage.setColumnLabels(rStateNames);
     
-    /*const auto coords = getCoordinatesInMultibodyTreeOrder();
-    for (const auto& coord : coords) {
-        if
-    }*/
-    
     // https://stackoverflow.com/questions/874134/find-if-string-ends-with-another-string-in-c
     auto string_ends_with =
             [](const std::string& str, const std::string& ending) {
@@ -1964,8 +1959,9 @@ bool Model::formStateStorage(const Storage& originalStorage,
                 return std::equal(ending.rbegin(), ending.rend(), str.rbegin());
             };
     for (int i = 0; i < mapColumns.size(); ++i) {
-        if (mapColumns[i] == -1 && string_ends_with(rStateNames[i], "/value")) {
-            std::cout << "DEBUG " << i << " " << mapColumns[i] << " " << rStateNames[i] << std::endl;
+        // Must add 1 because, at this point, rStateNames includes "time".
+        if (mapColumns[i] == -1
+                && string_ends_with(rStateNames[i+1], "/value")) {
             return false;
         }
     }

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1867,7 +1867,7 @@ void Model::setAllControllersEnabled( bool enabled ) {
     _allControllersEnabled = enabled;
 }
 
-void Model::formStateStorage(const Storage& originalStorage,
+bool Model::formStateStorage(const Storage& originalStorage,
                              Storage& statesStorage,
                              bool warnUnspecifiedStates) const
 {
@@ -1951,6 +1951,25 @@ void Model::formStateStorage(const Storage& originalStorage,
     }
     rStateNames.insert(0, "time");
     statesStorage.setColumnLabels(rStateNames);
+    
+    /*const auto coords = getCoordinatesInMultibodyTreeOrder();
+    for (const auto& coord : coords) {
+        if
+    }*/
+    
+    // https://stackoverflow.com/questions/874134/find-if-string-ends-with-another-string-in-c
+    auto string_ends_with =
+            [](const std::string& str, const std::string& ending) {
+                if (ending.size() > str.size()) return false;
+                return std::equal(ending.rbegin(), ending.rend(), str.rbegin());
+            };
+    for (int i = 0; i < mapColumns.size(); ++i) {
+        if (mapColumns[i] == -1 && string_ends_with(rStateNames[i], "/value")) {
+            std::cout << "DEBUG " << i << " " << mapColumns[i] << " " << rStateNames[i] << std::endl;
+            return false;
+        }
+    }
+    return true;
 }
 
 /**

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -424,8 +424,12 @@ public:
      * the state value unspecified in originalStorage. The input originalStorage 
      * must be in meters or radians for Coordinate values and their speeds
      * (m/s, rad/s) otherwise an Exception is thrown.
+     *
+     * @returns true if originalStorage has columns for the all coordinate
+     * values (including dependent coordinates), even if columns for other
+     * states (speeds, auxiliary states) are absent.
      */
-    void formStateStorage(const Storage& originalStorage, 
+    bool formStateStorage(const Storage& originalStorage,
                           Storage& statesStorage,
                           bool warnUnspecifiedStates = true) const;
 

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -239,8 +239,6 @@ void testFormStateStorage() {
     manager.integrate(0.05);
     Storage origStorage = manager.getStateStorage();
     Array<std::string> origLabels = origStorage.getColumnLabels();
-    for (int i = 0; i < origLabels.size(); ++i)
-        std::cout << "DEBUG " << origLabels[i] << std::endl;
     
     Storage statesStorage;
     
@@ -254,8 +252,6 @@ void testFormStateStorage() {
     SimTK_TEST(model.formStateStorage(origStorage, statesStorage));
     origLabels[origLabels.findIndex("r_elbow/r_elbow_flex/speed")]= "hide2";
     origStorage.setColumnLabels(origLabels);
-        for (int i = 0; i < origLabels.size(); ++i)
-        std::cout << "DEBUG " << origLabels[i] << std::endl;
     SimTK_TEST(model.formStateStorage(origStorage, statesStorage));
 
     // "Removing" a coordinate state variable causes a return value of false.


### PR DESCRIPTION
This is a first step towards addressing https://github.com/opensim-org/opensim-gui/issues/86

### Brief summary of changes

`Model::formStateStorage()` has a return value that denotes if all coordinate values are provided. This will allow the GUI to determine if needs to call `Model::assemble()` for visualization.

### Testing I've completed

I added a test case that ensures that "removing" a coordinate value column causes the function to return false.

### Looking for feedback on...

Are there more robust or faster ways to check if the unspecified states are coordinates?

### CHANGELOG.md (choose one)

- no need to update because...this is a minor change

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2239)
<!-- Reviewable:end -->
