### PR TITLE
[WIP] When trying to set connectee name use openSimContext 

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -221,6 +221,7 @@ public:
 
     void cacheModelAndState();
     void restoreStateFromCachedModel()  SWIG_DECLARE_EXCEPTION;
+    void setConnecteeName(Component& comp, AbstractSocket& socket, const std::string& newValue )   SWIG_DECLARE_EXCEPTION;
 //=============================================================================
 // DATA
 //=============================================================================

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -230,13 +230,11 @@ int main()
     const std::string originalConnecteeName = socket.getConnecteeName();
     try {
         // create an invalid model where joint connects two frames on ground
-        socket.setConnecteeName("ground"); 
-        context->restoreStateFromCachedModel();
+        context->setConnecteeName(shoulder, socket, "ground");
     }
-    catch (...) {
-        // undo the change
-        socket.setConnecteeName(originalConnecteeName);
-        context->restoreStateFromCachedModel();
+    catch (const std::exception& e) {
+        // Expect meaningful error message rather than a crash
+        cout << "Exception: " << e.what() << endl;
     }
     return status;
   } catch (const std::exception& e) {


### PR DESCRIPTION
Use OpenSimContext rather than direct call so that operation can be tested before doing irreversible change to model being edited.

Fixes issue #994

### Brief summary of changes

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
