### PR TITLE
Require trusty distribution on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: cpp
 
 # Use container-based infrastructure to allow caching (for ccache).
 sudo: false
+dist: trusty
 
 # For thread_local support on macOS, we require xcode8 or greater.
 # Before 2018, xcode7 was the default. Now that xcode8.3 is the default,


### PR DESCRIPTION
Fixes issue #2534
### Brief summary of changes
Change .travis.yml file to require trusty (linux 14.04 & clang 5.0) rather than the most recent xenial (16.04 with clang 7.0) as the latter reuires code changes to btk and simbody so outside the scope of this PR.
### Testing I've completed
ran ci
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because this is internal ci issue and we don't distribute on linux anyway

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2542)
<!-- Reviewable:end -->
