### PR TITLE
Wrap printing of object parsing and muscle negative force warnings with Object::_debugLevel 

### DIFF
--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -857,10 +857,12 @@ private:
     // a "defaults" section.
     static bool _serializeAllDefaults;
 
-    // Debug level: 
-    //  0: Hides non fatal warnings 
-    //  1: Shows illegal tags 
-    //  2: level 1 + registration troubleshooting
+    // Debug level:
+    // -1: Quiet mode, no warnings printed.
+    //  0: Print upon successful load of model, external loads, etc. Print 
+    //     warnings for muscles with negative force.
+    //  1: Shows illegal tags. 
+    //  2: level 1 + registration troubleshooting.
     //  3: 2 + more verbose troubleshooting of Object (de)serialization. When 
     //     used from Java wrapping in GUI/Matlab this catches all exceptions 
     //     thrown by the low-level libraries which is slower but helpful in 

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -224,9 +224,10 @@ Storage::Storage(const string &fileName, bool readHeadersOnly) :
     }
 
     // Process file as if it were a .mot file
-
-    // cout << "Storage: read data file =" << fileName
-    //    << " (nr=" << nr << " nc=" << nc << ")" << endl;
+    if (getDebugLevel() >= 2) {
+        cout << "Storage: read data file =" << fileName
+            << " (nr=" << nr << " nc=" << nc << ")" << endl;
+    }
     // Motion files from SIMM are in degrees
     if (_fileVersion < 1 && isMotFile) {
         _inDegrees = true;

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -225,8 +225,8 @@ Storage::Storage(const string &fileName, bool readHeadersOnly) :
 
     // Process file as if it were a .mot file
 
-    cout << "Storage: read data file =" << fileName
-        << " (nr=" << nr << " nc=" << nc << ")" << endl;
+    // cout << "Storage: read data file =" << fileName
+    //    << " (nr=" << nr << " nc=" << nc << ")" << endl;
     // Motion files from SIMM are in degrees
     if (_fileVersion < 1 && isMotFile) {
         _inDegrees = true;

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -224,7 +224,7 @@ Storage::Storage(const string &fileName, bool readHeadersOnly) :
     }
 
     // Process file as if it were a .mot file
-    if (getDebugLevel() >= 2) {
+    if (getDebugLevel() >= 0) {
         cout << "Storage: read data file =" << fileName
             << " (nr=" << nr << " nc=" << nc << ")" << endl;
     }

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -118,8 +118,10 @@ void ExternalForce::setDataSource(const Storage &dataSource)
 { 
     _dataSource = &dataSource;
 
-    // cout << "ExternalForce::" << getName() << endl;
-    // cout << "Data source being set to " << _dataSource->getName() << endl;
+    if (getDebugLevel() >= 2) {
+        cout << "ExternalForce::" << getName() << endl;
+        cout << "Data source being set to " << _dataSource->getName() << endl;   
+    }
 
     set_data_source_name(_dataSource->getName());
 }

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -118,8 +118,8 @@ void ExternalForce::setDataSource(const Storage &dataSource)
 { 
     _dataSource = &dataSource;
 
-    cout << "ExternalForce::" << getName() << endl;
-    cout << "Data source being set to " << _dataSource->getName() << endl;
+    // cout << "ExternalForce::" << getName() << endl;
+    // cout << "Data source being set to " << _dataSource->getName() << endl;
 
     set_data_source_name(_dataSource->getName());
 }

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -118,7 +118,7 @@ void ExternalForce::setDataSource(const Storage &dataSource)
 { 
     _dataSource = &dataSource;
 
-    if (getDebugLevel() >= 2) {
+    if (getDebugLevel() >= 0) {
         cout << "ExternalForce::" << getName() << endl;
         cout << "Data source being set to " << _dataSource->getName() << endl;   
     }

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -265,7 +265,7 @@ void Mesh::extendFinalizeFromProperties() {
                 std::cout << "Couldn't find file '" << file << "'." << std::endl;
                 warningGiven = true;
             }
-            if (getDebugLevel() == 0) { return; }
+            if (getDebugLevel() <= 0) { return; }
             std::cout << "The following locations were tried:\n";
             for (unsigned i = 0; i < attempts.size(); ++i)
                 std::cout << "\n  " << attempts[i];

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -39,6 +39,8 @@ using SimTK::Vec3;
 
 static const Vec3 DefaultMuscleColor(.8, .1, .1); // Red for backward compatibility
 //static int counter=0;
+bool Muscle::_printNegativeForceWarning = false;
+
 //=============================================================================
 // CONSTRUCTOR
 //=============================================================================
@@ -153,7 +155,6 @@ void Muscle::constructProperties()
     constructProperty_max_contraction_velocity(10.0);
     constructProperty_ignore_tendon_compliance(false);
     constructProperty_ignore_activation_dynamics(false);
-    constructProperty_allow_negative_force(false);
 
     // By default the min and max controls on muscle are 0.0 and 1.0
     setMinControl(0.0);
@@ -666,7 +667,7 @@ void Muscle::computeForce(const SimTK::State& s,
     // NOTE: Actuation could be negative, in particular during CMC, when the optimizer
     // is computing gradients, but in those cases the actuation will be 
     // overridden and will not be computed by the muscle
-    if (!isActuationOverridden(s) && !get_allow_negative_force() && 
+    if (!isActuationOverridden(s) && _printNegativeForceWarning &&
             (getActuation(s) < -SimTK::SqrtEps)) {
         string msg = getConcreteClassName()
             + "::computeForce, muscle "+ getName() + " force < 0";

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -39,7 +39,6 @@ using SimTK::Vec3;
 
 static const Vec3 DefaultMuscleColor(.8, .1, .1); // Red for backward compatibility
 //static int counter=0;
-bool Muscle::_printWarnings = true;
 
 //=============================================================================
 // CONSTRUCTOR
@@ -662,13 +661,14 @@ void Muscle::computeForce(const SimTK::State& s,
                           SimTK::Vector_<SimTK::SpatialVec>& bodyForces, 
                           SimTK::Vector& generalizedForces) const
 {
-    Super::computeForce(s, bodyForces, generalizedForces); // Calls compute actuation.
+    // This calls compute actuation.
+    Super::computeForce(s, bodyForces, generalizedForces); 
 
-    // NOTE: Actuation could be negative, in particular during CMC, when the optimizer
-    // is computing gradients, but in those cases the actuation will be 
-    // overridden and will not be computed by the muscle
-    if (!isActuationOverridden(s) && _printWarnings &&
-            (getActuation(s) < -SimTK::SqrtEps)) {
+    if (getDebugLevel() < 2) return;
+    // NOTE: Actuation could be negative, in particular during CMC, when the 
+    // optimizer is computing gradients, but in those cases the actuation will 
+    // be overridden and will not be computed by the muscle.
+    if (!isActuationOverridden(s) && (getActuation(s) < -SimTK::SqrtEps)) {
         string msg = getConcreteClassName()
             + "::computeForce, muscle "+ getName() + " force < 0";
         cout << msg << " at time = " << s.getTime() << endl;

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -38,7 +38,6 @@ using namespace OpenSim;
 using SimTK::Vec3;
 
 static const Vec3 DefaultMuscleColor(.8, .1, .1); // Red for backward compatibility
-//static int counter=0;
 
 //=============================================================================
 // CONSTRUCTOR

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -39,7 +39,7 @@ using SimTK::Vec3;
 
 static const Vec3 DefaultMuscleColor(.8, .1, .1); // Red for backward compatibility
 //static int counter=0;
-bool Muscle::_printNegativeForceWarning = false;
+bool Muscle::_printWarnings = true;
 
 //=============================================================================
 // CONSTRUCTOR
@@ -667,7 +667,7 @@ void Muscle::computeForce(const SimTK::State& s,
     // NOTE: Actuation could be negative, in particular during CMC, when the optimizer
     // is computing gradients, but in those cases the actuation will be 
     // overridden and will not be computed by the muscle
-    if (!isActuationOverridden(s) && _printNegativeForceWarning &&
+    if (!isActuationOverridden(s) && _printWarnings &&
             (getActuation(s) < -SimTK::SqrtEps)) {
         string msg = getConcreteClassName()
             + "::computeForce, muscle "+ getName() + " force < 0";

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -153,6 +153,7 @@ void Muscle::constructProperties()
     constructProperty_max_contraction_velocity(10.0);
     constructProperty_ignore_tendon_compliance(false);
     constructProperty_ignore_activation_dynamics(false);
+    constructProperty_allow_negative_force(false);
 
     // By default the min and max controls on muscle are 0.0 and 1.0
     setMinControl(0.0);
@@ -665,7 +666,8 @@ void Muscle::computeForce(const SimTK::State& s,
     // NOTE: Actuation could be negative, in particular during CMC, when the optimizer
     // is computing gradients, but in those cases the actuation will be 
     // overridden and will not be computed by the muscle
-    if (!isActuationOverridden(s) && (getActuation(s) < -SimTK::SqrtEps)) {
+    if (!isActuationOverridden(s) && !get_allow_negative_force() && 
+            (getActuation(s) < -SimTK::SqrtEps)) {
         string msg = getConcreteClassName()
             + "::computeForce, muscle "+ getName() + " force < 0";
         cout << msg << " at time = " << s.getTime() << endl;

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -664,7 +664,7 @@ void Muscle::computeForce(const SimTK::State& s,
     // This calls compute actuation.
     Super::computeForce(s, bodyForces, generalizedForces); 
 
-    if (getDebugLevel() < 2) return;
+    if (getDebugLevel() < 0) return;
     // NOTE: Actuation could be negative, in particular during CMC, when the 
     // optimizer is computing gradients, but in those cases the actuation will 
     // be overridden and will not be computed by the muscle.

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -333,17 +333,6 @@ public:
         and applied by the tendon to bones (i.e. not the fiber force) */
     double computeActuation(const SimTK::State& s) const override = 0;
 
-    /** Whether or not to print warnings (e.g. when muscle force goes negative). 
-        May be useful for optimization to ingore warnings when computing finite
-        differences. **/
-    static void setPrintWarnings(bool tf) {
-        _printWarnings = tf;
-    };
-    /** Get the current setting of the print warning flag. **/
-    static bool getPrintWarnings() {
-        return _printWarnings;
-    };
-
     /** @name Muscle initialization 
      */ 
     //@{
@@ -873,9 +862,6 @@ protected:
     double _optimalFiberLength;
     double _pennationAngleAtOptimal;
     double _tendonSlackLength;
-
-private:
-    static bool _printWarnings;
 
 //=============================================================================
 };  // END of class Muscle

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -333,14 +333,15 @@ public:
         and applied by the tendon to bones (i.e. not the fiber force) */
     double computeActuation(const SimTK::State& s) const override = 0;
 
-    /** Whether or not to print a warning when muscle force goes negative. May
-        be useful for optimization (e.g. computing finite differences). **/
-    static void setPrintNegativeForceWarning(bool tf) {
-        _printNegativeForceWarning = tf;
+    /** Whether or not to print warnings (e.g. when muscle force goes negative). 
+        May be useful for optimization to ingore warnings when computing finite
+        differences. **/
+    static void setPrintWarnings(bool tf) {
+        _printWarnings = tf;
     };
-    /** Get the current setting of the negative force warning flag. **/
-    static bool getPrintNegativeForceWarning() {
-        return _printNegativeForceWarning;
+    /** Get the current setting of the print warning flag. **/
+    static bool getPrintWarnings() {
+        return _printWarnings;
     };
 
     /** @name Muscle initialization 
@@ -874,7 +875,7 @@ protected:
     double _tendonSlackLength;
 
 private:
-    static bool _printNegativeForceWarning;
+    static bool _printWarnings;
 
 //=============================================================================
 };  // END of class Muscle

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -96,6 +96,8 @@ public:
         "Compute muscle dynamics ignoring tendon compliance. Tendon is assumed to be rigid.");
     OpenSim_DECLARE_PROPERTY(ignore_activation_dynamics, bool,
         "Compute muscle dynamics ignoring activation dynamics. Activation is equivalent to excitation.");
+    OpenSim_DECLARE_PROPERTY(allow_negative_force, bool,
+        "Don't print warnings if muscle force is negative. Useful for optimization.")
 
 //=============================================================================
 // OUTPUTS

--- a/OpenSim/Simulation/Model/Muscle.h
+++ b/OpenSim/Simulation/Model/Muscle.h
@@ -96,8 +96,6 @@ public:
         "Compute muscle dynamics ignoring tendon compliance. Tendon is assumed to be rigid.");
     OpenSim_DECLARE_PROPERTY(ignore_activation_dynamics, bool,
         "Compute muscle dynamics ignoring activation dynamics. Activation is equivalent to excitation.");
-    OpenSim_DECLARE_PROPERTY(allow_negative_force, bool,
-        "Don't print warnings if muscle force is negative. Useful for optimization.")
 
 //=============================================================================
 // OUTPUTS
@@ -335,6 +333,15 @@ public:
         and applied by the tendon to bones (i.e. not the fiber force) */
     double computeActuation(const SimTK::State& s) const override = 0;
 
+    /** Whether or not to print a warning when muscle force goes negative. May
+        be useful for optimization (e.g. computing finite differences). **/
+    static void setPrintNegativeForceWarning(bool tf) {
+        _printNegativeForceWarning = tf;
+    };
+    /** Get the current setting of the negative force warning flag. **/
+    static bool getPrintNegativeForceWarning() {
+        return _printNegativeForceWarning;
+    };
 
     /** @name Muscle initialization 
      */ 
@@ -865,6 +872,9 @@ protected:
     double _optimalFiberLength;
     double _pennationAngleAtOptimal;
     double _tendonSlackLength;
+
+private:
+    static bool _printNegativeForceWarning;
 
 //=============================================================================
 };  // END of class Muscle


### PR DESCRIPTION
This PR adds a static member variable to the `Muscle` class to allow the user to disable warnings that get printed out when actuation goes negative. We use this in Moco to avoid the output stream from becoming flooded with error messages during an optimization (e.g. we're okay with negative values while calculating sparsity for the Jacobian). 

Output messages in `Storage` and `ExternalForce` are commented out for a similar reason: messages get printed out everytime `initSystem()` is called (which can happen many times while solving a problem in Moco), and this pollutes the output making it hard to find the useful information we print out when solving a problem. It's outside the scope of this PR, but a general scheme for handling logging and when information is or isn't printed out would be appropriate for these messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2541)
<!-- Reviewable:end -->
