### PR TITLE
Simbody: avoid GCC-8 warning

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -149,7 +149,8 @@ AddDependency(NAME       BTK
 
 AddDependency(NAME       simbody
               URL        https://github.com/simbody/simbody.git
-              TAG        Simbody-3.6.1
+              # simbody-3.6 branch containing fixes for GCC-8 warnings
+              TAG        45654969ef2cf34555bf388472b78bec08ede84f
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
                      


### PR DESCRIPTION
### Brief summary of changes

This PR upgrades the commit of Simbody to avoid the following warning with GCC:

```cpp
In file included from /Users/chris/repos/simbody/6/simbody/SimTKcommon/./include/SimTKcommon/basics.h:43,
                 from /Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/EventHandler.h:27,
                 from /Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/src/EventHandler.cpp:24:
/Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h: In constructor 'SimTK::Measure_<T>::Plus::Plus(SimTK::Subsystem&, const SimTK::Measure_<T>&, const SimTK::Measure_<T>&)':
/Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h:603:34: warning: invalid use of incomplete type 'const class SimTK::Subsystem'
            (   this->getSubsystem().isSameSubsystem(left.getSubsystem())
```

### Testing I've completed

Compiler no longer generates these warnings.

### CHANGELOG.md (choose one)

- no need to update because...minor change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2549)
<!-- Reviewable:end -->
