### PR TITLE
InverseKinematicsStudy only converts purely Rotational coordinates to degrees.

### DIFF
--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -196,12 +196,7 @@ runInverseKinematicsWithOrientationsFromFile(Model& model,
     // Convert to degrees to compare with marker-based IK
     // but only for rotational coordinates
     model.getSimbodyEngine().convertRadiansToDegrees(report);
-
     report.updTableMetaData().setValueForKey<string>("name", outName);
-    report.updTableMetaData().setValueForKey<size_t>("nRows", report.getNumRows());
-    // getNumColumns returns the number of dependent columns, but Storage expects time
-    report.updTableMetaData().setValueForKey<size_t>("nColumns", report.getNumColumns()+1);
-    report.updTableMetaData().setValueForKey<string>("inDegrees","yes");
 
     STOFileAdapter_<double>::write(report, outputFile + ".mot");
 

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -1018,23 +1018,33 @@ void SimbodyEngine::convertRadiansToDegrees(Storage &rStorage) const
 }
 
 void SimbodyEngine::convertRadiansToDegrees(TimeSeriesTable& table) const {
-    OPENSIM_THROW_IF(table.getTableMetaData<std::string>("inDegrees") == "yes",
-                     Exception,
-                     "Columns of the table provided are already in degrees.");
+    if (table.hasTableMetaDataKey("inDegrees")) {
+        OPENSIM_THROW_IF(
+            table.getTableMetaData<std::string>("inDegrees") == "yes",
+            Exception,
+            "Columns of the table provided are already in degrees.");
+        table.removeTableMetaDataKey("inDegrees");
+    }
 
     scaleRotationalDofColumns(table, SimTK_RADIAN_TO_DEGREE);
-    table.removeTableMetaDataKey("inDegrees");
     table.addTableMetaData("inDegrees", std::string{"yes"});
 }
 
 void SimbodyEngine::convertDegreesToRadians(TimeSeriesTable& table) const {
-    OPENSIM_THROW_IF(table.getTableMetaData<std::string>("inDegrees") == "no",
-                     Exception,
-                     "Columns of the table provided are already in radians.");
-
-    scaleRotationalDofColumns(table, SimTK_DEGREE_TO_RADIAN);
-    table.removeTableMetaDataKey("inDegrees");
-    table.addTableMetaData("inDegrees", std::string{"no"});
+    if (table.hasTableMetaDataKey("inDegrees")) {
+        OPENSIM_THROW_IF(
+            table.getTableMetaData<std::string>("inDegrees") == "no",
+            Exception,
+            "Columns of the table provided are already in radians.");
+        table.removeTableMetaDataKey("inDegrees");
+        scaleRotationalDofColumns(table, SimTK_DEGREE_TO_RADIAN);
+        table.addTableMetaData("inDegrees", std::string{ "no" });
+    }
+    else {
+        OPENSIM_THROW(Exception,
+            "Table provided does not specify rotations to be in degrees.\n"
+            "No conversion can be applied.");
+    }
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Fixes issue  #2470

### Brief summary of changes
- Explicitly check for Rotational coordinates (instead of not Translational)

### Testing I've completed
- reran opensense IK and loaded calibrated model and resultant motion in OpenSim GUI where patellas moved as expected

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2473)
<!-- Reviewable:end -->
