### PR TITLE
osimTableFromStruct() Index fix

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimTableFromStruct.m
+++ b/Bindings/Java/Matlab/Utilities/osimTableFromStruct.m
@@ -1,3 +1,9 @@
+%% Convert Matlab Struct to OpenSim time Series Table
+%  Input is a Maltab stucture where data.label = nX1 or nX3 array
+%  eg s.LASI = [2 3 4; 4 5 6, ...
+%  One of the structures values MUST be a time vector and called 'time'
+%  Output is an OpenSim TimesSeriesTable
+
 % ----------------------------------------------------------------------- %
 % The OpenSim API is a toolkit for musculoskeletal modeling and           %
 % simulation. See http://opensim.stanford.edu and the NOTICE file         %
@@ -5,7 +11,7 @@
 % and supported by the US National Institutes of Health (U54 GM072970,    %
 % R24 HD065690) and by DARPA through the Warrior Web program.             %
 %                                                                         %
-% Copyright (c) 2005-2016 Stanford University and the Authors             %
+% Copyright (c) 2005-2018 Stanford University and the Authors             %
 % Author(s): James Dunne                                                  %
 %                                                                         %
 % Licensed under the Apache License, Version 2.0 (the "License");         %
@@ -20,108 +26,91 @@
 % permissions and limitations under the License.                          %
 % ----------------------------------------------------------------------- %
 
-%% Convert Matlab Struct to OpenSim time Series Table
-%  Input is a Maltab stucture where data.label = nX1 or nX3 array
-%  eg structdata.LASI = [2 3 4; 4 5 6, ...
-%  One of the structures values MUST be a time vector and called 'time'
-%  Output is an OpenSim TimesSeriesTable
+% Written by: James Dunne, Tom Uchida, Chris Dembia, Ajay Seth,
+%                   Ayman Habib, Jen Hicks,Shrinidhi K. Lakshmikanth.
 
-% Author: James Dunne, Tom Uchida, Shrinidhi K. Lakshmikanth, Chris Dembia, 
-% Ajay Seth, Ayman Habib, Jen Hicks.
-
-function timeseriesosimtable = osimTableFromStruct(structdata)
-% import Java Libraries
+function timeseriesosimtable = osimTableFromStruct_rogers(s)
+%% import Java Libraries
 import org.opensim.modeling.*
 
-% Each column of data has a label. We wiget all the data labels
-labelnames = fieldnames(structdata);
-% get the index for the time array
-timeIndex = find(cellfun(@(s) ~isempty(strfind('time', s)),lower(labelnames)));
+%% Get all the data labels in the Structure
+labels = fieldnames(s);
 
-%% Check the dimensions of the structure confirm to requirements
-if isempty(timeIndex)
-    error('Time field required ? none found')
+%% Check for, save, then remove the time array from the structure
+% Get the index for time array
+tIndex = find(cellfun(@(s) contains('time', s),lower(labels)));
+% Check to see if the time exists
+if isempty(tIndex)
+    error('"time" field required, none found')
 end
-
+% Get the time vector
+time = s.time();
+% Remove time from the struct
+s = rmfield(s,'time');
+% remove time from the labels
+labels(tIndex) = [];
+nfields = length(labels);
 %% Check the structure for 'shape' consistency across fields. 
-nRowsList = []; nColsList = [];
-
-for i = 1 : length(labelnames)
-    % The special case is for the time field. It should always be an 
-    % nX1 array. the number of rows (n) should will need to bec checked
-    % against all the rest of the fields for consistency. 
-    if i == timeIndex
-        % Check that the time field has the correct number of columns
-        [nRows,nCol] = size(structdata.(labelnames{timeIndex}));
-        if nCol ~= 1
-            error(['time field is a nX' num2str(nCol) ' array - nX1 required'])
+for i = 1 : nfields
+    % For all fields in s, check that the array size is either nX1 or nX3,
+    % other array sizes are unsupported. 
+    [nRows,nCols] = size(s.(labels{i}));
+    
+    if i == 1
+        rowRef = nRows; colRef = nCols;
+        % Check that the first field has 1 or 3 Columns
+        if ~(colRef == 1 || colRef == 3)
+           error(['Data Columns must be 1 or 3, s.' labels{i} ' has ' num2str(colRef)])
         end
-        % add the number of rows to a list to be checked
-        nRowsList = [nRowsList nRows];
     else
-        % for all other fields, we want to check that the array size is
-        % either nX1 or nX3, other array sizes are unsupported. The number
-        % of rows and columns of each field array must be checked for
-        % consistency. 
-        [nRows,nCol] = size(structdata.(labelnames{i}));
-
-        if nCol ~= 1 && nCol ~= 3
-            error(['Field .' labelnames{i} ' is nX' num2str(nCol) ' - must be nX1 or nX3'])
+        % Check that the current field has the same number of rows and
+        % columns as the reference. 
+        if rowRef ~= nRows || colRef ~= nCols
+            error('Array rows or columns are non-uniform across fields. Check input stucture for error')
         end
-        % add the number of rows to a list to be checked for consistency
-        nRowsList = [nRowsList nRows];
-        % add the number of columns to a list to be checked for consistency
-        nColsList = [nColsList nCol];
     end
-    
-    % check to see if nRows is uniform
-    if ~isempty(find( nRowsList ~= nRowsList(1)) )
-        error(['Number of rows is non-uniform across fields. Check .' labelnames{i} ' for error'])
-    end
-    
-    % check to see if nRows is uniform
-    if ~isempty(find( nColsList ~= nColsList(1)) )
-        error(['Number of columns is non-uniform across fields. Check .' labelnames{i} ' for error'])
-    end        
 end
-  
-%% make an array of index numbers that will be used in the main For loop
-indexArray = [0 : length(labelnames) - 1];
-indexArray(timeIndex) = [];
-nLabels = length(indexArray);
 
-%% Pre-allocate an empty data table from data type. Also set some flags. 
-if max(nColsList) == 3
-    vec3table = true;
-    osimtable = DataTableVec3();
-else
-    vec3table = false;
+%% Pre-allocate an empty data table from data type. 
+if colRef == 1
     osimtable = DataTable();
+else
+    osimtable = DataTableVec3();
 end
 
 %% set the osimtable column names
-labels =  StdVectorString();
-for i = indexArray
-    labels.add( labelnames{i+1} );
+osimlabels =  StdVectorString();
+for i = 1 : nfields
+    osimlabels.add( labels{i} );
 end
-osimtable.setColumnLabels(labels);
+osimtable.setColumnLabels(osimlabels);
 
-%% get a pointer to the time column
-timeColumn = osimtable.getIndependentColumn();
-
-if vec3table == true
-    % If the data is nX3, then build an osimtable of Vec3's.
-    % We build the osimtable row by row, filling a row vector from left to
-    % right and then appending the row to the OpenSim table.
-   for iRow = 1 : nRows
-        % elems will be a vec3 vector that we will append elements to
-        elems = StdVectorVec3();
+%% Build the osimtable row by row, filling a row vector from left to
+% right and then appending the row to the OpenSim osimtable. 
+if colRef == 1
+    % Get an OpenSim Row Vector
+    row = RowVector(nfields, NaN);
+    % create and fill a row of data 
+    for iRow = 1 : nRows 
+        for iCol = 1 : nfields 
+           % Get the row value of the array from each field and set that
+           % value in the OpenSim Row
+           row.set(iCol-1, s.(labels{iCol})(iRow) );
+        end
+        % Append the row vector to the opensim table
+        osimtable.appendRow(iRow-1, row);
+    end
+else
+    % Get an empty Vec3 
+	elems = StdVectorVec3();
+    % Fill rows and elements with 
+    for iRow = 1 : nRows
         % create and fill a row of data
-        for iCol = indexArray
+        for iCol = 1 : nfields 
             % get the data from the input structure
-            rowdata = structdata.(labelnames{iCol+1})(iRow,:);
+            elemtdata = s.(labels{iCol})(iRow,:);
             % make a vec3 element from the rowdata
-            elem = Vec3(rowdata(1), rowdata(2), rowdata(3));
+            elem = Vec3(elemtdata(1), elemtdata(2), elemtdata(3));
             % append the Vec3 element to the vec3 vector
             elems.add(elem);
         end
@@ -130,35 +119,21 @@ if vec3table == true
         % append the RowVectorofVec3's to the opensim table
         osimtable.appendRow(iRow-1, row);
         % set the time value for the appended row
-        timeColumn.set(iRow-1, structdata.(labelnames{timeIndex})(iRow));
-    end
-    
-else
-    % Else the data is in doubles, then build a osimtable of doubles.
-    % We build the osimtable row by row, filling a row vector from left to
-    % right and then appending the row to the OpenSim osimtable. 
-    row = RowVector(nLabels, NaN);
-
-    for iRow = 1 : nRows
-        % create and fill a row of data 
-        for iCol = indexArray
-            % get double from col and row index.
-            rowdata = structdata.(labelnames{iCol+1})(iRow,:);
-            % update the value in the row. 
-            row.set(iCol, rowdata);
-        end
-        % Append the row vector to the opensim table
-        osimtable.appendRow(iRow-1, row);
-        % set the time value
-        timeColumn.set(iRow-1, structdata.(labelnames{timeIndex})(iRow) );
+        timeColumn.set(iRow-1, s.(labels{tIndex})(iRow));
     end
 end
 
-% type change the DataTable to a TimeSeriesTable 
-if vec3table == true
-   timeseriesosimtable = TimeSeriesTableVec3(osimtable);
+%% Set the Time values
+DataTabletime = osimtable.getIndependentColumn();
+for i = 1 : nRows 
+      DataTabletime.set(i-1, time(i));
+end
+  
+%% Type change the DataTable to a TimeSeriesTable 
+if nCols == 1
+   timeseriesosimtable = TimeSeriesTable(osimtable);    
 else
-    timeseriesosimtable = TimeSeriesTable(osimtable);
+    timeseriesosimtable = TimeSeriesTableVec3(osimtable);
 end
 
 end

--- a/Bindings/Java/Matlab/Utilities/osimTableFromStruct.m
+++ b/Bindings/Java/Matlab/Utilities/osimTableFromStruct.m
@@ -29,7 +29,7 @@
 % Written by: James Dunne, Tom Uchida, Chris Dembia, Ajay Seth,
 %                   Ayman Habib, Jen Hicks,Shrinidhi K. Lakshmikanth.
 
-function timeseriesosimtable = osimTableFromStruct_rogers(s)
+function timeseriesosimtable = osimTableFromStruct(s)
 %% import Java Libraries
 import org.opensim.modeling.*
 

--- a/Bindings/Java/Matlab/tests/testosimTableStruct.m
+++ b/Bindings/Java/Matlab/tests/testosimTableStruct.m
@@ -1,4 +1,3 @@
-
 %% clear working space
 clear all;close all;clc;
 %% import opensim libraries

--- a/Bindings/Java/Matlab/tests/testosimTableStruct.m
+++ b/Bindings/Java/Matlab/tests/testosimTableStruct.m
@@ -2,7 +2,7 @@
 clear all;close all;clc;
 %% import opensim libraries
 import org.opensim.modeling.*
-%% Build a vec3 times series table programmatically 
+%% Build an OpenSim Times Series Table Programmatically 
 table = DataTableVec3();
 labels = StdVectorString();
 labels.add('marker1');labels.add('marker2');
@@ -27,7 +27,7 @@ for i = 0 : 9
     indCol.set(i, i/100)
 end
 
-%% Turn DataTable to a timesSeriesTable, then flatten
+% Turn DataTable to a timesSeriesTable, then flatten
 tsTable = TimeSeriesTableVec3(table);
 tsTable_d = tsTable().flatten();
 
@@ -48,7 +48,6 @@ assert(nCol == nCol_2 & nRow == nRow_2,'Vec3 conversion OpenSim-Matlab_OpenSim i
 assert(nCold == nCold_2 & nRowd == nRowd_2,'dbl conversion OpenSim-Matlab_OpenSim incorrect: Rows or Columns not preserved');
 
 %% Check data across is conserved across conversions. 
-
 for u = 0 : 9
     for i = 0 : 3
         % get the data from the element
@@ -71,18 +70,36 @@ end
 
 disp('New Table is the same as the original')
 
+%% Add new Data to a struct, then convert into an OpenSim table
+% Make copies of the data tables
+s = mData_d; sV3 = mData; 
+% Add new fields to the data
+f = fieldnames(s);
+for i = 1:length(f)-1
+    s.([f{i} '_new']) = s.(f{i});
+end
+f = fieldnames(sV3);
+for i = 1:length(f)-1
+    sV3.([f{i} '_new']) = sV3.(f{i});
+end
 
+% Convert the new struct into a another table.
+try 
+   oTable   = osimTableFromStruct(s);
+catch
+    error('Failed to convert structure (of doubles) with added fields to table')
+end
 
+try 
+    oTableV3 = osimTableFromStruct(sV3);
+catch
+    error('Failed to convert structure (of Vec3s) with added fields to table')
+end
 
+% Convert tables back into stucts
+s_new           = osimTableToStruct(oTable);
+sV3_new         = osimTableToStruct(oTableV3);
 
-
-
-
-
-
-
-
-
-
-
-
+% Check that the number of fields have been preserved. 
+assert(length(fieldnames(s)) == length(fieldnames(s_new)), 'Number of fields in s and s_new are different')
+assert(length(fieldnames(sV3)) == length(fieldnames(sV3_new)), 'Number of fields in sV3 and sV3_new are different')

--- a/Bindings/Java/Matlab/tests/testosimTableStruct.m
+++ b/Bindings/Java/Matlab/tests/testosimTableStruct.m
@@ -68,8 +68,6 @@ for u = 0 : 9
     end
 end
 
-disp('New Table is the same as the original')
-
 %% Add new Data to a struct, then convert into an OpenSim table
 % Make copies of the data tables
 s = mData_d; sV3 = mData; 


### PR DESCRIPTION
Fixes issue #2346

### Brief summary of changes
Revamped how the method works. Rather than trying to store the time index to use later, we store and remove the time field from the structure and do all remaining operations on the remaining (consistent) Matlab structure.

### Testing I've completed
[X] Updated Function to remove 'time' field and work on remaining struct
[X] Local test with known data
[X] Update Automated test

### Looking for feedback on...
This should have been caught in the tests, so having a better, more thorough test, is important. I will tag reviewers when ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2347)
<!-- Reviewable:end -->
