### PR TITLE
Popup warning message when MotionType between <=3.3 to 4.0 is inconsistent

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -655,19 +655,13 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
     if (message.size()) {
         message = "\nModel '" + getName() + "' has inconsistencies:\n" + message;
         message += 
-            "You must update any motion files you generated in version 3.3 or earlier. You can:\n"
-            "  (1) Run the updateKinematicsFilesForUpdatedModel() utility (in the scripting shell) OR\n"
-            "  (2) Re-run the inverse kinematics tool with the updated model in 4.0\n"
-            "In versions 3.3 and earlier, we allowed some Coupled coordinates to be incorrectly\n"
-            "labeled as Rotational. Coordinate values for Coupled coordinates previously (pre-4.0)\n"
-            "labeled Rotational, can be assigned values that are in degrees if a coordinate. This\n"
-            "will lead to incorrect motion when playing back a pre-4.0 motion file (.mot or .sto in\n"
-            "degrees) and produces erroneous velocity and acceleration estimates that\n"
-            "yield incorrect inverse-dynamics and static-optimization results. You can\n"
-            "apply the utility:\n"
-            "\tupdateKinematicsFilesForUpdatedModel(model_file, list_of_MOT_files)\n"
-            "to update motion files generated prior to 4.0 and undo the conversion of\n"
-            "Coupled coordinates to degrees so that they are consistent with the 4.0 model.";
+            "You must update any motion files you generated in versions prior to 4.0. You can:\n"
+            "  (1) Run the updatePre40KinematicsFilesFor40MotionType() utility (in the scripting shell) OR\n"
+            "  (2) Re-run the Inverse Kinematics Tool with the updated model in 4.0.\n"
+            "In versions prior to 4.0, we allowed some Coupled coordinates to be incorrectly\n"
+            "labeled as Rotational. This leads to incorrect motion when playing back a pre-4.0\n"
+            "motion file (.mot or .sto in degrees) and incorrect inverse dynamics and\n"
+            "static optimization results.";
     }
 
     return message;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -644,20 +644,27 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
 
         if( (oldMotionType != Coordinate::MotionType::Undefined ) &&
             (oldMotionType != motionType) ){
-            message += " Coordinate '" + coord.getName() +
+            message += "Coordinate '" + coord.getName() +
                 "' had incorrect MotionType '" + enumToString(oldMotionType) +
-                "', now set to '" + enumToString(motionType) + "'\n";
+                "' and is now set to '" + enumToString(motionType) + "'\n";
         }
     }
 
     // We have a reason to provide a warning. Add more details about the model
     // and how to resolve future issues.
     if (message.size()) {
-        message = "Model '" + getName() + "' has inconsistencies:\n" + message;
-        message += "Please consider updating kinematics (.mot) files associated\n"
-            "with this model to ensure consistent unit conversion (from degrees)\n"
-            "when applying kinematics to the model. See this utility:\n"
-            "updateKinematicsFilesForUpdatedModel(model_file, list_of_MOT_files)";
+        message = "\nModel '" + getName() + "' has inconsistencies:\n" + message;
+        message += 
+            "Consequently, Coordinate values for Coupled coordinates can be assigned\n"
+            "values that are in degrees if a coordinate was previously (pre-4.0) labeled\n"
+            "as Rotational. This will lead to incorrect motion of bodies governed by the\n"
+            "Coupled coordinate when playing back a pre-4.0 motion file (.mot or .sto in\n"
+            "degrees) and produces erroneous velocity and acceleration estimates that\n"
+            "yield incorrect inverse-dynamics and static-optimization results. You can\n"
+            "apply the utility:\n"
+            "\tupdateKinematicsFilesForUpdatedModel(model_file, list_of_MOT_files)\n"
+            "to update motion files generated prior to 4.0 and undo the conversion of\n"
+            "Coupled coordinates to degrees so that they are consistent with the 4.0 model.";
     }
 
     return message;
@@ -683,12 +690,6 @@ void Model::extendFinalizeFromProperties()
 
     std::string warn = getWarningMesssageForMotionTypeInconsistency();
     appendToValidationLog(warn);
