### PR TITLE
Update simbody doxygen location

### DIFF
--- a/doc/OpenSimDoxygenMain.dox
+++ b/doc/OpenSimDoxygenMain.dox
@@ -95,7 +95,7 @@ model components, such as body, constraint, or joint.
         <td rowspan="2">
             <img src="images/DoxygenFrontPage_small_07.gif" width="3" height="101" alt=""></td>
         <td colspan="3">
-            <a href="https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/classSimTK_1_1Optimizer.html"
+            <a href="https://simbody.github.io/3.7.0/classSimTK_1_1Optimizer.html"
                 onmouseover="window.status='SimTK::Optimizer';  return true;"
                 onmouseout="window.status='';  return true;">
                 <img src="images/Optimizer.gif" width="259" height="97" border="0" alt="SimTK::Optimizer"></a></td>
@@ -163,7 +163,7 @@ model components, such as body, constraint, or joint.
     </tr>
     <tr>
         <td colspan="10">
-            <a href="https://simtk.org/api_docs/simbody/api_docs33/Simbody/html/"
+            <a href="https://simbody.github.io/3.7.0/"
                 onmouseover="window.status='SimTK::System';  return true;"
                 onmouseout="window.status='';  return true;"
                 target = "_blank">


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Doxygen configuration file has stale url for simbody doxygen

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2670)
<!-- Reviewable:end -->
