### PR TITLE
DataTable constructor fixes for slow pack and flatten operations

### DIFF
--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1402,7 +1402,7 @@ protected:
     template<typename ELT>
     static
     SimTK::RowVector_<double> splitElement(const ELT& elt) {
-        SimTK::RowVector_<double> result;
+        SimTK::RowVector_<double> result(numComponentsPerElement_impl(elt));
         splitElementAndAppend(result.begin(), result.end(), elt);
         return result;
     }

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -385,7 +385,7 @@ public:
             (int)that.getNumColumns() / numComponentsPerElement());
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             auto thatRow = that.getRowAtIndex(r).getAsRowVector();
-            for(unsigned c = 0; this->getNumColumns(); ++c) {
+            for(unsigned c = 0; c < this->getNumColumns(); ++c) {
                 _depData.updElt(r,c) = makeElement(
                     thatRow.begin() + c*numComponentsPerElement(), 
                     thatRow.end());

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -213,7 +213,7 @@ public:
                            that.numComponentsPerElement());
         for(const auto& label : that.getColumnLabels()) {
             if(suffixes.empty()) {
-                for(unsigned i = 1; i <= that.numComponentsPerElement(); ++i)
+                for(unsigned i = 1; i <= that.numComponentsPerElement(); ++i) 
                     thisLabels.push_back(label + "_" + std::to_string(i));
             } else {
                 for(const auto& suffix : suffixes)
@@ -224,19 +224,19 @@ public:
         setColumnLabels(thisLabels);
 
         // Construct matrix for this table from that table.
-        _depData.resize((int)that.getNumRows(),
-            (int)that.getNumColumns() * numComponentsPerElement());
+        _depData.resize((int)that.getNumRows(), 
+            (int)that.getNumColumns() * that.numComponentsPerElement());
         SimTK::RowVector_<ETY> 
-        thisRow((int)that.getNumColumns() * numComponentsPerElement());
+        thisRow((int)that.getNumColumns() * that.numComponentsPerElement());
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             const auto& thatRow = that.getRowAtIndex(r);
-            for (unsigned c = 0; c < that.getNumColumns(); ++c)
-                splitElementAndAppend(
-                    _depData.updRow(r).begin() + c*numComponentsPerElement(), 
-                    _depData.updRow(r).end(),
-                    thatRow[c]);
+            for (unsigned c = 0; c < that.getNumColumns(); ++c) {
+                splitElementAndAppend(_depData.updRow(r).begin() + 
+                                        c*that.numComponentsPerElement(), 
+                                      _depData.updRow(r).end(),
+                                      thatRow[c]);
+            }
         }
-
         _indData = that.getIndependentColumn();
     }
 
@@ -389,7 +389,7 @@ public:
             auto thatRow = that.getRowAtIndex(r).getAsRowVector();
             for(unsigned c = 0;
                 c < that.getNumColumns() / numComponentsPerElement(); ++c) {
-                _depData[r,c] = makeElement(
+                _depData.updElt(r,c) = makeElement(
                     thatRow.begin() + c*numComponentsPerElement(), 
                     thatRow.end());
             }
@@ -1360,7 +1360,7 @@ protected:
     template<int N, typename Iter>
     static
     void splitElementAndAppend(Iter begin, Iter end, 
-                                 const SimTK::Vec<N>& elem) {
+                               const SimTK::Vec<N>& elem) {
         for(unsigned i = 0; i < N; ++i) {
             OPENSIM_THROW_IF(begin == end,
                 InvalidArgument,
@@ -1376,7 +1376,7 @@ protected:
     template<int M, int N, typename Iter>
     static
     void splitElementAndAppend(Iter begin, Iter end, 
-                                 const SimTK::Vec<M, SimTK::Vec<N>>& elem) {
+                               const SimTK::Vec<M, SimTK::Vec<N>>& elem) {
         for(unsigned i = 0; i < M; ++i) {
             for(unsigned j = 0; j < N; ++j) {
                 OPENSIM_THROW_IF(begin == end,

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -231,7 +231,7 @@ public:
             std::vector<ETY> thisRow{};
             for(unsigned c = 0; c < that.getNumColumns(); ++c)           
                 splitElementAndPushBack(thisRow, thatRow[c]);
-            // 
+            
             for(unsigned comp = 0; 
                 comp < that.getNumColumns() * numComponentsPerElement();
                 ++comp) {

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -229,7 +229,7 @@ public:
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             const auto& thatRow = that.getRowAtIndex(r);
             for (unsigned c = 0; c < that.getNumColumns(); ++c) {
-                splitElementAndAppend(_depData.updRow(r).begin() + 
+                splitElementAndCopy(_depData.updRow(r).begin() +
                                         c*that.numComponentsPerElement(), 
                                       _depData.updRow(r).end(),
                                       thatRow[c]);
@@ -385,8 +385,7 @@ public:
             (int)that.getNumColumns() / numComponentsPerElement());
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             auto thatRow = that.getRowAtIndex(r).getAsRowVector();
-            for(unsigned c = 0;
-                c < that.getNumColumns() / numComponentsPerElement(); ++c) {
+            for(unsigned c = 0; this->getNumColumns(); ++c) {
                 _depData.updElt(r,c) = makeElement(
                     thatRow.begin() + c*numComponentsPerElement(), 
                     thatRow.end());
@@ -1353,33 +1352,37 @@ protected:
         return result;
     }
 
-    // Split element into constituent components and append the components to
-    // the given vector. For example Vec3 has 3 components.
+    // Split element into constituent components and copy the components
+    // according to the iterator argument. This function will write N elements 
+    // starting from *begin* but not necessarily up to *end*. 
+    // Example: Vec3 has 3 components.
     template<int N, typename Iter>
     static
-    void splitElementAndAppend(Iter begin, Iter end, 
+    void splitElementAndCopy(Iter begin, Iter end, 
                                const SimTK::Vec<N>& elem) {
         for(unsigned i = 0; i < N; ++i) {
             OPENSIM_THROW_IF(begin == end,
                 InvalidArgument,
-                "Iterators do not produce enough elements."
+                "Iterators do not produce enough elements. "
                 "Expected: " + std::to_string(N) + " Received: " +
                 std::to_string(i));
 
             *begin++ = elem[i];
         }
     }
-    // Split element into constituent components and append the components to 
-    // the given vector. For example Vec<2, Vec3> has 6 components.
+    // Split element into constituent components and copy the components 
+    // according to the iterator argument. This function will write M*N elements 
+    // starting from *begin* but not necessarily up to *end*. 
+    // Example: Vec<2, Vec3> has 6 components.
     template<int M, int N, typename Iter>
     static
-    void splitElementAndAppend(Iter begin, Iter end, 
+    void splitElementAndCopy(Iter begin, Iter end, 
                                const SimTK::Vec<M, SimTK::Vec<N>>& elem) {
         for(unsigned i = 0; i < M; ++i) {
             for(unsigned j = 0; j < N; ++j) {
                 OPENSIM_THROW_IF(begin == end,
                     InvalidArgument,
-                    "Iterators do not produce enough elements."
+                    "Iterators do not produce enough elements. "
                     "Expected: " + std::to_string(M * N) +
                     " Received: " + std::to_string((i + 1) * j));
 
@@ -1390,7 +1393,7 @@ protected:
     // Unsupported type.
     template<typename Iter>
     static
-    void splitElementAndAppend(Iter begin, Iter end,
+    void splitElementAndCopy(Iter begin, Iter end,
                                  ...) {
         static_assert(!std::is_same<ETY, double>::value,
                       "This constructor cannot be used to construct from "
@@ -1401,7 +1404,7 @@ protected:
     static
     SimTK::RowVector_<double> splitElement(const ELT& elt) {
         SimTK::RowVector_<double> result(numComponentsPerElement_impl(elt));
-        splitElementAndAppend(result.begin(), result.end(), elt);
+        splitElementAndCopy(result.begin(), result.end(), elt);
         return result;
     }
     static
@@ -1415,7 +1418,7 @@ protected:
                             Iter begin, Iter end) {
         OPENSIM_THROW_IF(begin == end,
                          InvalidArgument,
-                         "Iterators do not produce enough elements."
+                         "Iterators do not produce enough elements. "
                          "Expected: 1 Received: 0");
         elem = *begin;
     }
@@ -1426,7 +1429,7 @@ protected:
         for(unsigned i = 0; i < N; ++i) {
             OPENSIM_THROW_IF(begin == end,
                              InvalidArgument,
-                             "Iterators do not produce enough elements."
+                             "Iterators do not produce enough elements. "
                              "Expected: " + std::to_string(N) + " Received: " +
                              std::to_string(i));
 

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -375,19 +375,21 @@ public:
         }
         setColumnLabels(thisLabels);
 
-        // Form rows for this table from that table.
+        // Construct matrix for this table from that table.
+        SimTK::Matrix_<ETY> depData((int)that.getNumRows(), 
+            (int)that.getNumColumns());
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
-            const auto& thatInd = that.getIndependentColumn().at(r);
             auto thatRow = that.getRowAtIndex(r).getAsRowVector();
-            std::vector<ETY> thisRow{};
+            SimTK::RowVector_<ETY> thisRow;
             for(unsigned c = 0;
                 c < that.getNumColumns();
                 c += numComponentsPerElement()) {
-                thisRow.push_back(makeElement(thatRow.begin() + c,
-                                              thatRow.end()));
+                thisRow[r] = makeElement(thatRow.begin() + c,thatRow.end());
             }
-            appendRow(thatInd, thisRow);
+            depData.updRow(r) = thisRow;
         }
+        _indData = that.getIndependentColumn();
+        _depData = depData;
     }
 
     /** Construct DataTable_<double, double> from 

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -231,7 +231,9 @@ public:
             std::vector<ETY> thisRow{};
             for(unsigned c = 0; c < that.getNumColumns(); ++c)           
                 splitElementAndPushBack(thisRow, thatRow[c]);
-            
+            // This loop could be replaced with
+            //      depData.updRow(r) = thisRow;
+            // if splitElementAndPushBack supported SimTK::RowVector_<ETY>
             for(unsigned comp = 0; 
                 comp < that.getNumColumns() * numComponentsPerElement();
                 ++comp) {

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -226,8 +226,6 @@ public:
         // Construct matrix for this table from that table.
         _depData.resize((int)that.getNumRows(), 
             (int)that.getNumColumns() * that.numComponentsPerElement());
-        SimTK::RowVector_<ETY> 
-        thisRow((int)that.getNumColumns() * that.numComponentsPerElement());
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             const auto& thatRow = that.getRowAtIndex(r);
             for (unsigned c = 0; c < that.getNumColumns(); ++c) {

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -229,7 +229,7 @@ public:
         for(unsigned r = 0; r < that.getNumRows(); ++r) {
             const auto& thatRow = that.getRowAtIndex(r);
             for (unsigned c = 0; c < that.getNumColumns(); ++c) {
-                splitElementAndCopy(_depData.updRow(r).begin() +
+                splitAndAssignElement(_depData.updRow(r).begin() +
                                         c*that.numComponentsPerElement(), 
                                       _depData.updRow(r).end(),
                                       thatRow[c]);
@@ -1352,17 +1352,18 @@ protected:
         return result;
     }
 
-    // Split element into constituent components and copy the components
+    // Split element into constituent components and assign the components
     // according to the iterator argument. This function will write N elements 
-    // starting from *begin* but not necessarily up to *end*. 
+    // starting from *begin* but not necessarily up to *end*. An exception is
+    // thrown if *end* is reached before assigning all components.
     // Example: Vec3 has 3 components.
     template<int N, typename Iter>
     static
-    void splitElementAndCopy(Iter begin, Iter end, 
+    void splitAndAssignElement(Iter begin, Iter end, 
                                const SimTK::Vec<N>& elem) {
         for(unsigned i = 0; i < N; ++i) {
             OPENSIM_THROW_IF(begin == end,
-                InvalidArgument,
+                Exception,
                 "Iterators do not produce enough elements. "
                 "Expected: " + std::to_string(N) + " Received: " +
                 std::to_string(i));
@@ -1370,18 +1371,19 @@ protected:
             *begin++ = elem[i];
         }
     }
-    // Split element into constituent components and copy the components 
+    // Split element into constituent components and assign the components 
     // according to the iterator argument. This function will write M*N elements 
-    // starting from *begin* but not necessarily up to *end*. 
+    // starting from *begin* but not necessarily up to *end*. An exception is
+    // thrown if *end* is reached before assigning all components.
     // Example: Vec<2, Vec3> has 6 components.
     template<int M, int N, typename Iter>
     static
-    void splitElementAndCopy(Iter begin, Iter end, 
+    void splitAndAssignElement(Iter begin, Iter end, 
                                const SimTK::Vec<M, SimTK::Vec<N>>& elem) {
         for(unsigned i = 0; i < M; ++i) {
             for(unsigned j = 0; j < N; ++j) {
                 OPENSIM_THROW_IF(begin == end,
-                    InvalidArgument,
+                    Exception,
                     "Iterators do not produce enough elements. "
                     "Expected: " + std::to_string(M * N) +
                     " Received: " + std::to_string((i + 1) * j));
@@ -1393,7 +1395,7 @@ protected:
     // Unsupported type.
     template<typename Iter>
     static
-    void splitElementAndCopy(Iter begin, Iter end,
+    void splitAndAssignElement(Iter begin, Iter end,
                                  ...) {
         static_assert(!std::is_same<ETY, double>::value,
                       "This constructor cannot be used to construct from "
@@ -1404,7 +1406,7 @@ protected:
     static
     SimTK::RowVector_<double> splitElement(const ELT& elt) {
         SimTK::RowVector_<double> result(numComponentsPerElement_impl(elt));
-        splitElementAndCopy(result.begin(), result.end(), elt);
+        splitAndAssignElement(result.begin(), result.end(), elt);
         return result;
     }
     static
@@ -1417,7 +1419,7 @@ protected:
     void makeElement_helper(double& elem,
                             Iter begin, Iter end) {
         OPENSIM_THROW_IF(begin == end,
-                         InvalidArgument,
+                         Exception,
                          "Iterators do not produce enough elements. "
                          "Expected: 1 Received: 0");
         elem = *begin;
@@ -1428,7 +1430,7 @@ protected:
                             Iter begin, Iter end) {
         for(unsigned i = 0; i < N; ++i) {
             OPENSIM_THROW_IF(begin == end,
-                             InvalidArgument,
+                             Exception,
                              "Iterators do not produce enough elements. "
                              "Expected: " + std::to_string(N) + " Received: " +
                              std::to_string(i));
@@ -1443,7 +1445,7 @@ protected:
         for(unsigned i = 0; i < M; ++i) {
             for(unsigned j = 0; j < N; ++j) {
                 OPENSIM_THROW_IF(begin == end,
-                                 InvalidArgument,
+                                 Exception,
                                  "Iterators do not produce enough elements."
                                  "Expected: " + std::to_string(M * N) +
                                  " Received: " + std::to_string((i + 1) * j));


### PR DESCRIPTION
Fixes issue #2244 

### Brief summary of changes
- `DataTable` constructors for flatten and pack operations now modify the underlying `SimTK::Matrix` directly rather than using `appendRow()`, which resized the `SimTK::Matrix` upon each call, causing performance issues.

### Testing I've completed
- Ran `testDataTable` and `testC3DFileAdapter` locally, which passed
- Used the Matlab `osimC3D` utility to write GRFs to a MOT file. The flatten operation in Matlab, which used to take ~15 minutes, now takes <1 second.
- AppVeyor and windows Travis builds pass.

### Looking for feedback on...
- At the time of writing, the Mac Travis build wasn't passing for some reason. Retriggered it since it passed on the last commit, which was the same except for one line of unused code. 

### CHANGELOG.md (choose one)
- no need to update because changes are for performance only, nothing user-facing

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
