### PR TITLE
Do not enforceConstraints by default.

### DIFF
--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -166,7 +166,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
         const Storage& sto,
         bool allowMissingColumns,
         bool allowExtraColumns,
-        bool enforceConstraints) {
+        bool assemble) {
 
     // Assemble the required objects.
     // ==============================
@@ -272,7 +272,7 @@ StatesTrajectory StatesTrajectory::createFromStatesStorage(
             statesValues[kv.second] = dependentValues[kv.first];
         }
         localModel.setStateVariableValues(state, statesValues);
-        if (enforceConstraints) {
+        if (assemble) {
             localModel.assemble(state);
         }
 

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -438,9 +438,11 @@ public:
      *      columns in the Storage that do not correspond to continuous state
      *      variables in the Model. If true, such columns of the Storage are
      *      ignored.
-     * @param enforceConstraints Modify state variable values to satisfy
-     *      kinematic constraints (by calling Model::assemble()). Be careful
-     *      with this option; enforcing constraints can drastically alter the
+     * @param assemble Modify state variable values to satisfy
+     *      kinematic constraints (by calling Model::assemble()).
+     *      Use this option if the provided states are incomplete (for example,
+     *      the values for dependent coordinates are unspecified).
+     *      Caution: enforcing constraints can drastically alter the
      *      provided states if they do not already obey the constraints.
      *
      * #### Usage
@@ -483,7 +485,7 @@ public:
             const Storage& sto,
             bool allowMissingColumns = false,
             bool allowExtraColumns = false,
-            bool enforceConstraints = false);
+            bool assemble = false);
 
     /** Convenience form of createFromStatesStorage() that takes the path to a
      * Storage file instead of a Storage object. This convenience form uses the

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -444,6 +444,11 @@ public:
      *      the values for dependent coordinates are unspecified).
      *      Caution: enforcing constraints can drastically alter the
      *      provided states if they do not already obey the constraints.
+     *      Do not use this option with results from a forward simulation: the
+     *      states trajectory from a forward simulation may not meet the
+     *      model's assembly accuracy, and therefore assembling could
+     *      alter the trajectory and cause inconsistency between coordinate
+     *      values and speeds.
      *
      * #### Usage
      * Here is how you might use this function in python:

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -439,7 +439,9 @@ public:
      *      variables in the Model. If true, such columns of the Storage are
      *      ignored.
      * @param enforceConstraints Modify state variable values to satisfy
-     *      kinematic constraints (by calling Model::assemble()).
+     *      kinematic constraints (by calling Model::assemble()). Be careful
+     *      with this option; enforcing constraints can drastically alter the
+     *      provided states if they do not already obey the constraints.
      *
      * #### Usage
      * Here is how you might use this function in python:
@@ -481,7 +483,7 @@ public:
             const Storage& sto,
             bool allowMissingColumns = false,
             bool allowExtraColumns = false,
-            bool enforceConstraints = true);
+            bool enforceConstraints = false);
 
     /** Convenience form of createFromStatesStorage() that takes the path to a
      * Storage file instead of a Storage object. This convenience form uses the


### PR DESCRIPTION
Related to #2271 

### Brief summary of changes

As-is, `StatesTrajectory::createFromStatesStorage()` will enforce constraints via assembly, by default. However, based on discussion in https://github.com/opensim-org/opensim-gui/issues/86, it seems that we do not want to call `assemble()` by default.

### Testing I've completed

Ran test suite

### Looking for feedback on...

Should we make this change?

### CHANGELOG.md (choose one)

- no need to update because...this function has not been released yet.