### PR TITLE
Build opensense executable always

### DIFF
--- a/Applications/opensense/CMakeLists.txt
+++ b/Applications/opensense/CMakeLists.txt
@@ -1,6 +1,4 @@
-if(OPENSIM_BUILD_INDIVIDUAL_APPS)
-    OpenSimAddApplication(NAME opensense)
-endif()
+OpenSimAddApplication(NAME opensense)
 
 if(BUILD_TESTING)
     subdirs(test)


### PR DESCRIPTION
Regardless of the value of BUILD_INDIVIDUA…L_APPS CMake variable, build opensense (other executables particularly id conflict with system level commands on non-windows machines)

Fixes issue #0

### Brief summary of changes
Remove conditional from CMakeLists.txt

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2636)
<!-- Reviewable:end -->
