### PR TITLE
Trap when ExternalLoads::_dataFileName cannot be found and throw

### DIFF
--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -189,13 +189,19 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
                 forceData = new Storage(_dataFileName);
             }
             catch (const std::exception &ex) {
-                cout << "Error: failed to construct ExternalLoads from file "
-                    << _dataFileName << endl;
+                cout << "Error: failed to read ExternalLoads data file '"
+                    << _dataFileName <<"'." << endl;
                 if (getDocument())
                     IO::chDir(savedCwd);
                 throw(ex);
             }
             IO::chDir(savedCwd);
+        }
+        else {
+            // Cannot find the data file and do not have an ExternalLoads (XML)
+            // document to test if file is in its directory.
+            throw Exception("Error: unable to read ExternalLoads data file '" +
+                _dataFileName + "'.");
         }
 
         for (int i = 0; i < getSize(); ++i)


### PR DESCRIPTION
Fixes an issue running `StaticOptimization` while testing https://github.com/opensim-org/opensim-gui/issues/1035

### Brief summary of changes
If the `ExternalLoads` data file for forces cannot be found, we must throw an Exception and not attempt to deference a nullptr!

### Testing I've completed
- all tests pass locally but needs to be verified through the GUI and specifically `StaticOptimization`

### CHANGELOG.md (choose one)
- no need to update because this is a bug fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2340)
<!-- Reviewable:end -->
