### PR TITLE
Fix OutputReporter output_paths syntax

### DIFF
--- a/Applications/Analyze/test/Tug_of_War_Setup_Analyze.xml
+++ b/Applications/Analyze/test/Tug_of_War_Setup_Analyze.xml
@@ -44,7 +44,13 @@
 				</ForceReporter>
 				<OutputReporter name="OutputReporter">
 					<!--The names of Outputs to be reported. To select specific Component Outputs, provide its path name. For example, 'slider/tx/value' is an Output for the value of a Coordinate 'tx' belonging to the Joint 'slider'.-->
-					<output_paths>forceset/LeftMuscle/fiber_length forceset/LeftMuscle/tendon_force com_position forceset/LeftMuscle/active_force_length_multiplier jointset/ground_block/reaction_on_child</output_paths>
+					<output_paths>
+						forceset/LeftMuscle|fiber_length
+						forceset/LeftMuscle|tendon_force
+						|com_position
+						forceset/LeftMuscle|active_force_length_multiplier
+						jointset/ground_block|reaction_on_child
+					</output_paths>
 					<!--Flag (true or false) specifying whether on. True by default.-->
 					<on>true</on>
 					<!--Start time.-->

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -54,6 +54,11 @@ namespace OpenSim {
  *   - `<results-file-name>Vec3.sto`, and
  *   - `<results-file-name>SpatialVec.sto`.
  *
+ * Output paths can be absolute (e.g., `/joint/slider/tx|value`) or relative
+ * to the model (by leaving off the first slash; `joint/slider/tx|value`).
+ * For outputs on the model itself, you can use `|com_position`, etc. As
+ * explained for AbstractInput, the vertical bar denotes the output name.
+ *
  * Note that the internal tables are reset at the beginning of a simulation or
  * AnalyzeTool::run() and does not append results to previous tables.
  */
@@ -63,8 +68,9 @@ OpenSim_DECLARE_CONCRETE_OBJECT(OutputReporter, Analysis);
 public:
 OpenSim_DECLARE_LIST_PROPERTY(output_paths, std::string,
     "The names of Outputs to be reported. To select specific Component Outputs"
-    ", provide its path name. For example, 'slider/tx/value' is an Output for "
-    "the value of a Coordinate 'tx' belonging to the Joint 'slider'.");
+    ", provide its path name. For example, '/joinset/slider/tx|value' is an "
+    "Output for the value of a Coordinate 'tx' belonging to the Joint "
+    "'slider'.");
 
 //=============================================================================
 // METHODS

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -68,7 +68,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(OutputReporter, Analysis);
 public:
 OpenSim_DECLARE_LIST_PROPERTY(output_paths, std::string,
     "The names of Outputs to be reported. To select specific Component Outputs"
-    ", provide its path name. For example, '/joinset/slider/tx|value' is an "
+    ", provide its path name. For example, '/jointset/slider/tx|value' is an "
     "Output for the value of a Coordinate 'tx' belonging to the Joint "
     "'slider'.");
 

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -183,15 +183,17 @@ void simulateMuscle(
     // 2. OUTPUTREPORTER SETUP: create and add the OutputReporter
     //==========================================================================
     OutputReporter* outputReporter = new OutputReporter(&model);
-    outputReporter->append_output_paths("kinetic_energy");
-    outputReporter->append_output_paths("jointset/slider/tx/value");
-    outputReporter->append_output_paths("bodyset/ball/linear_velocity");
-    outputReporter->append_output_paths("bodyset/ball/angular_acceleration");
-    outputReporter->append_output_paths("bodyset/ball/acceleration");
-    outputReporter->append_output_paths("jointset/slider/reaction_on_child");
+    outputReporter->append_output_paths("/|kinetic_energy");
+    outputReporter->append_output_paths("jointset/slider/tx|value");
+    outputReporter->append_output_paths("/bodyset/ball|linear_velocity");
+    outputReporter->append_output_paths("/bodyset/ball|angular_acceleration");
+    // Paths can also be relative to the model.
+    outputReporter->append_output_paths("bodyset/ball|acceleration");
+    outputReporter->append_output_paths("jointset/slider|reaction_on_child");
+    outputReporter->append_output_paths("|com_position");
 
     // should print a warning
-    outputReporter->append_output_paths("bodyset/ball/transform");
+    outputReporter->append_output_paths("/bodyset/ball|transform");
 
     model.addAnalysis(outputReporter);
 

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -184,7 +184,7 @@ void simulateMuscle(
     //==========================================================================
     OutputReporter* outputReporter = new OutputReporter(&model);
     outputReporter->append_output_paths("/|kinetic_energy");
-    outputReporter->append_output_paths("jointset/slider/tx|value");
+    outputReporter->append_output_paths("/jointset/slider/tx|value");
     outputReporter->append_output_paths("/bodyset/ball|linear_velocity");
     outputReporter->append_output_paths("/bodyset/ball|angular_acceleration");
     // Paths can also be relative to the model.

--- a/OpenSim/Common/ComponentOutput.cpp
+++ b/OpenSim/Common/ComponentOutput.cpp
@@ -27,5 +27,5 @@
 using namespace OpenSim;
 
 std::string AbstractOutput::getPathName() const {
-    return getOwner().getAbsolutePathString() + "/" + getName();
+    return getOwner().getAbsolutePathString() + "|" + getName();
 }

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -655,8 +655,7 @@ public:
                                             const std::string& channelName,
                                             const std::string& alias) {
         auto path = componentPath;
-        if(!path.empty())
-            path += "|";
+        path += "|";
         path += outputName;
         if(!channelName.empty())
             path += ":" + channelName;


### PR DESCRIPTION
Fixes #2349

### Brief summary of changes

- Updates the parsing in `OutputReporter` to be consistent with the syntax for input connectee paths. Instead of `/jointset/joint/coord/value`, one must now use `/jointset/joint/coord|value` or `jointset/joint/coord|value`.

### Testing I've completed

- Ran ctest.

### Looking for feedback on...

- The syntax for input connectee paths.

### CHANGELOG.md (choose one)

- no need to update because...this class is new in 4.0.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2352)
<!-- Reviewable:end -->
