### PR TITLE
Make output redirect optional (out.log & err.log)

### DIFF
--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -20,12 +20,13 @@ OpenSimAddLibrary(
     TESTDIRS "Test"
     )
 
-option(OPENSIM_REDIRECT_OUTPUT
+option(OPENSIM_LOG_TO_FILE
     "Redirect output to both the terminal and an output file."
     ON)
 
-if(OPENSIM_REDIRECT_OUTPUT)
-    target_compile_definitions(osimCommon PRIVATE OPENSIM_REDIRECT_OUTPUT)
+# Whether cerr & cout shold be redirected to err.log and out.log respectively
+if(OPENSIM_LOG_TO_FILE)
+    target_compile_definitions(osimCommon PRIVATE OPENSIM_LOG_TO_FILE)
 endif()
 
 if(WIN32)

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -20,6 +20,14 @@ OpenSimAddLibrary(
     TESTDIRS "Test"
     )
 
+option(OPENSIM_REDIRECT_OUTPUT
+    "Redirect output to both the terminal and an output file."
+    ON)
+
+if(OPENSIM_REDIRECT_OUTPUT)
+    target_compile_definitions(osimCommon PRIVATE OPENSIM_REDIRECT_OUTPUT)
+endif()
+
 if(WIN32)
     # On Windows only, debug libraries cannot be mixed with release
     # libraries, and we must copy the DLLs from the dependencies

--- a/OpenSim/Common/LogManager.cpp
+++ b/OpenSim/Common/LogManager.cpp
@@ -107,10 +107,11 @@ LogManager::LogManager()
     std::cout.rdbuf(&out);
     std::cerr.rdbuf(&err);
 
-    // Redirect output to both the terminal and an output file
+    // Redirect output to the terminal
     out.addLogCallback(new StreamLogCallback(&cout,false));
     err.addLogCallback(new StreamLogCallback(&cerr,false));
 
+    // Optional: Redirect output to file
 #if OPENSIM_LOG_TO_FILE
     out.addLogCallback(new StreamLogCallback("out.log"));
     err.addLogCallback(new StreamLogCallback("err.log"));

--- a/OpenSim/Common/LogManager.cpp
+++ b/OpenSim/Common/LogManager.cpp
@@ -102,7 +102,7 @@ sync()
 LogManager::LogManager()
 {
     // Seems to be causing crashes in the GUI... maybe a multithreading issue.
-#if 1
+#if OPENSIM_REDIRECT_OUTPUT
     // Change the underlying streambuf for the standard cout/cerr to our custom buffers
     std::cout.rdbuf(&out);
     std::cerr.rdbuf(&err);

--- a/OpenSim/Common/LogManager.cpp
+++ b/OpenSim/Common/LogManager.cpp
@@ -102,15 +102,17 @@ sync()
 LogManager::LogManager()
 {
     // Seems to be causing crashes in the GUI... maybe a multithreading issue.
-#if OPENSIM_REDIRECT_OUTPUT
+
     // Change the underlying streambuf for the standard cout/cerr to our custom buffers
     std::cout.rdbuf(&out);
     std::cerr.rdbuf(&err);
 
-    // Example setup: redirect output to both the terminal and an output file
+    // Redirect output to both the terminal and an output file
     out.addLogCallback(new StreamLogCallback(&cout,false));
-    out.addLogCallback(new StreamLogCallback("out.log"));
     err.addLogCallback(new StreamLogCallback(&cerr,false));
+
+#if OPENSIM_LOG_TO_FILE
+    out.addLogCallback(new StreamLogCallback("out.log"));
     err.addLogCallback(new StreamLogCallback("err.log"));
 #endif
 }


### PR DESCRIPTION
Fixes issue #2400

### Brief summary of changes
Added a cmake option `OPENSIM_REDIRECT_OUTPUT` (& a define of same name added to target `osimCommon` if option == ON) to make it optional whether output (cout/cerr) should be redirect to out.log & err.log.

### Testing I've completed
Built with `OPENSIM_REDIRECT_OUTPUT=ON` & `OPENSIM_REDIRECT_OUTPUT=OFF`, using `static_assert` to verify if assertion hit.

### CHANGELOG.md (choose one)

- no need to update because the change is irrelevant to most users (and defaults to current behavior).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2403)
<!-- Reviewable:end -->
