### PR TITLE
Remove start and end times for converting quaternion table

### DIFF
--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -135,7 +135,7 @@ runInverseKinematicsWithOrientationsFromFile(Model& model,
     auto startEnd = getTimeRangeInUse(quatTable.getIndependentColumn());
 
     TimeSeriesTable_<SimTK::Rotation> orientationsData =
-        OpenSenseUtilities::convertQuaternionsToRotations(quatTable, startEnd);
+        OpenSenseUtilities::convertQuaternionsToRotations(quatTable);
 
     OrientationsReference oRefs(orientationsData);
     MarkersReference mRefs{};

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -32,21 +32,20 @@ using namespace std;
 
 TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
     convertQuaternionsToRotations(
-        const TimeSeriesTableQuaternion& quaternionsTable,
-        const SimTK::Array_<int>& startEnd)
+        const TimeSeriesTableQuaternion& quaternionsTable)
 {
 
     int nc = int(quaternionsTable.getNumColumns());
 
     const auto& times = quaternionsTable.getIndependentColumn();
 
-    size_t nt = startEnd[1] - startEnd[0] + 1;
+    int nt = int(quaternionsTable.getNumRows());
 
     std::vector<double> newTimes(nt, SimTK::NaN);
     SimTK::Matrix_<SimTK::Rotation> matrix(int(nt), nc, Rotation());
 
     int cnt = 0;
-    for (size_t i = startEnd[0]; i <= startEnd[1]; ++i) {
+    for (int i = 0; i < nt; ++i) {
         newTimes[cnt] = times[i];
         const auto& quatRow = quaternionsTable.getRowAtIndex(i);
         for (int j = 0; j < nc; ++j) {
@@ -99,8 +98,6 @@ Model OpenSenseUtilities::calibrateModelFromOrientations(
 {
     Model model(modelCalibrationPoseFile);
 
-    const SimTK::Array_<int>& startEnd = { 0, 1 };
-
     TimeSeriesTable_<SimTK::Quaternion> quatTable(calibrationOrientationsFile);
 
     // Rotation matrix that maps the IMU World reference frame to
@@ -122,8 +119,7 @@ Model OpenSenseUtilities::calibrateModelFromOrientations(
 
     // This is now plain conversion, no Rotation or magic underneath
     TimeSeriesTable_<SimTK::Rotation> orientationsData =
-        OpenSenseUtilities::convertQuaternionsToRotations(quatTable,
-            startEnd);
+        OpenSenseUtilities::convertQuaternionsToRotations(quatTable);
 
     std::cout << "Loaded orientations as quaternions from "
         << calibrationOrientationsFile << std::endl;

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -39,13 +39,13 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
 
     const auto& times = quaternionsTable.getIndependentColumn();
 
-    int nt = int(quaternionsTable.getNumRows());
+    size_t nt = int(quaternionsTable.getNumRows());
 
     std::vector<double> newTimes(nt, SimTK::NaN);
     SimTK::Matrix_<SimTK::Rotation> matrix(int(nt), nc, Rotation());
 
     int cnt = 0;
-    for (int i = 0; i < nt; ++i) {
+    for (size_t i = 0; i < nt; ++i) {
         newTimes[cnt] = times[i];
         const auto& quatRow = quaternionsTable.getRowAtIndex(i);
         for (int j = 0; j < nc; ++j) {
@@ -76,7 +76,6 @@ void OpenSim::OpenSenseUtilities::rotateOrientationTable(
 
     int nc = int(quaternionsTable.getNumColumns());
     size_t nt = quaternionsTable.getNumRows();
-
 
     for (size_t i = 0; i < nt; ++i) {
         auto quatRow = quaternionsTable.updRowAtIndex(i);

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -50,9 +50,7 @@ namespace OpenSim {
             */
         static  OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>> 
             convertQuaternionsToRotations(
-                const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable,
-                const SimTK::Array_<int>& startEnd = { 0, 1 }
-        );
+                const OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>& qauternionsTable);
 
         /** Compute a SimTK::Rotation matrix that aligns the specified 
             baseIMU + CoordinateDirection combination with the positive X (=forward) direction 


### PR DESCRIPTION
Removes start and end times for converting the quaternion table

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2616)
<!-- Reviewable:end -->
