### PR TITLE
Replace opensense command line options to ReadXsens and ReadAPDM

### DIFF
--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -157,7 +157,8 @@ int main(int argc, char **argv)
                     Model model = imuPlacer.getCalibratedModel();
                     // If output_model was specified it will be written, otherwise preserve model by writing to "calibrated_"
                     if (imuPlacer.get_output_model_file().empty()) {
-                        auto filename = "calibrated_" + model.getName() + ".osim";
+                        auto filename =
+                                model.getName() + "_calibrated" + ".osim";
                         cout << "Wrote calibrated model to file: '" << filename << "'." << endl;
                         model.print(filename);
                     }
@@ -256,8 +257,14 @@ void PrintUsage(const char *aProgName, ostream &aOStream)
     aOStream << "-Help, -H                                 Print the command-line options for " << progName << ".\n";
     aOStream << "-PrintSetup, -PS                          Create a template inverse kinematics settings file that can be customized.\n";
     aOStream << "-PropertyInfo, -PI                        Print help information for properties in setup files.\n";
-    aOStream << "-ReadXsens, -RX directory settings.xml    Parse Xsens exported files from directory using settingsFile.xml.\n";
-    aOStream << "-ReadAPDM, -RA datafile.csv settings.xml  Parse single csv file provided by APDM using specified settingsFile.xml.\n";
+    aOStream << "-ReadXsens, -RX directory settings.xml    Parse Xsens exported files from directory using settings.xml.\n";
+    aOStream << "                                          Creates a storage file with the orientation data for each sensor, \n";
+    aOStream << "                                          where each column in the storage file is named\n"; 
+    aOStream << "                                          according to the Frame in the corresponding OpenSim model.\n";
+    aOStream << "-ReadAPDM, -RA datafile.csv settings.xml  Parse single csv file provided by APDM using specified settings.xml.\n";
+    aOStream << "                                          Creates a storage file with the orientation data for each sensor, \n";
+    aOStream << "                                          where each column in the storage file is named\n";
+    aOStream << "                                          according to the Frame in the corresponding OpenSim model.\n";
     aOStream << "-Calibrate, -C IMUPlacer_setup.xml        Place IMUs on the model that is specified in the IMUPlacer_setup.xml file.\n";
     aOStream << "                                          The model is positioned in its default pose. IMUs are then registered to the model according to\n ";
     aOStream << "                                          their orientations in the first frame of the quaternions file that is specified in IMUPlacer_setup.xml.\n";

--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
                     PrintUsage(argv[0], cout);
                     return 0;
                 }
-                else if ((option == "-ReadX") || (option == "-RX")) {
+                else if ((option == "-ReadXsens") || (option == "-RX")) {
                     if (argc < 4) {
                         cout << "Both the directory containing Xsens data files and the reader settings file are necessary to read Xsens data. Please retry with these inputs." << endl;
                         PrintUsage(argv[0], cout);
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
                     cout << "Done." << endl;
                     return 0;
                 }
-                else if ((option == "-ReadA") || (option == "-RA")) {
+                else if ((option == "-ReadAPDM") || (option == "-RA")) {
                     if (argc < 4) {
                         cout << "Both the data file (.csv) with APDM formatted data and the reader settings file are necessary to read APDM data. Please retry with these inputs." << endl;
                         PrintUsage(argv[0], cout);
@@ -251,20 +251,20 @@ void PrintUsage(const char *aProgName, ostream &aOStream)
 {
     string progName = IO::GetFileNameFromURI(aProgName);
     aOStream << "\n\n" << progName << ":\n\n";
-    aOStream << "Option             Argument             Action / Notes\n";
-    aOStream << "------             --------             --------------\n";
-    aOStream << "-Help, -H                               Print the command-line options for " << progName << ".\n";
-    aOStream << "-PrintSetup, -PS                        Create a template inverse kinematics settings file that can be customized.\n";
-    aOStream << "-PropertyInfo, -PI                      Print help information for properties in setup files.\n";
-    aOStream << "-ReadX, -RX  directory settings.xml     Parse Xsens exported files from directory using settingsFile.xml.\n";
-    aOStream << "-ReadA, -RA  datafile.csv settings.xml  Parse single csv file provided by APDM using specified settingsFile.xml.\n";
-    aOStream << "-Calibrate, -C IMUPlacer_setup.xml      Place IMUs on the model that is specified in the IMUPlacer_setup.xml file.\n";
-    aOStream << "                                        The model is positioned in its default pose. IMUs are then registered to the model according to\n ";
-    aOStream << "                                        their orientations in the first frame of the quaternions file that is specified in IMUPlacer_setup.xml.\n";
-    aOStream << "                                        The orientations of the IMUs in the quaternions file are assumed to be in the IMU world frame.\n";
-    aOStream << "                                        The resultant model with IMU frames registered is written to file if output_model_file is specified\n";
-    aOStream << "                                        in IMUPlacer_setup.xml. Additional options can be specified in IMUPlacer_setup.xml to perform heading correction.\n";
-    aOStream << "-InverseKinematics, -IK ik_settings.xml Run IK using an xml settings file to define the inverse kinematics problem.\n";
+    aOStream << "Option             Argument               Action / Notes\n";
+    aOStream << "------             --------               --------------\n";
+    aOStream << "-Help, -H                                 Print the command-line options for " << progName << ".\n";
+    aOStream << "-PrintSetup, -PS                          Create a template inverse kinematics settings file that can be customized.\n";
+    aOStream << "-PropertyInfo, -PI                        Print help information for properties in setup files.\n";
+    aOStream << "-ReadXsens, -RX directory settings.xml    Parse Xsens exported files from directory using settingsFile.xml.\n";
+    aOStream << "-ReadAPDM, -RA datafile.csv settings.xml  Parse single csv file provided by APDM using specified settingsFile.xml.\n";
+    aOStream << "-Calibrate, -C IMUPlacer_setup.xml        Place IMUs on the model that is specified in the IMUPlacer_setup.xml file.\n";
+    aOStream << "                                          The model is positioned in its default pose. IMUs are then registered to the model according to\n ";
+    aOStream << "                                          their orientations in the first frame of the quaternions file that is specified in IMUPlacer_setup.xml.\n";
+    aOStream << "                                          The orientations of the IMUs in the quaternions file are assumed to be in the IMU world frame.\n";
+    aOStream << "                                          The resultant model with IMU frames registered is written to file if output_model_file is specified\n";
+    aOStream << "                                          in IMUPlacer_setup.xml. Additional options can be specified in IMUPlacer_setup.xml to perform heading correction.\n";
+    aOStream << "-InverseKinematics, -IK ik_settings.xml   Run IK using an xml settings file to define the inverse kinematics problem.\n";
     aOStream << endl;
 /** Advanced options for experimental validation. Uncomment if/when ready to make public
     aOStream << "-Transform, -T markerFileWithIMUframes.trc  Transform experimental marker locations that define axes of IMUs, or the plates\n";


### PR DESCRIPTION
Fixes issue #2654

### Brief summary of changes
Change long name of parameters from ReadX to ReadXsens and ReadA to ReadAPDM

### Testing I've completed
None
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no to update if this is included in version 4.1 

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2655)
<!-- Reviewable:end -->
