### PR TITLE
Push to AppVeyor for non-master builds for make_component_sets_components

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ platform: x64
 # No need to run CI on the branch if we're also running CI for a PR.
 skip_branch_with_pr: true
 
-nuget:
-  disable_publish_on_pr: true
+# TODO nuget:
+# TODO   disable_publish_on_pr: true
 
 environment:
   CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,10 @@ environment:
   PYTHON_DIR: "C:\\Python27-x64"
   matrix:
     - CMAKE_TOOLSET: "v140"
+      NUGET_PACKAGE_ID_SUFFIX_SIMBODY: "-VC140"
       NUGET_PACKAGE_ID_SUFFIX: "-VC140-sets"
     - CMAKE_TOOLSET: "v141"
+      NUGET_PACKAGE_ID_SUFFIX_SIMBODY: "-VC141"
       NUGET_PACKAGE_ID_SUFFIX: "-VC141-sets"
 
 branches:
@@ -89,7 +91,7 @@ install:
   # The URL is for the public project feed that AppVeyor creates for the simbody project, obtained
   # from https://ci.appveyor.com/project/opensim-org/simbody/settings/nuget.
   - nuget sources add -name simbody -source https://ci.appveyor.com/nuget/simbody-9iv11sycwdny
-  - nuget install simbody%NUGET_PACKAGE_ID_SUFFIX% -Version 0.0.0 -ExcludeVersion -OutputDirectory C:\
+  - nuget install simbody%NUGET_PACKAGE_ID_SUFFIX_SIMBODY% -Version 0.0.0 -ExcludeVersion -OutputDirectory C:\
 
 build_script:
   ## Superbuild dependencies. 
@@ -104,7 +106,7 @@ build_script:
   - cd %OPENSIM_BUILD_DIR%
   # Configure. # TODO -DBUILD_SIMM_TRANSLATOR=ON
   # Set the CXXFLAGS environment variable to turn warnings into errors.
-  - cmake -E env CXXFLAGS="/WX" cmake %OPENSIM_SOURCE_DIR% -G"%CMAKE_GENERATOR%" -T"%CMAKE_TOOLSET%" -DSIMBODY_HOME=C:\simbody%NUGET_PACKAGE_ID_SUFFIX% -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON
+  - cmake -E env CXXFLAGS="/WX" cmake %OPENSIM_SOURCE_DIR% -G"%CMAKE_GENERATOR%" -T"%CMAKE_TOOLSET%" -DSIMBODY_HOME=C:\simbody%NUGET_PACKAGE_ID_SUFFIX_SIMBODY% -DOPENSIM_DEPENDENCIES_DIR=%OPENSIM_DEPENDENCIES_INSTALL_DIR% -DCMAKE_INSTALL_PREFIX=%OPENSIM_INSTALL_DIR% -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DWITH_BTK:BOOL=ON
 
   # Build.
   - cmake --build . --config Release -- /maxcpucount:4 /verbosity:quiet #/p:TreatWarningsAsErrors="true"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,9 @@ environment:
   PYTHON_DIR: "C:\\Python27-x64"
   matrix:
     - CMAKE_TOOLSET: "v140"
-      NUGET_PACKAGE_ID_SUFFIX: "-VC140"
+      NUGET_PACKAGE_ID_SUFFIX: "-VC140-sets"
     - CMAKE_TOOLSET: "v141"
-      NUGET_PACKAGE_ID_SUFFIX: "-VC141"
+      NUGET_PACKAGE_ID_SUFFIX: "-VC141-sets"
 
 branches:
   except:
@@ -56,7 +56,8 @@ init:
   - SET JAVA_HOME=%JAVA_DIR%
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # Detect if we are on the master branch; if so, we will deploy binaries.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  # TODO - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  - SET DISTR=TRUE
 
 cache:
   ## Cache swig, which we install via AppVeyor.


### PR DESCRIPTION
This PR addresses the following from https://github.com/opensim-org/opensim-gui/pull/1005:

> @aymanhab or @chrisdembia how do I update the version of the feed source (L54) to another appveyor build of core or do I need to somehow push PR build on core to the feed location (not edit L54)?

@aseth1 once we verify the builds actually deploy, we can merge this into `make_component_sets_components`.