### PR TITLE
Use python3 as default on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -269,7 +269,7 @@ script:
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/sdk/Python; fi
   # Run the python tests, verbosely.
-  - if [ "$WRAP" = "on" ]; then /usr/bin/python3 -m unittest discover --start-directory opensim/tests --verbose; fi
+  - if [ "$WRAP" = "on" ]; then python3 -m unittest discover --start-directory opensim/tests --verbose; fi
     
   ## Set up ssh for sourceforge.
   - if [[ "$DEPLOY" = "yes" || ("$DOXY" = "on" && "$TRAVIS_OS_NAME" = "linux" && "$TRAVIS_PULL_REQUEST" != "false") ]]; then PREP_SOURCEFORGE_SSH=0; else PREP_SOURCEFORGE_SSH=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,6 @@ before_install:
   # Avoid "Homebrew must be run under Ruby 2.3!"
   # https://github.com/PowerShell/PowerShell/issues/5062
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  # install python3 from brew
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python; fi
   
   ## Ensure that there are no tabs in source code.
   # GREP returns 0 (true) if there are any matches, and
@@ -228,7 +226,7 @@ install:
   # Bindings.
   - OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=$WRAP -DBUILD_JAVA_WRAPPING=$WRAP -DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
   # On Mac, use system python instead of Homebrew python.
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then OSIM_CMAKE_ARGS+=(-DPYTHON_EXECUTABLE=/usr/bin/python3); fi
+  #- if [ "$TRAVIS_OS_NAME" = "osx" ]; then OSIM_CMAKE_ARGS+=(-DPYTHON_EXECUTABLE=/usr/bin/python3); fi
   
   # Doxygen.
   - OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off -DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simtk.org/api_docs/simbody/latest/")

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ addons:
       - valgrind
       # To build doxygen documentation.
       # TOO OLD; see below. - doxygen
+      - "python3"
+      - "python3-pip"
   # To avoid being prompted when ssh'ing into sourceforge.
   ssh_known_hosts:
       # For uploading doxygen.

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,8 @@ addons:
       - valgrind
       # To build doxygen documentation.
       # TOO OLD; see below. - doxygen
-      - "python3"
-      - "python3-pip"
+      - python3
+      - python3-pip
   # To avoid being prompted when ssh'ing into sourceforge.
   ssh_known_hosts:
       # For uploading doxygen.
@@ -268,7 +268,7 @@ script:
   # Go to the python wrapping package directory.
   - if [ "$WRAP" = "on" ]; then cd $OPENSIM_HOME/sdk/Python; fi
   # Run the python tests, verbosely.
-  - if [ "$WRAP" = "on" ]; then /usr/bin/python -m unittest discover --start-directory opensim/tests --verbose; fi
+  - if [ "$WRAP" = "on" ]; then /usr/bin/python3 -m unittest discover --start-directory opensim/tests --verbose; fi
     
   ## Set up ssh for sourceforge.
   - if [[ "$DEPLOY" = "yes" || ("$DOXY" = "on" && "$TRAVIS_OS_NAME" = "linux" && "$TRAVIS_PULL_REQUEST" != "false") ]]; then PREP_SOURCEFORGE_SSH=0; else PREP_SOURCEFORGE_SSH=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ addons:
       - valgrind
       # To build doxygen documentation.
       # TOO OLD; see below. - doxygen
+      # python3 as linux and osx are still on python2
       - python3
       - python3-pip
   # To avoid being prompted when ssh'ing into sourceforge.
@@ -112,6 +113,8 @@ before_install:
   # Avoid "Homebrew must be run under Ruby 2.3!"
   # https://github.com/PowerShell/PowerShell/issues/5062
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  # install python3 from brew
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python; fi
   
   ## Ensure that there are no tabs in source code.
   # GREP returns 0 (true) if there are any matches, and

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,7 +225,7 @@ install:
   # Bindings.
   - OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=$WRAP -DBUILD_JAVA_WRAPPING=$WRAP -DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
   # On Mac, use system python instead of Homebrew python.
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then OSIM_CMAKE_ARGS+=(-DPYTHON_EXECUTABLE=/usr/bin/python); fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then OSIM_CMAKE_ARGS+=(-DPYTHON_EXECUTABLE=/usr/bin/python3); fi
   
   # Doxygen.
   - OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off -DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simtk.org/api_docs/simbody/latest/")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Other Changes
 - Performance of reading large data files has been significantly improved. A 50MB .sto file would take 10-11 min to read now takes 2-3 seconds. (PR #2399)
 - Added Matlab example script of plotting the Force-length properties of muscles in a models; creating an Actuator file from a model; 
 building and simulating a simple arm model;  using OutputReporters to record and write marker location and coordinate values to file.
-
+- OpenSim 4.1 ships with Python3 bindings as default. It is still possible to create bindings for Python2 if desired by setting CMake variable OPENSIM_PYTHON_VERSION to 2
 
 v4.0
 ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,7 +392,7 @@ set(BUILD_JAVA_WRAPPING OFF CACHE BOOL "Build Java wrapping (needed if you're bu
 
 set(BUILD_PYTHON_WRAPPING OFF CACHE BOOL "Build Python wrapping (needed if you're building the Python wrapping; requires that you have SWIG and Python installed on your machine.)")
 
-set(OPENSIM_PYTHON_VERSION 2 CACHE STRING
+set(OPENSIM_PYTHON_VERSION 3 CACHE STRING
     "The major Python version (2 or 3) for which to build the wrapping.")
 # To create a drop-down in the CMake GUI:
 set_property(CACHE OPENSIM_PYTHON_VERSION PROPERTY STRINGS "2" "3")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ branches:
   - /^(?i:devprop).*$/
 
 init:
-  # Note: python 3.7 32bit is already on the path. We want v3.7 64bit,
+  # Note: There could be other versions of python on the path. We want v3.7 64bit,
   # so we must add v3.7 64bit earlier on the PATH so that CMake finds it when
   # configuring.
   # The Scripts directory is for putting nosetests on the path.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ nuget:
 environment:
   CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
   JAVA_DIR: "C:\\Program Files\\Java\\jdk1.8.0"
-  PYTHON_DIR: "C:\\Python27-x64"
+  PYTHON_DIR: "C:\\Python37-x64"
   matrix:
     - CMAKE_TOOLSET: "v140"
       NUGET_PACKAGE_ID_SUFFIX: "-VC140"
@@ -40,8 +40,8 @@ branches:
   - /^(?i:devprop).*$/
 
 init:
-  # Note: python 2.7 32bit is already on the path. We want v2.7 64bit,
-  # so we must add v2.7 64bit earlier on the PATH so that CMake finds it when
+  # Note: python 3.7 32bit is already on the path. We want v3.7 64bit,
+  # so we must add v3.7 64bit earlier on the PATH so that CMake finds it when
   # configuring.
   # The Scripts directory is for putting nosetests on the path.
   # http://www.appveyor.com/docs/installed-software


### PR DESCRIPTION
Fixes issue #0
Make Python 3 the default on CI

### Brief summary of changes
Change CMake option to default PYTHON_OPENSIM_VERSION set to 3.
Fix ci files accordingly.

### Testing I've completed
Built locally and tests pass on windows

### Looking for feedback on...

### CHANGELOG.md (choose one)

- Will update once we agree to merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2525)
<!-- Reviewable:end -->
