### PR TITLE
Fix bug with getFormattedDateTime().

### DIFF
--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -53,7 +53,7 @@ std::string OpenSim::getFormattedDateTime(
     }
 
     std::stringstream ss;
-    ss << std::string(formatted.get(), size);
+    ss << formatted.get();
 
     if (appendMicroseconds) {
         // Get number of microseconds since last second.

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -25,6 +25,7 @@
 #include <OpenSim/Common/Reporter.h>
 #include <OpenSim/Common/TableSource.h>
 #include <OpenSim/Common/STOFileAdapter.h>
+#include <OpenSim/Common/CommonUtilities.h>
 #include <simbody/internal/SimbodyMatterSubsystem.h>
 #include <simbody/internal/GeneralForceSubsystem.h>
 #include <simbody/internal/Force.h>
@@ -2258,6 +2259,12 @@ void testGetAbsolutePathStringSpeed() {
     cout << "getName avgTime = " << avgTime / numTrials << "s" << endl;
 }
 
+void testFormattedDateTime() {
+    std::string withMicroseconds = getFormattedDateTime(true, "%Y");
+    std::string withoutMicroseconds = getFormattedDateTime(false, "%Y");
+    SimTK_TEST(withMicroseconds.find(withoutMicroseconds) == 0);
+}
+
 int main() {
 
     //Register new types for testing deserialization
@@ -2294,6 +2301,8 @@ int main() {
         // any new functionality. Make sure to uncomment to use (and
         // consider commenting other subtests for more stable benchmark).
         //SimTK_SUBTEST(testGetAbsolutePathStringSpeed);
+
+        SimTK_SUBTEST(testFormattedDateTime);
 
     SimTK_END_TEST();
 }


### PR DESCRIPTION
### Brief summary of changes

Fixed a bug with getFormattedDateTime() where we used an incorrect string length, causing bogus characters to appear in the string.

### Testing I've completed

Tested locally in Moco.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...this function hasn't been released yet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2634)
<!-- Reviewable:end -->
