### PR TITLE
Update docopt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ v4.1
 - Methods that operate on SimTK::Vec<n> are now available through Java/Matlab and python bindings to add/subtract/divide/multiply vec<n> contents with a scalar (PR #2558)
 - The new Stopwatch class allows C++ API users to easily measure the runtime of their code.
 - If finalizeConnections() method was not called on a model after making changes and before printing, an exception is thrown to avoid creating corrupt model files quietly (PR #2529)
+- Updated the docopt.cpp dependency so that OpenSim can be compiled with Visual C++ from Visual Studio 2019.
 
 Converting from v4.0 to v4.1
 ----------------------------

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -157,7 +157,7 @@ AddDependency(NAME       simbody
 
 AddDependency(NAME       docopt
               URL        https://github.com/docopt/docopt.cpp.git
-              TAG        af03fa044ee1eff20819549b534ea86829a24a54)
+              TAG        3dd23e3280f213bacefdf5fcb04857bf52e90917)
  
 #######################
 


### PR DESCRIPTION
Fixes issue #2601 

### Brief summary of changes

This PR uses a more recent version of docopt to avoid issues with VS2019.

### Testing I've completed

Built on Windows with VS2019 and ran all tests and they all passed. Note that AppVeyor does not use VS2019.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2618)
<!-- Reviewable:end -->
