### PR TITLE
Output model from OpenSense calibration

### DIFF
--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -145,10 +145,14 @@ int main(int argc, char **argv)
                         cout << "Calibration will perform heading correction using '"
                             << baseImuName << "'along its '" << imuHeading << "'axis." << endl;
                     }
-                    OpenSenseUtilities::calibrateModelFromOrientations(
+                    Model model = OpenSenseUtilities::calibrateModelFromOrientations(
                         modelCalibrationPoseFile,
                         calibrationOrientationsFile,
                         baseImuName, imuHeading);
+
+                    auto filename = "calibrated_" + model.getName() + ".osim";
+                    cout << "Wrote calibrated model to file: '" << filename << "'." << endl;
+                    model.print(filename);
 
                     cout << "Done." << endl;
                     return 0;

--- a/Applications/opensense/test/testOpensense.cpp
+++ b/Applications/opensense/test/testOpensense.cpp
@@ -37,15 +37,15 @@ int main()
     int itc = 0;
   
     // Calibrate model and compare result to standard
-    OpenSenseUtilities::calibrateModelFromOrientations(
+    Model model = OpenSenseUtilities::calibrateModelFromOrientations(
         "subject07.osim", 
         "imuOrientations.sto",
         "pelvis_imu", SimTK::ZAxis,
         false);
     // Previous line produces a model with same name but "calibrated_" prefix.
     Model stdModel{ "std_calibrated_subject07.osim" };
-    Model actualModel{ "calibrated_Subject07.osim" };
-    ASSERT(stdModel == actualModel);
+
+    ASSERT(model == stdModel);
     InverseKinematicsStudy ik("setup_OpenSense.xml");
     // RUN
     ik.run(); 

--- a/Applications/opensense/test/testOpensense.cpp
+++ b/Applications/opensense/test/testOpensense.cpp
@@ -42,6 +42,9 @@ int main()
         "imuOrientations.sto",
         "pelvis_imu", SimTK::ZAxis,
         false);
+
+    model.print("calibrated_" + model.getName() + ".osim");
+
     // Previous line produces a model with same name but "calibrated_" prefix.
     Model stdModel{ "std_calibrated_subject07.osim" };
 

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -139,7 +139,7 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
 }
 
 
-void OpenSenseUtilities::calibrateModelFromOrientations(
+Model OpenSenseUtilities::calibrateModelFromOrientations(
     const string& modelCalibrationPoseFile,
     const string& calibrationOrientationsFile,
     const std::string& baseImuName,
@@ -235,9 +235,6 @@ void OpenSenseUtilities::calibrateModelFromOrientations(
 
     model.finalizeConnections();
 
-    auto filename = "calibrated_" + model.getName() + ".osim";
-    cout << "Wrote calibrated model to file: '" << filename << "'." << endl;
-    model.print(filename);
     if (visualizeCalibratedModel) {
         model.setUseVisualizer(true);
         SimTK::State& s = model.initSystem();
@@ -261,6 +258,8 @@ void OpenSenseUtilities::calibrateModelFromOrientations(
         std::cout << "Press any key and return to close visualizer." << std::endl;
         std::cin >> c;
     }
+
+    return model;
 }
 
 SimTK::Transform OpenSenseUtilities::formTransformFromPoints(const Vec3& op,

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -53,16 +53,25 @@ namespace OpenSim {
             const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis
         );
         /// @}
-        /** Create a calibrated model from a model in the calibration pose.
+        /** Create a calibrated model from a model in the calibration pose and 
+            the sensor (IMU) orientations (as quaternions) during the calibration.
+            modelCalibrationPoseFile: a model file where default pose matches that
+                                      used to collect the calibration data.
+            calibrationOrientationsFile: a storage file with IMU orientations 
+                                         expressed as Quaternions.
+            baseImuName: The label of the base IMU in the orientations_file used
+                         to account for the heading difference between the sensor
+                         data and the forward direction of the model. Leave blank
+                         if no heading correction is to be applied.
+            baseHeadingAxis: The axis of the base IMU that corresponds to its
+                             heading direction. Options are SimTK::X/Y/ZAxis
             Assumptions about the inputs: 
-            1) the model default pose is the same as the pose used to collect calibration data
-            2) that IMUs are labeled <body(or physical frame)_in_model>_imu so the underlying 
-            PhysicalFrame in the model can be identified and a corresponding Offset frame attached.
-            
-            modelCalibrationPoseFile is model file where default pose matches that used to collect 
-                calibrationOrientationsFile.
-            calibrationOrientationsFile is a storage file with IMU orientations expressed
-                as Quaternions.
+             1) the model default pose is the same as the pose used to collect
+                calibration data
+             2) the sensors are labeled <body(or physical frame)_in_model>_imu in
+                the orientations data. The underlying PhysicalFrame in the model
+                is then identified and a corresponding Offset frame is attached, 
+                which represents the sensor affixed to the model.
          */
         static Model calibrateModelFromOrientations(
             const std::string& modelCalibrationPoseFile,

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -25,6 +25,7 @@
 
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
+#include <OpenSim/Simulation/Model/Model.h>
 #include <SimTKsimbody.h>
 
 namespace OpenSim {
@@ -52,8 +53,8 @@ namespace OpenSim {
             const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis
         );
         /// @}
-        /** create a calibrated model from a raw model (unscaled)
-            Assumptions about the model: 
+        /** Create a calibrated model from a model in the calibration pose.
+            Assumptions about the inputs: 
             1) the model default pose is the same as the pose used to collect calibration data
             2) that IMUs are labeled <body(or physical frame)_in_model>_imu so the underlying 
             PhysicalFrame in the model can be identified and a corresponding Offset frame attached.
@@ -63,7 +64,7 @@ namespace OpenSim {
             calibrationOrientationsFile is a storage file with IMU orientations expressed
                 as Quaternions.
          */
-        static void calibrateModelFromOrientations(
+        static Model calibrateModelFromOrientations(
             const std::string& modelCalibrationPoseFile,
             const std::string& calibrationOrientationsFile,
             const std::string& baseImuName = "",


### PR DESCRIPTION
Fixes issue #2446

### Brief summary of changes
Instead of automatically writing the calibrated model to file, the calibrated model is now the output of the utility method. The caller/user is then free to use the model directly or write it to file as they choose.

### Testing I've completed
Updated testopensense.cpp accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2452)
<!-- Reviewable:end -->
