### PR TITLE
Fix GCC 8 warnings about deprecated throw() and incomplete type.

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -24,19 +24,19 @@
  * -------------------------------------------------------------------------- */
 
 /** @file
- * This file defines the abstract Component class, which is used to add 
- * computational components to the underlying SimTK::System (MultibodySystem). 
- * It specifies the interface that components must satisfy in order to be part 
- * of the system and provides a series of helper methods for adding variables 
- * (state, discrete, cache, ...) to the underlying system. As such, 
- * Component handles all of the bookkeeping for variable indices and  
+ * This file defines the abstract Component class, which is used to add
+ * computational components to the underlying SimTK::System (MultibodySystem).
+ * It specifies the interface that components must satisfy in order to be part
+ * of the system and provides a series of helper methods for adding variables
+ * (state, discrete, cache, ...) to the underlying system. As such,
+ * Component handles all of the bookkeeping for variable indices and
  * provides convenience access via variable names. Furthermore, a component
  * embodies constructs of inputs, outputs and connections that are useful in
  * composing computational systems.
  *
- * A component may contain one or more underlying Simbody multibody system 
- * elements (MobilizedBody, Constraint, Force, or Measure) which are part of 
- * a SimTK::Subsystem. A SimTK::Subsystem is where new variables are 
+ * A component may contain one or more underlying Simbody multibody system
+ * elements (MobilizedBody, Constraint, Force, or Measure) which are part of
+ * a SimTK::Subsystem. A SimTK::Subsystem is where new variables are
  * allocated. A Component, by default, uses the System's DefaultSubsystem.
  * for allocating new variables.
  */
