### PR TITLE
Update osimC3D and test

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimC3D.m
+++ b/Bindings/Java/Matlab/Utilities/osimC3D.m
@@ -38,7 +38,7 @@ classdef osimC3D < matlab.mixin.SetGet
         ForceLocation
     end
     methods
-        function obj = osimC3D(path2c3d, ForceLocation)
+        function self = osimC3D(path2c3d, ForceLocation)
             % Class Constructor: input is an absolute path to a C3D file.
 
             % Verify the correct number of inputs
@@ -53,8 +53,8 @@ classdef osimC3D < matlab.mixin.SetGet
                 if isempty(path)
                     error('Input path must be full path to file (C:/data/Walking.mot)')
                 end
-                obj.path = path;
-                obj.name = name;
+                self.path = path;
+                self.name = name;
             end
             % Verify the ForceLocation input is correct
             if  ~isnumeric(ForceLocation) || ~ismember(ForceLocation,[0:2])
@@ -67,8 +67,8 @@ classdef osimC3D < matlab.mixin.SetGet
 			c3dAdapter.setLocationForForceExpression(ForceLocation);
             tables = c3dAdapter.read(path2c3d);
             % Set the marker and force data into OpenSim tables
-            obj.markers = c3dAdapter.getMarkersTable(tables);
-            obj.forces = c3dAdapter.getForcesTable(tables);
+            self.markers = c3dAdapter.getMarkersTable(tables);
+            self.forces = c3dAdapter.getForcesTable(tables);
             % Set the force location specifier in case someone wants to
             % check.
             switch(ForceLocation)
@@ -79,63 +79,63 @@ classdef osimC3D < matlab.mixin.SetGet
                 case 2
                     location = 'PointOfWrenchApplication';
             end
-            obj.ForceLocation = location;
+            self.ForceLocation = location;
         end
-        function p = getPath(obj)
-            p = obj.path();
+        function p = getPath(self)
+            p = self.path();
         end
-        function n = getName(obj)
-            n = obj.name();
+        function n = getName(self)
+            n = self.name();
         end
-        function location = getForceLocation(obj)
+        function location = getForceLocation(self)
             % Get the Force Location
-            location = obj.ForceLocation();
+            location = self.ForceLocation();
         end
-        function rate = getRate_marker(obj)
+        function rate = getRate_marker(self)
             % Get the capture rate used for the Marker Data
-            rate = str2double(obj.markers.getTableMetaDataAsString('DataRate'));
+            rate = str2double(self.markers.getTableMetaDataAsString('DataRate'));
         end
-        function rate = getRate_force(obj)
+        function rate = getRate_force(self)
             % Get the capture rate used for the Force Data
-            rate = str2double(obj.forces.getTableMetaDataAsString('DataRate'));
+            rate = str2double(self.forces.getTableMetaDataAsString('DataRate'));
         end
-        function n = getNumTrajectories(obj)
+        function n = getNumTrajectories(self)
             % Get the number of markers in the c3d file
-            n = obj.markers.getNumColumns();
+            n = self.markers.getNumColumns();
         end
-        function n = getNumForces(obj)
+        function n = getNumForces(self)
             % Get the number of forceplates in the c3d file
-            n = (obj.forces.getNumColumns())/3;
+            n = (self.forces.getNumColumns())/3;
         end
-        function t = getStartTime(obj)
+        function t = getStartTime(self)
             % Get the start time of the c3d file
-            t = obj.markers.getIndependentColumn().get(0);
+            t = self.markers.getIndependentColumn().get(0);
         end
-        function t = getEndTime(obj)
+        function t = getEndTime(self)
             % Get the end time of the c3d file
-            t = obj.markers.getIndependentColumn().get(obj.markers.getNumRows() - 1);
+            t = self.markers.getIndependentColumn().get(self.markers.getNumRows() - 1);
         end
-        function name = getFileName(obj)
+        function name = getFileName(self)
             % Get the name of the c3d file
