### PR TITLE
Remove connectee name suffix

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -28,6 +28,7 @@
 #include "XMLDocument.h"
 #include <unordered_map>
 #include <set>
+#include <regex>
 
 using namespace SimTK;
 
@@ -1137,6 +1138,21 @@ void Component::updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber)
                 }
             }
             
+        }
+        if (versionNumber == 30516) {
+            // Rename xml tags for socket_*_connectee_name to socket_*
+            for (auto iter = node.element_begin();
+                iter != node.element_end();
+                ++iter) {
+                auto tagname = iter->getElementTag();
+                if (std::regex_match(tagname, std::regex("(socket_)(.*)(_connectee_name)"))) {
+                    auto pos = tagname.find("_connectee_name");
+                    if (pos != std::string::npos) {
+                        tagname.replace(pos, 15, "");
+                        iter->setElementTag(tagname);
+                    }
+                }
+            }
         }
     }
     Super::updateFromXMLNode(node, versionNumber);

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1141,14 +1141,22 @@ void Component::updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber)
         }
         if (versionNumber <= 30516) {
             // Rename xml tags for socket_*_connectee_name to socket_*
+            std::string connecteeNameString = "_connectee_name";
             for (auto iter = node.element_begin();
                 iter != node.element_end();
                 ++iter) {
                 auto tagname = iter->getElementTag();
-                if (std::regex_match(tagname, std::regex("(socket_)(.*)(_connectee_name)"))) {
-                    auto pos = tagname.find("_connectee_name");
+                if (std::regex_match(tagname, std::regex("(socket_|input_)(.*)(_connectee_name)"))) {
+                    auto pos = tagname.find(connecteeNameString);
                     if (pos != std::string::npos) {
-                        tagname.replace(pos, 15, "");
+                        tagname.replace(pos, connecteeNameString.length(), "");
+                        iter->setElementTag(tagname);
+                    }
+                }
+                else if (std::regex_match(tagname, std::regex("(input_)(.*)(_connectee_names)"))) {
+                    auto pos = tagname.find(connecteeNameString);
+                    if (pos != std::string::npos) {
+                        tagname.replace(pos, connecteeNameString.length()+1, "");
                         iter->setElementTag(tagname);
                     }
                 }

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1139,7 +1139,7 @@ void Component::updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber)
             }
             
         }
