### PR TITLE
ExternalLoads itself finds datasource local to external loads (XML) file

### DIFF
--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -569,16 +569,11 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     copyModel.updForceSet().clearAndDestroy();
     copyModel.updControllerSet().clearAndDestroy();
 
-    // This is required so that the references to other files inside ExternalLoads file are interpreted 
-    // as relative paths
-    std::string savedCwd = IO::getCwd();
-    IO::chDir(IO::getParentDirectory(aExternalLoadsFileName));
     // Create external forces
     ExternalLoads* externalLoads = nullptr;
     try {
         externalLoads = new ExternalLoads(aExternalLoadsFileName, true);
         copyModel.addModelComponent(externalLoads);
-        copyModel.setup();
     }
     catch (const Exception &ex) {
         // Important to catch exceptions here so we can restore current working directory...
@@ -586,7 +581,6 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
         cout << "Error: failed to construct ExternalLoads from file " << aExternalLoadsFileName;
         cout << ". Please make sure the file exists and that it contains an ExternalLoads";
         cout << "object or create a fresh one." << endl;
-        if(getDocument()) IO::chDir(savedCwd);
         throw(ex);
     }
 
@@ -606,7 +600,6 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
         if(!(loadKinematicsFileName == "") && !(loadKinematicsFileName == "Unassigned")){
             temp = new Storage(loadKinematicsFileName);
             if(!temp){
-                IO::chDir(savedCwd);
                 throw Exception("AbstractTool: could not find external loads kinematics file '"+loadKinematicsFileName+"'."); 
             }
         }
@@ -650,7 +643,6 @@ bool AbstractTool::createExternalLoads( const string& aExternalLoadsFileName,
     if(!loadKinematics)
         delete loadKinematics;
 
-    IO::chDir(savedCwd);
     return true;
 }
 

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -368,8 +368,8 @@ public:
     virtual void printResults(const std::string &aBaseName,const std::string &aDir="",
         double aDT=-1.0,const std::string &aExtension=".sto");
 
-    bool createExternalLoads( const std::string &aExternalLoadsFileName,
-                                     Model& aModel, const Storage *loadKinematics=NULL);
+    bool createExternalLoads( const std::string& externalLoadsFileName,
+                              Model& model);
     void removeExternalLoadsFromModel();
 
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -190,9 +190,11 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
             catch (const std::exception &ex) {
                 cout << "Error: failed to construct ExternalLoads from file "
                     << _dataFileName << endl;
-                if (getDocument()) IO::chDir(savedCwd);
+                if (getDocument())
+                    IO::chDir(savedCwd);
                 throw(ex);
             }
+            IO::chDir(savedCwd);
         }
 
         for (int i = 0; i < getSize(); ++i)

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -134,7 +134,8 @@ void ExternalLoads::setupSerializedMembers()
     _propertySet.append(&_dataFileNameProp);
 
     _externalLoadsModelKinematicsFileName="";
-    comment =   "Optional motion file (.mot) or storage file (.sto) containing the model kinematics "
+    comment =   "The option is deprecated and unnecessary to apply external loads. " 
+                "A motion file (.mot) or storage file (.sto) containing the model kinematics "
                 "used to transform a point expressed in ground to the body of force application."
                 "If the point is not expressed in ground, the point is not transformed";
     _externalLoadsModelKinematicsFileNameProp.setComment(comment);

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -176,8 +176,24 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
     // BASE CLASS
     Super::extendConnectToModel(aModel);
 
