### PR TITLE
Ensure OpenSimVersion=4.0 is written to STO header.

### DIFF
--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -243,6 +243,8 @@ int main() {
     filenames.push_back("subject01_walk1_grf.mot");
     std::string tmpfile{"testmotfileadapter.mot"};
 
+    std::remove(tmpfile.c_str());
+
     std::cout << "Testing STOFileAdapter::read() and STOFileAdapter::write()"
               << std::endl;
     for(const auto& filename : filenames) {
@@ -272,8 +274,6 @@ int main() {
         STOFileAdapter_<double>::write(table, tmpfile);
         compareFiles(filename, tmpfile);
     }
-
-    std::remove(tmpfile.c_str());
 
     // test detection of invalid column labels
     TimeSeriesTable table{};
@@ -334,6 +334,26 @@ int main() {
     auto outputTables = FileAdapter::readFile("test.sto");
     SimTK_TEST(outputTables["table"]->getNumRows() == 2);
     SimTK_TEST(outputTables["table"]->getNumColumns() == 2);
+
+
+    std::cout << "Testing for the presence of OpenSimVersion in the header."
+              << std::endl;
+    {
+        auto table = STOFileAdapter::read("test.sto");
+        std::string filename = "OpenSimVersionHeader.sto";
+        STOFileAdapter::write(table, filename);
+        std::ifstream ifs("OpenSimVersionHeader.sto");
+        std::string line;
+        bool pass = false;
+        const std::string versionString = "OpenSimVersion=" + GetVersion();
+        while (std::getline(ifs, line)) {
+            if (line.find(versionString) != std::string::npos) {
+                pass = true;
+                break;
+            }
+        }
+        SimTK_TEST(pass);
+    }
 
     std::cout << "\nAll tests passed!" << std::endl;
 

--- a/OpenSim/Common/Test/testSTOFileAdapter.cpp
+++ b/OpenSim/Common/Test/testSTOFileAdapter.cpp
@@ -345,7 +345,8 @@ int main() {
         std::ifstream ifs("OpenSimVersionHeader.sto");
         std::string line;
         bool pass = false;
-        const std::string versionString = "OpenSimVersion=" + GetVersion();
+        const std::string versionString =
+            "OpenSimVersion=" + OpenSim::GetVersion();
         while (std::getline(ifs, line)) {
             if (line.find(versionString) != std::string::npos) {
                 pass = true;


### PR DESCRIPTION
Fixes issue #2382 

### Brief summary of changes

This PR ensures that `OpenSimVersion=4.0` is written to version 3 STO file headers.

### Testing I've completed

Ran testSTOFileAdapter.

### CHANGELOG.md (choose one)

- no need to update because...test case is not user-facing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2383)
<!-- Reviewable:end -->
