### PR TITLE
Fix Clang warning about implicitly deleted assignment operator.

### DIFF
--- a/OpenSim/Common/CSVFileAdapter.h
+++ b/OpenSim/Common/CSVFileAdapter.h
@@ -34,8 +34,6 @@ public:
     CSVFileAdapter();
     CSVFileAdapter(const CSVFileAdapter&)            = default;
     CSVFileAdapter(CSVFileAdapter&&)                 = default;
-    CSVFileAdapter& operator=(const CSVFileAdapter&) = default;
-    CSVFileAdapter& operator=(CSVFileAdapter&&)      = default;
     ~CSVFileAdapter()                                = default;
 
     CSVFileAdapter* clone() const override;


### PR DESCRIPTION
### Brief summary of changes

This PR gets rid of a warning with recent versions of Clang about an implicitly deleted assignment operator (because the base class has `const double` members that cannot be assigned).

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2572)
<!-- Reviewable:end -->
