### PR TITLE
Change "Labels" to "labels" to reduce confusion.

### DIFF
--- a/OpenSim/Common/FileAdapter.h
+++ b/OpenSim/Common/FileAdapter.h
@@ -93,7 +93,7 @@ public:
                           const std::string& expected,
                           const std::string& received) :
         IOError(file, line, func) {
-        std::string msg = "Error reading column Labels in file '" + filename;
+        std::string msg = "Error reading column labels in file '" + filename;
         msg += "'. Unexpected column label. ";
         msg += "Expected = " + expected + ". ";
         msg += "Received = " + received + ". ";

--- a/OpenSim/Common/TRCFileAdapter.h
+++ b/OpenSim/Common/TRCFileAdapter.h
@@ -122,7 +122,7 @@ public:
                              size_t expected,
                              size_t received) :
         IOError(file, line, func) {
-        std::string msg = "Error reading column Labels in file '" + filename;
+        std::string msg = "Error reading column labels in file '" + filename;
         msg += "'. Unexpected number of column labels. ";
         msg += "Expected = " + std::to_string(expected) + ". ";
         msg += "Recieved = " + std::to_string(received) + ".";


### PR DESCRIPTION
### Brief summary of changes

Change capitalization of "Labels" to "labels" in an exception message.

### Testing I've completed

None.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2669)
<!-- Reviewable:end -->
