### PR TITLE
Integrate spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,6 +749,15 @@ if(${OPENSIM_COPY_DEPENDENCIES})
                 DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
 
+	#SPDLOG
+	#---
+	set(SPDLOG_HOME "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
+    if(WIN32)
+         install(DIRECTORY "${SPDLOG_HOME}/include"
+                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+		include_directories("${SPDLOG_HOME}/include")
+	endif()
 endif()
 
 if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ else()
     set(OPENSIM_INSTALL_JAVASRCDIR sdk/Java)
     set(OPENSIM_INSTALL_APIEXDIR Resources/Code)
     set(OPENSIM_INSTALL_SIMBODYDIR sdk/Simbody)
+    set(OPENSIM_INSTALL_SPDLOGDIR sdk/spdlog)
 
 endif()
 
@@ -584,6 +585,15 @@ if(WITH_BTK)
     endif()
 endif()
 
+#find_package(spdlog REQUIRED)
+# if(NOT SPDLOG_FOUND)
+#    message("spdlog not found. Install spdlog and set
+#        SPDLOG_HOME to the installation directory of spdlog.")
+#endif()
+include_directories("${OPENSIM_DEPENDENCIES_DIR}/spdlog/include")
+
+
+
 if(NOT SIMBODY_HOME AND OPENSIM_DEPENDENCIES_DIR)
     set(SIMBODY_HOME "${OPENSIM_DEPENDENCIES_DIR}/simbody")
 endif()
@@ -754,9 +764,7 @@ if(${OPENSIM_COPY_DEPENDENCIES})
 	set(SPDLOG_HOME "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
     if(WIN32)
          install(DIRECTORY "${SPDLOG_HOME}/include"
-                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-
-		include_directories("${SPDLOG_HOME}/include")
+                DESTINATION "${OPENSIM_INSTALL_SPDLOGDIR}")
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,13 +759,13 @@ if(${OPENSIM_COPY_DEPENDENCIES})
                 DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
 
-	#SPDLOG
-	#---
-	set(SPDLOG_HOME "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
+    #SPDLOG
+    #---
+    set(SPDLOG_HOME "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
     if(WIN32)
          install(DIRECTORY "${SPDLOG_HOME}/include"
                 DESTINATION "${OPENSIM_INSTALL_SPDLOGDIR}")
-	endif()
+    endif()
 endif()
 
 if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -36,7 +36,7 @@
 #include "Property_Deprecated.h"
 #include "PropertyTransform.h"
 #include "IO.h"
-
+#include "spdlog/spdlog.h"
 #include <fstream>
 
 using namespace OpenSim;
@@ -517,6 +517,7 @@ registerType(const Object& aObject)
     }
     if (_debugLevel>=2) {
         cout << "Object.registerType: " << type << " .\n";
+        spdlog::debug("Object.registerType: {}!", type);
     }
 
     // REPLACE IF A MATCHING TYPE IS ALREADY REGISTERED

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -157,6 +157,13 @@ AddDependency(NAME       simbody
 AddDependency(NAME       docopt
               URL        https://github.com/docopt/docopt.cpp.git
               TAG        af03fa044ee1eff20819549b534ea86829a24a54)
+
+
+AddDependency(NAME       spdlog
+              URL        https://github.com/gabime/spdlog.git
+              TAG        v1.3.1
+			  CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
+			             -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF)
  
 #######################
 


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
Integrate spdlog into the build/installation process. 

### Testing I've completed
Local and  ci builds are running, added one use case in Object.cpp in prep for a full roll-out.

### Looking for feedback on...
Build mechanism uses dependencies and SUPERBUILD exclusively rather than complicated CMake structures/commands. Would be good to discuss this vs how Simbody, BTK are integrated and how to scale.

### CHANGELOG.md (choose one)

- no need to update unless we expose to users.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