-
-    if (getValidationLog().size() > 0) {
-        cout << "The following Errors/Warnings were encountered ";
-        cout << "interpreting properties of the model. " <<
-            getValidationLog() << endl;
-    }
 
     updCoordinateSet().populate(*this);
 }

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -645,8 +645,8 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
         if( (oldMotionType != Coordinate::MotionType::Undefined ) &&
             (oldMotionType != motionType) ){
             message += "Coordinate '" + coord.getName() +
-                "' had incorrect MotionType '" + enumToString(oldMotionType) +
-                "' and is now set to '" + enumToString(motionType) + "'\n";
+                "' was labeled as '" + enumToString(oldMotionType) +
+                "' but was found to be '" + enumToString(motionType) + "' based on the joint definition.\n";
         }
     }
 

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -655,10 +655,13 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
     if (message.size()) {
         message = "\nModel '" + getName() + "' has inconsistencies:\n" + message;
         message += 
-            "Consequently, Coordinate values for Coupled coordinates can be assigned\n"
-            "values that are in degrees if a coordinate was previously (pre-4.0) labeled\n"
-            "as Rotational. This will lead to incorrect motion of bodies governed by the\n"
-            "Coupled coordinate when playing back a pre-4.0 motion file (.mot or .sto in\n"
+            "You must update any motion files you generated in version 3.3 or earlier. You can:\n"
+            "  (1) Run the updateKinematicsFilesForUpdatedModel() utility (in the scripting shell) OR\n"
+            "  (2) Re-run the inverse kinematics tool with the updated model in 4.0\n"
+            "In versions 3.3 and earlier, we allowed some Coupled coordinates to be incorrectly\n"
+            "labeled as Rotational. Coordinate values for Coupled coordinates previously (pre-4.0)\n"
+            "labeled Rotational, can be assigned values that are in degrees if a coordinate. This\n"
+            "will lead to incorrect motion when playing back a pre-4.0 motion file (.mot or .sto in\n"
             "degrees) and produces erroneous velocity and acceleration estimates that\n"
             "yield incorrect inverse-dynamics and static-optimization results. You can\n"
             "apply the utility:\n"

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -367,6 +367,11 @@ void Model::constructProperties()
     constructProperty_ModelVisualPreferences(md);
 }
 
+// Append to the Model's validation log
+void Model::appendToValidationLog(const std::string& note) {
+    _validationLog.append(note);
+}
+
 //------------------------------------------------------------------------------
 //                                BUILD SYSTEM
 //------------------------------------------------------------------------------
@@ -393,10 +398,6 @@ void Model::buildSystem() {
 SimTK::State& Model::initializeState() {
     if (!hasSystem()) 
         throw Exception("Model::initializeState(): call buildSystem() first.");
-
-    std::string warn = getWarningMesssageForMotionTypeInconsistency();
-    if (warn.size())
-        cout << warn << endl;
 
     // This tells Simbody to finalize the System.
     getMultibodySystem().invalidateSystemTopologyCache();
@@ -679,6 +680,9 @@ void Model::extendFinalizeFromProperties()
         fs.updActuators();
         fs.updMuscles();
     }
+
+    std::string warn = getWarningMesssageForMotionTypeInconsistency();
+    appendToValidationLog(warn);
 
     if (getValidationLog().size() > 0) {
         cout << "The following Errors/Warnings were encountered ";

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1012,7 +1012,9 @@ public:
     /**
      * Get a log of errors/warnings encountered when loading/constructing the model
      */
-    const std::string& getValidationLog() { return _validationLog; };
+    const std::string& getValidationLog() const { return _validationLog; };
+    /** Append to the Model's validation log without affecting is current contents */
+    void appendToValidationLog(const std::string& note);
     void clearValidationLog() { _validationLog = ""; };
 
     /**


### PR DESCRIPTION
Final part of fixes to issue #2240 

### Brief summary of changes
Wired the message generated in #2243 to the validation log used by https://github.com/opensim-org/opensim-gui/pull/953. Added method to append to the log. 

### Testing I've completed
Loaded leg6dof9musc with a build of https://github.com/opensim-org/opensim-gui/pull/953 to produce the following error message:
![image](https://user-images.githubusercontent.com/6494122/44238440-92b87400-a169-11e8-97ef-14b1ef8c7d5a.png)

### Looking for feedback on...
Is the message comprehensible?

### CHANGELOG.md (choose one)
- MotionType handling was added to the CHANGELOG in #2240

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
