### PR TITLE
Ignore CLion build dirs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 tmp
 # Ignore build trees.
 /build*
+# CLion integrated development environment
+/cmake-build-*
 # Ignore install dir.
 install
 # Ignore settings from the CLion IDE (from JetBrains).
@@ -25,3 +27,4 @@ dependencies/*
 
 # MAC File System files
 .DS_Store
+


### PR DESCRIPTION
The CLion IDE requires that the build directory is inside the source
dir. This allows us to ignore such directories from git.
