### PR TITLE
Remove SWIG's Manager::setIntegratorAccuracy()

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -44,13 +44,6 @@ using namespace SimTK;
     }
 };
 
-
-%extend OpenSim::Manager {
-    void setIntegratorAccuracy(double accuracy){
-        self->getIntegrator().setAccuracy(accuracy);
-    }
-}
-
 %extend OpenSim::Object {
     static OpenSim::Array<std::string> getFunctionClassNames() {
         OpenSim::Array<std::string> availableClassNames;


### PR DESCRIPTION
Fixes issue #2269 

### Brief summary of changes

This PR removes the now-unnecessary redefinition of `Manager::setIntegratorAccuracy()`.

### Testing I've completed

- None!

### CHANGELOG.md (choose one)

- no need to update because...this doesn't change the interface.