### PR TITLE
osimC3D.m updated to use Vec3().scalarDivideEq()

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimC3D.m
+++ b/Bindings/Java/Matlab/Utilities/osimC3D.m
@@ -165,10 +165,11 @@ classdef osimC3D < matlab.mixin.SetGet
                 % and moment columns will have 'p' and 'm' prefixes,
                 % respectively.
                 if ~startsWith(char(labels.get(i)),'f')
-                    for u = 0 : nRows - 1
-                      % Divide by 1000
-                      self.forces.getDependentColumnAtIndex(i).get(u).scalarDivideEq(1000);
-                    end
+                   columnData = self.forces.updDependentColumnAtIndex(i);
+                   for u = 0 : nRows - 1
+                     % Divide by 1000
+                     columnData.set(u,columnData.get(u).scalarDivideEq(1000));
+                   end
                 end
             end
            disp('Point and Torque values convert from mm and Nmm to m and Nm, respectively')


### PR DESCRIPTION
### Fixes issue 
osimC3D.convertMillimeters2Meters() used computationally expensive implementation of dividing a Vec3() by a scalar. This PR tries to improve performance by using Vec3().scalarDivideEq() method. 

### Brief summary of changes
Implementation of Vec3().scalarDivideEq() method to convert point and moment values from mm to m. 

### Testing I've completed
**Performance**  
Tested current and proposed implementations locally using 'Walking2.c3d'. The completion times for running the convertMillimeters2Meters() function;
current = 8.5867 seconds.
proposed = 2.8066 seconds. 

**Consistency**
Matlab test passes and visual inspection in GUI passes. Double checked the outputs and everything is consistent. 

### CHANGELOG.md (choose one)
- no need to update because this is an implementation improvement for performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2561)
<!-- Reviewable:end -->
