### PR TITLE
Restore build options appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,11 +116,11 @@ test_script:
   # http://help.appveyor.com/discussions/problems/863-doxygen-installed-via-chocolatey-not-found
   #- IF DEFINED DISTR choco install doxygen.portable --yes
   - IF DEFINED DISTR ps: (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "C:\doxygen.zip")
-  - 7z x C:\doxygen.zip -oC:\doxygen
-  - SET PATH=C:\doxygen;%PATH%
+  - IF DEFINED DISTR 7z x C:\doxygen.zip -oC:\doxygen
+  - IF DEFINED DISTR SET PATH=C:\doxygen;%PATH%
   - IF DEFINED DISTR cmake .
   - IF DEFINED DISTR cmake --build . --target doxygen --config Release
-  
+  #
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ init:
   - SET JAVA_HOME=%JAVA_DIR%
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # Detect if we are on the master branch; if so, we will deploy binaries.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
+  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
 
 cache:
   ## Cache swig, which we install via AppVeyor.
@@ -115,12 +115,12 @@ test_script:
   ## Build doxygen (now that tests pass).
   # http://help.appveyor.com/discussions/problems/863-doxygen-installed-via-chocolatey-not-found
   #- IF DEFINED DISTR choco install doxygen.portable --yes
-  #- IF DEFINED DISTR ps: (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "C:\doxygen.zip")
-  #- IF DEFINED DISTR 7z x C:\doxygen.zip -oC:\doxygen
-  #- IF DEFINED DISTR SET PATH=C:\doxygen;%PATH%
-  #- IF DEFINED DISTR cmake .
-  #- IF DEFINED DISTR cmake --build . --target doxygen --config Release
-  #
+  - IF DEFINED DISTR ps: (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "C:\doxygen.zip")
+  - 7z x C:\doxygen.zip -oC:\doxygen
+  - SET PATH=C:\doxygen;%PATH%
+  - IF DEFINED DISTR cmake .
+  - IF DEFINED DISTR cmake --build . --target doxygen --config Release
+  
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet
   


### PR DESCRIPTION
Fixes issue #0
Restore publishing only on master branch and build Doxygen when specified in appveyor configuration, both were unintentionally modified by PR #2437
### Brief summary of changes

### Testing I've completed

### Looking for feedback on...
This only affects appveyor build, we can safely merge if Artifact can be found/published

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2453)
<!-- Reviewable:end -->
