### PR TITLE
Remove external loads from rra adjusted model

### DIFF
--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -638,8 +638,8 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     ExternalLoads* exLoadsClone = externalLoads->clone();
     aModel.addModelComponent(exLoadsClone);
 
-    // copy over created external loads to the external loads owned by the tool
-    _externalLoads = *externalLoads;
+    // let tool hold on to a reference to the external loads for convenience
+    _externalLoads = exLoadsClone;
     
     if(!loadKinematics)
         delete loadKinematics;
@@ -852,7 +852,7 @@ std::string AbstractTool::getNextAvailableForceName(const std::string prefix) co
             if (_model->getForceSet().contains(candidateName))
                 continue;
         }
-        found = !(_externalLoads.contains(candidateName));
+        found = !(_externalLoads->contains(candidateName));
     };
     return candidateName;
 }
@@ -909,11 +909,11 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
             sprintf(pad,"%d", f+1);
             std::string suffix = "ExternalForce_"+string(pad);
             xf->setName(suffix);
-            _externalLoads.adoptAndAppend(xf);
+            _externalLoads->adoptAndAppend(xf);
         }
-        _externalLoads.setDataFileName(oldFile);
+        _externalLoads->setDataFileName(oldFile);
         std::string newName=oldFile.substr(0, oldFile.length()-4)+".xml";
-        _externalLoads.print(newName);
+        _externalLoads->print(newName);
         if(getDocument()) IO::chDir(savedCwd);
         cout<<"\n\n- Created ForceSet file " << newName << "to apply forces from " << oldFile << ".\n\n";
         return newName;

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -128,7 +128,7 @@ protected:
     OpenSim::PropertyStr _externalLoadsFileNameProp;
     std::string &_externalLoadsFileName;
     /** Actual external forces being applied. e.g. GRF */
-    ExternalLoads   _externalLoads;
+    SimTK::ReferencePtr<ExternalLoads> _externalLoads;
 
 //=============================================================================
 // METHODS
@@ -253,9 +253,9 @@ public:
 
     std::string getNextAvailableForceName(const std::string prefix="Force") const;
     
-    const ExternalLoads& getExternalLoads() const { return _externalLoads; }
-    ExternalLoads& updExternalLoads() { return _externalLoads; }
-    void setExternalLoads(ExternalLoads& el) { _externalLoads = el; }
+    const ExternalLoads& getExternalLoads() const { return _externalLoads.getRef(); }
+    ExternalLoads& updExternalLoads() { return _externalLoads.getRef(); }
+    bool hasExternalLoads() {return !_externalLoads.empty(); }
 
     // External loads get/set
     const std::string &getExternalLoadsFileName() const { return _externalLoadsFileName; }

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -934,9 +934,9 @@ writeAdjustedModel()
     _model->updForceSet() = _originalForceSet;
 
     // ExternalLoads were added as miscellaneous ModelComponents
-    int exfIx = _model->getMiscModelComponentSet().getIndex("externalloads");
-    if (exfIx >= 0) {
-        _model->updMiscModelComponentSet().remove(exfIx);
+    cout << _model->updMiscModelComponentSet() << endl;
+    if (hasExternalLoads()) {
+        _model->updMiscModelComponentSet().remove(_externalLoads.release());
     }
 
     // CMC was added as a model controller, now remove before printing out

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -933,6 +933,12 @@ writeAdjustedModel()
     // NOTE: use operator= so actuator groups are properly copied over
     _model->updForceSet() = _originalForceSet;
 
+    // ExternalLoads were added as miscellaneous ModelComponents
+    int exfIx = _model->getMiscModelComponentSet().getIndex("externalloads");
+    if (exfIx >= 0) {
+        _model->updMiscModelComponentSet().remove(exfIx);
+    }
+
     // CMC was added as a model controller, now remove before printing out
     int c = _model->updControllerSet().getIndex("CMC");
     _model->updControllerSet().remove(c);


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-gui/issues/1021

### Brief summary of changes
`ExternalForce`s used to be individually added to the Model's `ForceSet`, but as of #2285 we simply add `ExternalLoads` as a `ModelComponent` itself. The `ForceSet` is reset to its original forces by the `RRATool` when writing out the adjusted model (removing `ExternalForce`s added by the Tool to the `ForceSet`), but does not clear `ExternalLoads` added to the miscellaneous `ModelComponentSet`. This PR removes `ExternalLoads` and any  lingering `ExternalForces` from anywhere in the `Model`.

### Testing I've completed
`testRRA` passes locally and added a case to verify that the adjusted model has no `ExternalForce`s.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix resulting from changes introduced in #2285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2314)
<!-- Reviewable:end -->
