### PR TITLE
Add no visualization option

### DIFF
--- a/OpenSim/Common/ModelDisplayHints.h
+++ b/OpenSim/Common/ModelDisplayHints.h
@@ -53,6 +53,7 @@ your component produces. The currently-supported flags are:
   - show frames
   - show labels
   - show debug geometry
+  - no visualization
 
 This class is intended to provide some minimal user control over generated
 geometry in a form that is easy for a ModelComponent author to deal with, since
@@ -102,6 +103,10 @@ public:
     OpenSim_DECLARE_PROPERTY(show_debug_geometry, bool,
         "Flag to indicate whether or not to show debug geometry, default to false.");
 
+    OpenSim_DECLARE_PROPERTY(no_visualization, bool,
+        "Flag to indicate whether or not to show geometry from mesh files, default to false.");
+
+
     /** Default construction creates a valid display hints object with all
     hints set to their default values. **/
     ModelDisplayHints() { constructProperties(); }
@@ -120,6 +125,7 @@ private:
         constructProperty_show_labels(false);
         constructProperty_show_forces(true);
         constructProperty_show_debug_geometry(false);
+        constructProperty_no_visualization(false);
     }
 };
 

--- a/OpenSim/Common/ModelDisplayHints.h
+++ b/OpenSim/Common/ModelDisplayHints.h
@@ -103,10 +103,6 @@ public:
     OpenSim_DECLARE_PROPERTY(show_debug_geometry, bool,
         "Flag to indicate whether or not to show debug geometry, default to false.");
 
-    OpenSim_DECLARE_PROPERTY(no_visualization, bool,
-        "Flag to indicate whether or not to show geometry from mesh files, default to false.");
-
-
     /** Default construction creates a valid display hints object with all
     hints set to their default values. **/
     ModelDisplayHints() { constructProperties(); }
@@ -125,7 +121,6 @@ private:
         constructProperty_show_labels(false);
         constructProperty_show_forces(true);
         constructProperty_show_debug_geometry(false);
-        constructProperty_no_visualization(false);
     }
 };
 

--- a/OpenSim/Common/ModelDisplayHints.h
+++ b/OpenSim/Common/ModelDisplayHints.h
@@ -53,7 +53,6 @@ your component produces. The currently-supported flags are:
   - show frames
   - show labels
   - show debug geometry
