### PR TITLE
Fix GeometryPath method to place new PathPoints 

### DIFF
--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -492,10 +492,12 @@ addPathPoint(const SimTK::State& s, int aIndex, const PhysicalFrame& frame)
 {
     PathPoint* newPoint = new PathPoint();
     newPoint->setParentFrame(frame);
-    Vec3 location = newPoint->getLocation(s); // 0 by construction
-    // location is now a COPY not a reference so the computed location is LOST unless setLocation is invoked
-    placeNewPathPoint(s, location, aIndex, frame);
-    newPoint->setLocation(location); // 
+    Vec3 newLocation(0.0); 
+    // placeNewPathPoint takes a newLocation reference and changes it 
+	// based on the index in the path (interpolate or extend, in ground frame)
+    placeNewPathPoint(s, newLocation, aIndex, frame);
+	// Now set computed new location into the newPoint
+    newPoint->setLocation(newLocation);
     upd_PathPointSet().insert(aIndex, newPoint);
 
     // Rename the path points starting at this new one.

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -492,8 +492,10 @@ addPathPoint(const SimTK::State& s, int aIndex, const PhysicalFrame& frame)
 {
     PathPoint* newPoint = new PathPoint();
     newPoint->setParentFrame(frame);
-    Vec3 location = newPoint->getLocation(s);
+    Vec3 location = newPoint->getLocation(s); // 0 by construction
+    // location is now a COPY not a reference so the computed location is LOST unless setLocation is invoked
     placeNewPathPoint(s, location, aIndex, frame);
+    newPoint->setLocation(location); // 
     upd_PathPointSet().insert(aIndex, newPoint);
 
     // Rename the path points starting at this new one.

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -493,10 +493,11 @@ addPathPoint(const SimTK::State& s, int aIndex, const PhysicalFrame& frame)
     PathPoint* newPoint = new PathPoint();
     newPoint->setParentFrame(frame);
     Vec3 newLocation(0.0); 
-    // placeNewPathPoint takes a newLocation reference and changes it 
-	// based on the index in the path (interpolate or extend, in ground frame)
+    // Note: placeNewPathPoint() returns a location by reference.
+    // It computes a new location according to the index where the new path point 
+    // will be inserted along the path(among the other path points).
     placeNewPathPoint(s, newLocation, aIndex, frame);
-	// Now set computed new location into the newPoint
+    // Now set computed new location into the newPoint
     newPoint->setLocation(newLocation);
     upd_PathPointSet().insert(aIndex, newPoint);
 


### PR DESCRIPTION
Fixes issue #0 obvious bug!

### Brief summary of changes
Method GeometryPath::placePathPoint was broken by earlier change in 4.0 that replaced passing a reference to the new point's location with passing a copy that gets thrown away on return. This PR restores old functionality.
### Testing I've completed
Built GUI with this PR and new pathpoints are  placed consistent with 3.3 (though not exact) where inserting at end points extends the geometry path out a little and inserting between points performs linear interpolation.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because this is a bugfix

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
