### PR TITLE
Fix signature of convertRotationToQuaternion for use in scripting

### DIFF
--- a/Bindings/SWIGSimTK/Rotation.h
+++ b/Bindings/SWIGSimTK/Rotation.h
@@ -229,7 +229,7 @@ public:
     /* SimTK_SimTKCOMMON_EXPORT */ Vec3  convertThreeAxesRotationToThreeAngles( BodyOrSpaceType bodyOrSpace, const CoordinateAxis& axis1, const CoordinateAxis& axis2, const CoordinateAxis& axis3 ) const;
     /// Converts rotation matrix to a quaternion.
 
-    /* SimTK_SimTKCOMMON_EXPORT */ Quaternion convertRotationToQuaternion() const;
+    /* SimTK_SimTKCOMMON_EXPORT */ Quaternion_<double> convertRotationToQuaternion() const;
 
     /// Converts rotation matrix to angle-axis form.
     Vec4  convertRotationToAngleAxis() const  { return convertRotationToQuaternion().convertQuaternionToAngleAxis(); }


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
Return type of the SWIG generated method to convert Rotation to Quaternion was incorrect, fixed by adjusting the signature in header.

### Testing I've completed
Checked signature in generated java file

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2693)
<!-- Reviewable:end -->