-  - no visualization
 
 This class is intended to provide some minimal user control over generated
 geometry in a form that is easy for a ModelComponent author to deal with, since

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -240,7 +240,7 @@ void Mesh::extendFinalizeFromProperties() {
         const Model* ownerModel = dynamic_cast<const Model*>(rootModel);
 
         //No visualization don't try to load meshes
-        if (!ownerModel->getUseVisualizer())
+        if (!ownerModel->visualizationIsEnabled())
             return;
 
         // Current interface to Visualizer calls generateDecorations on every

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -237,6 +237,11 @@ void Mesh::extendFinalizeFromProperties() {
             std::cout << "Mesh " << get_mesh_file() << " not connected to model..ignoring" << std::endl;
             return;   // Orphan Mesh not descendant of a model
         }
+        const Model* ownerModel = dynamic_cast<const Model*>(rootModel);
+
+        //No visualization don't try to load meshes
+        if (ownerModel->get_ModelVisualPreferences().get_ModelDisplayHints().get_no_visualization())
+            return;
 
         // Current interface to Visualizer calls generateDecorations on every
         // frame. On first time through, load file and create DecorativeMeshFile

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -240,7 +240,7 @@ void Mesh::extendFinalizeFromProperties() {
         const Model* ownerModel = dynamic_cast<const Model*>(rootModel);
 
         //No visualization don't try to load meshes
-        if (ownerModel->isVisualizationDisabled())
+        if (!ownerModel->isMeshVisualizationEnabled())
             return;
 
         // Current interface to Visualizer calls generateDecorations on every

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -240,7 +240,7 @@ void Mesh::extendFinalizeFromProperties() {
         const Model* ownerModel = dynamic_cast<const Model*>(rootModel);
 
         //No visualization don't try to load meshes
-        if (!ownerModel->isMeshVisualizationEnabled())
+        if (!ownerModel->getUseVisualizer())
             return;
 
         // Current interface to Visualizer calls generateDecorations on every

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -240,7 +240,7 @@ void Mesh::extendFinalizeFromProperties() {
         const Model* ownerModel = dynamic_cast<const Model*>(rootModel);
 
         //No visualization don't try to load meshes
-        if (ownerModel->get_ModelVisualPreferences().get_ModelDisplayHints().get_no_visualization())
+        if (ownerModel->isVisualizationDisabled())
             return;
 
         // Current interface to Visualizer calls generateDecorations on every

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -328,7 +328,16 @@ public:
     ModelVisualizer that provides visualization and interaction with the %Model
     as it is executing. The default is no visualization. 
     @see getModelVisualizer() **/
-    void setUseVisualizer(bool visualize) {_useVisualizer=visualize;}
+    void setUseVisualizer(bool visualize) {
+        _useVisualizer=visualize;
+        enableVisualization(visualize);
+    }
+
+    void enableVisualization(bool enable) {
+        // Propagate flag so that meshes are loaded (or not)
+        upd_ModelVisualPreferences().setVisualize(enable);
+        finalizeFromProperties();
+    }
     /** Return the current setting of the "use visualizer" flag, which will
     take effect at the next call to initSystem() on this %Model. **/
     bool getUseVisualizer() const {return _useVisualizer;}
@@ -1064,15 +1073,6 @@ public:
         SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const 
                                                                 override;
     /**@}**/
-    // Turn off visualization/loading of meshes for this model
-    // initSystem must be invoked after this call for it to take effect. 
-    void disableMeshVisualization() {
-        upd_ModelVisualPreferences().set_load_mesh_files(false);
-    }
-    // Return flag indicating visualization status for meshes
-    bool isMeshVisualizationEnabled() const {
-        return get_ModelVisualPreferences().get_load_mesh_files();
-    }
 
     //--------------------------------------------------------------------------
 

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -332,11 +332,15 @@ public:
         _useVisualizer=visualize;
         enableVisualization(visualize);
     }
-
+    // Enable visualization overall, loading mesh files etc.
     void enableVisualization(bool enable) {
         // Propagate flag so that meshes are loaded (or not)
         upd_ModelVisualPreferences().setVisualize(enable);
         finalizeFromProperties();
+    }
+    // Return status if visualize flag (different from useVisualizer)
+    bool visualizationIsEnabled() const {
+        return get_ModelVisualPreferences().visualize();
     }
     /** Return the current setting of the "use visualizer" flag, which will
     take effect at the next call to initSystem() on this %Model. **/

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1066,12 +1066,12 @@ public:
     /**@}**/
     // Turn off visualization/loading of meshes for this model
     // initSystem must be invoked after this call for it to take effect. 
-    void disableVisualization() {
-        upd_ModelVisualPreferences().set_no_visualization(true);
+    void disableMeshVisualization() {
+        upd_ModelVisualPreferences().set_load_mesh_files(false);
     }
-    // Return flag indicating if visualization has been turned off
-    bool isVisualizationDisabled() const {
-        return get_ModelVisualPreferences().get_no_visualization();
+    // Return flag indicating visualization status for meshes
+    bool isMeshVisualizationEnabled() const {
+        return get_ModelVisualPreferences().get_load_mesh_files();
     }
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1064,7 +1064,16 @@ public:
         SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const 
                                                                 override;
     /**@}**/
-    
+    // Turn off visualization/loading of meshes for this model
+    // initSystem must be invoked after this call for it to take effect. 
+    void disableVisualization() {
+        upd_ModelVisualPreferences().set_no_visualization(true);
+    }
+    // Return flag indicating if visualization has been turned off
+    bool isVisualizationDisabled() const {
+        return get_ModelVisualPreferences().get_no_visualization();
+    }
+
     //--------------------------------------------------------------------------
 
 private:

--- a/OpenSim/Simulation/Model/ModelVisualPreferences.h
+++ b/OpenSim/Simulation/Model/ModelVisualPreferences.h
@@ -54,6 +54,9 @@ public:
     OpenSim_DECLARE_UNNAMED_PROPERTY(ModelDisplayHints,
         "Model display preferences");
 
+    OpenSim_DECLARE_PROPERTY(no_visualization, bool,
+        "Flag to indicate whether or not to show geometry from mesh files, default to false.");
+
     //--------------------------------------------------------------------------
     // CONSTRUCTION
     //--------------------------------------------------------------------------
@@ -66,6 +69,7 @@ public:
 private:
     void constructProperties() {
         constructProperty_ModelDisplayHints(ModelDisplayHints());
+        constructProperty_no_visualization(false);
     }
 //=============================================================================
 };  // END of class ModelVisualPreferences

--- a/OpenSim/Simulation/Model/ModelVisualPreferences.h
+++ b/OpenSim/Simulation/Model/ModelVisualPreferences.h
@@ -53,10 +53,6 @@ public:
     //==========================================================================
     OpenSim_DECLARE_UNNAMED_PROPERTY(ModelDisplayHints,
         "Model display preferences");
-
-    OpenSim_DECLARE_PROPERTY(load_mesh_files, bool,
-        "Flag to indicate whether or not to show geometry from mesh files, default to true.");
-
     //--------------------------------------------------------------------------
     // CONSTRUCTION
     //--------------------------------------------------------------------------
@@ -66,11 +62,17 @@ public:
     }
     virtual ~ModelVisualPreferences() {};
 
+    bool visualize() const {
+        return _visualize;
+    }
+    void setVisualize(bool visualizationStatus) {
+        _visualize = visualizationStatus;
+    }
 private:
     void constructProperties() {
         constructProperty_ModelDisplayHints(ModelDisplayHints());
-        constructProperty_load_mesh_files(true);
     }
+    bool _visualize;
 //=============================================================================
 };  // END of class ModelVisualPreferences
 //=============================================================================

--- a/OpenSim/Simulation/Model/ModelVisualPreferences.h
+++ b/OpenSim/Simulation/Model/ModelVisualPreferences.h
@@ -54,8 +54,8 @@ public:
     OpenSim_DECLARE_UNNAMED_PROPERTY(ModelDisplayHints,
         "Model display preferences");
 
-    OpenSim_DECLARE_PROPERTY(no_visualization, bool,
-        "Flag to indicate whether or not to show geometry from mesh files, default to false.");
+    OpenSim_DECLARE_PROPERTY(load_mesh_files, bool,
+        "Flag to indicate whether or not to show geometry from mesh files, default to true.");
 
     //--------------------------------------------------------------------------
     // CONSTRUCTION
@@ -69,7 +69,7 @@ public:
 private:
     void constructProperties() {
         constructProperty_ModelDisplayHints(ModelDisplayHints());
-        constructProperty_no_visualization(false);
+        constructProperty_load_mesh_files(true);
     }
 //=============================================================================
 };  // END of class ModelVisualPreferences

--- a/OpenSim/Tools/Test/testVisualization.cpp
+++ b/OpenSim/Tools/Test/testVisualization.cpp
@@ -121,14 +121,16 @@ int main()
         LoadOpenSimLibrary("osimActuators");
         
         Model testModel("BuiltinGeometry.osim");
+        testModel.enableVisualization(true);
         testVisModel(testModel, "vis_BuiltinGeometry.txt");
         std::cout << "BuiltinGeometry Passed" << std::endl;
         Model testModel2 = createModel4AppearanceTest();
+        testModel2.enableVisualization(true);
         testVisModel(testModel2, "vis_AppearanceTest.txt");
         std::cout << "Appearance test Passed" << std::endl;
         // Load Model in 3.3 format that had transforms attached to Geometry
         Model testModel3("double_pendulum33.osim");
-        
+        testModel3.enableVisualization(true);
         SimTK::Array_<DecorativeGeometry> standard;
         testModel3.updDisplayHints().set_show_frames(true);
         populate_doublePendulumPrimitives(standard);
@@ -138,17 +140,20 @@ int main()
         // Now a model from 3.3 where both GeometrySet and individual DisplayGeometry 
         // have a non-trivial transform.
         Model composedTransformsModel("doubletransform33.osim");
+        composedTransformsModel.enableVisualization(true);
         composedTransformsModel.updDisplayHints().set_show_frames(true);
         populate_composedTransformPrimitives(standard);
         testVisModelAgainstStandard(composedTransformsModel, standard);
         // Model with contacts
         Model modelWithContacts("visualize_contacts.osim");
+        modelWithContacts.enableVisualization(true);
         modelWithContacts.updDisplayHints().set_show_frames(true);
         populate_contactModelPrimitives(standard);
         testVisModelAgainstStandard(modelWithContacts, standard);
         
         // Model with WrapObjects
         Model modelWithWrap("test_wrapAllVis.osim");
+        modelWithWrap.enableVisualization(true);
         modelWithWrap.updDisplayHints().set_show_frames(true);
         populate_wrapModelPrimitives(standard);
         modelWithWrap.updDisplayHints().set_show_frames(false);


### PR DESCRIPTION
Fixes issue #2375

### Brief summary of changes
Introduce a Property in ModelVisualPreferences to turn off loading mesh files.

### Testing I've completed
Modified a test case that loads a model and produce missing vtp files warning, then set flag to no_visualization, printed the model. Got no warning on reading model back.

### Looking for feedback on...
1. We could do this without using the Property mechanism by passing an argument to the constructor but that would require more changes to API programs. 
2. Default value was discussed with @jimmyDunne and he prefers default to no visualization.
3. We could use this flag more widely to generateDecorations but that would be a bigger change.
4. There's no convenience method to turn visualization back on, can be done through Property methods.

### CHANGELOG.md (choose one)
- Not modified pending agreement on behavior

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2522)
<!-- Reviewable:end -->
