### PR TITLE
Enable users to "press any key" to quit in the visualizer

### DIFF
--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -239,14 +239,22 @@ Model OpenSenseUtilities::calibrateModelFromOrientations(
         const double accuracy = 1e-4;
         InverseKinematicsSolver ikSolver(model, mRefs, oRefs, coordRefs);
         ikSolver.setAccuracy(accuracy);
+        
+        SimTK::Visualizer& viz = model.updVisualizer().updSimbodyVisualizer();
+        // We use the input silo to get key presses.
+        auto silo = &model.updVisualizer().updInputSilo();
+        silo->clear(); // Ignore any previous key presses.
 
+        SimTK::DecorativeText help("Press any key to quit.");
+        help.setIsScreenText(true);
+        viz.addDecoration(SimTK::MobilizedBodyIndex(0), SimTK::Vec3(0), help);
         model.getVisualizer().getSimbodyVisualizer().setShowSimTime(true);
         ikSolver.assemble(s);
         model.getVisualizer().show(s);
 
-        char c;
-        std::cout << "Press any key and return to close visualizer." << std::endl;
-        std::cin >> c;
+        unsigned key, modifiers;
+        silo->waitForKeyHit(key, modifiers);
+        viz.shutdown();
     }
 
     return model;


### PR DESCRIPTION
Fixes issue #2469

### Brief summary of changes
- removed `cin` wait in the terminal for character that also requires `enter` to be pressed
- added wait for key press in Visualizer, before shutting down the visualizer

### Testing I've completed
- ran `testOpensense` with visualization turned on for calibration with intended behavior
- ran `opensense -C` on the command-line which only requires single key press in visualizer window to close it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2475)
<!-- Reviewable:end -->
