### PR TITLE
Throw exception on model files that are before version 1.8.1

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -105,7 +105,7 @@ Model::Model(const string &aFileName) :
     updateFromXMLDocument();
     // Check is done below because only Model files have migration issues, version is not available until 
     // updateFromXMLDocument is called. Fixes core issue #2395
-    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 30000,
+    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 20302,
         Exception,
         "Model file " + aFileName + " is using unsupported file format"
         ". Please open model and save it in OpenSim version 3.3 to upgrade.");

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -105,7 +105,7 @@ Model::Model(const string &aFileName) :
     updateFromXMLDocument();
     // Check is done below because only Model files have migration issues, version is not available until 
     // updateFromXMLDocument is called. Fixes core issue #2395
-    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 20001,
+    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 10901,
         Exception,
         "Model file " + aFileName + " is using unsupported file format"
         ". Please open model and save it in OpenSim version 3.3 to upgrade.");

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -103,6 +103,12 @@ Model::Model(const string &aFileName) :
     constructProperties();
     setNull();
     updateFromXMLDocument();
+    // Check is done below because only Model files have migration issues, version is not available until 
+    // updateFromXMLDocument is called. Fixes core issue #2395
+    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 30000,
+        Exception,
+        "Model file " + aFileName + " is using unsupported file format"
+        ". Please open model and save it in OpenSim version 3.3 to upgrade.");
 
     _fileName = aFileName;
     cout << "Loaded model " << getName() << " from file " << getInputFileName() << endl;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -105,7 +105,7 @@ Model::Model(const string &aFileName) :
     updateFromXMLDocument();
     // Check is done below because only Model files have migration issues, version is not available until 
     // updateFromXMLDocument is called. Fixes core issue #2395
-    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 20302,
+    OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 20001,
         Exception,
         "Model file " + aFileName + " is using unsupported file format"
         ". Please open model and save it in OpenSim version 3.3 to upgrade.");


### PR DESCRIPTION
Fixes issue #2395

### Brief summary of changes
Throw exception when model file format predates version 1.8.1 (document version 10901) since we don't handle the upgrade for these model files.

### Testing I've completed
Loaded model in issue report and Exception was thrown.

### Looking for feedback on...
The text/language of the exception message.

### CHANGELOG.md (choose one)

- no need to update because bugfix?

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2498)
<!-- Reviewable:end -->
