### PR TITLE
Remove member variables/properties representing quadrants

### DIFF
--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -293,51 +293,17 @@ private:
 
 
 /**
- * Utility class used to abstract analytic geometry. This will need to be 
- * revisited when wrapping is re-done to handle quadrants or analytic shapes
- * that were supported in earlier releases before 4.0. 
+ * Utility class used to abstract analytic geometry (surfaces of revolution)
  *
- * TODO: using start/end angle may be a better choice.
+ * TODO: using start/end angle to indicate partial surfaces.
  */
 class OSIMSIMULATION_API AnalyticGeometry : public Geometry
 {    
     OpenSim_DECLARE_ABSTRACT_OBJECT(AnalyticGeometry, Geometry);
-    // Amended with a quadrants array to support pieces of analytic geometry (for wrapping)
-    OpenSim_DECLARE_LIST_PROPERTY(quadrants, std::string,
-        "Quadrants to use: combination of +X -X +Y -Y +Z -Z space separated."); 
-private:
-    bool                    _bounds[6];     //-X, +X, -Y, +Y, -Z, +Z
-    bool                    _piece;
+
 public:
-    AnalyticGeometry():
-        _piece(false)
-    {
-        constructProperties();
-        for(int i=0; i<6; i++) _bounds[i]=true;
-    }
+    AnalyticGeometry() {}
     virtual ~AnalyticGeometry() {}
-    void setQuadrants(const bool quadrants[6])
-    {
-        _piece=false;
-        for(int i=0; i<6; i++){
-            _bounds[i]=quadrants[i];
-            _piece = _piece || (!quadrants[i]);
-        }
-    }
-    void getQuadrants(bool quadrants[6])
-    {
-        for(int i=0; i<6; i++){
-            quadrants[i]=_bounds[i];
-        }
-    }
-    const bool isPiece() const
-    {
-        return _piece;
-    }
-private:
-    void constructProperties() {
-        constructProperty_quadrants();
-    }
 };
 /**
  * A class to represent Sphere geometry. 

--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -294,8 +294,10 @@ private:
 
 /**
  * Utility class used to abstract analytic geometry (surfaces of revolution)
+ * This class is used as base for (Sphere, Cylinder, Cone, Ellisoid, Torus) which 
+ * need special treatment by OpenSim visualizer since they need to be recreated on 
+ * Edit (optimized on construction by threejs library)
  *
- * TODO: using start/end angle to indicate partial surfaces.
  */
 class OSIMSIMULATION_API AnalyticGeometry : public Geometry
 {    

--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -293,11 +293,11 @@ private:
 
 
 /**
- * Utility class used to abstract analytic geometry (surfaces of revolution)
- * This class is used as base for (Sphere, Cylinder, Cone, Ellisoid, Torus) which 
- * need special treatment by OpenSim visualizer since they need to be recreated on 
- * Edit (optimized on construction by threejs library)
- *
+ * Abstract class for analytical geometry (e.g. surfaces of revolution) whose
+ * rendering is optimized by the graphics library (e.g. threejs). Unlike other
+ * geometry, property edits require a recreation of the AnalyticGeometry on
+ * the renderer and not simple updates. AnalyticGeometry is the base class for
+ * Sphere, Cylinder, Cone, Ellipsoid and Torus geometry.
  */
 class OSIMSIMULATION_API AnalyticGeometry : public Geometry
 {    


### PR DESCRIPTION
 AnalyticGeometry  doesn't use quadrants now as they're not implemented by underlying DecorativeGeometry, and we don't want them sticking around in the API.

Fixes issue opensim-gui#346 follow up

### Brief summary of changes
Unused Properties/member variables were removed.

### Testing I've completed
Nothing to test since they were unused, just compiled and ran tests.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because these classes are new in 4.0

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