@@ -119,7 +119,7 @@ public:
         Exception(file, line, func) {
         std::string msg = "Component '" + thisName + "' of type " +
             componentConcreteClassName + " has no owner and is not the root.\n" +
-            "Verify that finalizeFromProperties() has been invoked on the " + 
+            "Verify that finalizeFromProperties() has been invoked on the " +
             "root Component or that this Component is not a clone, which has " +
             "not been added to another Component.";
         addMessage(msg);
@@ -150,7 +150,7 @@ public:
         const std::string& componentConcreteClassName) :
         Exception(file, line, func) {
         std::string msg = "Component '" + thisName + "' of type " +
-            componentConcreteClassName + " is the root but has no " + 
+            componentConcreteClassName + " is the root but has no " +
             "subcomponents listed.\n" +
             "Verify that finalizeFromProperties() was called on this "
             "Component to identify its subcomponents.";
@@ -236,45 +236,45 @@ public:
  * The abstract Component class defines the interface used to add computational
  * elements to the underlying SimTK::System (MultibodySystem). It specifies
  * the interface that components must satisfy in order to be part of the system
- * and provides a series of helper methods for adding variables 
+ * and provides a series of helper methods for adding variables
  * (state, discrete, cache, ...) to the underlying system. As such, Component
- * handles all of the bookkeeping of system indices and provides convenience 
- * access to variable values (incl. derivatives) via their names as strings. 
+ * handles all of the bookkeeping of system indices and provides convenience
+ * access to variable values (incl. derivatives) via their names as strings.
  *
  * ### System and State
  *
  * The MultibodySystem and its State are defined by Simbody (ref ...). Briefly,
  * a System represents the mathematical equations that specify the behavior
- * of a computational model. The State is a collection of all the variables 
- * that uniquely define the unknowns in the system equations. Consider a single 
- * differential equation as a system, while a single set of variable values that  
- * satisfy the equation is a state of that system. These could be values for 
+ * of a computational model. The State is a collection of all the variables
+ * that uniquely define the unknowns in the system equations. Consider a single
+ * differential equation as a system, while a single set of variable values that
+ * satisfy the equation is a state of that system. These could be values for
  * joint coordinates, their speeds, as well other variables that govern
- * the system dynamics (e.g. muscle activation and fiber-length variables 
- * that dictate muscle force). These variables are called continuous state 
+ * the system dynamics (e.g. muscle activation and fiber-length variables
+ * that dictate muscle force). These variables are called continuous state
  * variables in Simbody, but are more simply referred to as <em>StateVariables</em>
- * in OpenSim. Component provides services to define and access its 
- * StateVariables and specify their dynamics (derivatives with respect to time) 
+ * in OpenSim. Component provides services to define and access its
+ * StateVariables and specify their dynamics (derivatives with respect to time)
  * that are automatically and simultaneously integrated with the MultibodySystem
- * dynamics. Common operations to integrate, take the max or min, or to delay a 
- * signal, etc. require internal variables to perform their calculations and 
+ * dynamics. Common operations to integrate, take the max or min, or to delay a
+ * signal, etc. require internal variables to perform their calculations and
  * these are also held in the State. Simbody provides the infrastructure to
  * ensure that calculations are kept up-to-date with the state variable values.
  *
- * There are other types of "State" variables such as a flag (or options) that 
- * enables a component to be disabled or for a muscle force to be overridden and 
- * and these are identified as <em>ModelingOptions</em> since they may change 
+ * There are other types of "State" variables such as a flag (or options) that
+ * enables a component to be disabled or for a muscle force to be overridden and
+ * and these are identified as <em>ModelingOptions</em> since they may change
  * the modeled dynamics of the component. Component provides services
  * that enable developers of components to define additional ModelingOptions.
  *
  * ### Discrete variables
  *
- * Often a component requires input from an outside source (precomputed data 
+ * Often a component requires input from an outside source (precomputed data
  * from a file, another program, or interaction from a user) in which case these
- * variables do not have dynamics (differential eqns.) known to the component, 
+ * variables do not have dynamics (differential eqns.) known to the component,
  * but are necessary to describe the dynamical "state" of the system. An example,
- * is a throttle component (a "controller" that provides an actuator, e.g. a 
- * motor, with a control signal like a voltage or current) which it gets as direct 
+ * is a throttle component (a "controller" that provides an actuator, e.g. a
+ * motor, with a control signal like a voltage or current) which it gets as direct
  * input from the user (via a joystick, key press, etc..). The throttle controls
  * the motor torque output and therefore the behavior of the model. The input by
  * the user to the throttle the motor (the controls) is necessary to specify the
@@ -285,69 +285,69 @@ public:
  *
  * ### Cache variables
  *
- * Fast and efficient simulations also require computationally expensive 
+ * Fast and efficient simulations also require computationally expensive
  * calculations to be performed only when necessary. Often the result of an
  * expensive calculation can be reused many times over, while the variables it
- * is dependent on remain fixed. The concept of holding onto these values is 
- * called caching and the variables that hold these values are call 
+ * is dependent on remain fixed. The concept of holding onto these values is
+ * called caching and the variables that hold these values are call
  * <em>CacheVariables</em>. It is important to note, that cache variables are
  * not state variables. Cache variables can always be recomputed exactly
- * from the State. OpenSim uses the Simbody infrastructure to manage cache 
+ * from the State. OpenSim uses the Simbody infrastructure to manage cache
  * variables and their validity. Component provides a simplified interface to
  * define and access CacheVariables.
  *
  * ### Stages
  *
- * Many modeling and simulation codes put the onus on users and component 
- * creators to manage the validity of cache variables, which is likely to lead 
+ * Many modeling and simulation codes put the onus on users and component
+ * creators to manage the validity of cache variables, which is likely to lead
  * to undetectable errors where cache values are stale (calculated based on past
  * state variable values). Simbody, on the other hand, provides a more strict
- * infrastructure to make it easy to exploit the efficiencies of caching while 
+ * infrastructure to make it easy to exploit the efficiencies of caching while
  * reducing the risks of validity errors. To do this, Simbody employs the concept
- * of computational stages to "realize" (or compute) a model's system to a 
- * particular stage requires cached quantities up to and including the stage to 
- * to computed/specified. Simbody utilizes nine realization stages 
+ * of computational stages to "realize" (or compute) a model's system to a
+ * particular stage requires cached quantities up to and including the stage to
+ * to computed/specified. Simbody utilizes nine realization stages
  * (<tt>SimTK::Stage::</tt>)
  *
  * -# \c Topology       finalize System with "slots" for most variables (above)
  * -# \c %Model         specify modeling choices
  * -# \c Instance       specify modifiable model parameters
  * -# \c Time           compute time dependent quantities
- * -# \c Position       compute position dependent quantities   
+ * -# \c Position       compute position dependent quantities
  * -# \c Velocity       compute velocity dependent quantities
- * -# \c Dynamics       compute system applied forces and dependent quantities  
+ * -# \c Dynamics       compute system applied forces and dependent quantities
  * -# \c Acceleration   compute system accelerations and all other derivatives
  * -# \c Report         compute quantities for reporting/output
- *  
- * The Component interface is automatically invoked by the System and its 
+ *
+ * The Component interface is automatically invoked by the System and its
  * realizations. Component users and most developers need not concern themselves
  * with \c Topology, \c %Model or \c Instance stages. That interaction is managed
- * by Component when component creators implement extendAddToSystem() and use the 
- * services provided by Component. Component creators do need to determine and 
- * specify stage dependencies for Discrete and CacheVariables that they add to 
+ * by Component when component creators implement extendAddToSystem() and use the
+ * services provided by Component. Component creators do need to determine and
+ * specify stage dependencies for Discrete and CacheVariables that they add to
  * their components. For example, the throttle controller reads its value from
- * user input and it is valid for all calculations as long as time does not 
- * change. If the simulation (via numerical integration) steps forward (or 
+ * user input and it is valid for all calculations as long as time does not
+ * change. If the simulation (via numerical integration) steps forward (or
  * backward for a trial step) and updates the state, the control from a previous
  * state (time) should be invalid and an error generated for trying to access
- * the DiscreteVariable for the control value. To do this one specifies the 
+ * the DiscreteVariable for the control value. To do this one specifies the
  * "invalidates" stage (e.g. <tt>SimTK::Stage::Time</tt>) for a DiscreteVariable
- * when the variable is added to the Component. A subsequent change to that 
+ * when the variable is added to the Component. A subsequent change to that
  * variable will invalidate all state cache entries at that stage or higher. For
  * example, if a DiscreteVariable is declared to invalidate <tt>Stage::Position</tt>
- * then changing it will invalidate cache entries that depend on positions, 
+ * then changing it will invalidate cache entries that depend on positions,
  * velocities, forces, and accelerations.
  *
- * Similar principles apply to CacheVariables, which requires a "dependsOn" stage to 
- * be specified when a CacheVariable is added to the component. In this case, 
+ * Similar principles apply to CacheVariables, which requires a "dependsOn" stage to
+ * be specified when a CacheVariable is added to the component. In this case,
  * the cache variable "shadows" the State (unlike a DiscreteVariable, which is a
- * part of the State) holding already-computed state-dependent values so that 
+ * part of the State) holding already-computed state-dependent values so that
  * they do not need to be recomputed until the state changes.
- * Accessing the CacheVariable in a State whose current stage is lower than 
- * that CacheVariable's specified dependsOn stage will trigger an exception. 
+ * Accessing the CacheVariable in a State whose current stage is lower than
+ * that CacheVariable's specified dependsOn stage will trigger an exception.
  * It is up to the component to update the value of the cache variable.
  * Component provides methods to check if the cache is valid, update its value
- * and then to mark it as valid. 
+ * and then to mark it as valid.
  *
  * ### The interface of this class
  *
@@ -378,7 +378,7 @@ public:
  *   one-value properties or limiting the size of a list property). The bodies,
  *   joints, forces, etc. in a Model's BodySet, JointSet, ForceSet, etc. are
  *   all examples of property subcomponents. This category of subcomponent is
- *   the most similar to what was available pre-v4.0. 
+ *   the most similar to what was available pre-v4.0.
  * - **member subcomponents** These are *not* configurable by the user of this
  *   Component, and can only be modified by this Component. You can
  *   still access member subcomponents through the API, but only the component
@@ -430,11 +430,11 @@ public:
     virtual ~Component() = default;
 
     /** @name Component Structural Interface
-    The structural interface ensures that deserialization, resolution of 
+    The structural interface ensures that deserialization, resolution of
     inter-connections, and handling of dependencies are performed systematically
     and prior to system creation, followed by allocation of necessary System
     resources. These methods can be extended by virtual methods that form the
-    Component Extension Interface (e.g. #extendFinalizeFromProperties) 
+    Component Extension Interface (e.g. #extendFinalizeFromProperties)
     that can be implemented by subclasses of Components.
 
     Component ensures that the corresponding calls are propagated to all of its
@@ -459,7 +459,7 @@ public:
         Components. */
     void finalizeConnections(Component& root);
 
-    /** Disconnect/clear this Component from its aggregate component. Empties 
+    /** Disconnect/clear this Component from its aggregate component. Empties
         all component's sockets and sets them as disconnected.*/
     void clearConnections();
 
@@ -473,11 +473,11 @@ public:
     void setPropertiesFromState(const SimTK::State& state);
 
     // End of Component Structural Interface (public non-virtual).
-    ///@} 
+    ///@}
 
     /** Optional method for generating arbitrary display geometry that reflects
-    this %Component at the specified \a state. This will be called once to 
-    obtain ground- and body-fixed geometry (with \a fixed=\c true), and then 
+    this %Component at the specified \a state. This will be called once to
+    obtain ground- and body-fixed geometry (with \a fixed=\c true), and then
     once per frame (with \a fixed=\c false) to generate on-the-fly geometry such
     as rubber band lines, force arrows, labels, or debugging aids.
 
@@ -490,17 +490,17 @@ public:
     effects such as evaluating all model forces even when performing a purely
     kinematic study.
 
-    If you override this method, be sure to invoke the base class method first, 
+    If you override this method, be sure to invoke the base class method first,
     using code like this:
     @code
     void MyComponent::generateDecorations
-       (bool                                        fixed, 
+       (bool                                        fixed,
         const ModelDisplayHints&                    hints,
         const SimTK::State&                         state,
         SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
     {
         // invoke parent class method
-        Super::generateDecorations(fixed,hints,state,appendToThis); 
+        Super::generateDecorations(fixed,hints,state,appendToThis);
         // ... your code goes here
         // can render velocity dependent quanities if stage is Velocity or higher
         if(state.getSystemStage() >= Stage::Velocity) {
@@ -513,13 +513,13 @@ public:
     }
     @endcode
 
-    @param[in]      fixed   
-        If \c true, generate only geometry that is fixed to a PhysicalFrame, 
-        configuration, and velocity. Otherwise generate only such dependent 
+    @param[in]      fixed
+        If \c true, generate only geometry that is fixed to a PhysicalFrame,
+        configuration, and velocity. Otherwise generate only such dependent
         geometry.
-    @param[in]      hints   
-        See documentation for ModelDisplayHints; you may want to alter the 
-        geometry you generate depending on what you find there. For example, 
+    @param[in]      hints
+        See documentation for ModelDisplayHints; you may want to alter the
+        geometry you generate depending on what you find there. For example,
         you can determine whether the user wants to see debug geometry.
     @param[in]      state
         The State for which geometry should be produced. See below for more
@@ -528,14 +528,14 @@ public:
         %Array to which generated geometry should be \e appended via the
         \c push_back() method.
 
-    When called with \a fixed=\c true only modeling options and parameters 
+    When called with \a fixed=\c true only modeling options and parameters
     (Instance variables) should affect geometry; time, position, and velocity
     should not. In that case OpenSim will already have realized the \a state
-    through Instance stage. When called with \a fixed=\c false, you may 
+    through Instance stage. When called with \a fixed=\c false, you may
     consult any relevant value in \a state. However, to avoid unnecessary
     computation, OpenSim guarantees only that \a state will have been realized
-    through Position stage; if you need anything higher than that (reaction 
-    forces, for example) you should make sure the \a state is realized through 
+    through Position stage; if you need anything higher than that (reaction
+    forces, for example) you should make sure the \a state is realized through
     Acceleration stage. **/
     virtual void generateDecorations
             (bool                                       fixed,
@@ -583,10 +583,10 @@ public:
         newBody->setName("newBody");
         newBody->setMass(10.0);
         newBody->setMassCenter(SimTK::Vec3(0));
-        // ... 
+        // ...
         // Now add it to your model, which will take ownership of it
         myModel.addComponent(newBody);
-        // 
+        //
         // Keep creating and adding new components, like Joints, Forces, etc..
     @endcode
     *
@@ -618,21 +618,21 @@ public:
         initComponentTreeTraversal(*this);
         return ComponentList<const T>(*this);
     }
-    
+
     /** Similar to getComponentList(), except the resulting list allows one to
     modify the components. For example, you could use this method to change
     the max isometric force of all muscles:
-    
+
     @code{.cpp}
     for (auto& muscle : model.updComponentList<Muscle>()) {
         muscle.set_max_isometric_force(...);
     }
     @endcode
-    
+
     @note Do NOT use this method to add (or remove) (sub)components from any
     component. The tree structure of the components should not be altered
     through this ComponentList.
-    
+
     @tparam T A subclass of Component (e.g., Body, Muscle). */
     template <typename T = Component>
     ComponentList<T> updComponentList() {
@@ -679,10 +679,10 @@ public:
      * and, therefore, calling this method is not "free". */
     std::string getAbsolutePathString() const;
 
-    /** Return a ComponentPath of the absolute path of this Component. 
-     * Note that this has more overhead than calling `getName()` because 
+    /** Return a ComponentPath of the absolute path of this Component.
+     * Note that this has more overhead than calling `getName()` because
      * it traverses up the tree to generate the absolute pathname (and its
-     * computational cost is thus a function of depth). Consider other 
+     * computational cost is thus a function of depth). Consider other
      * options if this is repeatedly called and efficiency is important.
      * For instance, `getAbsolutePathString()` is faster if you only
      * need the path as a string. */
@@ -698,7 +698,7 @@ public:
 
     /** Query if there is a component (of any type) at the specified
      * path name. For example,
-     * @code 
+     * @code
      * bool exists = model.hasComponent("right_elbow/elbow_flexion");
      * @endcode
      * checks if `model` has a subcomponent "right_elbow," which has a
@@ -709,7 +709,7 @@ public:
 
     /** Query if there is a component of a given type at the specified
      * path name. For example,
-     * @code 
+     * @code
      * bool exists = model.hasComponent<Coordinate>("right_elbow/elbow_flexion");
      * @endcode
      * checks if `model` has a subcomponent "right_elbow," which has a
@@ -718,18 +718,18 @@ public:
      * non-templatized hasComponent(). */
     template <class C = Component>
     bool hasComponent(const std::string& pathname) const {
-        static_assert(std::is_base_of<Component, C>::value, 
+        static_assert(std::is_base_of<Component, C>::value,
             "Template parameter 'C' must be derived from Component.");
         const C* comp = this->template traversePathToComponent<C>({pathname});
         return comp != nullptr;
     }
 
     /**
-     * Get a unique subcomponent of this Component by its path name and type 'C'. 
+     * Get a unique subcomponent of this Component by its path name and type 'C'.
      * Throws ComponentNotFoundOnSpecifiedPath exception if the component at
      * that path name location does not exist OR it is not of the correct type.
-     * For example, 
-     * @code 
+     * For example,
+     * @code
      *    auto& coord = model.getComponent<Coordinate>("right_elbow/elbow_flexion");
      * @endcode
      * returns coord which is a Coordinate named "elbow_flexion" from a Joint
@@ -741,7 +741,7 @@ public:
      * non-templatized getComponent().
      *
      * @param  pathname        a pathname of a Component of interest
-     * @return const reference to component of type C at 
+     * @return const reference to component of type C at
      * @throws ComponentNotFoundOnSpecifiedPath if no component exists
      */
     template <class C = Component>
@@ -750,7 +750,7 @@ public:
     }
     template <class C = Component>
     const C& getComponent(const ComponentPath& pathname) const {
-        static_assert(std::is_base_of<Component, C>::value, 
+        static_assert(std::is_base_of<Component, C>::value,
             "Template parameter 'CompType' must be derived from Component.");
 
         const C* comp = this->template traversePathToComponent<C>(pathname);
@@ -777,7 +777,7 @@ public:
      * %Exception: in Python, you will get the concrete type (in most cases):
      * @code{.py}
      * coord = model.getComponent('right_elbow/elbow_flexion')
-     * coord.getDefaultClamped() # works; no downcasting necessary. 
+     * coord.getDefaultClamped() # works; no downcasting necessary.
      * @endcode
      */
     const Component& getComponent(const std::string& pathname) const {
@@ -788,7 +788,7 @@ public:
     * to edit the properties and connections of the subcomponent.
     * Note: the method will mark this Component as out-of-date with
     * its properties and will require finalizeFromProperties() to be
-    * invoked directly or indirectly (by finalizeConnections() or 
+    * invoked directly or indirectly (by finalizeConnections() or
     * Model::initSystem())
     * @param name       the pathname of the Component of interest
     * @return Component the component of interest
@@ -817,8 +817,8 @@ public:
 
 
     /** Print a list to the console of all components whose absolute path name
-     * contains the given string. You might use this if (a) you know the name 
-     * of a component in your model but don't know its absolute path, (b) if 
+     * contains the given string. You might use this if (a) you know the name
+     * of a component in your model but don't know its absolute path, (b) if
      * you want to find all components with a given name, or (c) to get a list
      * of all components on the right leg of a model (if all components on the
      * right side have "_r" in their name).
@@ -855,7 +855,7 @@ public:
 
     /** @name Component Socket Access methods
         Access Sockets of this component by name. */
-    //@{ 
+    //@{
     /** Get the number of Sockets in this Component. */
     int getNumSockets() const {
         return int(_socketsTable.size());
@@ -926,7 +926,7 @@ public:
     *
     * Exception: in Python, you will get the concrete type (in most cases):
     * @code{.py}
-    * f = joint.getConnectee("parent_frame"); 
+    * f = joint.getConnectee("parent_frame");
     * m = f.getMass() # works (if the parent frame is a body)
     * @endcode
     */
@@ -975,7 +975,7 @@ public:
 
     /** Get a writable reference to the AbstractSocket for the given
      * socket name. Use this method to connect the Socket to something.
-     * 
+     *
      * <b>C++ example</b>
      * @code
      * joint.updSocket("parent_frame").connect(model.getGround());
@@ -1083,7 +1083,7 @@ public:
             // the copied AbstractSocket (base class of AbstractInput)
             // cannot know its new owner immediately after copying.
             if (!it->second->hasOwner()) {
-            
+
                 // The `this` pointer must be non-const because the Socket
                 // will want to be able to modify the connectee_name property.
                 const_cast<AbstractInput*>(it->second.get())->setOwner(
@@ -1094,11 +1094,11 @@ public:
 
         OPENSIM_THROW_FRMOBJ(InputNotFound, name);
     }
-    
+
     /**
     * Get a writable reference to an Input provided by this Component by name.
     *
-    * <b>C++ example:</b> get a writable reference to an Input of a 
+    * <b>C++ example:</b> get a writable reference to an Input of a
     * Component in a model
     * @code{.cpp}
     * model.updComponent("/path/to/component").updInput("inputName");
@@ -1147,7 +1147,7 @@ public:
     const AbstractOutput& getOutput(const std::string& name) const
     {
         auto it = _outputsTable.find(name);
-        
+
         if (it != _outputsTable.end()) {
             return it->second.getRef();
         }
@@ -1158,7 +1158,7 @@ public:
     /**
     * Get a writable reference to an Output provided by this Component by name.
     *
-    * <b>C++ example:</b> get a writable reference to an Output of a 
+    * <b>C++ example:</b> get a writable reference to an Output of a
     * Component in a model
     * @code{.cpp}
     * model.updComponent("/path/to/component").updOutput("outputName");
@@ -1187,7 +1187,7 @@ public:
      * @endcode
      * This provides access to the outputs as AbstractOutput%s, not as the
      * concrete type. This also does not permit modifying the outputs.
-     * 
+     *
      * Not available in Python/Java/MATLAB; use getOutputNames() and
      * getOutput() instead.
      */
@@ -1199,14 +1199,14 @@ public:
 
 
     /** @name Component State Access methods
-        Get and set modeling option, input and output values, state variable, 
+        Get and set modeling option, input and output values, state variable,
         discrete and/or cache variables in the State.
-     */ 
+     */
     //@{
-    
+
     /**
      * Get a ModelingOption flag for this Component by name.
-     * The flag is an integer corresponding to the index of modelingOptionNames used 
+     * The flag is an integer corresponding to the index of modelingOptionNames used
      * add the modeling option to the component. @see addModelingOption
     *
      * @param state  the State in which to set the modeling option
@@ -1218,7 +1218,7 @@ public:
     /**
      * %Set the value of a ModelingOption flag for this Component.
      * if the integer value exceeds the number of option names used to
-     * define the options, an exception is thrown. The SimTK::State 
+     * define the options, an exception is thrown. The SimTK::State
      * Stage will be reverted back to Stage::Instance.
      *
      * @param state  the State in which to set the flag
@@ -1247,7 +1247,7 @@ public:
         if (in.isConnected()) {
             return (Input<T>::downcast(in)).getValue(state);
         }
-        
+
         else {
         std::stringstream msg;
             msg << "Component::getInputValue: ERR- Input '" << name << "' not connected.\n "
@@ -1268,8 +1268,8 @@ public:
     {
         return (Output<T>::downcast(getOutput(name))).getValue(state);
     }
-    
-    
+
+
     /**
      * Get the value of a state variable allocated by this Component.
      *
@@ -1339,7 +1339,7 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    double getStateVariableDerivativeValue(const SimTK::State& state, 
+    double getStateVariableDerivativeValue(const SimTK::State& state,
         const std::string& name) const;
 
     /**
@@ -1375,7 +1375,7 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    template<typename T> const T& 
+    template<typename T> const T&
     getCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
@@ -1391,7 +1391,7 @@ public:
         } else {
             std::stringstream msg;
             msg << "Component::getCacheVariable: ERR- name not found.\n "
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
         }
@@ -1408,7 +1408,7 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    template<typename T> T& 
+    template<typename T> T&
     updCacheVariableValue(const SimTK::State& state, const std::string& name) const
     {
         // Must have already called initSystem.
@@ -1424,9 +1424,9 @@ public:
         }
         else{
             std::stringstream msg;
-            msg << "Component::updCacheVariable: ERR- '" << name 
+            msg << "Component::updCacheVariable: ERR- '" << name
                 << "' name not found.\n "
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
         }
@@ -1460,7 +1460,7 @@ public:
         else{
             std::stringstream msg;
             msg << "Component::markCacheVariableValid: ERR- name not found.\n "
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
         }
@@ -1484,7 +1484,7 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    void markCacheVariableInvalid(const SimTK::State& state, 
+    void markCacheVariableInvalid(const SimTK::State& state,
                                   const std::string& name) const
     {
         // Must have already called initSystem.
@@ -1500,7 +1500,7 @@ public:
         else{
             std::stringstream msg;
             msg << "Component::markCacheVariableInvalid: ERR- name not found.\n"
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
         }
@@ -1533,7 +1533,7 @@ public:
         else{
             std::stringstream msg;
             msg << "Component::isCacheVariableValid: ERR- name not found.\n "
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
         }
@@ -1550,8 +1550,8 @@ public:
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
-    template<typename T> void 
-    setCacheVariableValue(const SimTK::State& state, const std::string& name, 
+    template<typename T> void
+    setCacheVariableValue(const SimTK::State& state, const std::string& name,
                      const T& value) const
     {
         // Must have already called initSystem.
@@ -1563,32 +1563,32 @@ public:
         if(it != _namedCacheVariableInfo.end()) {
             SimTK::CacheEntryIndex ceIndex = it->second.index;
             SimTK::Value<T>::downcast(
-                getDefaultSubsystem().updCacheEntry( state, ceIndex)).upd() 
+                getDefaultSubsystem().updCacheEntry( state, ceIndex)).upd()
                 = value;
             getDefaultSubsystem().markCacheValueRealized(state, ceIndex);
         }
         else{
             std::stringstream msg;
             msg << "Component::setCacheVariable: ERR- name not found.\n "
-                << "for component '"<< getName() << "' of type " 
+                << "for component '"<< getName() << "' of type "
                 << getConcreteClassName();
             throw Exception(msg.str(),__FILE__,__LINE__);
-        }   
+        }
     }
     // End of Model Component State Accessors.
-    //@} 
+    //@}
 
     /** @name Print information to the console */
     /// @{
-    /** List all subcomponents by name and recurse into these components to 
+    /** List all subcomponents by name and recurse into these components to
     list their subcomponents, and so on.                                      */
     void printSubcomponentInfo() const;
-    
-    /** List all the Sockets of this component and whether or not they are 
+
+    /** List all the Sockets of this component and whether or not they are
     connected. Also list the connectee paths for sockets that are connected. */
     void printSocketInfo() const;
 
-    /** List all the inputs of this component and whether or not they are 
+    /** List all the inputs of this component and whether or not they are
     connected. Also list the (desired) connectee paths for the inputs.       */
     void printInputInfo() const;
 
@@ -1642,7 +1642,7 @@ public:
         std::cout << std::endl;
     }
 
-    /** Print outputs of this component and optionally, those of all 
+    /** Print outputs of this component and optionally, those of all
     subcomponents.                                                            */
     void printOutputInfo(const bool includeDescendants = true) const;
     /// @}
@@ -1715,18 +1715,18 @@ protected:
 
     /** @name  Component Extension Interface
     The interface ensures that deserialization, resolution of inter-connections,
-    and handling of dependencies are performed systematically and prior to 
-    system creation, followed by allocation of necessary System resources. These 
-    methods are virtual and may be implemented by subclasses of 
-    Components. 
-    
+    and handling of dependencies are performed systematically and prior to
+    system creation, followed by allocation of necessary System resources. These
+    methods are virtual and may be implemented by subclasses of
+    Components.
+
     @note Every implementation of virtual extend method xxx(args) must begin
     with the line "Super::extend<xxx>(args);" to ensure that the parent class
     is called before the child class method.
-    
+
     The base class implementations ensures that the corresponding calls are made
     to any subcomponents which are owned by this Component. Ownership is
-    established by the subcomponent being a data member (not serialized), a 
+    established by the subcomponent being a data member (not serialized), a
     property (serialized), or created and adopted based on other settings
     or options that arise from the properties. For example, a Model (Component)
     may have to split a body and add a Weld constraint to handle a closed
@@ -1735,19 +1735,19 @@ protected:
     form a valid multibody tree.
 
     So assuming that your concrete %Component and all intermediate classes from
-    which it derives properly follow the requirement of calling the Super class 
-    method first, the order of operations enforced here for a call to a single 
+    which it derives properly follow the requirement of calling the Super class
+    method first, the order of operations enforced here for a call to a single
     method will be
       -# %Component base class computations
-      -# calls to that same method for intermediate %Component-derived 
+      -# calls to that same method for intermediate %Component-derived
          objects' computations, in order down from %Component, and
-      -# call to that method for the bottom-level concrete class. 
+      -# call to that method for the bottom-level concrete class.
       -# finally calls to that same method for \e all subcomponents
-    You should consider this ordering when designing a %Component.  **/ 
+    You should consider this ordering when designing a %Component.  **/
 
     ///@{
 
-    /** Perform any secondary operations, e.g. to investigate the component or 
+    /** Perform any secondary operations, e.g. to investigate the component or
     to insert it into a particular internal list (for grouping), after adding
     the subcomponent to this component. This is intended primarily for composites
     like Model to have more control over the handling of a component being added
@@ -1786,19 +1786,19 @@ protected:
 
     /** Perform any necessary initializations required to connect the component
     (and it subcomponents) to other components and mark the connection status.
-    Provides a check for error conditions. connect() is invoked on all components 
+    Provides a check for error conditions. connect() is invoked on all components
     to form a directed acyclic graph of the multibody system, prior to creating the
     Simbody MultibodySystem to represent it computationally. It may also be invoked
     at times just for its error-checking side effects.
 
     The "root" Component argument is the root node of the directed graph composed
     of all the subcomponents (and their subcomponents and so on ...) and their
-    interconnections. This should yield a fully connected root component. For 
+    interconnections. This should yield a fully connected root component. For
     ModelComponents this is the Model component. But a Model can be connected to
     an environment or world component with several other models, by choosing the
     environment/world as the root.
-    
-    If you override this method, be sure to invoke the base class method first, 
+
+    If you override this method, be sure to invoke the base class method first,
     using code like this:
     @code
     void MyComponent::extendFinalizeConnections(Component& root) {
@@ -1814,50 +1814,50 @@ protected:
     otherwise it will not be included in the tree and will not be found for
     iteration or for connection. The implementation populates the _nextComponent
     ReferencePtr with a pointer to the next Component in tree pre-order traversal.
-    
-    @throws ComponentIsRootWithNoSubcomponents if the Component is the root and 
+
+    @throws ComponentIsRootWithNoSubcomponents if the Component is the root and
             yet has no subcomponents.
     */
     void initComponentTreeTraversal(const Component &root) const;
 
     ///@cond
-    /** Opportunity to remove connection-related information. 
+    /** Opportunity to remove connection-related information.
     If you override this method, be sure to invoke the base class method first,
         using code like this:
         @code
         void MyComponent::disconnect(Component& root) {
         // disconnect your subcomponents and your Super first
-        Super::extendDisconnect(); 
+        Super::extendDisconnect();
             //your code to wipe out your connection-related information
     }
     @endcode  */
     //virtual void extendDisconnect() {};
     ///@endcond
 
-    /** Add appropriate Simbody elements (if needed) to the System 
-    corresponding to this component and specify needed state resources. 
-    extendAddToSystem() is called when the Simbody System is being created to 
+    /** Add appropriate Simbody elements (if needed) to the System
+    corresponding to this component and specify needed state resources.
+    extendAddToSystem() is called when the Simbody System is being created to
     represent a completed system (model) for computation. That is, connect()
     will already have been invoked on all components before any addToSystem()
-    call is made. Helper methods for adding modeling options, state variables 
-    and their derivatives, discrete variables, and cache entries are available 
+    call is made. Helper methods for adding modeling options, state variables
+    and their derivatives, discrete variables, and cache entries are available
     and can be called within extendAddToSystem() only.
 
     Note that this method is const; you may not modify your model component
     or the containing model during this call. Any modifications you need should
     instead be performed in finalizeFromProperties() or at the latest connect(),
-    which are non-const. The only exception is that you may need to record access 
+    which are non-const. The only exception is that you may need to record access
     information for resources you create in the \a system, such as an index number.
     For most Components, OpenSim base classes either provide convenience methods
     or handle indices automatically. Otherwise, you must declare indices as mutable
     data members so that you can set them here.
-   
+
     If you override this method, be sure to invoke the base class method at the
     beginning, using code like this:
     @code
     void MyComponent::extendAddToSystem(SimTK::MultibodySystem& system) const {
         // Perform any additions to the system required by your Super
-        Super::extendAddToSystem(system);       
+        Super::extendAddToSystem(system);
         // ... your code goes here
     }
     @endcode
@@ -1867,17 +1867,17 @@ protected:
     first (e.g. require of a Force to be anchored to a SimTK::MobilizedBody
     specified by subcomponents) then you must implement:
         extendAddToSystemAfterSubcomponents().
-    It is possible to implement both method to add system elements before and then 
+    It is possible to implement both method to add system elements before and then
     after your subcomponents have added themselves. Caution is required that
     Simbody elements are not added twice especially when order is unimportant.
 
     @param[in,out] system   The MultibodySystem being added to.
 
-    @see addModelingOption(), addStateVariable(), addDiscreteVariables(), 
+    @see addModelingOption(), addStateVariable(), addDiscreteVariables(),
          addCacheVariable() **/
     virtual void extendAddToSystem(SimTK::MultibodySystem& system) const {};
 
-    /** Add appropriate Simbody elements (if needed) to the System after your 
+    /** Add appropriate Simbody elements (if needed) to the System after your
     component's subcomponents have had a chance to add themselves to the system.
 
     If you override this method, be sure to invoke the base class method at the
@@ -1886,28 +1886,28 @@ protected:
     void MyComponent::
         extendAddToSystemAfterSubcomponents(SimTK::MultibodySystem& system) const {
         // Perform any additions to the system required by your Super
-        Super::extendAddToSystemAfterSubcomponents(system);       
+        Super::extendAddToSystemAfterSubcomponents(system);
         // ... your code goes here
     }
     @endcode
-    
+
     @param[in,out] system   The MultibodySystem being added to.
-    
+
     @see extendAddToSystem() **/
-    virtual void 
+    virtual void
         extendAddToSystemAfterSubcomponents(SimTK::MultibodySystem& system)
                                                                       const {};
 
     /** Transfer property values or other state-independent initial values
     into this component's state variables in the passed-in \a state argument.
-    This is called after a SimTK::System and State have been created for the 
-    Model (that is, after extendAddToSystem() has been called on all components). 
+    This is called after a SimTK::System and State have been created for the
+    Model (that is, after extendAddToSystem() has been called on all components).
     You should override this method if your component has properties
     (serializable values) that can affect initial values for your state
     variables. You can also perform any other state-independent calculations
     here that result in state initial conditions.
-   
-    If you override this method, be sure to invoke the base class method first, 
+
+    If you override this method, be sure to invoke the base class method first,
     using code like this:
     @code
     void MyComponent::extendInitStateFromProperties(SimTK::State& state) const {
@@ -1924,10 +1924,10 @@ protected:
 
     /** Update this component's property values to match the specified State,
     if the component has created any state variable that is intended to
-    correspond to a property. Thus, state variable values can persist as part 
+    correspond to a property. Thus, state variable values can persist as part
     of the model component and be serialized as a property.
-   
-    If you override this method, be sure to invoke the base class method first, 
+
+    If you override this method, be sure to invoke the base class method first,
     using code like this:
     @code
     void MyComponent::extendSetPropertiesFromState(const SimTK::State& state) {
@@ -1936,7 +1936,7 @@ protected:
     }
     @endcode
 
-    @param      state    
+    @param      state
         The State from which values may be extracted to set persistent
         property values.
 
@@ -1946,7 +1946,7 @@ protected:
     /** If a model component has allocated any continuous state variables
     using the addStateVariable() method, then %computeStateVariableDerivatives()
     must be implemented to provide time derivatives for those states.
-    Override to set the derivatives of state variables added to the system 
+    Override to set the derivatives of state variables added to the system
     by this component. (also see extendAddToSystem()). If the component adds states
     and computeStateVariableDerivatives is not implemented by the component,
     an exception is thrown when the system tries to evaluate its derivatives.
@@ -1954,14 +1954,14 @@ protected:
     Implement like this:
     @code
     void computeStateVariableDerivatives(const SimTK::State& state) const {
-        
-        // Let the parent class set the derivative values for the 
+
+        // Let the parent class set the derivative values for the
         // the state variables that it added.
         Super::computeStateVariableDerivatives(state)
 
         // Compute derivative values for states allocated by this component
         // as a function of the state.
-        double deriv = ... 
+        double deriv = ...
 
         // Then set the derivative value by state variable name
         setStateVariableDerivativeValue(state, "<state_variable_name>", deriv);
@@ -1971,7 +1971,7 @@ protected:
     For subclasses, it is highly recommended that you first call
     Super::computeStateVariableDerivatives(state) to preserve the derivative
     computation of the parent class and to only specify the derivatives of the state
-    variables added by name. One does have the option to override all the derivative 
+    variables added by name. One does have the option to override all the derivative
     values for the parent by accessing the derivatives by their state variable name.
     This is necessary, for example, if a newly added state variable is coupled to the
     dynamics (derivatives) of the states variables that were added by the parent.
@@ -1986,25 +1986,25 @@ protected:
      * @param name   the name of the state variable
      * @param deriv  the derivative value to set
      */
-    void setStateVariableDerivativeValue(const SimTK::State& state, 
+    void setStateVariableDerivativeValue(const SimTK::State& state,
                             const std::string& name, double deriv) const;
 
 
     // End of Component Extension Interface (protected virtuals).
-    ///@} 
+    ///@}
 
     /** @name           Component Advanced Interface
     You probably won't need to override methods in this section. These provide
-    a way for you to perform computations ("realizations") that must be 
+    a way for you to perform computations ("realizations") that must be
     scheduled in carefully-ordered stages as described in the class description
     above. The typical operation will be that the given SimTK::State provides
-    you with the inputs you need for your computation, which you will then 
+    you with the inputs you need for your computation, which you will then
     write into some element of the state cache, where later computations can
     pick it up.
 
     @note Once again it is crucial that, if you override a method here,
     you invoke the superclass method as the <em>first line</em> in your
-    implementation, via a call like "Super::extendRealizePosition(state);". This 
+    implementation, via a call like "Super::extendRealizePosition(state);". This
     will ensure that all necessary base class computations are performed, and
     that subcomponents are handled properly.
 
@@ -2022,7 +2022,7 @@ protected:
     virtual void extendRealizeTopology(SimTK::State& state) const;
     /** Obtain and name state resources (like state variables allocated by
     an underlying Simbody component) that may be needed, depending on modeling
-    options. Also, perform any computations that depend only on topology and 
+    options. Also, perform any computations that depend only on topology and
     selected modeling options. **/
     virtual void extendRealizeModel(SimTK::State& state) const;
     /** Perform computations that depend only on instance variables, like
@@ -2033,11 +2033,11 @@ protected:
     /** Perform computations that depend only on position-level state
     variables and computations performed in earlier stages (including time). **/
     virtual void extendRealizePosition(const SimTK::State& state) const;
-    /** Perform computations that depend only on velocity-level state 
-    variables and computations performed in earlier stages (including position, 
+    /** Perform computations that depend only on velocity-level state
+    variables and computations performed in earlier stages (including position,
     and time). **/
     virtual void extendRealizeVelocity(const SimTK::State& state) const;
-    /** Perform computations (typically forces) that may depend on 
+    /** Perform computations (typically forces) that may depend on
     dynamics-stage state variables, and on computations performed in earlier
     stages (including velocity, position, and time), but not on other forces,
     accelerations, constraint multipliers, or reaction forces. **/
@@ -2060,22 +2060,22 @@ protected:
 
     //@{
 
-    /** Add a modeling option (integer flag stored in the State) for use by 
-    this Component. Each modeling option is identified by its own 
+    /** Add a modeling option (integer flag stored in the State) for use by
+    this Component. Each modeling option is identified by its own
     \a optionName, specified here. Modeling options enable the model
-    component to be configured differently in order to represent different 
+    component to be configured differently in order to represent different
     operating modes. For example, if two modes of operation are necessary (mode
-    off and mode on) then specify optionName, "mode" with maxFlagValue = 1. 
-    Subsequent gets will return 0 or 1 and set will only accept 0 and 1 as 
-    acceptable values. Changing the value of a model option invalidates 
+    off and mode on) then specify optionName, "mode" with maxFlagValue = 1.
+    Subsequent gets will return 0 or 1 and set will only accept 0 and 1 as
+    acceptable values. Changing the value of a model option invalidates
     Stage::Instance and above in the State, meaning all calculations involving
     time, positions, velocity, and forces are invalidated. **/
-    void addModelingOption(const std::string&  optionName, 
+    void addModelingOption(const std::string&  optionName,
                            int                 maxFlagValue) const;
 
 
     /** Add a continuous system state variable belonging to this Component,
-    and assign a name by which to refer to it. Changing the value of this state 
+    and assign a name by which to refer to it. Changing the value of this state
     variable will automatically invalidate everything at and above its
     \a invalidatesStage, which is normally Stage::Dynamics meaning that there
     are forces that depend on this variable. If you define one or more
@@ -2083,7 +2083,7 @@ protected:
     to provide time derivatives for them. Note, all corresponding system
     indices are automatically determined using this interface. As an advanced
     option you may choose to hide the state variable from being accessed outside
-    of this component, in which case it is considered to be "hidden". 
+    of this component, in which case it is considered to be "hidden".
     You may also want to create an Output for this state variable; see
     #OpenSim_DECLARE_OUTPUT_FOR_STATE_VARIABLE for more information. Reporters
     should use such an Output to get the StateVariable's value (instead of using
@@ -2121,49 +2121,49 @@ protected:
                              SimTK::Stage       invalidatesStage) const;
 
     /** Add a state cache entry belonging to this Component to hold
-    calculated values that must be automatically invalidated when certain 
+    calculated values that must be automatically invalidated when certain
     state values change. Cache entries contain values whose computations depend
-    on state variables and provide convenience and/or efficiency by holding on 
-    to them in memory (cache) to avoid recomputation. Once the state changes, 
+    on state variables and provide convenience and/or efficiency by holding on
+    to them in memory (cache) to avoid recomputation. Once the state changes,
     the cache values automatically become invalid and has to be
     recomputed based on the current state before it can be referenced again.
     Any attempt to reference an invalid cache entry results in an exception
     being thrown.
 
-    Cache entry validity is managed by computation Stage, rather than by 
+    Cache entry validity is managed by computation Stage, rather than by
     dependence on individual state variables. Changing a variables whose
     "invalidates" stage is the same or lower as the one specified as the
-    "depends on" stage here cause the cache entry to be invalidated. For 
-    example, a body's momentum, which is dependent on position and velocity 
+    "depends on" stage here cause the cache entry to be invalidated. For
+    example, a body's momentum, which is dependent on position and velocity
     states, should have Stage::Velocity as its \a dependsOnStage. Then if a
-    Velocity stage variable or lower (e.g. Position stage) changes, then the 
-    cache is invalidated. But, if a Dynamics stage variable (or above) is 
-    changed, the velocity remains valid so the cache entry does not have to be 
+    Velocity stage variable or lower (e.g. Position stage) changes, then the
+    cache is invalidated. But, if a Dynamics stage variable (or above) is
+    changed, the velocity remains valid so the cache entry does not have to be
     recomputed.
 
     @param[in]      cacheVariableName
         The name you are assigning to this cache entry. Must be unique within
         this model component.
-    @param[in]      variablePrototype   
+    @param[in]      variablePrototype
         An object defining the type of value, and a default value of that type,
         to be held in this cache entry. Can be a simple int or an elaborate
         class, as long as it has deep copy semantics.
-    @param[in]      dependsOnStage      
+    @param[in]      dependsOnStage
         This is the highest computational stage on which this cache entry's
         value computation depends. State changes at this level or lower will
-        invalidate the cache entry. **/ 
-    template <class T> void 
+        invalidate the cache entry. **/
+    template <class T> void
     addCacheVariable(const std::string&     cacheVariableName,
-                     const T&               variablePrototype, 
+                     const T&               variablePrototype,
                      SimTK::Stage           dependsOnStage) const
     {
-        // Note, cache index is invalid until the actual allocation occurs 
+        // Note, cache index is invalid until the actual allocation occurs
         // during realizeTopology.
-        _namedCacheVariableInfo[cacheVariableName] = 
+        _namedCacheVariableInfo[cacheVariableName] =
             CacheInfo(new SimTK::Value<T>(variablePrototype), dependsOnStage);
     }
 
-    
+
     /**
      * Get writable reference to the MultibodySystem that this component is
      * connected to.
@@ -2181,7 +2181,7 @@ protected:
      * found.
      * @param stateVariableName   the name of the state variable
      */
-    SimTK::SystemYIndex 
+    SimTK::SystemYIndex
         getStateVariableSystemIndex(const std::string& stateVariableName) const;
 
    /**
@@ -2189,17 +2189,17 @@ protected:
      * allocations. This method is intended for derived Components that may need
      * direct access to its underlying Subsystem.
      */
-    const SimTK::DiscreteVariableIndex 
+    const SimTK::DiscreteVariableIndex
     getDiscreteVariableIndex(const std::string& name) const;
 
     /** Get the index of a Component's cache variable in the Subsystem for allocations.
         This method is intended for derived Components that may need direct access
         to its underlying Subsystem.*/
-    const SimTK::CacheEntryIndex 
+    const SimTK::CacheEntryIndex
     getCacheVariableIndex(const std::string& name) const;
 
     // End of System Creation and Access Methods.
-    //@} 
+    //@}
 
 public:
 
@@ -2233,7 +2233,7 @@ public:
     supplying "elbow_flexion" requires a tree search. Returns nullptr (None in
     Python, empty array in Matlab) if Component of that specified name cannot
     be found.
-        
+
     NOTE: If the component name is ambiguous, an exception is thrown. To
     disambiguate, more information must be provided, such as the template
     argument to specify the type and/or a path rather than just the name. */
@@ -2266,7 +2266,7 @@ public:
         }
 
         ComponentList<const C> compsList = this->template getComponentList<C>();
-        
+
         for (const C& comp : compsList) {
             // if a child of this Component, one should not need
             // to specify this Component's absolute path name
@@ -2276,7 +2276,7 @@ public:
             if (compAbsPath == thisAbsPathPlusSubname) {
                 foundCs.push_back(&comp);
                 break;
-            } 
+            }
 
             // otherwise, we just have a type and name match
             // which we may need to support for compatibility with older models
@@ -2289,7 +2289,7 @@ public:
                 // when what appears to be the complete path.
                 if (comp.getDebugLevel() > 0) {
                     std::string details = msg + " Found '" + compAbsPath.toString() +
-                        "' as a match for:\n Component '" + name + "' of type " + 
+                        "' as a match for:\n Component '" + name + "' of type " +
                         comp.getConcreteClassName() + ", but it "
                         "is not on specified path.\n";
                     //throw Exception(details, __FILE__, __LINE__);
@@ -2345,7 +2345,7 @@ protected:
                 ++iPathEltStart;
             }
         }
-        
+
         using RefComp = SimTK::ReferencePtr<const Component>;
 
         // Skip over the root component name.
@@ -2453,7 +2453,7 @@ protected:
             new Socket<T>(name, propIndex, SimTK::Stage::Topology, *this));
         return propIndex;
     }
-    
+
 #ifndef SWIG // SWIG can't parse the const at the end of the second argument.
     /** Construct an output for a member function of the same component.
         The following must be true about componentMemberFunction, the function
@@ -2462,7 +2462,7 @@ protected:
            -# It is a member function of \a this component.
            -# The member function is const.
            -# It takes only one input, which is `const SimTK::State&`
-           -# The function returns the computed quantity *by value* (e.g., 
+           -# The function returns the computed quantity *by value* (e.g.,
               `double computeQuantity(const SimTK::State&) const`).
 
         You must also provide the stage on which the output depends.
@@ -2495,7 +2495,7 @@ protected:
         return constructOutput<T>(name, outputFunc, dependsOn);
     }
     /** This variant handles component member functions that return the
-     * output value by const reference (const T&). 
+     * output value by const reference (const T&).
      * @warning ONLY use this with member functions that fetch quantities that
      * are stored within the passed-in SimTK::State. The function cannot return
      * local variables. */
@@ -2561,7 +2561,7 @@ protected:
      * non-existent. This also specifies at what stage the output must be valid
      * for the component to consume it as an input.  If the Output's
      * dependsOnStage is above the Input's requiredAtStage, an Exception is
-     * thrown because the output cannot satisfy the Input's requirement. 
+     * thrown because the output cannot satisfy the Input's requirement.
      * This function also creates a Property in this component to store the
      * connectee paths for this input; the
      * propertyComment argument is the comment to use for that Property. */
@@ -2602,12 +2602,12 @@ protected:
 private:
 
     //Mark components that are properties of this Component as subcomponents of
-    //this Component. This happens automatically upon construction of the 
+    //this Component. This happens automatically upon construction of the
     //component. If a Component property is added programmatically, then one must
     //also mark it by calling markAsPropertySubcomponent() with that component.
     void markPropertiesAsSubcomponents();
 
-    // Internal use: mark as a subcomponent, a component that is owned by this 
+    // Internal use: mark as a subcomponent, a component that is owned by this
     // Component by virtue of being one of its properties.
     void markAsPropertySubcomponent(const Component* subcomponent);
 
@@ -2653,11 +2653,11 @@ private:
         return true;
     }
 
-    // Get the number of continuous states that the Component added to the 
-    // underlying computational system. It includes the number of built-in states  
-    // exposed by this component. It represents the number of state variables  
+    // Get the number of continuous states that the Component added to the
+    // underlying computational system. It includes the number of built-in states
+    // exposed by this component. It represents the number of state variables
     // managed by this Component.
-    int getNumStateVariablesAddedByComponent() const 
+    int getNumStateVariablesAddedByComponent() const
     {   return (int)_namedStateVariableInfo.size(); }
     Array<std::string> getStateVariableNamesAddedByComponent() const;
 
@@ -2676,11 +2676,11 @@ private:
     void warnBeforePrint() const override;
 
 protected:
-    //Derived Components must create concrete StateVariables to expose their state 
+    //Derived Components must create concrete StateVariables to expose their state
     //variables. When exposing state variables allocated by the underlying Simbody
-    //component (MobilizedBody, Constraint, Force, etc...) use its interface to 
+    //component (MobilizedBody, Constraint, Force, etc...) use its interface to
     //implement the virtual methods below. Otherwise, if the Component is adding its
-    //own state variables using the addStateVariable() helper, then an 
+    //own state variables using the addStateVariable() helper, then an
     //AddedStateVariable implements the interface and automatically handles state
     //variable access.
     class StateVariable {
@@ -2704,9 +2704,9 @@ protected:
         const Component& getOwner() const { return *owner; }
 
         const int& getVarIndex() const { return varIndex; }
-        // return the index of the subsystem used to make resource allocations 
+        // return the index of the subsystem used to make resource allocations
         const SimTK::SubsystemIndex& getSubsysIndex() const { return subsysIndex; }
-        // return the index in the global list of continuous state variables, Y 
+        // return the index in the global list of continuous state variables, Y
         const SimTK::SystemYIndex& getSystemYIndex() const { return sysYIndex; }
 
         bool isHidden() const { return hidden; }
@@ -2730,7 +2730,7 @@ protected:
         std::string name;
         SimTK::ReferencePtr<const Component> owner;
 
-        // Identify which subsystem this state variable belongs to, which should 
+        // Identify which subsystem this state variable belongs to, which should
         // be determined and set at creation time
         SimTK::SubsystemIndex subsysIndex;
         // The local variable index in the subsystem also provided at creation
@@ -2820,7 +2820,7 @@ private:
     // Component. This list must be populated prior to addToSystem(), and is
     // used strictly to specify the order in which addToSystem() is invoked
     // on its subcomponents. The order is necessary for the construction
-    // of Simbody elements (e.g. MobilizedBodies, Constraints, Forces, 
+    // of Simbody elements (e.g. MobilizedBodies, Constraints, Forces,
     // Measures, ...) which cannot be added to the SimTK::MultibodySystem in
     // arbitrary order. In the case of MobilizedBodies, for example, the parent
     // MobilizedBody must be part of the system before the child can be added.
@@ -2835,7 +2835,7 @@ private:
     // discrete state variable that invalidates Model stage if changed.
     struct ModelingOptionInfo {
         ModelingOptionInfo() : maxOptionValue(-1) {}
-        explicit ModelingOptionInfo(int maxOptVal) 
+        explicit ModelingOptionInfo(int maxOptVal)
         :   maxOptionValue(maxOptVal) {}
         // Model
         int                             maxOptionValue;
@@ -2850,14 +2850,14 @@ private:
         AddedStateVariable() : StateVariable(),
             invalidatesStage(SimTK::Stage::Empty)  {}
 
-        /** Convenience constructor for defining a Component added state variable */ 
+        /** Convenience constructor for defining a Component added state variable */
         explicit AddedStateVariable(const std::string& name, //state var name
                         const Component& owner,       //owning component
                         SimTK::Stage invalidatesStage,//stage this variable invalidates
-                        bool hide=false) : 
+                        bool hide=false) :
                     StateVariable(name, owner,
                             SimTK::SubsystemIndex(SimTK::InvalidIndex),
-                            SimTK::InvalidIndex, hide), 
+                            SimTK::InvalidIndex, hide),
                         invalidatesStage(SimTK::Stage::Empty) {}
 
         //override virtual methods
@@ -2868,13 +2868,13 @@ private:
         void setDerivative(const SimTK::State& state, double deriv) const override;
 
         private: // DATA
-        // Changes in state variables trigger recalculation of appropriate cache 
+        // Changes in state variables trigger recalculation of appropriate cache
         // variables by automatically invalidating the realization stage specified
         // upon allocation of the state variable.
         SimTK::Stage    invalidatesStage;
     };
 
-    // Structure to hold related info about discrete variables 
+    // Structure to hold related info about discrete variables
     struct StateVariableInfo {
         StateVariableInfo() {}
         explicit StateVariableInfo(Component::StateVariable* sv, int order) :
@@ -2902,7 +2902,7 @@ private:
         int order;
     };
 
-    // Structure to hold related info about discrete variables 
+    // Structure to hold related info about discrete variables
     struct DiscreteVariableInfo {
         DiscreteVariableInfo() {}
         explicit DiscreteVariableInfo(SimTK::Stage invalidates)
@@ -2913,7 +2913,7 @@ private:
         SimTK::DiscreteVariableIndex    index;
     };
 
-    // Structure to hold related info about cache variables 
+    // Structure to hold related info about cache variables
     struct CacheInfo {
         CacheInfo() {}
         CacheInfo(SimTK::AbstractValue* proto,
@@ -2929,24 +2929,24 @@ private:
     // Map names of modeling options for the Component to their underlying
     // SimTK indices.
     // These are mutable here so they can ONLY be modified in extendAddToSystem().
-    // This is not an API bug. The purpose of these maps is to automate the 
-    // bookkeeping of component variables (state variables and cache entries) with 
-    // their index in the computational system. The earliest time we have a valid 
+    // This is not an API bug. The purpose of these maps is to automate the
+    // bookkeeping of component variables (state variables and cache entries) with
+    // their index in the computational system. The earliest time we have a valid
     // index is when we ask the system to allocate the resources and that only
     // happens in extendAddToSystem. Furthermore, extendAddToSystem may not
     // alter the Component in any way that would affect its behavior- that is
     // why it is const!
-    // The setting of the variable indices is not in the public interface and is 
+    // The setting of the variable indices is not in the public interface and is
     // not polymorphic.
 
     mutable std::map<std::string, ModelingOptionInfo> _namedModelingOptionInfo;
-    // Map names of continuous state variables of the Component to their 
+    // Map names of continuous state variables of the Component to their
     // underlying SimTK indices.
     mutable std::map<std::string, StateVariableInfo> _namedStateVariableInfo;
     // Map names of discrete variables of the Component to their underlying
     // SimTK indices.
     mutable std::map<std::string, DiscreteVariableInfo> _namedDiscreteVariableInfo;
-    // Map names of cache entries of the Component to their individual 
+    // Map names of cache entries of the Component to their individual
     // cache information.
     mutable std::map<std::string, CacheInfo>            _namedCacheVariableInfo;
 
@@ -2954,7 +2954,7 @@ private:
     bool isAllStatesVariablesListValid() const;
 
     // Array of all state variables for fast access during simulation
-    mutable SimTK::Array_<SimTK::ReferencePtr<const StateVariable> > 
+    mutable SimTK::Array_<SimTK::ReferencePtr<const StateVariable> >
                                                             _allStateVariables;
     // A handle the System associated with the above state variables
     mutable SimTK::ReferencePtr<const SimTK::System> _statesAssociatedSystem;
@@ -2963,7 +2963,7 @@ private:
 };  // END of class Component
 //==============================================================================
 //==============================================================================
-    
+
 // Implement methods for ComponentListIterator
 /// ComponentListIterator<T> pre-increment operator, advances the iterator to
 /// the next valid entry.
@@ -2997,8 +2997,8 @@ template <typename T>
 void ComponentListIterator<T>::advanceToNextValidComponent() {
     // Advance _node to next valid (of type T) if needed
     // Similar logic to operator++ but applies _filter->isMatch()
-    while (_node != nullptr && (dynamic_cast<const T*>(_node) == nullptr || 
-                                !_filter.isMatch(*_node) || 
+    while (_node != nullptr && (dynamic_cast<const T*>(_node) == nullptr ||
+                                !_filter.isMatch(*_node) ||
                                 (_node == _root))){
         if (_node->_memberSubcomponents.size() > 0) {
             _node = _node->_memberSubcomponents[0].get();
@@ -3019,7 +3019,7 @@ void ComponentListIterator<T>::advanceToNextValidComponent() {
     }
     return;
 }
-    
+
 
 class ConnecteeNotSpecified : public Exception {
 public:
@@ -3040,7 +3040,27 @@ public:
     }
 };
 
+template<class C>
+const C& Socket<C>::getConnectee() const {
+    if (!isConnected()) {
+        std::string msg = "Socket " + getName() + " of type " +
+                          C::getClassName() + " in " +
+                          getOwner().getAbsolutePathString() + " of type " +
+                          getOwner().getConcreteClassName() + " is not connected.";
+        OPENSIM_THROW(Exception, msg);
+    }
+    return connectee.getRef();
+}
 
+template<class C>
+void Socket<C>::findAndConnect(const ComponentPath& connectee) {
+    const auto* comp =
+            getOwner().getRoot().template findComponent<C>(connectee);
+    OPENSIM_THROW_IF(!comp, ComponentNotFound, connectee.toString(),
+                     getConnecteeTypeName(),
+                     getOwner().getAbsolutePathString());
+    connect(*comp);
+}
 
 template<class C>
 void Socket<C>::finalizeConnection(const Component& root) {
@@ -3067,7 +3087,7 @@ void Socket<C>::finalizeConnection(const Component& root) {
                 connecteePath.getSubcomponentNameAtLevel(0) == "..")
             connecteePath = connectee->getAbsolutePath();
         updConnecteePathProp().setValue(0, connecteePath.toString());
-        
+
     } else {
         const auto connecteePath = getConnecteePath();
         OPENSIM_THROW_IF(connecteePath.empty(), ConnecteeNotSpecified,
@@ -3180,7 +3200,7 @@ void Input<T>::finalizeConnection(const Component& root) {
                                compPathStr, outputName, channelName, alias);
             ComponentPath compPath(compPathStr);
             const AbstractOutput* output = nullptr;
-            
+
             if (compPath.isAbsolute()) { //absolute path string
                 if (compPathStr.empty()) {
                     output = &root.getOutput(outputName);

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -361,16 +361,7 @@ public:
         For example, Input should short circuit to its Output's getValue()
         once it is connected.
     Return a const reference to the object connected to this Socket */
-    const T& getConnectee() const {
-        if (!isConnected()) {
-            std::string msg = "Socket " + getName() + " of type " +
-                    T::getClassName() + " in " +
-                    getOwner().getAbsolutePathString() + " of type " +
-                    getOwner().getConcreteClassName() + " is not connected.";
-            OPENSIM_THROW(Exception, msg);
-        }
-        return connectee.getRef();
-    }
+    const T& getConnectee() const;
 
     /** Connect this Socket to the provided connectee object */
     void connect(const Object& object) override {
@@ -394,13 +385,7 @@ public:
      * Throws an exception If you provide only a component name and the
      * model has multiple components with that nume.
      * */
-    void findAndConnect(const ComponentPath& connectee) override {
-        const auto* comp =
-            getOwner().getRoot().template findComponent<T>(connectee);
-        OPENSIM_THROW_IF(!comp, ComponentNotFound, connectee.toString(),
-                getConnecteeTypeName(), getOwner().getAbsolutePathString());
-        connect(*comp);
-    }
+    void findAndConnect(const ComponentPath& connectee) override;
 
     /** Connect this Socket given its connectee path property  */
     void finalizeConnection(const Component& root) override;

--- a/OpenSim/Common/PropertySet.cpp
+++ b/OpenSim/Common/PropertySet.cpp
@@ -136,7 +136,7 @@ getSize() const
  * @throws Exception if the index is out of bounds.
  */
 Property_Deprecated* PropertySet::
-get(int aIndex) throw(Exception)
+get(int aIndex)
 {
     // NO SUCH PROPERTY - THROW EXCEPTION
     if((aIndex<0)||(aIndex>=_array.getSize())) {
@@ -172,7 +172,7 @@ get(int aIndex) const
  * @throws Exception if there is no such property.
  */
 Property_Deprecated* PropertySet::
-get(const string &aName) throw(Exception)
+get(const string &aName)
 {
     int i;
     PropertyInt prop(aName,0);

--- a/OpenSim/Common/PropertySet.h
+++ b/OpenSim/Common/PropertySet.h
@@ -113,11 +113,11 @@ public:
     // Number of properties
     int getSize() const;
     // Get
-    virtual Property_Deprecated* get(int i) throw (Exception);
+    virtual Property_Deprecated* get(int i);
 #ifndef SWIG
     virtual const Property_Deprecated* get(int i) const;
 #endif
-    virtual Property_Deprecated* get(const std::string &aName) throw (Exception);
+    virtual Property_Deprecated* get(const std::string &aName);
 #ifndef SWIG
     virtual const Property_Deprecated* get(const std::string &aName) const;
 #endif


### PR DESCRIPTION
This PR fixes some warnings generated by GCC-8 about throw() being deprecated and Component being an incomplete type in ComponentSocket.h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2552)
<!-- Reviewable:end -->
