### PR TITLE
Do not put experimental markers in static pose file.

### DIFF
--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -385,12 +385,7 @@ bool MarkerPlacer::processModel(Model* aModel,
     
     _outputStorage.reset(new Storage(statesReporter.updStatesStorage()));
     _outputStorage->setName("static pose");
-    //_outputStorage->print("statesReporterOutput.sto");
-    Storage markerStorage;
-    staticPose->makeRdStorage(*_outputStorage);
     _outputStorage->getStateVector(0)->setTime(s.getTime());
-    statesReporter.updStatesStorage().addToRdStorage(*_outputStorage, s.getTime(), s.getTime());
-    //_outputStorage->print("statesReporterOutputWithMarkers.sto");
 
     if(_printResultFiles) {
         std::string savedCwd = IO::getCwd();


### PR DESCRIPTION
Fixes https://github.com/opensim-org/opensim-core/issues/2362

### Brief summary of changes

- No longer add static pose marker data to static pose motion file.

### Testing I've completed

- Built the GUI and ensured the static pose output did not contain markers and that I could successfully association the static TRC file.

<img width="409" alt="image" src="https://user-images.githubusercontent.com/846001/48295080-714fe700-e43d-11e8-9434-0db9a65134b2.png">


- no need to update because...minor bugfix.