### PR TITLE
Make warnBeforePrint throw exception unless raised debug level.

### DIFF
--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -796,7 +796,7 @@ void testActuatorsCombination()
     pointActuator->set_direction(forceUnitAxis);
     pointActuator->set_point(Vec3(0, blockSideLength/2,0));
     model->addForce(pointActuator);
-
+    model->finalizeConnections(); // Needed so connections have correct path
     // ------ build the model -----
     model->print("TestActuatorCombinationModel.osim");
     model->setUseVisualizer(false);

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -796,7 +796,7 @@ void testActuatorsCombination()
     pointActuator->set_direction(forceUnitAxis);
     pointActuator->set_point(Vec3(0, blockSideLength/2,0));
     model->addForce(pointActuator);
-    model->finalizeConnections(); // Needed so connections have correct path
+    model->finalizeConnections(); // Needed so sockets have correct path
     // ------ build the model -----
     model->print("TestActuatorCombinationModel.osim");
     model->setUseVisualizer(false);

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -308,6 +308,7 @@ void simulateMuscle(
     jointWorkProbe->setOperation("integrate");
     model.addProbe(jointWorkProbe);
 
+    model.finalizeConnections(); // Needed so sockets have correct absolute path on print
     /* Since all components are allocated on the stack don't have model 
        own them (and try to free)*/
 //  model.disownAllComponents();
@@ -732,6 +733,7 @@ void testThelen2003Muscle()
             SimTK::SignificantReal, __FILE__, __LINE__,
             "minimum_activation was not set in activation model");
 