-            [filedirectory, name, extension] = fileparts(obj.path);
+            [filedirectory, name, extension] = fileparts(self.path);
         end
-        function filedirectory = getDirectory(obj)
+        function filedirectory = getDirectory(self)
             % Get the directory path for the c3d file
-            [filedirectory, name, extension] = fileparts(obj.path);
+            [filedirectory, name, extension] = fileparts(self.path);
         end
-        function table = getTable_markers(obj)
-            table = obj.markers().clone();
+        function table = getTable_markers(self)
+            table = self.markers().clone();
         end
-        function table = getTable_forces(obj)
-            table = obj.forces().clone();
+        function table = getTable_forces(self)
+            table = self.forces().clone();
         end
-        function [markerStruct, forcesStruct] = getAsStructs(obj)
+        function [markerStruct, forcesStruct] = getAsStructs(self)
             % Convert the OpenSim tables into Matlab Structures
-            markerStruct = osimTableToStruct(obj.markers);
-            forcesStruct = osimTableToStruct(obj.forces);
+            markerStruct = osimTableToStruct(self.markers);
+            forcesStruct = osimTableToStruct(self.forces);
             disp('Maker and force data returned as Matlab Structs')
         end
-        function rotateData(obj,axis,value)
+        function rotateData(self,axis,value)
             % Method for rotating marker and force data stored in osim
             % tables.
             % c3d.rotateData('x', 90)
@@ -147,63 +147,63 @@ classdef osimC3D < matlab.mixin.SetGet
                 error('value must be numeric (90, -90, 270, ...')
             end
             % rotate the tables
-            obj.rotateTable(obj.markers, axis, value);
-            obj.rotateTable(obj.forces, axis, value);
+            self.rotateTable(self.markers, axis, value);
+            self.rotateTable(self.forces, axis, value);
             disp('Marker and Force tables have been rotated')
         end
-        function convertMillimeters2Meters(obj)
+        function convertMillimeters2Meters(self)
             % Function to convert  point data (mm) to m and Torque data 
             % (Nmm) to Nm.
             
             import org.opensim.modeling.*
             
-            nRows  = obj.forces.getNumRows();
-            labels = obj.forces.getColumnLabels();
+            nRows  = self.forces.getNumRows();
+            labels = self.forces.getColumnLabels();
             
-            for i = 0 : obj.forces.getNumColumns - 1
+            for i = 0 : self.forces.getNumColumns - 1
                 % All force columns will have the 'f' prefix while point
                 % and moment columns will have 'p' and 'm' prefixes,
                 % respectively. 
-                if ~contains(char(labels.get(i)),'f')
+                if ~startsWith(char(labels.get(i)),'f')
                     for u = 0 : nRows - 1
                         % Get the Vec3
-                        vec3 = obj.forces.getDependentColumnAtIndex(i).get(u);
+                        vec3 = self.forces.getDependentColumnAtIndex(i).get(u);
                         % Divide the Vec3 by 1000
                         vec3_new = Vec3(vec3.get(0)/1000,vec3.get(1)/1000,vec3.get(2)/1000);
                         % set the table value
-                        obj.forces.getDependentColumnAtIndex(i).set(u,vec3_new);
+                        self.forces.getDependentColumnAtIndex(i).set(u,vec3_new);
                     end
                 end    
             end
            disp('Point and Torque values convert from mm and Nmm to m and Nm, respectively')
         end
-        function writeTRC(obj,varargin)
+        function writeTRC(self,varargin)
             % Write marker data to trc file.
             % osimC3d.writeTRC()                       Write to dir of input c3d.
             % osimC3d.writeTRC('Walking.trc')          Write to dir of input c3d with defined file name.
             % osimC3d.writeTRC('C:/data/Walking.trc')  Write to defined path input path.
 
             % Compute an output path to use for writing to file
