### PR TITLE
Specify/modify the underlying IMU World to OpenSim ground rotation for OpenSense

### DIFF
--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -42,14 +42,6 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
     // OpenSim ground reference frame with Y up and X forward.
     SimTK::Rotation R_XG = sensorToOpenSim;
 
-    //SimTK::Vec3 grav(9.807, 0., 0.);
-    //double theta = acos(avg_accel.transpose() * grav / (avg_accel.norm() * grav.norm()));
-    //SimTK::Vec3 C = SimTK::cross(avg_accel, grav);
-    //C = C / C.norm();
-
-    //SimTK::Rotation tilt_correction = SimTK::Rotation(axisAngleToRotation(C, theta));
-    //R_XG = R_XG * tilt_correction;
-
     int nc = int(quaternionsTable.getNumColumns());
 
     const auto& times = quaternionsTable.getIndependentColumn();

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -35,7 +35,7 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
         const TimeSeriesTableQuaternion& quaternionsTable,
         const SimTK::Array_<int>& startEnd,
         const std::string& baseImuName,
-        const SimTK::CoordinateAxis& baseHeadingAxis,
+        const SimTK::CoordinateDirection& baseHeadingDirection,
         const SimTK::Rotation& sensorToOpenSim)
 {
     // Fixed transform to rotate sensor orientations in world with Z up into the 
@@ -89,7 +89,9 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
         const Rotation& base_R = startRow.getElt(0, int(pix));
 
         // Heading direction of the base IMU in this case the pelvis_imu heading is its ZAxis
-        UnitVec3 pelvisHeading = base_R(baseHeadingAxis);
+        UnitVec3 pelvisHeading = base_R(baseHeadingDirection.getAxis());
+        if(baseHeadingDirection.getDirection() < 0) 
+            pelvisHeading = pelvisHeading.negate();
         UnitVec3 groundX = UnitVec3(1, 0, 0);
         SimTK::Real angularDifference = acos(~pelvisHeading*groundX);
 

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -35,16 +35,12 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
         const TimeSeriesTableQuaternion& quaternionsTable,
         const SimTK::Array_<int>& startEnd,
         const std::string& baseImuName,
-        const SimTK::CoordinateAxis& baseHeadingAxis)
+        const SimTK::CoordinateAxis& baseHeadingAxis,
+        const SimTK::Rotation& sensorToOpenSim)
 {
-
     // Fixed transform to rotate sensor orientations in world with Z up into the 
     // OpenSim ground reference frame with Y up and X forward.
-    SimTK::Rotation R_XG = SimTK::Rotation(
-        SimTK::BodyOrSpaceType::BodyRotationSequence,
-        -SimTK_PI / 2, SimTK::XAxis,
-        0, SimTK::YAxis,
-        0, SimTK::ZAxis);
+    SimTK::Rotation R_XG = sensorToOpenSim;
 
     //SimTK::Vec3 grav(9.807, 0., 0.);
     //double theta = acos(avg_accel.transpose() * grav / (avg_accel.norm() * grav.norm()));

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -56,7 +56,7 @@ namespace OpenSim {
                 const SimTK::Array_<int>& startEnd = { 0, 1 },
                 const std::string& baseImuName = "",
                 const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis,
-                const SimTK::Rotation& sensorToOpenSim = 
+                const SimTK::Rotation_<double>& sensorToOpenSim = 
                     SimTK::Rotation(-SimTK_PI/2, SimTK::XAxis)
         );
         /// @}

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -45,7 +45,11 @@ namespace OpenSim {
             a heading correction on all the experimental (quaternion) data so that
             when tracking rotation data, the initial pose of the model is facing
             forward. If the baseImuName is empty, no correction is made. If no
-            axis is specified, the default is the Z axis.*/
+            axis is specified, the default is the Z axis. Final optional argument
+            is the Rotation matrix that maps the IMU World reference frame to
+            OpenSim's ground reference frame. The default is to rotate -Pi/2
+            about the IMU world X-axis to get IMU World Z-axis to point up as
+            OpenSim's ground Y-axis.*/
         static  OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>> 
             convertQuaternionsToRotations(
                 const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable,

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -55,7 +55,7 @@ namespace OpenSim {
                 const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable,
                 const SimTK::Array_<int>& startEnd = { 0, 1 },
                 const std::string& baseImuName = "",
-                const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis,
+                const SimTK::CoordinateDirection& baseHeadingDirection = SimTK::ZAxis,
                 const SimTK::Rotation_<double>& sensorToOpenSim = 
                     SimTK::Rotation(-SimTK_PI/2, SimTK::XAxis)
         );

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -46,11 +46,14 @@ namespace OpenSim {
             when tracking rotation data, the initial pose of the model is facing
             forward. If the baseImuName is empty, no correction is made. If no
             axis is specified, the default is the Z axis.*/
-        static  OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>>  convertQuaternionsToRotations(
-            const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable,
-            const SimTK::Array_<int>& startEnd = { 0, 1 },
-            const std::string& baseImuName = "",
-            const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis
+        static  OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>> 
+            convertQuaternionsToRotations(
+                const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable,
+                const SimTK::Array_<int>& startEnd = { 0, 1 },
+                const std::string& baseImuName = "",
+                const SimTK::CoordinateAxis& baseHeadingAxis = SimTK::ZAxis,
+                const SimTK::Rotation& sensorToOpenSim = 
+                    SimTK::Rotation(-SimTK_PI/2, SimTK::XAxis)
         );
         /// @}
         /** Create a calibrated model from a model in the calibration pose and 

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -45,7 +45,7 @@ namespace OpenSim {
             a heading correction on all the experimental (quaternion) data so that
             when tracking rotation data, the initial pose of the model is facing
             forward. If the baseImuName is empty, no correction is made. If no
-            axis is specified, the default is the Z axis. Final optional argument
+            direction is specified, the default is the Z axis. Final optional argument
             is the Rotation matrix that maps the IMU World reference frame to
             OpenSim's ground reference frame. The default is to rotate -Pi/2
             about the IMU world X-axis to get IMU World Z-axis to point up as


### PR DESCRIPTION
Fixes issue #2463

### Brief summary of changes
- Added another optional argument to `OpenSense::convertQuaternionsToRotations` which is the assumed sensor world to opensim transform.  It has a default that works for most IMUs with Z-axis up (gravity) and X is the magnetic north direction.

### Testing I've completed
- test produce the same result as before with the default argument.

### Looking for feedback on...
- testing with marker-based orientations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2501)
<!-- Reviewable:end -->