-        if (versionNumber == 30516) {
+        if (versionNumber <= 30516) {
             // Rename xml tags for socket_*_connectee_name to socket_*
             for (auto iter = node.element_begin();
                 iter != node.element_end();

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -955,7 +955,7 @@ public:
             // immediately after copying.
             if (!it->second->hasOwner()) {
                 // The `this` pointer must be non-const because the Socket
-                // will want to be able to modify the connectee_name property.
+                // will want to be able to modify the connectee name property.
                 const_cast<AbstractSocket*>(it->second.get())->setOwner(
                         const_cast<Self&>(*this));
             }
@@ -2433,7 +2433,7 @@ protected:
         // create a custom-copy-ctor version of all of this?
         // TODO property type should be ComponentPath or something like that.
         PropertyIndex propIndex = this->template addProperty<std::string>(
-                "socket_" + name + "_connectee_name", propertyComment, "");
+                "socket_" + name , propertyComment, "");
         // We must create the Property first: the Socket needs the property's
         // index in order to access the property later on.
         _socketsTable[name].reset(

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2567,11 +2567,11 @@ protected:
         // TODO property type should be OutputPath or ChannelPath.
         if (isList) {
             propIndex = this->template addListProperty<std::string>(
-                    "input_" + name + "_connectee_names", propertyComment,
+                    "input_" + name, propertyComment,
                     0, std::numeric_limits<int>::max());
         } else {
             propIndex = this->template addProperty<std::string>(
-                    "input_" + name + "_connectee_name", propertyComment, "");
+                    "input_" + name, propertyComment, "");
         }
         // We must create the Property first: the Input needs the property's
         // index in order to access the property later on.

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -413,14 +413,13 @@ can connect to multiple (Output) Channels.
 #### XML Syntax of a connectee name
 
 For every %Input that a component has, the XML representation of the component
-contains an element named `input_<input_name>_connectee_name` (or
-`input_<input_name>_connectee_names` for list inputs). For example, a component
+contains an element named `input_<input_name>`. For example, a component
 that has an Input named `desired_angle` might look like the following in XML:
 @code
     <MyComponent name="my_comp">
-        <input_desired_angle_connectee_name>
+        <input_desired_angle>
             ../foo/angle
-        </input_desired_angle_connectee_name>
+        </input_desired_angle>
         ...
     </MyComponent>
 @endcode
@@ -454,9 +453,9 @@ Here are some examples:
 List inputs can contain multiple entries in its connectee name, with the
 entries separated by a space. For example:
 @code
-<input_experimental_markers_connectee_names>
+<input_experimental_markers>
     ../marker_data|column:left_ankle ../marker_data|column:right_ankle ../averager|output(knee_joint_center)
-</input_experimental_markers_connectee_names>
+</input_experimental_markers>
 @endcode
 */
 class OSIMCOMMON_API AbstractInput : public AbstractSocket {
@@ -617,7 +616,7 @@ protected:
     Only Component should ever construct this class.
     @param name              name of the dependent (Abstract)Output.
     @param connecteeNameIndex Index of the property in the containing Component
-                              that holds this Input's connectee_name(s).
+                              that holds this Input's connectee name(s).
     @param connectAtStage     Stage at which Input should be connected.
     @param owner              The component that contains this input. */
     AbstractInput(const std::string& name,
@@ -651,7 +650,7 @@ public:
                  const std::string& alias = "") override;
 
     /** Connect this Input given a root Component to search for
-    the Output according to the connectee_name of this Input  */
+    the Output according to the connectee name of this Input  */
     void findAndConnect(const Component& root) override;
     
     void disconnect() override {
@@ -829,7 +828,7 @@ protected:
     construct an Input.
     @param name               name of the Output dependency.
     @param connecteeNameIndex Index of the property in the containing Component
-                              that holds this Input's connectee_name(s).
+                              that holds this Input's connectee name(s).
     @param connectAtStage     Stage at which Input should be connected.
     @param owner              The component that contains this input. */
     Input(const std::string& name, const PropertyIndex& connecteeNameIndex,
@@ -884,7 +883,7 @@ private:
     /** @{                                                               */ \
     /** comment                                                          */ \
     /** In an XML file, you can set this Socket's connectee name         */ \
-    /** via the <b>\<socket_##cname\></b> element.      */ \
+    /** via the <b>\<socket_##cname\></b> element.                       */ \
     /** This socket was generated with the                               */ \
     /** #OpenSim_DECLARE_SOCKET macro;                                   */ \
     /** see AbstractSocket for more information.                         */ \
@@ -1045,7 +1044,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     /** comment                                                          */ \
     /** This input is needed at stage istage##.                          */ \
     /** In an XML file, you can set this Input's connectee name          */ \
-    /** via the <b>\<input_##iname##_connectee_name\></b> element.       */ \
+    /** via the <b>\<input_##iname\></b> element.                        */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
     /** This input was generated with the                                */ \
@@ -1055,7 +1054,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    PropertyIndex PropertyIndex_input_##iname##_connectee_name {            \
+    PropertyIndex PropertyIndex_input_##iname {                             \
         this->template constructInput<T>(#iname, false,                     \
             "Path to an output (channel) to satisfy the one-value Input '"  \
             #iname "' of type " #T " (description: " comment ").",  istage) \
@@ -1084,7 +1083,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
 
 // TODO create new macros to handle custom copy constructors: with
 // constructInput_() methods, etc. NOTE: constructProperty_() must be called
-// first within these macros, b/c the connectee_name property must exist before
+// first within these macros, b/c the connectee name property must exist before
 // the Input etc is constructed.
 
 
@@ -1106,7 +1105,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     /** This input can connect to multiple outputs, all of which are     */ \
     /** needed at stage istage##.                                        */ \
     /** In an XML file, you can set this Input's connectee name          */ \
-    /** via the <b>\<input_##iname##_connectee_names\></b> element.      */ \
+    /** via the <b>\<input_##iname\></b> element.                        */ \
     /** The syntax for a connectee name is                               */ \
     /** `<path/to/component>|<output_name>[:<channel_name>][(<alias>)]`. */ \
     /** This input was generated with the                                */ \
@@ -1116,7 +1115,7 @@ PropertyIndex Class::constructSocket_##cname() {                            \
     OpenSim_DOXYGEN_Q_PROPERTY(T, iname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    PropertyIndex PropertyIndex_input_##iname##_connectee_names {           \
+    PropertyIndex PropertyIndex_input_##iname {                             \
         this->template constructInput<T>(#iname, true,                      \
             "Paths to outputs (channels) to satisfy the list Input '"       \
             #iname "' of type " #T " (description: " comment "). "          \

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -891,7 +891,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    PropertyIndex PropertyIndex_socket_##cname {           \
+    PropertyIndex PropertyIndex_socket_##cname {                            \
         this->template constructSocket<T>(#cname,                           \
                 "Path to a Component that satisfies the Socket '"           \
                 #cname "' of type " #T " (description: " comment ").")      \

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -141,7 +141,7 @@ public:
         otherwise, the provided connectee replaces the single connectee. */
     virtual void connect(const Object& connectee) = 0;
 
-    /** Connect this %Socket according to its connectee_name property
+    /** Connect this %Socket according to its connectee name property
         given a root %Component to search its subcomponents for the connect_to
         Component. */
     virtual void findAndConnect(const Component& root) {
@@ -202,7 +202,7 @@ protected:
     @param name               name of the socket, usually describes its 
                               dependency.
     @param connecteeNameIndex Index of the property in the containing Component
-                              that holds this Socket's connectee_name(s).
+                              that holds this Socket's connectee name(s).
     @param connectAtStage     Stage at which Socket should be connected.
     @param owner              Component to which this Socket belongs. */
     AbstractSocket(const std::string& name,
@@ -221,7 +221,7 @@ protected:
     This should only be called by Component.
     This exists so that after the containing Component is copied, the 'owner'
     is the new Component. This Socket needs to be able to modify
-    the associated connectee_name property in the Component. Thus, we require
+    the associated connectee name property in the Component. Thus, we require
     a writable reference. */
     // We could avoid the need for this function by writing a custom copy
     // constructor for Component.
@@ -229,10 +229,10 @@ protected:
     /** This will be false immediately after copy construction or assignment.*/
     bool hasOwner() const { return !_owner.empty(); }
     
-    /** Check if entries of the connectee_name property's value is valid (if 
+    /** Check if entries of the connectee name property's value is valid (if 
     it contains spaces, etc.); if so, print out a warning. */
     void checkConnecteeNameProperty() {
-        // TODO Move this check elsewhere once the connectee_name
+        // TODO Move this check elsewhere once the connectee name
         // property is a ComponentPath (or a ChannelPath?).
         for (unsigned iname = 0u; iname < getNumConnectees(); ++iname) {
             const auto& connecteeName = getConnecteeName(iname);
@@ -248,24 +248,24 @@ protected:
                 OPENSIM_THROW(Exception, msg);
             }
             
-            // Use the cleaned-up connectee_name created by ComponentPath.
+            // Use the cleaned-up connectee name created by ComponentPath.
             setConnecteeName(cp.toString(), iname);
             // TODO update the above for Inputs when ChannelPath exists.
             
-            // TODO There might be a bug with empty connectee_name being
+            // TODO There might be a bug with empty connectee name being
             // interpreted as "this component."
         }
     }
 
 private:
     
-    /// Const access to the connectee_name property from the Component in which
+    /// Const access to the connectee name property from the Component in which
     /// this Socket resides. The name of that property is something like
-    /// 'socket_<name>_connectee_name'. This is a special type of property
+    /// 'socket_<name>'. This is a special type of property
     /// that users cannot easily access (e.g., there is no macro-generated
-    /// `get_socket_<name>_connectee_name()` function).
+    /// `get_socket_<name>()` function).
     const Property<std::string>& getConnecteeNameProp() const;
-    /// Writable access to the connectee_name property from the Component in
+    /// Writable access to the connectee name property from the Component in
     /// which this Socket resides. Calling this will mark the Component as
     /// not "up to date with properties"
     /// (Object::isObjectUpToDateWithProperties()).
@@ -360,7 +360,7 @@ public:
         }
     }
 
-    /** Connect this Socket given its connectee_name property  */
+    /** Connect this Socket given its connectee name property  */
     void findAndConnect(const Component& root) override;
 
     void disconnect() override {
@@ -387,7 +387,7 @@ protected:
     can ever construct this class.
     @param name               name of the socket used to describe its dependency.
     @param connecteeNameIndex Index of the property in the containing Component
-                              that holds this Socket's connectee_name(s).
+                              that holds this Socket's connectee name(s).
     @param connectAtStage     Stage at which Socket should be connected.
     @param owner              The component that contains this input. */
     Socket(const std::string& name,
@@ -884,7 +884,7 @@ private:
     /** @{                                                               */ \
     /** comment                                                          */ \
     /** In an XML file, you can set this Socket's connectee name         */ \
-    /** via the <b>\<socket_##cname##_connectee_name\></b> element.      */ \
+    /** via the <b>\<socket_##cname\></b> element.      */ \
     /** This socket was generated with the                               */ \
     /** #OpenSim_DECLARE_SOCKET macro;                                   */ \
     /** see AbstractSocket for more information.                         */ \
@@ -892,7 +892,7 @@ private:
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    PropertyIndex PropertyIndex_socket_##cname##_connectee_name {           \
+    PropertyIndex PropertyIndex_socket_##cname {           \
         this->template constructSocket<T>(#cname,                           \
                 "Path to a Component that satisfies the Socket '"           \
                 #cname "' of type " #T " (description: " comment ").")      \
@@ -960,13 +960,13 @@ private:
     /** @{                                                               */ \
     /** comment                                                          */ \
     /** In an XML file, you can set this socket's connectee name         */ \
-    /** via the <b>\<socket_##cname##_connectee_name\></b> element.      */ \
+    /** via the <b>\<socket_##cname\></b> element.                       */ \
     /** See AbstractSocket for more information.                         */ \
     /** @see connectsocket_##cname##()                                   */ \
     OpenSim_DOXYGEN_Q_PROPERTY(T, cname)                                    \
     /** @}                                                               */ \
     /** @cond                                                            */ \
-    PropertyIndex PropertyIndex_socket_##cname##_connectee_name {           \
+    PropertyIndex PropertyIndex_socket_##cname {           \
         constructSocket_##cname()                                           \
     };                                                                      \
     /* Declare the method used in the in-class member initializer.       */ \

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -2015,7 +2015,7 @@ void testSingleValueInputConnecteeSerialization() {
         // for editing the input's connectee_name does not allow multiple
         // connectee names for a single-value input.
         auto& connectee_name = Property<std::string>::updAs(
-                        foo->updPropertyByName("input_input1_connectee_name"));
+                        foo->updPropertyByName("input_input1"));
         connectee_name.setAllowableListSize(0, 10);
         connectee_name.appendValue("apple");
         connectee_name.appendValue("banana");

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -64,7 +64,8 @@ using namespace std;
 // 30514 for removing "reverse" property from Joint
 // 30515 for WrapObject color, display_preference, VisibleObject -> Appearance
 // 30516 for GeometryPath default_color -> Appearance
-const int XMLDocument::LatestVersion = 30516;
+// 30517 for removal of Socket _connectee_name from XML markup for Socket
+const int XMLDocument::LatestVersion = 30517;
 //=============================================================================
 // DESTRUCTOR AND CONSTRUCTOR(S)
 //=============================================================================

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -64,7 +64,7 @@ using namespace std;
 // 30514 for removing "reverse" property from Joint
 // 30515 for WrapObject color, display_preference, VisibleObject -> Appearance
 // 30516 for GeometryPath default_color -> Appearance
-// 30517 for removal of Socket _connectee_name from XML markup for Socket
+// 30517 for removal of _connectee_name suffix from XML markup for socket, input
 const int XMLDocument::LatestVersion = 30517;
 //=============================================================================
 // DESTRUCTOR AND CONSTRUCTOR(S)


### PR DESCRIPTION
Fixes issue #2293 

### Brief summary of changes
Change XML tag for Socket's connectee_name to remove the trailing 'connectee_name'

### Testing I've completed
Loaded, saved model, contents were same but tags changed as expected. Ran test suite.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
