### PR TITLE
Splice TimeSeriesTable

### DIFF
--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -190,6 +190,17 @@ int main() {
     if (failed)
         return 1;
 
+    TimeSeriesTable_<SimTK::Vec3> table(tmpfile);
+    double cropToTime = 0.1;
+    table.crop(0.0, cropToTime);
+    TRCFileAdapter::write(table, "cropped_"+tmpfile);
+    TimeSeriesTable_<SimTK::Vec3> roundTripTable("cropped_" + tmpfile);
+    OPENSIM_THROW_IF(roundTripTable.getNumRows() != 7, OpenSim::Exception,
+            "Cropped table has wrong size");
+    OPENSIM_THROW_IF(roundTripTable.getIndependentColumn().back() > cropToTime,
+            OpenSim::Exception,
+            "Cropped table has wrong time column");
+
     std::remove(tmpfile.c_str());
     std::cout << "\nAll tests passed!" << std::endl;
 

--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -138,7 +138,7 @@ int main() {
     std::string tmpfile{"testtrcfileadapter.trc"};
 
     bool failed = false;
-
+    
     std::cout << "Testing TRCFileAdapter::read() and TRCFileAdapter::write()"
               << std::endl;
     for(const auto& filename : filenames) {
@@ -189,18 +189,19 @@ int main() {
 
     if (failed)
         return 1;
-
+    
     TimeSeriesTable_<SimTK::Vec3> table(tmpfile);
     double cropToTime = 0.1;
-    table.crop(0.0, cropToTime);
+    table.crop(0.02, cropToTime);
     TRCFileAdapter::write(table, "cropped_"+tmpfile);
     TimeSeriesTable_<SimTK::Vec3> roundTripTable("cropped_" + tmpfile);
-    OPENSIM_THROW_IF(roundTripTable.getNumRows() != 7, OpenSim::Exception,
+    OPENSIM_THROW_IF(roundTripTable.getNumRows() != 6, OpenSim::Exception,
             "Cropped table has wrong size");
     OPENSIM_THROW_IF(roundTripTable.getIndependentColumn().back() > cropToTime,
-            OpenSim::Exception,
-            "Cropped table has wrong time column");
-
+            OpenSim::Exception, "Cropped table has wrong end time.");
+    OPENSIM_THROW_IF(roundTripTable.getIndependentColumn().front() > 0.02,
+            OpenSim::Exception, "Cropped table has wrong start time.");
+    std::remove(("cropped_" + tmpfile).c_str());
     std::remove(tmpfile.c_str());
     std::cout << "\nAll tests passed!" << std::endl;
 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -404,21 +404,22 @@ public:
      * newStartTime, newFinalTime. The cropping is done in place, no copy is made. Uses getNearestRowIndexForTime to handle locating proper rows.
      */
     void crop(const double newStartTime, const double newFinalTime) {
-        const auto& timeCol = getIndependentColumn();
+        const auto& timeCol = this->getIndependentColumn();
         size_t start_index = 0;
-        size_t last_index = getNumRows() - 1;
+        size_t last_index = this->getNumRows() - 1;
         if (newStartTime > timeCol.front()) // Avoid throwing exception if newStartTime is less than first time
-            start_index = getNearestRowIndexForTime(newStartTime);
+            start_index = this->getNearestRowIndexForTime(newStartTime);
         if (newFinalTime <timeCol.back()) 
-            last_index = getNearestRowIndexForTime(newFinalTime);
+            last_index = this->getNearestRowIndexForTime(newFinalTime);
 
-        SimTK::Matrix_<ETY> matrixBlock = updMatrix()(start_index, (size_t)0,
+        SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()(start_index,
+                (size_t)0,
                 last_index - start_index + 1, getNumColumns());
-        updMatrix() = matrixBlock;
+        this->updMatrix() = matrixBlock;
         std::vector<double> newIndependentVector = std::vector<double>(
-                getIndependentColumn().begin() + start_index,
-                getIndependentColumn().begin() + last_index+1 );
-        _indData = newIndependentVector;
+                this->getIndependentColumn().begin() + start_index,
+                this->getIndependentColumn().begin() + last_index + 1);
+        this->_indData = newIndependentVector;
     }
 
 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -401,7 +401,7 @@ public:
     }
     /**
      * Crop TimeSeriesTable to rows that have timestamp that lies between 
-     * newStartTime, newFinalTime. The cropping is done in place, no copy is made
+     * newStartTime, newFinalTime. The cropping is done in place, no copy is made. Uses getNearestRowIndexForTime to handle locating proper rows.
      */
     void crop(const double newStartTime, const double newFinalTime) {
         const auto& timeCol = getIndependentColumn();
@@ -415,6 +415,10 @@ public:
         SimTK::Matrix_<ETY> matrixBlock = updMatrix()(start_index, (size_t)0,
                 last_index - start_index + 1, getNumColumns());
         updMatrix() = matrixBlock;
+        std::vector<double> newIndependentVector = std::vector<double>(
+                getIndependentColumn().begin() + start_index,
+                getIndependentColumn().begin() + last_index+1 );
+        _indData = newIndependentVector;
     }
 
 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -399,6 +399,24 @@ public:
 
         return row;
     }
+    /**
+     * Crop TimeSeriesTable to rows that have timestamp that lies between 
+     * newStartTime, newFinalTime. The cropping is done in place, no copy is made
+     */
+    void crop(const double newStartTime, const double newFinalTime) {
+        const auto& timeCol = getIndependentColumn();
+        size_t start_index = 0;
+        size_t last_index = getNumRows() - 1;
+        if (newStartTime > timeCol.front()) // Avoid throwing exception if newStartTime is less than first time
+            start_index = getNearestRowIndexForTime(newStartTime);
+        if (newFinalTime <timeCol.back()) 
+            last_index = getNearestRowIndexForTime(newFinalTime);
+
+        SimTK::Matrix_<ETY> matrixBlock = updMatrix()(start_index, (size_t)0,
+                last_index - start_index + 1, getNumColumns());
+        updMatrix() = matrixBlock;
+    }
+
 
 protected:
     /** Validate the given row. 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -414,7 +414,7 @@ public:
 
         SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()(start_index,
                 (size_t)0,
-                last_index - start_index + 1, getNumColumns());
+                last_index - start_index + 1, this->getNumColumns());
         this->updMatrix() = matrixBlock;
         std::vector<double> newIndependentVector = std::vector<double>(
                 this->getIndependentColumn().begin() + start_index,

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -417,9 +417,9 @@ public:
         // Side effect may include that headers/metaData may be left stale. 
         // Alternatively we can create a new TimeSeriesTable and copy contents one row 
         // at a time but that's rather overkill
-        SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()(start_index,
-                (size_t)0,
-                last_index - start_index + 1, this->getNumColumns());
+        SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()((int)start_index,
+                0,
+                (int) (last_index - start_index + 1), (int) this->getNumColumns());
         this->updMatrix() = matrixBlock;
         std::vector<double> newIndependentVector = std::vector<double>(
                 this->getIndependentColumn().begin() + start_index,
@@ -438,7 +438,6 @@ public:
     void cropTo(const double newFinalTime) {
         this->crop(this->getIndependentColumn().front(), newFinalTime);
     }
-
 protected:
     /** Validate the given row. 
 


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Introduce methods that crop a TimeSeriesTable to a specified time range

### Testing I've completed
I updated the test case testTRCFileAdapter to test the new methods and used my development environment to successfully chop IMU data files for use in OpenSense

### Looking for feedback on...
- Implementation feedback, 
- Crop in-place vs return copy, 
- Potential additional functions to split based on events, or passed-in-lambdas to enable detecting static-poses, turns, gait-cycle etc.

### CHANGELOG.md (choose one)

- no need to update yet because still work in progress

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.
