### PR TITLE
Warn if mesh file is specified in model and is not found

### DIFF
--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -264,7 +264,7 @@ void Mesh::extendFinalizeFromProperties() {
 
             std::cout << "Couldn't find file '" << file << "'." << std::endl;
             if (getDebugLevel() == 0) { return; }
-            std::cout << "Following locations were tried\n";
+            std::cout << "The following locations were tried:\n";
             for (unsigned i = 0; i < attempts.size(); ++i)
                 std::cout << "\n  " << attempts[i];
             std::cout << std::endl;

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -262,7 +262,7 @@ void Mesh::extendFinalizeFromProperties() {
 
         if (!foundIt) {
 
-            std::cout << "Couldn't find file '" << file << std::endl;
+            std::cout << "Couldn't find file '" << file << "'." << std::endl;
             if (getDebugLevel() == 0) { return; }
             std::cout << "Following locations were tried\n";
             for (unsigned i = 0; i < attempts.size(); ++i)

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -261,10 +261,10 @@ void Mesh::extendFinalizeFromProperties() {
         bool foundIt = ModelVisualizer::findGeometryFile(model, file, isAbsolutePath, attempts);
 
         if (!foundIt) {
-            if (getDebugLevel()==0) { return; }
 
-            std::cout << "ModelVisualizer couldn't find file '" << file
-                << "'; tried\n";
+            std::cout << "Couldn't find file '" << file << std::endl;
+            if (getDebugLevel() == 0) { return; }
+            std::cout << "Following locations were tried\n";
             for (unsigned i = 0; i < attempts.size(); ++i)
                 std::cout << "\n  " << attempts[i];
             std::cout << std::endl;


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-gui/issues/1062

### Brief summary of changes
If mesh file is specified and not found, warn user. 

### Testing I've completed
Build core and GUI and got the messages on model loading

### Looking for feedback on...
Message text.

### CHANGELOG.md (choose one)

- no need to update because behavior is not documented!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2365)
<!-- Reviewable:end -->
