### PR TITLE
{WIP} Update time range for IKStudy analysis

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -436,6 +436,7 @@ public:
      * newStartTime, newFinalTime. The trimming is done in place, no copy is made. 
      * Uses getRowIndexAfterTime to locate first row and
      * getNearestRowIndexForTime method to locate last row.
+     * The method throws if the resulting TimeSeriesTable is empty
      */
     void trim(const double& newStartTime, const double& newFinalTime) {
         OPENSIM_THROW_IF(newFinalTime < newStartTime, EmptyTable);
@@ -449,6 +450,8 @@ public:
 
         // do the actual trimming based on index instead of time.
         trimToIndices(start_index, last_index);
+        // If resulting table is empty, throw
+        OPENSIM_THROW_IF(this->getNumRows()==0, EmptyTable);
     }
     /**
      * trim TimeSeriesTable, keeping rows at newStartTime to the end.

--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -225,8 +225,8 @@ SimTK::Array_<int> InverseKinematicsStudy::getTimeRangeInUse(
     int nt = static_cast<int>(times.size());
     int startIx = 0;
     int endIx = nt-1;
-    int startTime = times[startIx];
-    int endTime   = times[endIx];
+    auto startTime = times[startIx];
+    auto endTime   = times[endIx];
     
     if (get_time_range(0)>get_time_range(1)){
       throw std::invalid_argument( "Start time greater than End time" );

--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -143,7 +143,10 @@ runInverseKinematicsWithOrientationsFromFile(Model& model,
 
     TimeSeriesTable_<SimTK::Rotation> orientationsData =
         OpenSenseUtilities::convertQuaternionsToRotations(quatTable);
-
+    
+    // Trim orientation data based on User input times 
+    orientationsData.trim(get_time_range(0),get_time_range(1));
+        
     OrientationsReference oRefs(orientationsData);
     MarkersReference mRefs{};
 

--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -140,12 +140,14 @@ runInverseKinematicsWithOrientationsFromFile(Model& model,
     OpenSenseUtilities::rotateOrientationTable(quatTable, sensorToOpenSim);
 
     auto startEnd = getTimeRangeInUse(quatTable.getIndependentColumn());
-
+    
     TimeSeriesTable_<SimTK::Rotation> orientationsData =
         OpenSenseUtilities::convertQuaternionsToRotations(quatTable);
-    
-    // Trim orientation data based on User input times 
-    orientationsData.trim(get_time_range(0),get_time_range(1));
+
+    // Trim orientation data based on User input times
+    cout << startEnd[0] << endl;
+    cout << startEnd[1] << endl;
+    orientationsData.trim(startEnd[0],startEnd[1]);
         
     OrientationsReference oRefs(orientationsData);
     MarkersReference mRefs{};
@@ -225,27 +227,39 @@ SimTK::Array_<int> InverseKinematicsStudy::getTimeRangeInUse(
     int nt = static_cast<int>(times.size());
     int startIx = 0;
     int endIx = nt-1;
-
-    for (int i = 0; i < nt; ++i) {
-        if (times[i] <= get_time_range(0)) {
-            startIx = i;
-        }
-        else {
-            break;
-        }
+    int startTime = times[startIx];
+    int endTime   = times[endIx];
+    
+    if (get_time_range(0)>get_time_range(1)){
+      throw std::invalid_argument( "Start time greater than End time" );
     }
-
-    for (int i = nt - 1; i > 0; --i) {
-        if (times[i] >= get_time_range(1)) {
-            endIx= i;
-        }
-        else {
-            break;
-        }
+    
+    // Check and set the start time
+    if (get_time_range(0) != Infinity) {
+        // Check if User Specified time ranges are legal
+        if (get_time_range(0)<times[startIx]) {
+          throw std::invalid_argument( "Start time out of range" );
+        } else {
+          startTime = get_time_range(0);
+        } 
     }
+    
+    // Check and set end time
+    if (get_time_range(1) != Infinity) {
+        // Check if User Specified time ranges are legal
+        if (get_time_range(1)>times[endIx]) {
+          throw std::invalid_argument( "End time out of range" );
+        } else {
+          endTime = get_time_range(1);
+        } 
+    }
+    
     SimTK::Array_<int> retArray;
-    retArray.push_back(startIx);
-    retArray.push_back(endIx);
+    retArray.push_back(startTime);
+    retArray.push_back(endTime);
+    std::cout << "startTime::" << startTime << std::endl;
+    std::cout << "endTime::"   << endTime << std::endl;
+    
     return retArray;
 }
 

--- a/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
+++ b/OpenSim/Simulation/OpenSense/InverseKinematicsStudy.cpp
@@ -145,8 +145,6 @@ runInverseKinematicsWithOrientationsFromFile(Model& model,
         OpenSenseUtilities::convertQuaternionsToRotations(quatTable);
 
     // Trim orientation data based on User input times
-    cout << startEnd[0] << endl;
-    cout << startEnd[1] << endl;
     orientationsData.trim(startEnd[0],startEnd[1]);
         
     OrientationsReference oRefs(orientationsData);
@@ -257,9 +255,6 @@ SimTK::Array_<int> InverseKinematicsStudy::getTimeRangeInUse(
     SimTK::Array_<int> retArray;
     retArray.push_back(startTime);
     retArray.push_back(endTime);
-    std::cout << "startTime::" << startTime << std::endl;
-    std::cout << "endTime::"   << endTime << std::endl;
-    
     return retArray;
 }
 


### PR DESCRIPTION
### Fixes issue 
User input time is not respected by the IK Study. This is most likely caused due to the times being defined directly from the orientationsTable and (seemingly) not from the user-specified times. 

```
...
auto& times = oRefs.getTimes();

s0.updTime() = times[0];
    ikSolver.assemble(s0);
    if (visualizeResults) {
        model.getVisualizer().show(s0);
        model.getVisualizer().getSimbodyVisualizer().setShowSimTime(true);
    }
    for (auto time : times) {
        s0.updTime() = time;
...
```

### Brief summary of changes
I added a line that trim's the orientationTable based on user specified times. This seemed to be the quickest/easiest way for me to get the user-specified times working locally. 

### Testing I've completed
Run locally (through Matlab) on my own files. 

### Looking for feedback on...
I doubt this is the most robust way to solve this bug, but was the easiest for me to code. Happy to improve :)
### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2621)
<!-- Reviewable:end -->
