### PR TITLE
Replace hard coded file names with name based on input

### DIFF
--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -309,7 +309,7 @@ TimeSeriesTable_<SimTK::Quaternion> readRotationsFromXSensFiles(const std::strin
     DataAdapter::OutputTables tables = reader.read(directory);
     const TimeSeriesTableQuaternion& quatTableTyped =  reader.getOrientationsTable(tables);
 
-    STOFileAdapter_<SimTK::Quaternion>::write(quatTableTyped, "imuOrientations.sto");
+    STOFileAdapter_<SimTK::Quaternion>::write(quatTableTyped, readerSettings.get_trial_prefix()+"_orientations.sto");
  
     return quatTableTyped;
 }
@@ -323,7 +323,8 @@ TimeSeriesTable_<SimTK::Quaternion> readRotationsFromAPDMFile(const std::string&
     DataAdapter::OutputTables tables = reader.read(apdmCsvFile);
     const TimeSeriesTableQuaternion& quatTableTyped = reader.getOrientationsTable(tables);
 
-    STOFileAdapter_<SimTK::Quaternion>::write(quatTableTyped, "imuOrientations.sto");
+    STOFileAdapter_<SimTK::Quaternion>::write(quatTableTyped, 
+        apdmCsvFile.substr(0, apdmCsvFile.rfind('.'))+"_orientations.sto");
 
     return quatTableTyped;
 }


### PR DESCRIPTION
Fixes issue #2468

### Brief summary of changes
append _orientations to input file name or prefix rather than hardcoded imuOrientations to avoid overwriting user data files.

### Testing I've completed
Ran command line in debugger and got expected file name.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2477)
<!-- Reviewable:end -->
