### PR TITLE
Only run the Matlab testOsimC3D if BTK is available.

### DIFF
--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -89,7 +89,9 @@ OpenSimAddMatlabTest(AccessSubcomponents testAccessSubcomponents.m)
 OpenSimAddMatlabTest(Simbody testSimbody.m)
 OpenSimAddMatlabTest(osimTableStruct testosimTableStruct.m)
 OpenSimAddMatlabTest(testOsimVec3 testOsimVec3.m)
-OpenSimAddMatlabTest(testOsimC3D testOsimC3D.m)
+if(WITH_BTK)
+    OpenSimAddMatlabTest(testOsimC3D testOsimC3D.m)
+endif()
 OpenSimAddMatlabTest(testOsimList2MatlabCell testOsimList2MatlabCell.m)
 
 # Copy resources.


### PR DESCRIPTION
On master right now, the Matlab test testOsimC3D is run regardless of whether OpenSim was built with BTK, and if BTK was not available, the test fails.

In this PR, testOsimC3D is only run if OpenSim was built with BTK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2330)
<!-- Reviewable:end -->