+    Storage *forceData = nullptr;
     if (_dataFileName.length() > 0) {
-        Storage *forceData = new Storage(_dataFileName);
+        if(IO::FileExists(_dataFileName))
+            forceData = new Storage(_dataFileName);
+        else if(getDocument()) { // ExternalLoads constructed from file
+            // then change working directory the ExternalLoads location
+            std::string savedCwd = IO::getCwd();
+            IO::chDir(IO::getParentDirectory(getDocumentFileName()));
+            try {
+                forceData = new Storage(_dataFileName);
+            }
+            catch (const std::exception &ex) {
+                cout << "Error: failed to construct ExternalLoads from file "
+                    << _dataFileName << endl;
+                if (getDocument()) IO::chDir(savedCwd);
+                throw(ex);
+            }
+        }
 
         for (int i = 0; i < getSize(); ++i)
             get(i).setDataSource(*forceData);

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -236,10 +236,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
     copyModel.updForceSet().clearAndDestroy();
     copyModel.updControllerSet().clearAndDestroy();
 
-    // This is required so that the references to other files inside ExternalLoads file are interpreted 
-    // as relative paths
-    std::string savedCwd = IO::getCwd();
-    IO::chDir(IO::getParentDirectory(aExternalLoadsFileName));
     // Create external forces
     ExternalLoads* externalLoads = nullptr;
     try {
@@ -253,7 +249,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
         cout << "Error: failed to construct ExternalLoads from file " << aExternalLoadsFileName;
         cout << ". Please make sure the file exists and that it contains an ExternalLoads";
         cout << "object or create a fresh one." << endl;
-        if (getDocument()) IO::chDir(savedCwd);
         throw(ex);
     }
 
@@ -273,7 +268,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
         if(!(loadKinematicsFileName == "") && !(loadKinematicsFileName == "Unassigned")){
             temp = new Storage(loadKinematicsFileName);
             if(!temp){
-                IO::chDir(savedCwd);
                 throw Exception("DynamicsTool: could not find external loads kinematics file '"+loadKinematicsFileName+"'."); 
             }
         }
@@ -317,7 +311,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
     if(!loadKinematics)
         delete loadKinematics;
 
-    IO::chDir(savedCwd);
     return true;
 }
 

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -223,7 +223,7 @@ void DynamicsTool::disableModelForces(Model &model, SimTK::State &s, const Array
 // createExternalLoads to ensure consistent behavior of Tools in the GUI
 // TODO: Unify the code bases.
 bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
-                                        Model& aModel, const Storage *loadKinematics)
+                                        Model& aModel)
 {
     if(aExternalLoadsFileName==""||aExternalLoadsFileName=="Unassigned") {
         cout<<"No external loads will be applied (external loads file not specified)."<<endl;
@@ -255,29 +255,38 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
         externalLoads->getExternalLoadsModelKinematicsFileName();
     
     const Storage *loadKinematicsForPointTransformation = nullptr;
-    
-    //If the Tool is already loading the storage allow it to pass it in for use rather than reloading and processing
-    if(loadKinematics && loadKinematics->getName() == loadKinematicsFileName){
-        loadKinematicsForPointTransformation = loadKinematics;
-    }
-    else{
-        IO::TrimLeadingWhitespace(loadKinematicsFileName);
-        Storage *temp = NULL;
-        // fine if there are no kinematics as long as it was not assigned
-        if(!(loadKinematicsFileName == "") && !(loadKinematicsFileName == "Unassigned")){
+
+    IO::TrimLeadingWhitespace(loadKinematicsFileName);
+    Storage *temp = NULL;
+    // fine if there are no kinematics as long as it was not assigned
+    if (!(loadKinematicsFileName == "") && !(loadKinematicsFileName == "Unassigned")) {
+        if (IO::FileExists(loadKinematicsFileName)) {
             temp = new Storage(loadKinematicsFileName);
-            if(!temp){
-                throw Exception("DynamicsTool: could not find external loads kinematics file '"+loadKinematicsFileName+"'."); 
+        }
+        else {
+            // attempt to find the file local to the external loads XML file
+            std::string savedCwd = IO::getCwd();
+            IO::chDir(IO::getParentDirectory(aExternalLoadsFileName));
+            if (IO::FileExists(loadKinematicsFileName)) {
+                temp = new Storage(loadKinematicsFileName);
+                IO::chDir(savedCwd);
+            }
+            else {
+                IO::chDir(savedCwd);
+                throw Exception("DynamicsTool: could not find external loads kinematics file '"
+                    + loadKinematicsFileName + "'.");
             }
         }
         // if loading the data, do whatever filtering operations are also specified
-        if(temp && externalLoads->getLowpassCutoffFrequencyForLoadKinematics() >= 0) {
-            cout<<"\n\nLow-pass filtering coordinates data with a cutoff frequency of "<<_externalLoads.getLowpassCutoffFrequencyForLoadKinematics()<<"."<<endl;
-            temp->pad(temp->getSize()/2);
+        if (temp && externalLoads->getLowpassCutoffFrequencyForLoadKinematics() >= 0) {
+            cout << "\n\nLow-pass filtering coordinates data with a cutoff frequency of "
+                << _externalLoads.getLowpassCutoffFrequencyForLoadKinematics() << "." << endl;
+            temp->pad(temp->getSize() / 2);
             temp->lowpassIIR(externalLoads->getLowpassCutoffFrequencyForLoadKinematics());
         }
         loadKinematicsForPointTransformation = temp;
     }
+
 
     // if load kinematics for performing re-expressing the point of application is provided
     // then perform the transformations
@@ -306,9 +315,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
     // tool holds on to a reference of the external loads in the model so it can
     // be removed afterwards
     _modelExternalLoads = exLoadsClone;
-
-    if(!loadKinematics)
-        delete loadKinematics;
 
     return true;
 }

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -241,7 +241,6 @@ bool DynamicsTool::createExternalLoads( const string& aExternalLoadsFileName,
     try {
         externalLoads = new ExternalLoads(aExternalLoadsFileName, true);
         copyModel.addModelComponent(externalLoads);
-        copyModel.setup();
     }
     catch (const Exception &ex) {
         // Important to catch exceptions here so we can restore current working directory...

--- a/OpenSim/Tools/DynamicsTool.h
+++ b/OpenSim/Tools/DynamicsTool.h
@@ -140,8 +140,8 @@ public:
     void setExcludedForces(const Array<std::string> &aExcluded) {
         _excludedForces = aExcluded;
     }
-    bool createExternalLoads( const std::string &aExternalLoadsFileName,
-                              Model& aModel, const Storage *loadKinematics=NULL);
+    bool createExternalLoads( const std::string &externalLoadsFileName,
+                              Model& model);
 
     bool modelHasExternalLoads() { return !_modelExternalLoads.empty(); }
 

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -251,7 +251,7 @@ bool InverseDynamicsTool::run()
 
         cout<<"Running tool " << getName() <<".\n"<<endl;
 
-        /*bool externalLoads = */createExternalLoads(_externalLoadsFileName, *_model, _coordinateValues);
+        /*bool externalLoads = */createExternalLoads(_externalLoadsFileName, *_model);
         // Initialize the model's underlying computational system and get its default state.
         SimTK::State& s = _model->initSystem();
 


### PR DESCRIPTION
Fixes issue #2324

### Brief summary of changes
- made `ExternalLoads` "self-sufficient" in terms of loading its own data source. If the data source cannot be located directly, the file is tested in the in the same location of the `ExternalLoads` document directory, if it has one.
- removed change of directory maneuvers from `AbstractTool` and `DynamicsTool` `createExternalLoads()` for loading the external loads data source.

### Testing I've completed
- all API tests pass locally
- build GUI (master) on top and was able to edit existing external loads (xml) file and perform steps in https://github.com/opensim-org/opensim-gui/issues/1035

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2332)
<!-- Reviewable:end -->
