### PR TITLE
Make transform explicit in XML files of IMUInverseKinematicsTool 

### DIFF
--- a/Applications/opensense/test/setup_IMUInverseKinematics_HJC_trial.xml
+++ b/Applications/opensense/test/setup_IMUInverseKinematics_HJC_trial.xml
@@ -3,7 +3,7 @@
 	<IMUInverseKinematicsTool name="track_HJC_trial">
 		<!--The accuracy of the solution in absolute terms, i.e. the number of significant digits to which the solution can be trusted. Default 1e-6.-->
 		<accuracy>9.9999999999999995e-07</accuracy>
-		<!-- Space fixed Euler angles (XYZ order) from IMU Space to OpenSim. Default to Identity. -->
+		<!-- Space fixed Euler angles (XYZ order) from IMU Space to OpenSim. Default to (0, 0, 0). -->
 		<sensor_to_opensim_rotations>-1.5707963 0 0</sensor_to_opensim_rotations>
 		<!--The relative weighting of kinematic constraint errors. By default this is Infinity, which means constraints are strictly enforced as part of the optimization and are not appended to the objective (cost) function. Any other non-zero positive scalar is the penalty factor for constraint violations.-->
 		<constraint_weight>Inf</constraint_weight>

--- a/Applications/opensense/test/setup_IMUInverseKinematics_HJC_trial.xml
+++ b/Applications/opensense/test/setup_IMUInverseKinematics_HJC_trial.xml
@@ -3,6 +3,8 @@
 	<IMUInverseKinematicsTool name="track_HJC_trial">
 		<!--The accuracy of the solution in absolute terms, i.e. the number of significant digits to which the solution can be trusted. Default 1e-6.-->
 		<accuracy>9.9999999999999995e-07</accuracy>
+		<!-- Space fixed Euler angles (XYZ order) from IMU Space to OpenSim. Default to Identity. -->
+		<sensor_to_opensim_rotations>-1.5707963 0 0</sensor_to_opensim_rotations>
 		<!--The relative weighting of kinematic constraint errors. By default this is Infinity, which means constraints are strictly enforced as part of the optimization and are not appended to the objective (cost) function. Any other non-zero positive scalar is the penalty factor for constraint violations.-->
 		<constraint_weight>Inf</constraint_weight>
 		<!--The time range for the study.-->

--- a/Applications/opensense/test/testOpenSense.cpp
+++ b/Applications/opensense/test/testOpenSense.cpp
@@ -57,7 +57,7 @@ int main()
     IMUInverseKinematicsTool ik_hjc("setup_IMUInverseKinematics_HJC_trial.xml");
     ik_hjc.setModel(facingX);
     ik_hjc.set_results_directory("ik_hjc_" + facingX.getName());
-    ik_hjc.run(true);
+    ik_hjc.run(false);
 
     // Now facing the opposite direction (negative X)
     IMUPlacer placerNegX("imuPlacerFaceNegX.xml");
@@ -68,7 +68,7 @@ int main()
 
     ik_hjc.setModel(facingNegX);
     ik_hjc.set_results_directory("ik_hjc_" + facingNegX.getName());
-    ik_hjc.run(true);
+    ik_hjc.run(false);
 
     Storage ik_X("ik_hjc_" + facingX.getName() + 
         "/ik_MT_012005D6_009-quaternions_RHJCSwinger.mot");

--- a/Applications/opensense/test/testOpenSense.cpp
+++ b/Applications/opensense/test/testOpenSense.cpp
@@ -57,7 +57,7 @@ int main()
     IMUInverseKinematicsTool ik_hjc("setup_IMUInverseKinematics_HJC_trial.xml");
     ik_hjc.setModel(facingX);
     ik_hjc.set_results_directory("ik_hjc_" + facingX.getName());
-    ik_hjc.run(false);
+    ik_hjc.run(true);
 
     // Now facing the opposite direction (negative X)
     IMUPlacer placerNegX("imuPlacerFaceNegX.xml");
@@ -68,7 +68,7 @@ int main()
 
     ik_hjc.setModel(facingNegX);
     ik_hjc.set_results_directory("ik_hjc_" + facingNegX.getName());
-    ik_hjc.run(false);
+    ik_hjc.run(true);
 
     Storage ik_X("ik_hjc_" + facingX.getName() + 
         "/ik_MT_012005D6_009-quaternions_RHJCSwinger.mot");

--- a/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.cpp
@@ -45,7 +45,7 @@ void IMUInverseKinematicsTool::constructProperties()
     constructProperty_time_range(range);
 
     constructProperty_sensor_to_opensim_rotations(
-            SimTK::Vec3(-SimTK_PI / 2, 0, 0));
+            SimTK::Vec3(0));
 
     constructProperty_model_file("");
     constructProperty_marker_file("");

--- a/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h
+++ b/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h
@@ -75,7 +75,7 @@ public:
 
     OpenSim_DECLARE_PROPERTY(sensor_to_opensim_rotations, SimTK::Vec3,
             "Space fixed Euler angles (XYZ order) from IMU Space to OpenSim."
-            " Default to Identity");
+            " Default to (0, 0, 0).");
 
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(time_range, double, 2,
         "The time range for the study.");

--- a/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h
+++ b/OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h
@@ -75,7 +75,7 @@ public:
 
     OpenSim_DECLARE_PROPERTY(sensor_to_opensim_rotations, SimTK::Vec3,
             "Space fixed Euler angles (XYZ order) from IMU Space to OpenSim."
-            " Default fom IMU world (Z up) to OpenSim (Y up, X forward)");
+            " Default to Identity");
 
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(time_range, double, 2,
         "The time range for the study.");


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
Made builtin transform in IMUInvereseKinematicsTool identity and changed property comment and setup file for test accordingly
### Testing I've completed
Ran tests
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2626)
<!-- Reviewable:end -->