+        myModel.finalizeConnections();  // Needed so sockets have correct absolute path on print
         // Print model and read back in.
         myModel.print(filename);
         Model myModel2(filename);

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1795,6 +1795,7 @@ void Component::warnBeforePrint() const {
                 << "::print(): The following connections are not finalized "
                    "and will not appear in the resulting XML file. "
                    "Call finalizeConnections() before print().\n"
+                   "To ignore, please call Object::setDebugLevel(1) first.\n"
                 << message << std::endl;
     }
 }

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1791,12 +1791,14 @@ void Component::warnBeforePrint() const {
         }
     }
     if (!message.empty()) {
-        std::cout << "Warning in " << getConcreteClassName()
+        std::stringstream buffer;
+        buffer << "Warning in " << getConcreteClassName()
                 << "::print(): The following connections are not finalized "
                    "and will not appear in the resulting XML file. "
                    "Call finalizeConnections() before print().\n"
                    "To ignore, please call Object::setDebugLevel(1) first.\n"
                 << message << std::endl;
+        OPENSIM_THROW_FRMOBJ(Exception, buffer.str());
     }
 }
 

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1796,7 +1796,8 @@ void Component::warnBeforePrint() const {
                 << "::print(): The following connections are not finalized "
                    "and will not appear in the resulting XML file. "
                    "Call finalizeConnections() before print().\n"
-                   "To ignore, please call Object::setDebugLevel(1) first.\n"
+                   "To ignore, set the debug level to at least 1 "
+                   "(e.g, by calling Object::setDebugLevel(1)) first.\n"
                 << message << std::endl;
         OPENSIM_THROW_FRMOBJ(Exception, buffer.str());
     }

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1367,9 +1367,15 @@ setAllPropertiesUseDefault(bool aUseDefault)
 bool Object::
 print(const string &aFileName) const
 {
-    try {
+    // Default to strict exception to avoid creating bad files
+    // but for debugging allow users to be more lenient.
+    if (_debugLevel >= 1) { 
+        try {
+            warnBeforePrint();
+        } catch (...) {}
+    }
+    else
         warnBeforePrint();
-    } catch (...) {}
     // Temporarily change current directory so that inlined files are written to correct relative directory
     std::string savedCwd = IO::getCwd();
     IO::chDir(IO::getParentDirectory(aFileName));

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -815,7 +815,7 @@ private:
      * printing is aborted.
      * Derived classes can use this as an opportunity to issue warnings to users.
      */
-    virtual void warnBeforePrint(bool debug) const {}
+    virtual void warnBeforePrint() const {}
 
 //==============================================================================
 // DATA

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -596,7 +596,9 @@ public:
     /** Write this %Object into an XML file of the given name; conventionally
     the suffix to use is ".osim". This is useful for writing out a Model that
     has been created programmatically, and also very useful for testing and
-    debugging. **/
+    debugging. If object has invalid connections, then printing is aborted.
+    You can override this behavior by calling Object::setDebugLevel(1) prior
+    to printing. **/
     bool print(const std::string& fileName) const;
 
     /** dump the XML representation of this %Object into an std::string and return it.
@@ -808,12 +810,12 @@ private:
     void updateDefaultObjectsFromXMLNode();
     void updateDefaultObjectsXMLNode(SimTK::Xml::Element& aParent);
 
-    /** This is invoked at the start of print(). Derived classes can use this
-     * as an opportunity to issue warnings to users.
-     * Any exception thrown in this function is ignored, as exceptions would
-     * prevent the user from printing the object, which could be useful for
-     * debugging. */
-    virtual void warnBeforePrint() const {}
+    /** This is invoked at the start of print() if second argument to print is true
+     * printing is allowed to proceed even if the resulting file is corrupt, otherwise
+     * printing is aborted.
+     * Derived classes can use this as an opportunity to issue warnings to users.
+     */
+    virtual void warnBeforePrint(bool debug) const {}
 
 //==============================================================================
 // DATA

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -810,7 +810,7 @@ private:
     void updateDefaultObjectsFromXMLNode();
     void updateDefaultObjectsXMLNode(SimTK::Xml::Element& aParent);
 
-    /** This is invoked at the start of print() if second argument to print is true
+    /** This is invoked at the start of print() if _debugLevel is greater than 0 then
      * printing is allowed to proceed even if the resulting file is corrupt, otherwise
      * printing is aborted.
      * Derived classes can use this as an opportunity to issue warnings to users.

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -597,8 +597,8 @@ public:
     the suffix to use is ".osim". This is useful for writing out a Model that
     has been created programmatically, and also very useful for testing and
     debugging. If object has invalid connections, then printing is aborted.
-    You can override this behavior by calling Object::setDebugLevel(1) prior
-    to printing. **/
+    You can override this behavior by setting the debug level to at least 1 
+    (e.g., Object::setDebugLevel(1)) prior to printing. **/
     bool print(const std::string& fileName) const;
 
     /** dump the XML representation of this %Object into an std::string and return it.
@@ -810,7 +810,7 @@ private:
     void updateDefaultObjectsFromXMLNode();
     void updateDefaultObjectsXMLNode(SimTK::Xml::Element& aParent);
 
-    /** This is invoked at the start of print() if _debugLevel is greater than 0 then
+    /** This is invoked at the start of print(). If _debugLevel is at least 1 then
      * printing is allowed to proceed even if the resulting file is corrupt, otherwise
      * printing is aborted.
      * Derived classes can use this as an opportunity to issue warnings to users.

--- a/OpenSim/Examples/BuildDynamicWalker/BuildDynamicWalkerModel.cpp
+++ b/OpenSim/Examples/BuildDynamicWalker/BuildDynamicWalkerModel.cpp
@@ -333,6 +333,7 @@ int main() {
         CoordinateLimitForce* clfRKnee = new CoordinateLimitForce("RKnee_rz",
             0, 1e6, -100, 1e6, 1e5, 5);
         osimModel.addForce(clfRKnee);
+        osimModel.finalizeConnections(); // Needed so sockets have correct absolute path on print
 
         // Save the model to a file
         osimModel.print("DynamicWalkerModel.osim");

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -928,7 +928,7 @@ void testExpressionBasedBushingForceTranslational()
     spring.setName("translational_linear_bushing");
     
     osimModel.addForce(&spring);
-    
+    osimModel.finalizeConnections();
     osimModel.print("ExpressionBasedBushingForceTranslationalModel.osim");
     
     // Create the force reporter
@@ -1048,7 +1048,7 @@ void testExpressionBasedBushingForceRotational()
     spring.setName("rotational_linear_bushing");
 
     osimModel.addForce(&spring);
-
+    osimModel.finalizeConnections();
     osimModel.print("ExpressionBasedBushingForceRotationalModel.osim");
 
     // Create the force reporter
@@ -1602,6 +1602,7 @@ void testExternalForce()
     ExternalForce xf(forces, "force", "point", "", "tower", "ground", "ground");
     
     model.addForce(&xf);
+    model.finalizeConnections(); // Needed so sockets have correct absolute path on print
     model.print("ExternalForceTest.osim");
     ForceReporter frp;
     model.addAnalysis(&frp);

--- a/OpenSim/Tests/AddComponents/testAddComponents.cpp
+++ b/OpenSim/Tests/AddComponents/testAddComponents.cpp
@@ -340,6 +340,7 @@ int main()
         addComponentsToModel(osimModel);
 
         osimModel.printSubcomponentInfo();
+        osimModel.finalizeConnections(); // Needed so sockets have correct absolute path on print
 
         // Save the model to a file
         osimModel.print(osimModel.getName()+".osim");


### PR DESCRIPTION
Fixes issue #<issue_number>

### Brief summary of changes
Make warnBeforePrint method throw an exception if it detects missing connections rather than quietly produce corrupt model files. 

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2529)
<!-- Reviewable:end -->