-            outputPath = generateOutputPath(obj,varargin,'.trc');
+            outputPath = generateOutputPath(self,varargin,'.trc');
 
 
             import org.opensim.modeling.*
             % Write to file
-            TRCFileAdapter().write( obj.markers, outputPath)
+            TRCFileAdapter().write( self.markers, outputPath)
             disp(['Marker file written to ' outputPath]);
         end
-        function writeMOT(obj,varargin)
+        function writeMOT(self,varargin)
         % Write force data to mot file.
         % osimC3d.writeMOT()                       Write to dir of input c3d.
         % osimC3d.writeMOT('Walking.mot')          Write to dir of input c3d with defined file name.
         % osimC3d.writeMOT('C:/data/Walking.mot')  Write to defined path input path.
 
          % Compute an output path to use for writing to file
-         outputPath = generateOutputPath(obj,varargin,'.mot');
+         outputPath = generateOutputPath(self,varargin,'.mot');
          
          import org.opensim.modeling.*
          % Get the forces table
-         forces = obj.getTable_forces();
+         forces = self.getTable_forces();
          % Get the column labels
          labels = forces.getColumnLabels();
          % Make a copy
@@ -259,15 +259,15 @@ classdef osimC3D < matlab.mixin.SetGet
    end
 
    methods (Access = private, Hidden = true)
-        function setMarkers(obj, a)
+        function setMarkers(self, a)
             % Private Method for setting the internal Marker table
-            obj.markers = a;
+            self.markers = a;
         end
-        function setForces(obj, a)
+        function setForces(self, a)
             % Private Method for setting the internal Force table
-            obj.forces = a;
+            self.forces = a;
         end
-        function rotateTable(obj, table, axisString, value)
+        function rotateTable(self, table, axisString, value)
             % Private Method for doing the table rotation operations
 
             import org.opensim.modeling.*
@@ -282,7 +282,7 @@ classdef osimC3D < matlab.mixin.SetGet
                 error('input axis must ne either x,y, or z')
             end
 
-            % instantiate a transform object. Rotation() is a Simbody class
+            % instantiate a transform selfect. Rotation() is a Simbody class
             R = Rotation( deg2rad(value) , axis ) ;
 
             % Rotation() works on each row.
@@ -295,13 +295,13 @@ classdef osimC3D < matlab.mixin.SetGet
                 table.setRowAtIndex(iRow,rowVec_rotated)
             end
         end
-        function outputPath = generateOutputPath(obj,path, ext)
+        function outputPath = generateOutputPath(self,path, ext)
             % Function to generate an output path from no, partial, or fully
             % defined user path. 
             
             % Validate the output filename
             if size(path,2) > 1
-                % Path object should be of size == 1, any larger and user
+                % Path selfect should be of size == 1, any larger and user
                 % input multiple variables into function. 
                 error([ num2str(size(path,2)) ' inputs, expecting zero or one'])
             end
@@ -309,8 +309,8 @@ classdef osimC3D < matlab.mixin.SetGet
             if isempty(path)
                % No file path has been input, so use the path and name from
                % the c3d file. 
-               filepath = obj.getPath();
-               name = obj.getName();
+               filepath = self.getPath();
+               name = self.getName();
             else
             
                 if ~ischar(path{1})
@@ -325,7 +325,7 @@ classdef osimC3D < matlab.mixin.SetGet
                 [filepath, name, e] = fileparts(path{1}); 
                 if isempty(filepath)
                   % Only the file name is given
-                  filepath = obj.getPath();
+                  filepath = self.getPath();
                 end
             end
             % Generate the output path.

