### PR TITLE
Undo removal of ExternalLoads member of Abstract/DynamicsTool and invoke datasource loading

### DIFF
--- a/Applications/RRA/test/testRRA.cpp
+++ b/Applications/RRA/test/testRRA.cpp
@@ -30,7 +30,7 @@
 using namespace OpenSim;
 using namespace std;
 
-void checkAdjustedModelCOM(string modelFile, string body, 
+void checkCOM(string resultsFile, string body, 
                 const SimTK::Vec3 &standardCOM, 
                 const Array<double> &tolerances);
 
@@ -38,7 +38,7 @@ int main() {
     try {
         RRATool rra("subject01_Setup_RRA.xml");
         if (rra.run()){
-            checkAdjustedModelCOM( "subject01_RRA_adjusted.osim", "torso",
+            checkCOM( "subject01_RRA_adjusted.osim", "torso", 
                       SimTK::Vec3(0.00598028440188985017, 0.34551, 0.1), 
                       Array<double>(1e-4, 3) );
             Storage result("ResultsRRA/subject01_walk1_RRA_Kinematics_q.sto"), 
@@ -59,9 +59,8 @@ int main() {
     return 0;
 }
 
-void checkAdjustedModelCOM(string resultsFile, string body,
-    const SimTK::Vec3 &standardCOM, const Array<double> &tolerances)
-{
+void checkCOM(string resultsFile, string body, const SimTK::Vec3 &standardCOM, const Array<double> &tolerances) {
+
     // compare the adjusted center of mass to OpenSim 1.9.1 values
     Model adjusted_model(resultsFile);
     const BodySet& bodies = adjusted_model.getBodySet();
@@ -73,12 +72,4 @@ void checkAdjustedModelCOM(string resultsFile, string body,
     cout << "tolerances:     (" << tolerances[0] << ", " << tolerances[1] << ", " << tolerances[2] << ")\n" << endl;
     for (int i = 0; i < 3; ++i)
         ASSERT_EQUAL(standardCOM[i], com[i], tolerances[i]);
-
-    auto loadsList = adjusted_model.getComponentList<ExternalLoads>();
-    OPENSIM_THROW_IF(loadsList.begin() != loadsList.end(), Exception,
-        "RRA adjusted model still contains ExternalLoads.");
-
-    auto exfList = adjusted_model.getComponentList<ExternalForce>();
-    OPENSIM_THROW_IF(exfList.begin() != exfList.end(), Exception,
-        "RRA adjusted model still contains ExternalForce(s).");
 }

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -656,8 +656,6 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
 
 void AbstractTool::removeExternalLoadsFromModel()
 {
-    cout << "'" << getName() << "'" << getConcreteClassName()
-        << "::removeExternalLoadsFromModel" << endl;
     // If ExternalLoads were added to the model by the Tool, then remove them
     if (modelHasExternalLoads()) {
         _model->updMiscModelComponentSet().remove(_modelExternalLoads.release());

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -638,8 +638,10 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     ExternalLoads* exLoadsClone = externalLoads->clone();
     aModel.addModelComponent(exLoadsClone);
 
+    // copy over created external loads to the external loads owned by the tool
+    _externalLoads = *externalLoads;
     // let tool hold on to a reference to the external loads for convenience
-    _externalLoads = exLoadsClone;
+    _modelExternalLoads = exLoadsClone;
     
     if(!loadKinematics)
         delete loadKinematics;
@@ -852,7 +854,7 @@ std::string AbstractTool::getNextAvailableForceName(const std::string prefix) co
             if (_model->getForceSet().contains(candidateName))
                 continue;
         }
-        found = !(_externalLoads->contains(candidateName));
+        found = !(_externalLoads.contains(candidateName));
     };
     return candidateName;
 }
@@ -909,11 +911,11 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
             sprintf(pad,"%d", f+1);
             std::string suffix = "ExternalForce_"+string(pad);
             xf->setName(suffix);
-            _externalLoads->adoptAndAppend(xf);
+            _externalLoads.adoptAndAppend(xf);
         }
-        _externalLoads->setDataFileName(oldFile);
+        _externalLoads.setDataFileName(oldFile);
         std::string newName=oldFile.substr(0, oldFile.length()-4)+".xml";
-        _externalLoads->print(newName);
+        _externalLoads.print(newName);
         if(getDocument()) IO::chDir(savedCwd);
         cout<<"\n\n- Created ForceSet file " << newName << "to apply forces from " << oldFile << ".\n\n";
         return newName;

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -552,7 +552,9 @@ printResults(const string &aBaseName,const string &aDir,double aDT,
     _model->updAnalysisSet().printResults(aBaseName,aDir,aDT,aExtension);
 }
 
-
+// NOTE: The implementation here should be verbatim that of DynamicsTool::
+// createExternalLoads to ensure consistent behavior of Tools in the GUI
+// TODO: Unify the code bases.
 bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
                                         Model& aModel, const Storage *loadKinematics)
 {
@@ -640,7 +642,8 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
 
     // copy over created external loads to the external loads owned by the tool
     _externalLoads = *externalLoads;
-    // let tool hold on to a reference to the external loads for convenience
+    // tool holds on to a reference of the external loads in the model so it can
+    // be removed afterwards
     _modelExternalLoads = exLoadsClone;
     
     if(!loadKinematics)
@@ -650,6 +653,15 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     return true;
 }
 
+void AbstractTool::removeExternalLoadsFromModel()
+{
+    cout << "'" << getName() << "'" << getConcreteClassName()
+        << "::removeExternalLoadsFromModel" << endl;
+    // If ExternalLoads were added to the model by the Tool, then remove them
+    if (modelHasExternalLoads()) {
+        _model->updMiscModelComponentSet().remove(_modelExternalLoads.release());
+    }
+}
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -578,6 +578,7 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     try {
         externalLoads = new ExternalLoads(aExternalLoadsFileName, true);
         copyModel.addModelComponent(externalLoads);
+        copyModel.setup();
     }
     catch (const Exception &ex) {
         // Important to catch exceptions here so we can restore current working directory...

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -128,7 +128,9 @@ protected:
     OpenSim::PropertyStr _externalLoadsFileNameProp;
     std::string &_externalLoadsFileName;
     /** Actual external forces being applied. e.g. GRF */
-    SimTK::ReferencePtr<ExternalLoads> _externalLoads;
+    ExternalLoads   _externalLoads;
+    // Reference to model's external loads not owned by tool
+    SimTK::ReferencePtr<ExternalLoads> _modelExternalLoads;
 
 //=============================================================================
 // METHODS
@@ -253,9 +255,9 @@ public:
 
     std::string getNextAvailableForceName(const std::string prefix="Force") const;
     
-    const ExternalLoads& getExternalLoads() const { return _externalLoads.getRef(); }
-    ExternalLoads& updExternalLoads() { return _externalLoads.getRef(); }
-    bool hasExternalLoads() {return !_externalLoads.empty(); }
+    const ExternalLoads& getExternalLoads() const { return _externalLoads; }
+    ExternalLoads& updExternalLoads() { return _externalLoads; }
+    void setExternalLoads(ExternalLoads& el) { _externalLoads = el; }
 
     // External loads get/set
     const std::string &getExternalLoadsFileName() const { return _externalLoadsFileName; }

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -127,9 +127,11 @@ protected:
     /** Name of the file containing the external loads applied to the model. */
     OpenSim::PropertyStr _externalLoadsFileNameProp;
     std::string &_externalLoadsFileName;
-    /** Actual external forces being applied. e.g. GRF */
+    
+    /** ExternalLoads member for creating and editing applied external forces
+        (e.g. GRFS through the GUI) prior to running the Tool */
     ExternalLoads   _externalLoads;
-    // Reference to model's external loads not owned by tool
+    // Reference to external loads added to the model but not owned by the Tool
     SimTK::ReferencePtr<ExternalLoads> _modelExternalLoads;
 
 //=============================================================================
@@ -258,6 +260,7 @@ public:
     const ExternalLoads& getExternalLoads() const { return _externalLoads; }
     ExternalLoads& updExternalLoads() { return _externalLoads; }
     void setExternalLoads(ExternalLoads& el) { _externalLoads = el; }
+    bool modelHasExternalLoads() {return !_modelExternalLoads.empty(); }
 
     // External loads get/set
     const std::string &getExternalLoadsFileName() const { return _externalLoadsFileName; }
@@ -367,6 +370,7 @@ public:
 
     bool createExternalLoads( const std::string &aExternalLoadsFileName,
                                      Model& aModel, const Storage *loadKinematics=NULL);
+    void removeExternalLoadsFromModel();
 
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
     virtual void loadQStorage (const std::string& statesFileName, Storage& rQStore) const;

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -596,6 +596,8 @@ bool AnalyzeTool::run(bool plotting)
 
     IO::chDir(saveWorkingDirectory);
 
+    removeExternalLoadsFromModel();
+
     return completed;
 }
 

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -323,8 +323,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
 
 void DynamicsTool::removeExternalLoadsFromModel()
 {
-    cout << "'" << getName() << "'" << getConcreteClassName()
-        << "::removeExternalLoadsFromModel" << endl;
     // If ExternalLoads were added to the model by the Tool, then remove them
     if (modelHasExternalLoads()) {
         _model->updMiscModelComponentSet().remove(_modelExternalLoads.release());

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -245,6 +245,7 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
     try {
         externalLoads = new ExternalLoads(aExternalLoadsFileName, true);
         copyModel.addModelComponent(externalLoads);
+        copyModel.setup();
     }
     catch (const Exception &ex) {
         // Important to catch exceptions here so we can restore current working directory...

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -218,6 +218,10 @@ void DynamicsTool::disableModelForces(Model &model, SimTK::State &s, const Array
     }
 }
 
+
+// NOTE: The implementation here should be verbatim that of AbstractTool::
+// createExternalLoads to ensure consistent behavior of Tools in the GUI
+// TODO: Unify the code bases.
 bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
                                         Model& aModel, const Storage *loadKinematics)
 {
@@ -305,10 +309,23 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
 
     // copy over created external loads to the external loads owned by the tool
     _externalLoads = *externalLoads;
+    // tool holds on to a reference of the external loads in the model so it can
+    // be removed afterwards
+    _modelExternalLoads = exLoadsClone;
 
     if(!loadKinematics)
         delete loadKinematics;
 
     IO::chDir(savedCwd);
     return true;
+}
+
+void DynamicsTool::removeExternalLoadsFromModel()
+{
+    cout << "'" << getName() << "'" << getConcreteClassName()
+        << "::removeExternalLoadsFromModel" << endl;
+    // If ExternalLoads were added to the model by the Tool, then remove them
+    if (modelHasExternalLoads()) {
+        _model->updMiscModelComponentSet().remove(_modelExternalLoads.release());
+    }
 }

--- a/OpenSim/Tools/DynamicsTool.h
+++ b/OpenSim/Tools/DynamicsTool.h
@@ -75,9 +75,11 @@ protected:
     /** Name of the file containing the external loads applied to the model. */
     OpenSim::PropertyStr _externalLoadsFileNameProp;
     std::string &_externalLoadsFileName;
-    /** External loads object that manages loading and applying external forces
-        to the model, including transformations required by the Tool */
+    /** ExternalLoads member for creating and editing applied external forces
+    (e.g. GRFs through the GUI) prior to running the Tool */
     ExternalLoads   _externalLoads;
+    // Reference to external loads added to the model but not owned by the Tool
+    SimTK::ReferencePtr<ExternalLoads> _modelExternalLoads;
 
 
 //=============================================================================
@@ -139,7 +141,11 @@ public:
         _excludedForces = aExcluded;
     }
     bool createExternalLoads( const std::string &aExternalLoadsFileName,
-                                     Model& aModel, const Storage *loadKinematics=NULL);
+                              Model& aModel, const Storage *loadKinematics=NULL);
+
+    bool modelHasExternalLoads() { return !_modelExternalLoads.empty(); }
+
+    void removeExternalLoadsFromModel();
 
     virtual bool run() override SWIG_DECLARE_EXCEPTION=0;
 

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -420,6 +420,7 @@ bool InverseDynamicsTool::run()
             IO::chDir(saveWorkingDirectory);
         }
 
+        removeExternalLoadsFromModel();
     }
     catch (const OpenSim::Exception& ex) {
         std::cout << "InverseDynamicsTool Failed: " << ex.what() << std::endl;

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -909,8 +909,7 @@ bool RRATool::run()
 //=============================================================================
 // UTILITY
 //=============================================================================
-void RRATool::
-writeAdjustedModel() 
+void RRATool::writeAdjustedModel() 
 {
     if(_outputModelFile=="") {
         cerr<<"Warning: A name for the output model was not set.\n";
@@ -932,6 +931,8 @@ writeAdjustedModel()
     // So we need to put back the muscles before writing out the adjusted model.
     // NOTE: use operator= so actuator groups are properly copied over
     _model->updForceSet() = _originalForceSet;
+
+    removeExternalLoadsFromModel();
 
     // CMC was added as a model controller, now remove before printing out
     int c = _model->updControllerSet().getIndex("CMC");

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -933,12 +933,6 @@ writeAdjustedModel()
     // NOTE: use operator= so actuator groups are properly copied over
     _model->updForceSet() = _originalForceSet;
 
-    // ExternalLoads were added as miscellaneous ModelComponents
-    cout << _model->updMiscModelComponentSet() << endl;
-    if (hasExternalLoads()) {
-        _model->updMiscModelComponentSet().remove(_externalLoads.release());
-    }
-
     // CMC was added as a model controller, now remove before printing out
     int c = _model->updControllerSet().getIndex("CMC");
     _model->updControllerSet().remove(c);


### PR DESCRIPTION
Fixes issues https://github.com/opensim-org/opensim-gui/issues/1021, #2324

### Brief summary of changes
- Restore `_externalLoads` data member in AbstractTool and DynamicsTool.
- Maintain fix in #2314 to remove `ExternalLoads` from model when execution is complete.
- make sure that datasource is loaded in `###Tool::createExternalLoads()` by invoking `Model::setup()` (which invokes both `finalizeFromProperties()` and `finalizeConnections(*this)` to address #2324

### Testing I've completed
- all API tests pass locally.
- need to test with GUI build

### Looking for feedback on...
- Tools operation in the GUI

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2325)
<!-- Reviewable:end -->
