### PR TITLE
Do not dereference ExternalForce::_dataSource if it's null.

### DIFF
--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -200,12 +200,8 @@ void ExternalForce::extendConnectToModel(Model& model)
     }
 
     if(!_dataSource){
-        throw Exception("ExternalForce: Not Data source has been set.");
-        // No property set either
-        // if((dataSourceProp.size()==0) || (dataSourceProp.getValue(0) == "") ||
-        //         dataSourceProp.getValue(0) == "Unassigned" ){
-        // }
-        // else: TODO load the data from the source. Currently this is overly
+        throw Exception("ExternalForce: No Data source has been set.");
+        // TODO: Load the data from dataSourceProp. Currently this is overly
         // complicated and handled by the ExternalLoads class.
     }
     else if(dataSourceProp.size()) {

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -200,10 +200,11 @@ void ExternalForce::extendConnectToModel(Model& model)
     }
 
     if(!_dataSource){
+        throw Exception("ExternalForce: Not Data source has been set.");
         // No property set either
-        if((dataSourceProp.size()==0) || (dataSourceProp.getValue(0) == "")){
-            throw(Exception("ExternalForce: Not Data source has been set."));
-        }
+        // if((dataSourceProp.size()==0) || (dataSourceProp.getValue(0) == "") ||
+        //         dataSourceProp.getValue(0) == "Unassigned" ){
+        // }
         // else: TODO load the data from the source. Currently this is overly
         // complicated and handled by the ExternalLoads class.
     }


### PR DESCRIPTION
Fixes an issue mentioned in https://github.com/opensim-org/opensim-gui/issues/1035

### Brief summary of changes

- Do not dereference `_dataSource` if it's null. This was occurring if an ExternalLoads' `datafile` was empty.

### Testing I've completed

- Tested that `opensim-cmd` now gives an exception instead of crashing.

### CHANGELOG.md (choose one)

- no need to update because...within 4.0 development

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2350)
<!-- Reviewable:end -->
