### PR TITLE
Change default display size of Model markers from 5mm to 10mm 

### DIFF
--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -173,7 +173,7 @@ void Marker::generateDecorations(bool fixed, const ModelDisplayHints& hints, con
     //SimTK::Transform bTrans = frame.findTransformInBaseFrame();
     //const Vec3& p_BM = bTrans*get_location();
     appendToThis.push_back(
-        SimTK::DecorativeSphere(.005).setBodyId(frame.getMobilizedBodyIndex())
+        SimTK::DecorativeSphere(.01).setBodyId(frame.getMobilizedBodyIndex())
         .setColor(color).setOpacity(1.0)
         .setTransform(get_location()));
     


### PR DESCRIPTION
Per opensim-gui issue https://github.com/opensim-org/opensim-gui/issues/951

Fixes issue #

### Brief summary of changes
Changed hardcoded Model marker size from previous default of 5 (mm) to new default (10 mm)

### Testing I've completed
Built GUI against this API change and saw larger model markers. Changing Default Experimental Marker size in GUI to 10 made experimental and model markers appear the same size.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because this internal change/bugfix

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
