### PR TITLE
Revert "Restore build options appveyor"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ init:
   - SET JAVA_HOME=%JAVA_DIR%
   - SET PATH=%JAVA_HOME%\bin;%PATH%
   # Detect if we are on the master branch; if so, we will deploy binaries.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
 
 cache:
   ## Cache swig, which we install via AppVeyor.
@@ -115,11 +115,11 @@ test_script:
   ## Build doxygen (now that tests pass).
   # http://help.appveyor.com/discussions/problems/863-doxygen-installed-via-chocolatey-not-found
   #- IF DEFINED DISTR choco install doxygen.portable --yes
-  - IF DEFINED DISTR ps: (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "C:\doxygen.zip")
-  - IF DEFINED DISTR 7z x C:\doxygen.zip -oC:\doxygen
-  - IF DEFINED DISTR SET PATH=C:\doxygen;%PATH%
-  - IF DEFINED DISTR cmake .
-  - IF DEFINED DISTR cmake --build . --target doxygen --config Release
+  #- IF DEFINED DISTR ps: (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "C:\doxygen.zip")
+  #- IF DEFINED DISTR 7z x C:\doxygen.zip -oC:\doxygen
+  #- IF DEFINED DISTR SET PATH=C:\doxygen;%PATH%
+  #- IF DEFINED DISTR cmake .
+  #- IF DEFINED DISTR cmake --build . --target doxygen --config Release
   #
   ## Ensure we have no trouble installing.
   - cmake --build . --target install --config Release -- /maxcpucount:4 /verbosity:quiet


### PR DESCRIPTION
Reverts opensim-org/opensim-core#2453 to allow builds from branches on Appveyor since build on master fails for random reasons and doesn't generate artifacts