### PR TITLE
Add opensim-install-command-line.sh.

### DIFF
--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -12,3 +12,8 @@ add_subdirectory(opensense)
 add_subdirectory(versionUpdate)
 
 add_subdirectory(opensim-cmd)
+
+if(UNIX)
+    install(PROGRAMS opensim-install-command-line.sh DESTINATION
+        ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/Applications/opensim-install-command-line.sh
+++ b/Applications/opensim-install-command-line.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script makes the OpenSim command-line tools accessible from any
+# directory (assuming /usr/local/bin is on the PATH, by being listed in the file
+# /etc/paths).
+# This script should be run from the directory containing opensim-cmd and
+# opensense.
+
+if [ ! -f "$(pwd)/opensim-cmd" ]; then
+    echo "Could not find opensim-cmd in the current working directory. Aborting."
+    exit 1;
+fi
+
+# Create symbolic links.
+# -i: Prompt the user if the target file already exists.
+# -s: Create a symbolic link.
+sudo ln -i -s $(pwd)/opensim-cmd /usr/local/bin/opensim-cmd
+sudo ln -i -s $(pwd)/opensense /usr/local/bin/opensense
+# Un-cache the password, so that the next time sudo is used, a password is
+# required.
+sudo -k
+
+echo "Created symlinks to opensim-cmd and opensense in /usr/local/bin."
+echo "You can now use these commands from any directory."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ v4.1
 - If finalizeConnections() method was not called on a model after making changes and before printing, an exception is thrown to avoid creating corrupt model files quietly (PR #2529)
 - Updated the docopt.cpp dependency so that OpenSim can be compiled with Visual C++ from Visual Studio 2019.
 - Updated Simbody to 3.7 to fix an issue with the simbody-visualizer on macOS 10.15 Catalina.
+- On Mac and Linux, we include a shell script opensim-install-command-line.sh to make OpenSim's command-line tools easily accessible.
+ 
 
 Converting from v4.0 to v4.1
 ----------------------------


### PR DESCRIPTION
### Brief summary of changes

This PR adds a shell script on Mac and Linux systems to aid with making OpenSim's command-line tools accessible in the Terminal from any directory.

### Testing I've completed

Locally, I installed opensim-core and ran the script multiple times. I ensured that I get a password prompt and that I get prompts if the symlinks already exist.

### CHANGELOG.md (choose one)

- updated...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2657)
<!-- Reviewable:end -->
