### PR TITLE
Fix IAA exception when reporting constraint forces

### DIFF
--- a/Applications/Analyze/test/subject02_Setup_IAA_02_232.xml
+++ b/Applications/Analyze/test/subject02_Setup_IAA_02_232.xml
@@ -75,7 +75,7 @@
 					<compute_potentials_only> false </compute_potentials_only>
 					<!--Report individual contributions to constraint reactions in addition to
 					    accelerations.-->
-					<report_constraint_reactions> false </report_constraint_reactions>
+					<report_constraint_reactions> true </report_constraint_reactions>
 				</InducedAccelerations>
 			</objects>
 			<groups/>

--- a/OpenSim/Simulation/SimbodyEngine/Constraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Constraint.cpp
@@ -228,24 +228,24 @@ Array<std::string> Constraint::getRecordLabels() const
     // number of mobilities being directly constrained
     int ncm = simConstraint.getNumConstrainedU(ds);
 
-    const BodySet &bodies = _model->getBodySet();
+    const auto& physicalFrames = _model->getComponentList<PhysicalFrame>();
     
     Array<std::string> labels("");
 
     for(int i=0; i<ncb; ++i){
         const SimTK::MobilizedBody &b = simConstraint.getMobilizedBodyFromConstrainedBody(SimTK::ConstrainedBodyIndex(i));
         const SimTK::MobilizedBodyIndex &bx =  b.getMobilizedBodyIndex();
-        Body *bod = NULL;
-        for(int j=0; j<bodies.getSize(); ++j ){
-            if(bodies[j].getMobilizedBodyIndex() == bx){
-                bod = &bodies[j];
+        const PhysicalFrame *frame = nullptr;
+        for(auto& phf : physicalFrames){
+            if(phf.getMobilizedBodyIndex() == bx){
+                frame = &phf;
                 break;
             }
         }
-        if(bod == NULL){
+        if(frame == nullptr){
             throw Exception("Constraint "+getName()+" does not have an identifiable body index.");
         }
-        string prefix = getName()+"_"+bod->getName();
+        string prefix = getName()+"_"+frame->getName();
         labels.append(prefix+"_Fx");
         labels.append(prefix+"_Fy");
         labels.append(prefix+"_Fz");


### PR DESCRIPTION
Fixes issue #2435 

### Brief summary of changes
Identify constraint's `PhysicalFrame` instead of `Body`. 

### Testing I've completed
- user supplied case works
- enabled reporting of constraint reactions for IAA test case and it produces GRF like totals:
![image](https://user-images.githubusercontent.com/6494122/59225372-66049b80-8b85-11e9-8dff-6874522e8041.png)

### Looking for feedback on...
- none

### CHANGELOG.md (choose one)
- no need to update because this is a simple bug fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2489)
<!-- Reviewable:end -->
