### PR TITLE
Fix comment about activation time constant.

### DIFF
--- a/OpenSim/Actuators/ActivationCoordinateActuator.h
+++ b/OpenSim/Actuators/ActivationCoordinateActuator.h
@@ -47,7 +47,7 @@ class OSIMACTUATORS_API ActivationCoordinateActuator
         CoordinateActuator);
 public:
     OpenSim_DECLARE_PROPERTY(activation_time_constant, double,
-        "Larger value means activation can change more rapidly "
+        "Larger value means activation changes more slowly "
         "(units: seconds; default: 0.01 seconds).");
 
     OpenSim_DECLARE_PROPERTY(default_activation, double,


### PR DESCRIPTION
### Brief summary of changes

Correct the comment for the `ActivationCoordinateActuator`'s `activation_time_constant` property.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2705)
<!-- Reviewable:end -->
