### PR TITLE
Use absolute pathname when serializing connections

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -719,7 +719,8 @@ ComponentPath Component::getAbsolutePath() const
 
     while (up && up->hasOwner()) {
         up = &up->getOwner();
-        pathVec.insert(pathVec.begin(), up->getName());
+        if (up->hasOwner()) // Prepend parent only of not top level issue #2276 
+            pathVec.insert(pathVec.begin(), up->getName());
     }
 
     return ComponentPath(pathVec, true);

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -702,7 +702,8 @@ std::string Component::getAbsolutePathString() const
 
     while (up && up->hasOwner()) {
         up = &up->getOwner();
-        absPathName.insert(0, "/" + up->getName());
+        if (up->hasOwner()) // Prepend parent only of not top level issue #2276 
+            absPathName.insert(0, "/" + up->getName());
     }
 
     return absPathName;

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -355,7 +355,7 @@ public:
         else if(objPathName == ownerPathName)
             setConnecteeName(objPathName);
         else { // otherwise store the absolute path name to the object
-            std::string absPathName = objT->getAbsolutePath().toString();
+            std::string absPathName = objT->getAbsolutePathString();
             setConnecteeName(absPathName);
         }
     }

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -354,9 +354,9 @@ public:
         // connects to a Body of the same name.
         else if(objPathName == ownerPathName)
             setConnecteeName(objPathName);
-        else { // otherwise store the relative path name to the object
-            std::string relPathName = objT->getRelativePathName(getOwner());
-            setConnecteeName(relPathName);
+        else { // otherwise store the absolute path name to the object
+            std::string absPathName = objT->getAbsolutePath().toString();
+            setConnecteeName(absPathName);
         }
     }
 


### PR DESCRIPTION
Fixes issue #2292 

### Brief summary of changes
One place where connections are serialized, replace call to getRelativePathName() with getAbsolutePath()
### Testing I've completed
Loaded models, saved in GUI and got Absolute paths inside sockets.

### Looking for feedback on...
Should we do the removal of model name by changing the implementation of getAbsolutePath(), or write a variant e.g. getAbsolutePathToTop() or pass an optional argument to getAbsolutePath() this depends on how widely used are these across the API.

### CHANGELOG.md 
- no need to update because this is new for 4.0

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2302)
<!-- Reviewable:end -->
