### PR TITLE
Add quotes around first argument

### DIFF
--- a/Applications/opensim-install-command-line.sh
+++ b/Applications/opensim-install-command-line.sh
@@ -13,8 +13,8 @@ fi
 # Create symbolic links.
 # -i: Prompt the user if the target file already exists.
 # -s: Create a symbolic link.
-sudo ln -i -s $(pwd)/opensim-cmd /usr/local/bin/opensim-cmd
-sudo ln -i -s $(pwd)/opensense /usr/local/bin/opensense
+sudo ln -i -s "$(pwd)/opensim-cmd" /usr/local/bin/opensim-cmd
+sudo ln -i -s "$(pwd)/opensense" /usr/local/bin/opensense
 # Un-cache the password, so that the next time sudo is used, a password is
 # required.
 sudo -k


### PR DESCRIPTION
### Brief summary of changes

Fix `opensim-install-command-line.sh` for when it's run from a directory containing spaces.

### Testing I've completed

Edited the shell script locally from a directory containing spaces. Before, `ln` gave an error. Now, the symlinks are created properly.

### CHANGELOG.md (choose one)

- no need to update because...no release yet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2661)
<!-- Reviewable:end -->
