### PR TITLE
Reduce SWIG warnings.

### DIFF
--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -118,6 +118,12 @@ macro(OpenSimAddPythonModule)
         # 4114: "const const T"
         set(_COMPILE_FLAGS "/wd4996 /wd4114")
     endif()
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND
+            NOT (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "10"))
+        # SWIG uses the register keyword, which is deprecated in C++17.
+        set(_COMPILE_FLAGS "${_COMPILE_FLAGS} -Wno-deprecated-register")
+    endif()
+
     set_source_files_properties("${_output_cxx_file}"
         PROPERTIES COMPILE_FLAGS "${_COMPILE_FLAGS}")
 

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -13,6 +13,7 @@
 %include <OpenSim/Common/Array.h>
 %include <OpenSim/Common/ArrayPtrs.h>
 %include <OpenSim/Common/AbstractProperty.h>
+%ignore OpenSim::Property<std::string>::appendValue(std::string const *);
 %include <OpenSim/Common/Property.h>
 %include <OpenSim/Common/PropertyGroup.h>
 %template(ArrayPtrsPropertyGroup) OpenSim::ArrayPtrs<OpenSim::PropertyGroup>;
@@ -383,6 +384,7 @@ namespace OpenSim {
 %template(STOFileAdapterSpatialVec) OpenSim::STOFileAdapter_<SimTK::SpatialVec>;
 
 %include <OpenSim/Common/CSVFileAdapter.h>
+
 %include <OpenSim/Common/C3DFileAdapter.h>
 
 %extend OpenSim::C3DFileAdapter {

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -47,6 +47,10 @@ OpenSim::ModelComponentSet<OpenSim::Body>;
 %include <OpenSim/Simulation/Model/BodyScaleSet.h>
 
 %include <OpenSim/Simulation/SimbodyEngine/SimbodyEngine.h>
+%warnfilter(509) OpenSim::TransformAxis;
+namespace OpenSim {
+%warnfilter(509) TransformAxis::setFunction;
+}
 %include <OpenSim/Simulation/SimbodyEngine/TransformAxis.h>
 %include <OpenSim/Simulation/SimbodyEngine/SpatialTransform.h>
 %include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
@@ -91,6 +95,9 @@ OpenSim::ModelComponentSet<OpenSim::Constraint>;
 %include <OpenSim/Simulation/SimbodyEngine/WeldConstraint.h>
 %include <OpenSim/Simulation/SimbodyEngine/PointConstraint.h>
 %include <OpenSim/Simulation/SimbodyEngine/ConstantDistanceConstraint.h>
+namespace OpenSim {
+%warnfilter(509) CoordinateCouplerConstraint::setFunction;
+}
 %include <OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.h>
 %include <OpenSim/Simulation/SimbodyEngine/PointOnLineConstraint.h>
 
@@ -338,7 +345,7 @@ EXPOSE_SET_CONSTRUCTORS_HELPER(ModelComponentSet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(BodySet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(JointSet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(ConstraintSet);
-EXPOSE_SET_CONSTRUCTORS_HELPER(ForcesSet);
+EXPOSE_SET_CONSTRUCTORS_HELPER(ForceSet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(ControllerSet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(ContactGeometrySet);
 EXPOSE_SET_CONSTRUCTORS_HELPER(PathPointSet);

--- a/OpenSim/Simulation/Model/BodySet.h
+++ b/OpenSim/Simulation/Model/BodySet.h
@@ -40,7 +40,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(BodySet, ModelComponentSet<Body>);
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ComponentSet.h
+++ b/OpenSim/Simulation/Model/ComponentSet.h
@@ -43,7 +43,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(ComponentSet,
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ConstraintSet.h
+++ b/OpenSim/Simulation/Model/ConstraintSet.h
@@ -40,7 +40,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(ConstraintSet, ModelComponentSet<Constraint>);
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ContactGeometrySet.h
+++ b/OpenSim/Simulation/Model/ContactGeometrySet.h
@@ -41,7 +41,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(ContactGeometrySet,
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ControllerSet.h
+++ b/OpenSim/Simulation/Model/ControllerSet.h
@@ -53,7 +53,7 @@ public:
     // CONSTRUCTION
     //--------------------------------------------------------------------------
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     void constructStorage();
     void storeControls( const SimTK::State& s, int step );

--- a/OpenSim/Simulation/Model/CoordinateSet.h
+++ b/OpenSim/Simulation/Model/CoordinateSet.h
@@ -39,7 +39,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(CoordinateSet, Set<Coordinate>);
 
 public:
     /** Use Super's constructors. @see Set */
-    using Super::Set;
+    using Super::Super;
 
     /**
      * Populate this %Set as a flat list of all Model Coordinates given 

--- a/OpenSim/Simulation/Model/ForceSet.h
+++ b/OpenSim/Simulation/Model/ForceSet.h
@@ -67,7 +67,7 @@ protected:
     //--------------------------------------------------------------------------
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
 private:
     void updateActuators();

--- a/OpenSim/Simulation/Model/MarkerSet.h
+++ b/OpenSim/Simulation/Model/MarkerSet.h
@@ -39,7 +39,7 @@ class OSIMSIMULATION_API MarkerSet : public ModelComponentSet<Marker> {
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -61,7 +61,7 @@ class ModelComponentSet : public Set<T, ModelComponent> {
 // METHODS
 //=============================================================================
 public:
-    using Set<T, ModelComponent>::Set;
+    using Super::Super;
     void extendFinalizeFromProperties() override final {
         Super::extendFinalizeFromProperties();
         // ModelComponentSets are unnamed properties of models, but as

--- a/OpenSim/Simulation/Model/PathPointSet.h
+++ b/OpenSim/Simulation/Model/PathPointSet.h
@@ -41,7 +41,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(PathPointSet, Set<AbstractPathPoint>);
 
 public:
     /** Use Super's constructors. @see Set */
-    using OpenSim::Set<OpenSim::AbstractPathPoint, OpenSim::Object>::Set;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Model/ProbeSet.h
+++ b/OpenSim/Simulation/Model/ProbeSet.h
@@ -42,7 +42,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(ProbeSet, ModelComponentSet<Probe>);
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 

--- a/OpenSim/Simulation/Wrap/WrapObjectSet.h
+++ b/OpenSim/Simulation/Wrap/WrapObjectSet.h
@@ -42,7 +42,7 @@ OpenSim_DECLARE_CONCRETE_OBJECT(WrapObjectSet, ModelComponentSet<WrapObject>);
 
 public:
     /** Use Super's constructors. @see ModelComponentSet */
-    using Super::ModelComponentSet;
+    using Super::Super;
 
     // default copy, assignment operator, and destructor
 //=============================================================================


### PR DESCRIPTION
Fixes #2331 

### Brief summary of changes

This PR avoids warnings about Sets from inheriting constructors.

### Testing I've completed

Ran ctest and observed the warnings produced.

### CHANGELOG.md (choose one)

- no need to update because...not user-facing.
