### PR TITLE
OPENSIM_COPY_DEPENDENCIES with wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Other Changes
 - Added Matlab example script of plotting the Force-length properties of muscles in a models; creating an Actuator file from a model; 
 building and simulating a simple arm model;  using OutputReporters to record and write marker location and coordinate values to file.
 - OpenSim 4.1 ships with Python3 bindings as default. It is still possible to create bindings for Python2 if desired by setting CMake variable OPENSIM_PYTHON_VERSION to 2
+- For CMake, the option OPENSIM_COPY_DEPENDENCIES option is now an advanced option, and it is also turned on automatically if building Java or Python wrapping (a warning is provided if this option is off but wrapping is turned on.)
 
 v4.0
 ====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Other Changes
 - Added Matlab example script of plotting the Force-length properties of muscles in a models; creating an Actuator file from a model; 
 building and simulating a simple arm model;  using OutputReporters to record and write marker location and coordinate values to file.
 - OpenSim 4.1 ships with Python3 bindings as default. It is still possible to create bindings for Python2 if desired by setting CMake variable OPENSIM_PYTHON_VERSION to 2
-- For CMake, the option OPENSIM_COPY_DEPENDENCIES option is now an advanced option, and it is also turned on automatically if building Java or Python wrapping (a warning is provided if this option is off but wrapping is turned on.)
+- For CMake, the option OPENSIM_COPY_DEPENDENCIES option is now an advanced option, and a warning is provided if this option is off but wrapping is turned on.
 
 v4.0
 ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ OpenSim installation. This should be set to ON when making a relocatable
 distribution, and should be set to OFF when packaging for Homebrew, Debian,
 etc. On Linux and macOS: we use relative RPATHs when ON, and absolute RPATHs
 when OFF." ON)
+mark_as_advanced(OPENSIM_COPY_DEPENDENCIES)
 
 option(OPENSIM_PYTHON_STANDALONE "Make the Python package standalone, meaning
 the OpenSim (and Simbody and BTK) shared libraries it depends on are copied
@@ -440,6 +441,15 @@ if(${BUILD_JAVA_WRAPPING})
             endif()
         endif()
     endif()
+    # Need copies of dependencies for wrapping. Turn it on and warn user
+    # if it wasn't on.
+    if (NOT OPENSIM_COPY_DEPENDENCIES)
+        set(OPENSIM_COPY_DEPENDENCIES ON)
+        string(CONCAT MSG
+           "BUILD_JAVA_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
+           "OPENSIM_COPY_DEPENDENCIES is now ON.")
+        message(WARNING ${MSG})
+    endif()
 endif()
 
 if(${BUILD_PYTHON_WRAPPING})
@@ -488,7 +498,16 @@ if(${BUILD_PYTHON_WRAPPING})
             CACHE FILEPATH "${pylib_desc}")
     endif()
     find_package(PythonLibs ${required_python_version} REQUIRED)
