### PR TITLE
Put OpenSim version in Storage metadata

### DIFF
--- a/OpenSim/Analyses/About.cpp
+++ b/OpenSim/Analyses/About.cpp
@@ -70,7 +70,7 @@ using namespace std;
 
 extern "C" {
 
-void opensim_version_Analyses(int* major, int* minor, int* build) {
+void opensim_version_analyses(int* major, int* minor, int* build) {
     static const char* l = "OPENSIM library="   GET_LIBRARY_STRING;
     static const char* t = "OPENSIM type="      GET_TYPE_STRING;
     static const char* d = "OPENSIM debug="     GET_DEBUG_STRING;
@@ -89,7 +89,7 @@ void opensim_version_Analyses(int* major, int* minor, int* build) {
     }
 }
 
-void opensim_about_Analyses(const char* key, int maxlen, char* value) {
+void opensim_about_analyses(const char* key, int maxlen, char* value) {
     if (maxlen <= 0 || value==0) return;
     value[0] = '\0'; // in case we don't find a match
     if (key==0) return;

--- a/OpenSim/Common/About.cpp
+++ b/OpenSim/Common/About.cpp
@@ -25,10 +25,11 @@
  * Define the standard SimTK compliant "version" and "about" routines.
  */
 
-
-#include <string>
+#include "About.h"
 #include <cstring>
-
+#include <cstdio>
+#include <stdio.h>
+#include <stdlib.h>
 
 #define STR(var) #var
 #define MAKE_VERSION_STRING(maj,min,build)  STR(maj.min.build)
@@ -54,19 +55,29 @@
 #define GET_TYPE_STRING \
     MAKE_STRING(OPENSIM_COMMON_TYPE)
 
+#define GET_SYSTEM_INFO \
+    MAKE_STRING(OSIM_SYS_INFO)
+
+#define GET_COMPILER_INFO \
+    MAKE_STRING(OSIM_COMPILER_INFO)
+
+#define GET_OS_NAME \
+    MAKE_STRING(OSIM_OS_NAME)
+
+#define GET_OSIM_VERSION \
+    MAKE_STRING(OSIM_VERSION)
+
 #ifndef NDEBUG
     #define GET_DEBUG_STRING "debug"
 #else
     #define GET_DEBUG_STRING "release"
 #endif
 
-
 using namespace std;
-
 
 extern "C" {
 
-void opensim_version_tools(int* major, int* minor, int* build) {
+void opensim_version_common(int* major, int* minor, int* build) {
     static const char* l = "OPENSIM library="   GET_LIBRARY_STRING;
     static const char* t = "OPENSIM type="      GET_TYPE_STRING;
     static const char* d = "OPENSIM debug="     GET_DEBUG_STRING;
@@ -85,7 +96,7 @@ void opensim_version_tools(int* major, int* minor, int* build) {
     }
 }
 
-void opensim_about_tools(const char* key, int maxlen, char* value) {
+void opensim_about_common(const char* key, int maxlen, char* value) {
     if (maxlen <= 0 || value==0) return;
     value[0] = '\0'; // in case we don't find a match
     if (key==0) return;
@@ -107,6 +118,96 @@ void opensim_about_tools(const char* key, int maxlen, char* value) {
         strncpy(value,v,maxlen-1);
         value[maxlen-1] = '\0'; // in case we ran out of room
     }
+}
+
+} // extern "C"
+
+namespace OpenSim {
+
+static const char* OpenSimVersion = GET_OSIM_VERSION;
+
+std::string GetVersionAndDate() { 
+    char buffer[256];
+    sprintf(buffer,"version %s, build date %s %s",
+            OpenSimVersion, __TIME__, __DATE__);
+    return std::string(buffer);
+}
+
+std::string GetVersion() {
+    return OpenSimVersion;
+}
+
+std::string GetOSInfoVerbose() {
+    const char * str = GET_SYSTEM_INFO;
+    return str;
+}
+
+std::string GetOSInfo() {
+    const char * str = GET_OS_NAME;
+    return str;
+}
+
+std::string GetCompilerVersion() {
+    std::string os = GetOSInfo();
+    std::string str = "(Unknown)";
+
+    if( 0 == os.compare("Windows")) {
+        const int MSVCVersion = atoi(GET_COMPILER_INFO);
+        if( MSVCVersion >= 1910 ) {
+            // With Visual Studio 2017, the versioning of the Visual C++
+            // compiler became more fine-grained, so we can no longer use
+            // a switch statement.
+            // Also, Visual Studio 2017 decouples the Visual Studio IDE
+            // from the C++ toolset (compiler), so providing the IDE year 
+            // does not indicate the compiler version (it may be possible
+            // to use the Visual Studio 2019 IDE, or whatever is next, 
+            // with the same C++ toolset that came with Visual Studio 2017.
+            // Therefore, we no longer provide the Visual Studio year.
+            // https://blogs.msdn.microsoft.com/vcblog/2016/10/05/visual-c-compiler-version/
+            // https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
+            if (1910 <= MSVCVersion && MSVCVersion < 2000) {
+                str = "Microsoft Visual C++ 14.1";
+            }
+            str += " (MSC_VER " + std::to_string(MSVCVersion) + ")";
+        } else {
+            switch( MSVCVersion ) {
+                case 1900:
+                    str = "Visual Studio 2015";
+                    break;
+                case 1800:
+                    str = "Visual Studio 2013";
+                    break;
+                case 1700:
+                    str = "Visual Studio 2011";
+                    break;
+                case 1600:
+                    str = "Visual Studio 2010";
+                    break;
+                case 1500:
+                    str = "Visual Studio 2008";
+                    break;
+                case 1400:
+                    str = "Visual Studio 2005";
+                    break;
+                case 1310:
+                    str = "Visual Studio 2003";
+                    break;
+                case 1300:
+                    str = "Visual Studio 2002";
+                    break;
+            }
+        }
+    } else if( 0 == os.compare("Darwin")) {
+        str = "Mac OS X :";
+        str += GET_COMPILER_INFO;
+    } else if( 0 == os.compare("Linux")){
+        str = "Linux :";
+        str = GET_COMPILER_INFO;
+    } else {
+        str = GET_COMPILER_INFO;
+    }
+
+    return str;
 }
 
 }

--- a/OpenSim/Common/About.h
+++ b/OpenSim/Common/About.h
@@ -1,0 +1,48 @@
+#ifndef OPENSIM_COMMON_ABOUT_H_
+#define OPENSIM_COMMON_ABOUT_H_
+/* -------------------------------------------------------------------------- *
+ *                            OpenSim:  About.h                               *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2018 Stanford University and the Authors                *
+ * Author(s): Christopher Dembia                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "osimCommonDLL.h"
+
+extern "C" {
+
+OSIMCOMMON_API
+    void opensim_version_common(int* major, int* minor, int* build);
+OSIMCOMMON_API
+    void opensim_about_common(const char* key, int maxlen, char* value);
+
+}
+
+#if defined(__cplusplus) || defined(SWIG)
+#include <string>
+namespace OpenSim {
+std::string GetVersionAndDate();
+std::string GetVersion();
+std::string GetOSInfoVerbose();
+std::string GetOSInfo();
+std::string GetCompilerVersion();
+}
+#endif
+
+#endif // OPENSIM_COMMON_ABOUT_H_

--- a/OpenSim/Common/About.h
+++ b/OpenSim/Common/About.h
@@ -37,11 +37,11 @@ OSIMCOMMON_API
 #if defined(__cplusplus) || defined(SWIG)
 #include <string>
 namespace OpenSim {
-std::string GetVersionAndDate();
-std::string GetVersion();
-std::string GetOSInfoVerbose();
-std::string GetOSInfo();
-std::string GetCompilerVersion();
+OSIMCOMMON_API std::string GetVersionAndDate();
+OSIMCOMMON_API std::string GetVersion();
+OSIMCOMMON_API std::string GetOSInfoVerbose();
+OSIMCOMMON_API std::string GetOSInfo();
+OSIMCOMMON_API std::string GetCompilerVersion();
 }
 #endif
 

--- a/OpenSim/Common/STOFileAdapter.cpp
+++ b/OpenSim/Common/STOFileAdapter.cpp
@@ -1,3 +1,24 @@
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim:  STOFileAdapter.cpp                       *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2018 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
 #include "STOFileAdapter.h"
 
 namespace OpenSim {

--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -86,6 +86,9 @@ void compareHeaders(std::ifstream& filenameA,
         if(line.find("version") != std::string::npos)
           continue;
 
+        if(line.find("OpenSimVersion") != std::string::npos)
+            continue;
+
         headerA.insert(line);
     }
     while(std::getline(filenameB, line)) {
@@ -108,6 +111,9 @@ void compareHeaders(std::ifstream& filenameA,
         // will have older version number.
         if(line.find("version") != std::string::npos)
           continue;
+
+        if(line.find("OpenSimVersion") != std::string::npos)
+            continue;
 
         headerB.insert(line);
     }

--- a/OpenSim/Common/osimCommon.h
+++ b/OpenSim/Common/osimCommon.h
@@ -23,6 +23,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "About.h"
 #include "Object.h"
 #include "RegisterTypes_osimCommon.h"
 #include "FunctionSet.h"

--- a/OpenSim/Tools/About.cpp
+++ b/OpenSim/Tools/About.cpp
@@ -69,7 +69,7 @@ using namespace std;
 
 extern "C" {
 
-void opensim_version_actuators(int* major, int* minor, int* build) {
+void opensim_version_tools(int* major, int* minor, int* build) {
     static const char* l = "OPENSIM library="   GET_LIBRARY_STRING;
     static const char* t = "OPENSIM type="      GET_TYPE_STRING;
     static const char* d = "OPENSIM debug="     GET_DEBUG_STRING;
@@ -88,7 +88,7 @@ void opensim_version_actuators(int* major, int* minor, int* build) {
     }
 }
 
-void opensim_about_actuators(const char* key, int maxlen, char* value) {
+void opensim_about_tools(const char* key, int maxlen, char* value) {
     if (maxlen <= 0 || value==0) return;
     value[0] = '\0'; // in case we don't find a match
     if (key==0) return;

--- a/OpenSim/version.h
+++ b/OpenSim/version.h
@@ -22,19 +22,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#if defined(__cplusplus) || defined(SWIG)
-
-#include <string>
-
-// Defined in OpenSim/Common/About.cpp
-namespace OpenSim {
-    std::string GetVersionAndDate();
-    std::string GetVersion();
-    std::string GetOSInfoVerbose();
-    std::string GetOSInfo();
-    std::string GetCompilerVersion();
-}
-
-#endif
+#include <OpenSim/Common/About.h>
 
 #endif // OPENSIM_version_H_

--- a/OpenSim/version.h
+++ b/OpenSim/version.h
@@ -1,5 +1,5 @@
-#ifndef _version_h_
-#define _version_h_
+#ifndef OPENSIM_version_H_
+#define OPENSIM_version_H_
 /* -------------------------------------------------------------------------- *
  *                            OpenSim:  version.h                             *
  * -------------------------------------------------------------------------- *
@@ -23,113 +23,18 @@
  * -------------------------------------------------------------------------- */
 
 #if defined(__cplusplus) || defined(SWIG)
+
 #include <string>
-#include <cstdio>
-#include <stdio.h>
-#include <stdlib.h>
 
-#define STR(var) #var
-#define MAKE_STRING(a) STR(a)
-#define GET_SYSTEM_INFO \
-    MAKE_STRING(OSIM_SYS_INFO)
-
-#define GET_COMPILER_INFO \
-    MAKE_STRING(OSIM_COMPILER_INFO)
-
-#define GET_OS_NAME \
-    MAKE_STRING(OSIM_OS_NAME)
-
-#define GET_OSIM_VERSION \
-    MAKE_STRING(OSIM_VERSION)
-
+// Defined in OpenSim/Common/About.cpp
 namespace OpenSim {
-#endif
-
-    static const char *OpenSimVersion = GET_OSIM_VERSION;
-
-#if defined(__cplusplus) || defined(SWIG)
-    inline std::string GetVersionAndDate() { 
-        char buffer[256];
-        sprintf(buffer,"version %s, build date %s %s", OpenSimVersion, __TIME__, __DATE__);
-        return std::string(buffer);
-    }
-
-    inline std::string GetVersion() {
-        return OpenSimVersion;
-    }
-
-    inline std::string GetOSInfoVerbose() {
-        const char * str = GET_SYSTEM_INFO;
-        return str;
-    }
-    inline std::string GetOSInfo() {
-        const char * str = GET_OS_NAME;
-        return str;
-    }
-    inline std::string GetCompilerVersion() {
-        std::string os = GetOSInfo();
-        std::string str = "(Unknown)";
-
-        if( 0 == os.compare("Windows")) {
-            const int MSVCVersion = atoi(GET_COMPILER_INFO);
-            if( MSVCVersion >= 1910 ) {
-                // With Visual Studio 2017, the versioning of the Visual C++
-                // compiler became more fine-grained, so we can no longer use
-                // a switch statement.
-                // Also, Visual Studio 2017 decouples the Visual Studio IDE
-                // from the C++ toolset (compiler), so providing the IDE year 
-                // does not indicate the compiler version (it may be possible
-                // to use the Visual Studio 2019 IDE, or whatever is next, 
-                // with the same C++ toolset that came with Visual Studio 2017.
-                // Therefore, we no longer provide the Visual Studio year.
-                // https://blogs.msdn.microsoft.com/vcblog/2016/10/05/visual-c-compiler-version/
-                // https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
-                if (1910 <= MSVCVersion && MSVCVersion < 2000) {
-                    str = "Microsoft Visual C++ 14.1";
-                }
-                str += " (MSC_VER " + std::to_string(MSVCVersion) + ")";
-            } else {
-                switch( MSVCVersion ) {
-                case 1900:
-                    str = "Visual Studio 2015";
-                    break;
-                case 1800:
-                    str = "Visual Studio 2013";
-                    break;
-                case 1700:
-                    str = "Visual Studio 2011";
-                    break;
-                case 1600:
-                    str = "Visual Studio 2010";
-                    break;
-                case 1500:
-                    str = "Visual Studio 2008";
-                    break;
-                case 1400:
-                    str = "Visual Studio 2005";
-                    break;
-                case 1310:
-                    str = "Visual Studio 2003";
-                    break;
-                case 1300:
-                    str = "Visual Studio 2002";
-                    break;
-                }
-            }
-        } else if( 0 == os.compare("Darwin")) {
-            str = "Mac OS X :";
-            str += GET_COMPILER_INFO;
-        } else if( 0 == os.compare("Linux")){
-            str = "Linux :";
-            str = GET_COMPILER_INFO;
-        } else {
-            str = GET_COMPILER_INFO;
-        }
-    
-        return str;
-    }
-
+    std::string GetVersionAndDate();
+    std::string GetVersion();
+    std::string GetOSInfoVerbose();
+    std::string GetOSInfo();
+    std::string GetCompilerVersion();
 }
-#endif
 
 #endif
+
+#endif // OPENSIM_version_H_


### PR DESCRIPTION
Fixes part of issue #2351

### Brief summary of changes

- Refactor code for getting OpenSim's version (this code should be in .cpp files anyway, not in a header, where the behavior of the code depends on using the correct compiler definitions).
- Use OpenSim::GetVersion() in the DelimFileAdapter when writing a file.

### Testing I've completed

- All tests passed; ensured the OpenSim version is present in STO files we write using the STOFileAdapter.
- Made sure the version info produced by opensim-cmd and the GUI (About dialog) is still correct.

### CHANGELOG.md (choose one)

- no need to update because...minor changes

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2364)
<!-- Reviewable:end -->
