### PR TITLE
explicit_Array_constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
+v4.1
+====
+
+Converting from v4.0 to v4.1
+----------------------------
+- The `OpenSim::Array` constructor is now marked explicit, which prevents
+  accidental implicit conversion to `Array`. If you relied on this implicit
+  conversion, you will need to update your code to use the constructor
+  explicitly.
+
+
 v4.0
 ====
 

--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -97,7 +97,7 @@ virtual ~Array()
  * @param aCapacity Initial capacity of the array.  The initial capacity
  * is guaranteed to be at least as large as aSize + 1.
  */
-Array(const T &aDefaultValue=T(),int aSize=0,int aCapacity=Array_CAPMIN)
+explicit Array(const T &aDefaultValue=T(),int aSize=0,int aCapacity=Array_CAPMIN)
 {
     setNull();
 

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
@@ -54,8 +54,9 @@ AnalysisPlugin_Template::AnalysisPlugin_Template() : Analysis()
 void AnalysisPlugin_Template::
 setNull()
 {
-    _bodyIndices = 0;
-    _bodypos = 0;
+
+    _bodyIndices = Array<int>();
+    _bodypos = Array<double>();
 }
 
 


### PR DESCRIPTION
Fixes #2384

### Brief summary of changes

Make the Array constructor explicit to avoid accidental casting to an empty Array.

### Testing I've completed

ctest

### CHANGELOG.md (choose one)

- updated.
