### PR TITLE
Fix scale factors for Marker geometry so it doesn't show inside-out

### DIFF
--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -176,6 +176,7 @@ void Marker::generateDecorations(bool fixed, const ModelDisplayHints& hints, con
     appendToThis.push_back(
         SimTK::DecorativeSphere(.01).setBodyId(frame.getMobilizedBodyIndex())
         .setColor(color).setOpacity(1.0)
-        .setTransform(get_location()));
+        .setTransform(get_location())
+        .setScaleFactors(Vec3(1)));
     
 }


### PR DESCRIPTION

Fixes issue https://github.com/opensim-org/opensim-gui/issues/1107

### Brief summary of changes
GenerateDecorations for Marker was not setting scaleFactors so they default to -1,-1,-1 which makes them show as inside-out. This PR fixes the scale factors to 1.0 so shading is correct.

### Testing I've completed
Loaded model with a marker in GUI, pictures below

### Looking for feedback on whether latest visuals are good enough or other material properties for the model markers can be adjusted.

### CHANGELOG.md (choose one)

- Will update once agreed to include on 4.1

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2576)
<!-- Reviewable:end -->
