### PR TITLE
Weaken StatesTrajectory::isCompatibleWith()

### DIFF
--- a/OpenSim/Simulation/StatesTrajectory.cpp
+++ b/OpenSim/Simulation/StatesTrajectory.cpp
@@ -98,12 +98,9 @@ bool StatesTrajectory::isCompatibleWith(const Model& model) const {
     // need to check if the first one is compatible with the model.
     const auto& state0 = get(0);
 
-    if (model.getNumStateVariables() != state0.getNY()) {
-        return false;
-    }
-    if (model.getNumCoordinates() != state0.getNQ()) {
-        return false;
-    }
+    // We only check the number of speeds because OpenSim does not count
+    // quaternion slots, while the SimTK State contains quaternion slots even if
+    // quaternions are not used.
     if (model.getNumSpeeds() != state0.getNU()) {
         return false;
     }

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -252,8 +252,6 @@ public:
     /** Weak check for if the trajectory can be used with the given model.
      * Returns true if the trajectory isConsistent() and if the following
      * quantities are the same:
-     * - number of model state variables and number of Y's in the state 
-     * - number of coordinates in the model and number of Q's in state
      * - number of speeds in the model and number of U's in state
      *
      * Returns false otherwise. This method **cannot** guarantee that the

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -250,9 +250,8 @@ public:
     bool isConsistent() const;
 
     /** Weak check for if the trajectory can be used with the given model.
-     * Returns true if the trajectory isConsistent() and if the following
-     * quantities are the same:
-     * - number of speeds in the model and number of U's in state
+     * Returns true if the trajectory isConsistent() and if the number of speeds
+     * in the model matches the number of U's in state.
      *
      * Returns false otherwise. This method **cannot** guarantee that the
      * trajectory will work with the given model, and makes no attempt to


### PR DESCRIPTION
The current implementation of StatesTrajectory::isCompatibleWith() does not properly handle models with (unused) quaternion slots. This PR removes checks that would incorrectly fail for models and states that are actually compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2539)
<!-- Reviewable:end -->