-
+    
+    # Need copies of dependencies for wrapping. Turn it on and warn user
+    # if it wasn't on.
+    if (NOT OPENSIM_COPY_DEPENDENCIES)
+        set(OPENSIM_COPY_DEPENDENCIES ON)
+        string(CONCAT MSG
+           "BUILD_JAVA_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
+           "OPENSIM_COPY_DEPENDENCIES is now ON.")
+        message(WARNING ${MSG})
+    endif()
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,8 @@ option(OPENSIM_COPY_DEPENDENCIES "Copy Simbody and BTK into the
 OpenSim installation. This should be set to ON when making a relocatable
 distribution, and should be set to OFF when packaging for Homebrew, Debian,
 etc. On Linux and macOS: we use relative RPATHs when ON, and absolute RPATHs
-when OFF. This should also be on if BUILD_JAVA_WRAPPING or 
-BUILD_PYTHON_WRAPPING is ON, so if this OFF, a warning is thrown to the user
-and this option is automatically turned ON." ON)
+when OFF. For most users, this should also be on if BUILD_JAVA_WRAPPING or 
+BUILD_PYTHON_WRAPPING is ON, so if this OFF, a warning is thrown." ON)
 mark_as_advanced(OPENSIM_COPY_DEPENDENCIES)
 
 option(OPENSIM_PYTHON_STANDALONE "Make the Python package standalone, meaning
@@ -443,13 +442,13 @@ if(${BUILD_JAVA_WRAPPING})
             endif()
         endif()
     endif()
-    # Need copies of dependencies for wrapping. Turn it on and warn user
-    # if it wasn't on.
+    # Most users need to copy dependencies if wrapping is on. Warn user
+    # if it isn't on.
     if (NOT OPENSIM_COPY_DEPENDENCIES)
-        set(OPENSIM_COPY_DEPENDENCIES ON)
         string(CONCAT MSG
            "BUILD_JAVA_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
-           "OPENSIM_COPY_DEPENDENCIES is now ON.")
+           "Wrapping may not work correctly. Consider switching the "
+		   "OPENSIM_COPY_DEPENDENCIES flag to ON.")
         message(WARNING ${MSG})
     endif()
 endif()
@@ -501,13 +500,13 @@ if(${BUILD_PYTHON_WRAPPING})
     endif()
     find_package(PythonLibs ${required_python_version} REQUIRED)
     
-    # Need copies of dependencies for wrapping. Turn it on and warn user
-    # if it wasn't on.
+    # Most users need to copy dependencies if wrapping is on. Warn user
+    # if it isn't on.
     if (NOT OPENSIM_COPY_DEPENDENCIES)
-        set(OPENSIM_COPY_DEPENDENCIES ON)
         string(CONCAT MSG
-           "BUILD_JAVA_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
-           "OPENSIM_COPY_DEPENDENCIES is now ON.")
+           "BUILD_PYTHON_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
+           "Wrapping may not work correctly. Consider switching the "
+		   "OPENSIM_COPY_DEPENDENCIES flag to ON.")
         message(WARNING ${MSG})
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ if(${BUILD_JAVA_WRAPPING})
         string(CONCAT MSG
            "BUILD_JAVA_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
            "Wrapping may not work correctly. Consider switching the "
-		   "OPENSIM_COPY_DEPENDENCIES flag to ON.")
+           "OPENSIM_COPY_DEPENDENCIES flag to ON.")
         message(WARNING ${MSG})
     endif()
 endif()
@@ -506,7 +506,7 @@ if(${BUILD_PYTHON_WRAPPING})
         string(CONCAT MSG
            "BUILD_PYTHON_WRAPPING is ON but OPENSIM_COPY_DEPENDENCIES is OFF. "
            "Wrapping may not work correctly. Consider switching the "
-		   "OPENSIM_COPY_DEPENDENCIES flag to ON.")
+           "OPENSIM_COPY_DEPENDENCIES flag to ON.")
         message(WARNING ${MSG})
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,9 @@ option(OPENSIM_COPY_DEPENDENCIES "Copy Simbody and BTK into the
 OpenSim installation. This should be set to ON when making a relocatable
 distribution, and should be set to OFF when packaging for Homebrew, Debian,
 etc. On Linux and macOS: we use relative RPATHs when ON, and absolute RPATHs
-when OFF." ON)
+when OFF. This should also be on if BUILD_JAVA_WRAPPING or 
+BUILD_PYTHON_WRAPPING is ON, so if this OFF, a warning is thrown to the user
+and this option is automatically turned ON." ON)
 mark_as_advanced(OPENSIM_COPY_DEPENDENCIES)
 
 option(OPENSIM_PYTHON_STANDALONE "Make the Python package standalone, meaning


### PR DESCRIPTION
Fixes issue #2598 

### Brief summary of changes
Change CMakeLists to ensure OPENSIM_COPY_DEPENDENCIES is ON and warn user that it's on now if java or python wrapping is ON. Also make OPENSIM_COPY_DEPENDENCIES an advanced option.

### Testing I've completed
Local tests to see that correct output occurs in CMake when Configuring.

### Looking for feedback on...
- Does the logic make sense?
- Does the warning message make sense?
- Need more local testing?

### CHANGELOG.md (choose one)
- updated to note change to CMake interface

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2600)
<!-- Reviewable:end -->
