### PR TITLE
Remove duplicate typedef

### DIFF
--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -521,9 +521,8 @@ typedef TimeSeriesTable_<SimTK::Vec3> TimeSeriesTableVec3;
 /** See TimeSeriesTable_ for details on the interface.                        */
 typedef TimeSeriesTable_<SimTK::Quaternion> TimeSeriesTableQuaternion;
 
-typedef OpenSim::TimeSeriesTable_<SimTK::Quaternion> TimeSeriesTableQuaternion;
-
-typedef OpenSim::TimeSeriesTable_<SimTK::Rotation> TimeSeriesTableRotation;
+/** See TimeSeriesTable_ for details on the interface.                        */
+typedef TimeSeriesTable_<SimTK::Rotation> TimeSeriesTableRotation;
 
 } // namespace OpenSim
 


### PR DESCRIPTION
This PR removes a duplicate typedef for `TimeSeriesTableRotation`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2630)
<!-- Reviewable:end -->
