### PR TITLE
Fix crash following failed IK attempted run

### DIFF
--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -295,7 +295,7 @@ bool InverseKinematicsTool::run()
         IO::chDir(directoryOfSetupFile);
 
         // Define reporter for output
-        Kinematics* kinematicsReporter = new Kinematics();
+        kinematicsReporter = new Kinematics();
         kinematicsReporter->setRecordAccelerations(false);
         kinematicsReporter->setInDegrees(true);
         _model->addAnalysis(kinematicsReporter);

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -272,6 +272,7 @@ bool InverseKinematicsTool::run()
 {
     bool success = false;
     bool modelFromFile=true;
+    Kinematics* kinematicsReporter = nullptr;
     try{
         //Load and create the indicated model
         if (!_model) {
@@ -294,10 +295,10 @@ bool InverseKinematicsTool::run()
         IO::chDir(directoryOfSetupFile);
 
         // Define reporter for output
-        Kinematics kinematicsReporter;
-        kinematicsReporter.setRecordAccelerations(false);
-        kinematicsReporter.setInDegrees(true);
-        _model->addAnalysis(&kinematicsReporter);
+        Kinematics* kinematicsReporter = new Kinematics();
+        kinematicsReporter->setRecordAccelerations(false);
+        kinematicsReporter->setInDegrees(true);
+        _model->addAnalysis(kinematicsReporter);
 
         cout<<"Running tool "<<getName()<<".\n";
 
@@ -341,7 +342,7 @@ bool InverseKinematicsTool::run()
         ikSolver.setAccuracy(_accuracy);
         s.updTime() = times[start_ix];
         ikSolver.assemble(s);
-        kinematicsReporter.begin(s);
+        kinematicsReporter->begin(s);
 
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         analysisSet.begin(s);
@@ -403,17 +404,17 @@ bool InverseKinematicsTool::run()
 
             }
 
-            kinematicsReporter.step(s, i);
+            kinematicsReporter->step(s, i);
             analysisSet.step(s, i);
         }
 
         // Do the maneuver to change then restore working directory 
         // so that output files are saved to same folder as setup file.
         if (_outputMotionFileName!= "" && _outputMotionFileName!="Unassigned"){
-            kinematicsReporter.getPositionStorage()->print(_outputMotionFileName);
+            kinematicsReporter->getPositionStorage()->print(_outputMotionFileName);
         }
-        // Remove the analysis we added, don't delete as it was allocated on stack
-        _model->removeAnalysis(&kinematicsReporter, false);
+        // Remove the analysis we added to the model, this also deletes it
+        _model->removeAnalysis(kinematicsReporter);
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);
@@ -463,6 +464,9 @@ bool InverseKinematicsTool::run()
     }
     catch (const std::exception& ex) {
         std::cout << "InverseKinematicsTool Failed: " << ex.what() << std::endl;
+        // If failure happened after kinematicsReporter was added, make sure to cleanup
+        if (kinematicsReporter!= nullptr)
+            _model->removeAnalysis(kinematicsReporter);
         throw (Exception("InverseKinematicsTool Failed, "
             "please see messages window for details..."));
     }


### PR DESCRIPTION
Fixes issue GUI issue #1004
### Brief summary of changes
When Ik::run fails and throws an exception a corrupt Kinematics analysis stays with the Model causing crash downstream. This fix cleans up properly even when an exception is thrown.

### Testing I've completed
Tested scenario in bug report, no crashes, also ran succesful IK on one model.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because bugfix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2354)
<!-- Reviewable:end -->
