### PR TITLE
If data missing from c3d file, return an empty table 

### DIFF
--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -155,7 +155,13 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
 
         tables.emplace(_markers, marker_table);
     }
-
+    else { // insert empty table
+        std::vector<double> emptyTimes;
+        std::vector<std::string> emptyLabels;
+        SimTK::Matrix_<SimTK::Vec3> noData;
+        auto emptyMarkersTable = std::make_shared<TimeSeriesTableVec3>(emptyTimes, noData, emptyLabels);
+        tables.emplace(_markers, emptyMarkersTable);
+    }
     // This is probably the right way to get the raw forces data from force 
     // platforms. Extract the collection of force platforms.
     auto force_platforms_extractor = btk::ForcePlatformsExtractor::New();
@@ -295,6 +301,13 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
             std::shared_ptr<TimeSeriesTableVec3>(&force_table));
 
         force_table.updTableMetaData().setValueForKey("events", event_table);
+    }
+    else { // insert empty table
+        std::vector<double> emptyTimes;
+        std::vector<std::string> emptyLabels;
+        SimTK::Matrix_<SimTK::Vec3> noData;
+        auto emptyforcesTable = std::make_shared<TimeSeriesTableVec3>(emptyTimes, noData, emptyLabels);
+        tables.emplace(_forces, emptyforcesTable);
     }
 
     return tables;


### PR DESCRIPTION
rather than throw exception downstream

Fixes issue #2421

### Brief summary of changes
Branch of the code that reads data updated to return empty Markers/Forces tables

### Testing I've completed
Stepped through the files in provided dataset and empty tables were created and returned indeed.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- not sure if this needs documentation somewhere since the old behavior was basically a bug. May need mention in changelog.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2495)
<!-- Reviewable:end -->
