### PR TITLE
Bring spdlog into OpenSim.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ if(${OPENSIM_INSTALL_UNIX_FHS})
     set(OPENSIM_INSTALL_JAVASRCDIR "${CMAKE_INSTALL_DATAROOTDIR}/OpenSim/java")
     set(OPENSIM_INSTALL_APIEXDIR "${CMAKE_INSTALL_DOCDIR}/Code")
     set(OPENSIM_INSTALL_SIMBODYDIR ".")
+    set(OPENSIM_INSTALL_SPDLOGDIR ".")
 
 else()
 
@@ -189,6 +190,7 @@ else()
     set(OPENSIM_INSTALL_JAVASRCDIR sdk/Java)
     set(OPENSIM_INSTALL_APIEXDIR Resources/Code)
     set(OPENSIM_INSTALL_SIMBODYDIR sdk/Simbody)
+    set(OPENSIM_INSTALL_SPDLOGDIR sdk/spdlog)
 
 endif()
 
@@ -584,6 +586,10 @@ if(WITH_BTK)
     endif()
 endif()
 
+find_package(spdlog REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
+
+
 if(NOT SIMBODY_HOME AND OPENSIM_DEPENDENCIES_DIR)
     set(SIMBODY_HOME "${OPENSIM_DEPENDENCIES_DIR}/simbody")
 endif()
@@ -749,6 +755,10 @@ if(${OPENSIM_COPY_DEPENDENCIES})
                 DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
 
+    # spdlog
+    # ------
+    install(DIRECTORY "${spdlog_DIR}/../../../"
+            DESTINATION "${OPENSIM_INSTALL_SPDLOGDIR}")
 endif()
 
 if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -14,7 +14,7 @@ OpenSimAddLibrary(
     KIT Common
     AUTHORS "Clay_Anderson-Ayman_Habib-Peter_Loan"
     # Clients of osimCommon need not link to BTK.
-    LINKLIBS PUBLIC ${Simbody_LIBRARIES} PRIVATE ${BTK_LIBRARIES}
+    LINKLIBS PUBLIC ${Simbody_LIBRARIES} spdlog::spdlog PRIVATE ${BTK_LIBRARIES}
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}
     TESTDIRS "Test"

--- a/README.md
+++ b/README.md
@@ -436,7 +436,6 @@ state = manager.integrate(10.0);
 ```
 
 </details>
----
 
 Building from the source code
 -----------------------------
@@ -492,6 +491,9 @@ On Windows using Visual Studio
 * **command-line argument parsing**: docopt.cpp. Two options:
     * Let OpenSim get this for you using superbuild (see below); much easier!
     * [Build on your own](https://github.com/docopt/docopt.cpp) (no instructions).
+* **logging**: spdlog. Two options:
+    * Let OpenSim get this for you using superbuild (see below); much easier!
+    * [Build on your own](https://github.com/gabime/spdlog).
 * **API documentation** (optional):
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6
 * **version control** (optional): git. There are many options:
@@ -605,10 +607,14 @@ On Windows using Visual Studio
            `BTKConfig.cmake`. If the root directory of your BTK installation is
            `C:/BTKCore-install`, then set this variable to
            `C:/BTKCore-install/share/btk-0.4dev`.
-        3. docopt.cpp. Set the variable `docopt_DIR` to the directory
+        3. docopt.cpp: Set the variable `docopt_DIR` to the directory
            containing `docopt-config.cmake`. If the root directory of your
            docopt.cpp installation is `C:/docopt.cpp-install`, then set this
            variable to `C:/docopt.cpp-install/lib/cmake`.
+        4. spdlog: Set the variable `spdlog_DIR` to the directory containing
+           `spdlogConfig.cmake`. If the root directory of your spdlog 
+           installation is `C:/spdlog-install`, then set this variable to
+           `C:/spdlog-install/lib/spdlog/cmake`.
 7. Set the remaining configuration options.
     * `BUILD_API_EXAMPLES` to compile C++ API examples.
     * `BUILD_TESTING` to ensure that OpenSim works correctly. The tests take a
@@ -767,6 +773,9 @@ ctest -j8
 * **command-line argument parsing**: docopt.cpp. Two options:
     * Let OpenSim get this for you using superbuild (see below); much easier!
     * [Build on your own](https://github.com/docopt/docopt.cpp) (no instructions).
+* **logging**: spdlog. Two options:
+    * Let OpenSim get this for you using superbuild (see below); much easier!
+    * [Build on your own](https://github.com/gabime/spdlog).
 * **API documentation** (optional):
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6
 * **version control** (optional): git.
@@ -866,10 +875,14 @@ You can get most of these dependencies using [Homebrew](http://brew.sh):
         2. BTK: Set the `BTK_DIR` variable to the directory containing
            `BTKConfig.cmake`. If you installed BTK in `~/BTKCore-install`, then
            set `BTK_DIR` to `~/BTKCore-install/share/btk-0.4dev`
-        3. docopt.cpp. Set the variable `docopt_DIR` to the directory
+        3. docopt.cpp: Set the variable `docopt_DIR` to the directory
            containing `docopt-config.cmake`. If the root directory of your
            docopt.cpp installation is `~/docopt.cpp-install`, then set this
            variable to `~/docopt.cpp-install/lib/cmake`.
+        4. spdlog: Set the variable `spdlog_DIR` to the directory containing
+           `spdlogConfig.cmake`. If the root directory of your spdlog 
+           installation is `~/spdlog-install`, then set this variable to
+           `~/spdlog-install/lib/spdlog/cmake`.
 7. Set the remaining configuration options.
     * `BUILD_API_EXAMPLES` to compile C++ API examples.
     * `BUILD_TESTING` to ensure that OpenSim works correctly. The tests take a
@@ -953,6 +966,9 @@ specific Ubuntu versions under 'For the impatient' below.
 * **command-line argument parsing**: docopt.cpp. Two options:
     * Let OpenSim get this for you using superbuild (see below); much easier!
     * [Build on your own](https://github.com/docopt/docopt.cpp) (no instructions).
+* **logging**: spdlog. Two options:
+    * Let OpenSim get this for you using superbuild (see below); much easier!
+    * [Build on your own](https://github.com/gabime/spdlog).
 * **API documentation** (optional):
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6;
   `doxygen`.
@@ -1057,10 +1073,14 @@ And you could get all the optional dependencies via:
         2. BTK: Set the `BTK_DIR` variable to the directory containing
            `BTKConfig.cmake`. If you installed BTK in `~/BTK-install`, then set
            `BTK-DIR` to `~/BTK-install/share/btk-0.4dev`.
-        3. docopt.cpp. Set the variable `docopt_DIR` to the directory
+        3. docopt.cpp: Set the variable `docopt_DIR` to the directory
            containing `docopt-config.cmake`. If the root directory of your
            docopt.cpp installation is `~/docopt.cpp-install`, then set this
            variable to `~/docopt.cpp-install/lib/cmake`.
+        4. spdlog: Set the variable `spdlog_DIR` to the directory containing
+           `spdlogConfig.cmake`. If the root directory of your spdlog 
+           installation is `~/spdlog-install`, then set this variable to
+           `~/spdlog-install/lib/spdlog/cmake`.
 7. Choose your build type by setting `CMAKE_BUILD_TYPE` to one of the following:
     * **Debug**: debugger symbols; no optimizations (more than 10x slower).
     Library names end with `_d`.

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -17,6 +17,7 @@ configure_package_config_file(
         CMAKE_INSTALL_LIBDIR
         OPENSIM_INSTALL_CMAKEDIR
         OPENSIM_INSTALL_SIMBODYDIR
+        OPENSIM_INSTALL_SPDLOGDIR
     )
 
 # Version file.

--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -74,13 +74,20 @@ set(@CMAKE_PROJECT_NAME@_JAR_FILE
 # Dependencies
 # ------------
 if (@OPENSIM_COPY_DEPENDENCIES@) # OPENSIM_COPY_DEPENDENCIES
-    # Find the copy of Simbody within the OpenSim installation.
+    # Find the copies of Simbody and spdlog within the OpenSim installation.
+    # We pre-define these variables because finding Simbody redefines variables
+    # that we need for finding spdlog.
+    set(_SIMBODY_PATH "@PACKAGE_OPENSIM_INSTALL_SIMBODYDIR@")
+    set(_SPDLOG_PATH "@PACKAGE_OPENSIM_INSTALL_SPDLOGDIR@")
     find_package(Simbody @SIMBODY_VERSION_TO_USE@ REQUIRED
-        PATHS "@PACKAGE_OPENSIM_INSTALL_SIMBODYDIR@" NO_MODULE NO_DEFAULT_PATH)
+        PATHS "${_SIMBODY_PATH}" NO_MODULE NO_DEFAULT_PATH)
+    find_package(spdlog REQUIRED
+        PATHS "${_SPDLOG_PATH}" NO_MODULE NO_DEFAULT_PATH)
 else()
     # Find the correct version anywhere on the machine.
     include(CMakeFindDependencyMacro)
     find_dependency(Simbody @SIMBODY_VERSION_TO_USE@)
+    find_dependency(spdlog)
 endif()
 
 

--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -75,8 +75,10 @@ set(@CMAKE_PROJECT_NAME@_JAR_FILE
 # ------------
 if (@OPENSIM_COPY_DEPENDENCIES@) # OPENSIM_COPY_DEPENDENCIES
     # Find the copies of Simbody and spdlog within the OpenSim installation.
-    # We pre-define these variables because finding Simbody redefines variables
-    # that we need for finding spdlog.
+    # We define _SIMBODY_PATH and _SPDLOG_PATH before find_package(Simbody)
+    # because finding Simbody redefines the PACKAGE_PREFIX_DIR variable
+    # that appears in this file after configuring, thereby incorrectly
+    # causing CMake to look for spdlog within Simbody's installation.
     set(_SIMBODY_PATH "@PACKAGE_OPENSIM_INSTALL_SIMBODYDIR@")
     set(_SPDLOG_PATH "@PACKAGE_OPENSIM_INSTALL_SPDLOGDIR@")
     find_package(Simbody @SIMBODY_VERSION_TO_USE@ REQUIRED

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -158,7 +158,16 @@ AddDependency(NAME       simbody
 AddDependency(NAME       docopt
               URL        https://github.com/docopt/docopt.cpp.git
               TAG        af03fa044ee1eff20819549b534ea86829a24a54)
- 
+
+
+AddDependency(NAME       spdlog
+              URL        https://github.com/gabime/spdlog.git
+              TAG        v1.4.1
+              CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
+                         -DSPDLOG_BUILD_TESTS:BOOL=OFF
+                         -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF
+                         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
+
 #######################
 
 RemoveDefaultInstallDirIfEmpty("${DEFAULT_CMAKE_INSTALL_PREFIX}")


### PR DESCRIPTION
### Brief summary of changes

This PR is an offshoot of #2551. I built on @aymanhab's original work to build and install spdlog.

The destination for this PR is `feature_logging`, not `master`.
### Testing I've completed

I can build and run an OpenSim C++ example from the OpenSim installation on Mac. I did not test on Windows.

### CHANGELOG.md (choose one)

- no need to update because...this feature is not complete yet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2591)
<!-- Reviewable:end -->
