### PR TITLE
Do not test CMA example.

### DIFF
--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -299,7 +299,7 @@ if(WIN32)
     # want to accidentally use a different OpenSim build/installation somewhere
     # on the machine.
     foreach(folder tests examples)
-        set_tests_properties(python_${folder} PROPERTIES ENVIRONMENT
+        set_property(TEST python_${folder} APPEND PROPERTY ENVIRONMENT
             "PATH=${CMAKE_BINARY_DIR}/$<CONFIG>")
     endforeach()
 endif()

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -270,15 +270,26 @@ add_test(NAME python_tests
                 --start-directory "${CMAKE_CURRENT_SOURCE_DIR}/tests"
                 --verbose
     )
+
+# List the examples we want to test. Some examples might run too long for
+# testing, or might require additional libraries.
+# Leave off the .py extension; here, we are listing module names.
+set(PYTHON_EXAMPLES_UNITTEST_ARGS
+        build_simple_arm_model
+        extend_OpenSim_Vec3_class
+        posthoc_StatesTrajectory_example
+        wiring_inputs_and_outputs_with_TableReporter
+        )
 # Similar as above, but for the example files. These files aren't named as
 # test_*.py, so we must specify a more general search pattern.
 add_test(NAME python_examples
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>"
-    COMMAND "${PYTHON_EXECUTABLE}" -m unittest discover
-                --start-directory "${CMAKE_CURRENT_SOURCE_DIR}/examples"
-                --pattern *.py
+    COMMAND "${PYTHON_EXECUTABLE}" -m unittest
+                ${PYTHON_EXAMPLES_UNITTEST_ARGS}
                 --verbose
     )
+set_tests_properties(python_examples PROPERTIES
+        ENVIRONMENT PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/examples)
 
 if(WIN32)
     # On Windows, CMake cannot use RPATH to hard code the location of libraries

--- a/Bindings/Python/examples/extend_OpenSim_Vec3_class.py
+++ b/Bindings/Python/examples/extend_OpenSim_Vec3_class.py
@@ -43,5 +43,5 @@ osim.Vec3.__add__ = myVec3Add
 a = osim.Vec3(1,2,3)
 b = osim.Vec3(4,5,6)
 c = a+b
-print c
-print type(c)
+print(c)
+print(type(c))


### PR DESCRIPTION
Fixes issue #2605 

### Brief summary of changes

Enumerate python examples to test to avoid testing examples that require additional dependencies or might run long.

### Testing I've completed

`python_examples` used to fail for me and now it doesn't, and all the listed examples are tested.

### CHANGELOG.md (choose one)

- no need to update because...minor fix to build system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2606)
<!-- Reviewable:end -->