--- a/Bindings/Java/Matlab/Utilities/osimC3D.m
+++ b/Bindings/Java/Matlab/Utilities/osimC3D.m
@@ -1,3 +1,13 @@
+classdef osimC3D < matlab.mixin.SetGet
+% osimC3D(filepath, ForceLocation)
+%   C3D data to OpenSim Tables.
+%   OpenSim Utility Class
+%   Inputs:
+%   filepath           Full path to the location of the C3D file
+%   ForceLocation      Integer value for representation of force from plate
+%                      0 = forceplate orgin, 1 = COP, 2 = Point Of Wrench
+%                      Application
+
 % ----------------------------------------------------------------------- %
 % The OpenSim API is a toolkit for musculoskeletal modeling and           %
 % simulation. See http://opensim.stanford.edu and the NOTICE file         %
@@ -20,15 +30,6 @@
 % permissions and limitations under the License.                          %
 % ----------------------------------------------------------------------- %
 
-classdef osimC3D < matlab.mixin.SetGet
-% osimC3D(filepath, ForceLocation)
-%   C3D data to OpenSim Tables.
-%   OpenSim Utility Class
-%   Inputs:
-%   filepath           Full path to the location of the C3D file
-%   ForceLocation      Integer value for representation of force from plate
-%                      0 = forceplate orgin, 1 = COP, 2 = Point Of Wrench
-%                      Application
     properties (Access = private)
         path
         name
@@ -151,9 +152,9 @@ classdef osimC3D < matlab.mixin.SetGet
             disp('Marker and Force tables have been rotated')
         end
         function convertMillimeters2Meters(obj)
-            % Function to convert displacement forceplate measurements made
-            % in millimeters to meters. This will convert point data (mm)
-            % to m and Torque data (Nmm) to Nm.
+            % Function to convert  point data (mm) to m and Torque data 
+            % (Nmm) to Nm.
+            
             import org.opensim.modeling.*
             
             nRows  = obj.forces.getNumRows();

--- a/Bindings/Java/Matlab/examples/c3dExport.m
+++ b/Bindings/Java/Matlab/examples/c3dExport.m
@@ -58,6 +58,9 @@ forceTable = c3d.getTable_forces();
 % Get as Matlab Structures
 [markerStruct forceStruct] = c3d.getAsStructs();
 
+%% Convert COP (mm to m) and Moments (Nmm to Nm)
+c3d.convertMillimeters2Meters();
+
 %% Write the marker and force data to file
 
 % Write marker data to trc file.

