### PR TITLE
Remove 'core' as reference to SimTK libraries in the API guide

### DIFF
--- a/doc/APIGuide.md
+++ b/doc/APIGuide.md
@@ -19,7 +19,7 @@ The ethos of the OpenSim API is that the code is modular, reusable, and easily e
 
 ## Organization of OpenSim {#organization}
 
-OpenSim is built on the computational and simulation libraries provided by SimTK. This core includes low-level, efficient math and matrix algebra libraries, such as LAPACK, as well as the infrastructure for defining a dynamic System and its State. One can think of the System as the set of differential equations, and the state as its variables. 
+OpenSim is built on SimTK computational and simulation libraries that provide low-level, efficient math and matrix algebra libraries, such as LAPACK, as well as the infrastructure for defining a dynamic System and its State. One can think of the System as the set of differential equations, and the state as its variables. 
 
 Empowering the computational layer is Simbody, an efficient multibody dynamics solver, which provides an extensible multibody System and State. The OpenSim modeling layer maps biomechanical structures (bones, muscles, tendons, etc.) into bodies and forces so that the dynamics of the System can be computed by Simbody. The Simbody Users Guide can be found [here](https://github.com/simbody/simbody/raw/master/Simbody/doc/SimbodyAndMolmodelUserGuide.pdf) and can help new users to understand the structure of OpenSim.
 


### PR DESCRIPTION
Small change to the API guide that didn't make it into #2275. This removes the term "core" as a reference to the underlying SimTK libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2311)
<!-- Reviewable:end -->