--- a/Bindings/Java/Matlab/tests/testOsimC3D.m
+++ b/Bindings/Java/Matlab/tests/testOsimC3D.m
@@ -34,76 +34,92 @@ assert(markers.getNumColumns() == nMlabels, 'Number or markers from osimC3D is n
 assert(forces.getNumColumns()  == nFlabels, 'Number or forces from osimC3D is not equal to number in osim table');
 
 
-%% Test Rotations
+%% Perform Table Rotations
 % Rotate Data 180 degrees around X and check that Y and Z data are
 % mirrored
 c3d.rotateData('x',-90);c3d.rotateData('x',-90);
-[markerRef180X, forceRef180X] = c3d.getAsStructs;
 % For each marker, Y and Z data should be mirrored when rotating 180
 % about x. 
-for u = 1 : nMlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(markerRef.(mlabels{u}) + markerRef180X.(mlabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(2),5) ~= 0 | round(p(3),5) ~= 0
-        error(['Error in rotateData(). Rotations about X are incorrect'])
-    end
-end
-for u = 1 : nFlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(forceRef.(flabels{u}) + forceRef180X.(flabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(2),5) ~= 0 | round(p(3),5) ~= 0
-        error(['Error in rotateData(). Rotations about X are incorrect'])
+markers_rotated = c3d.getTable_markers();
+forces_rotated = c3d.getTable_forces();
+
+%% Test Rotations
+% Compare the values between original and rotated data. Use random row and
+% col numbers.
+
+% Test Marker Rotations
+randomRows = randsample(markers.getNumRows(),10)-1;
+randomCols = randsample(markers.getNumColumns(),10)-1;
+for i = 1 : 10
+    % Get the values in the original and rotated marker tables
+    loc = osimVec3ToArray(markers.getRowAtIndex(randomRows(i)).get(randomCols(i)));
+    loc_rotated = osimVec3ToArray(markers_rotated.getRowAtIndex(randomRows(i)).get(randomCols(i)));
+    % Compute the difference in the marker locations. The Y and Z values
+    % should be mirroed and result in 0 when added. Round to 8 decimal
+    % places. 
+    diff_array = round(loc + loc_rotated,8);
+    % Compare the difference
+    if isnan(diff_array)
+        % If the value is a nan then move the next value
+        continue
+    elseif diff_array(2) ~= 0 || diff_array(3) ~= 0
+        error(['Error in rotateData(). Marker rotations about X are incorrect'])
     end
 end
 
-% Rotate Data 180 degrees around Y and check that Z and X data are
-% mirrored
-c3d.rotateData('y',-90);c3d.rotateData('y',-90);
-[markerRef180Y, forceRef180Y] = c3d.getAsStructs;
-% For each marker, Y and Z data should be mirrored when rotating 180
-% about x. 
-for u = 1 : nMlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(markerRef180X.(mlabels{u}) + markerRef180Y.(mlabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(1),5) ~= 0 | round(p(3),5) ~= 0
-        error(['Error in rotateData(). Rotations about Y are incorrect'])
-    end
-end
-for u = 1 : nFlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(forceRef180X.(flabels{u}) + forceRef180Y.(flabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(1),5) ~= 0 | round(p(3),5) ~= 0
-        error(['Error in rotateData(). Rotations about Y are incorrect'])
-    end
- end
-
-% Rotate Data 180 degrees around Z and check that X and Y data are
-% mirrored
-c3d.rotateData('z',-90);c3d.rotateData('z',-90);
-[markerRef180Z, forceRef180Z] = c3d.getAsStructs;
-% For each marker, Y and Z data should be mirrored when rotating 180
-% about x. 
-for u = 1 : nMlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(markerRef180Z.(mlabels{u}) + markerRef180Y.(mlabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(1),5) ~= 0 | round(p(2),5) ~= 0
-        error(['Error in rotateData(). Rotations about Z are incorrect'])
-    end
-end
-for u = 1 : nFlabels
-    % Get the sum of the differences between original and rotated data
-    p = nansum(forceRef180Z.(flabels{u}) + forceRef180Y.(flabels{u}));
-    % Sum should be at or near zero. Round to 5 decimal places 
-    if round(p(1),5) ~= 0 | round(p(2),5) ~= 0
-        error(['Error in rotateData(). Rotations about Z are incorrect'])
+% Test Force Rotations
+randomRows = randsample(forces.getNumRows(),6)-1;
+randomCols = randsample(forces.getNumColumns(),6)-1;
+for i = 1 : 6
+    % Get the values in the original and rotated marker tables
+    val = osimVec3ToArray(forces.getRowAtIndex(randomRows(i)).get(randomCols(i)));
+    val_rotated = osimVec3ToArray(forces_rotated.getRowAtIndex(randomRows(i)).get(randomCols(i)));
+    % Compute the difference in the marker locations. The Y and Z values
+    % should be mirroed and result in 0 when added. Round to 8 decimal
+    % places. 
+    diff_array = round(val + val_rotated,8);
+    % Compare the difference
+    if isnan(diff_array)
+        % If the value is a nan then move the next value
+        continue
+    elseif diff_array(2) ~= 0 || diff_array(3) ~= 0
+        error(['Error in rotateData(). Force rotations about X are incorrect'])
     end
 end
 
+%% Test mm to M conversion for forces
+c3d.convertMillimeters2Meters();
+forces_m = c3d.getTable_forces();
+
+% Forces should remain unchanged, point and moments should be in meters
+% (divided by 1000)
+randomRows = randsample(forces.getNumRows(),101)-1;
+for i =  0 : forces_m.getNumColumns() - 1
+    
+    col =  forces_rotated.getDependentColumnAtIndex(i);
+    col_m = forces_m.getDependentColumnAtIndex(i);
+    label = forces_m.getColumnLabel(i);
+    
+    for u = 1 : length(randomRows)
+        if contains(char(forces_m.getColumnLabels().get(i)),'f')
+            % Get the values
+            d   = col.get(randomRows(u));
+            d_m = col_m.get(randomRows(u));
+            
+            assert(d.get(0)==d_m.get(0),'Force Data has been incorrectly altered');
+            assert(d.get(1)==d_m.get(1),'Force Data has been incorrectly altered')
+            assert(d.get(2)==d_m.get(2),'Force Data has been incorrectly altered')
+        else
+            % Get the values
+            d   = col.get(randomRows(u));
+            d_m = col_m.get(randomRows(u));
+            
+            assert(d.get(0)/1000==d_m.get(0),'Point or Moment Data has been incorrectly altered');
+            assert(d.get(1)/1000==d_m.get(1),'Point or Moment Data has been incorrectly altered');
+            assert(d.get(2)/1000==d_m.get(2),'Point or Moment Data has been incorrectly altered');
+        end
+    end
+end
 %% Test Writing Methods
 c3d.writeTRC()
 if isempty(exist( fullfile(cd, 'walking2.trc') ,'file'))
@@ -144,4 +160,4 @@ sto  = Storage(fullfile(cd, 'walking2.trc'));
 sto  = Storage(fullfile(cd, 'walking2.mot'));
 
 %%
-
+disp('Tests Passed!')

--- a/Bindings/Java/Matlab/tests/testOsimC3D.m
+++ b/Bindings/Java/Matlab/tests/testOsimC3D.m
@@ -101,7 +101,7 @@ for i =  0 : forces_m.getNumColumns() - 1
     label = forces_m.getColumnLabel(i);
     
     for u = 1 : length(randomRows)
-        if contains(char(forces_m.getColumnLabels().get(i)),'f')
+        if startsWith(char(forces_m.getColumnLabels().get(i)),'f')
             % Get the values
             d   = col.get(randomRows(u));
             d_m = col_m.get(randomRows(u));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v4.1
 - Model files from very old versions (pre 1.8.1) are not supported, an exception is thrown rather than fail quietly (issue #2395).
 - Initializing a Component from an existing Component with correct socket connectees yields invalid paths (issue #2418).
 - Reading DataTables from files has been simplified. Reading one table from a file typically uses the Table constructor except when the data-source/file contains multiple tables. (In these cases e.g. C3D files, use C3DFileAdapter.read method, then use functions in C3DFileAdapter to get the individual TimeSeriesTable(s)). Writing tables to files has not changed.
+- Exposed convertMillimeters2Meters() in osimC3D.m. This function converts COP and moment data from mm to m and now must be invoked prior to writing force data to file. Previously, this was automatically performed during writing forces to file. 
 
 Converting from v4.0 to v4.1
 ----------------------------


### PR DESCRIPTION
### Brief summary of changes
#### osimC3D.m 
expose convertMillimeters2Meters(). This was previously performed internally only when writing the forces to file during and should be user-controlled. 

#### testOsimC3D.m 
Updated test so that it runs in significantly less time (120 seconds -> 57 seconds on my local machine). 
- I compare OpenSim table values, rather than Matlab Structures, since the conversion of tables to structs is expensive. 
- I only test rotations about 1 axis. 
- Added test for convertMillimeters2Meters() (not previously tested).

#### c3dExport.m 
included improved use of convertMillimeters2Meters() in example script

### Testing I've completed
Running ctest locally (passed) and checking the outputs on various C3D files (locally). 

### CHANGELOG.md (choose one)
- updated since users will have to change their code to explicitly use convertMillimeters2Meters() before writing to file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2556)
<!-- Reviewable:end -->
