### PR TITLE
Merge ik tools

### DIFF
--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -40,8 +40,8 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/MarkersReference.h>
 #include <OpenSim/Simulation/InverseKinematicsSolver.h>
-#include <OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h>
 #include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
+#include <OpenSim/Tools/IMUInverseKinematicsTool.h>
 
 #include <ctime>  // clock(), clock_t, CLOCKS_PER_SEC
 

--- a/Applications/opensense/test/testOpenSense.cpp
+++ b/Applications/opensense/test/testOpenSense.cpp
@@ -26,8 +26,8 @@
 #include <OpenSim/Common/STOFileAdapter.h>
 #include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
 #include <OpenSim/Simulation/OpenSense/IMUPlacer.h>
-#include <OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Tools/IMUInverseKinematicsTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
 using namespace OpenSim;

--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -140,7 +140,6 @@
 #include <OpenSim/Simulation/InverseKinematicsSolver.h>
 #include <OpenSim/Simulation/OpenSense/IMUPlacer.h>
 #include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
-#include <OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h>
 
 #include <OpenSim/Simulation/StatesTrajectory.h>
 #include <OpenSim/Simulation/StatesTrajectoryReporter.h>

--- a/Bindings/OpenSimHeaders_tools.h
+++ b/Bindings/OpenSimHeaders_tools.h
@@ -35,6 +35,8 @@
 #include <OpenSim/Tools/ScaleTool.h>
 #include <OpenSim/Tools/AnalyzeTool.h>
 #include <OpenSim/Tools/InverseKinematicsTool.h>
+#include <OpenSim/Tools/IMUInverseKinematicsTool.h>
+
 
 #endif // OPENSIM_OPENSIM_HEADERS_TOOLS_H_
 

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -223,7 +223,6 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/InverseKinematicsSolver.h>
 %include <OpenSim/Simulation/OpenSense/IMUPlacer.h>
 %include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
-%include <OpenSim/Simulation/OpenSense/IMUInverseKinematicsTool.h>
 
 %include <OpenSim/Simulation/StatesTrajectory.h>
 // This enables iterating using the getBetween() method.

--- a/Bindings/tools.i
+++ b/Bindings/tools.i
@@ -34,3 +34,4 @@
 %include <OpenSim/Tools/AnalyzeTool.h>
 %include <OpenSim/Tools/InverseKinematicsToolBase.h>
 %include <OpenSim/Tools/InverseKinematicsTool.h>
+%include <OpenSim/Tools/IMUInverseKinematicsTool.h>

--- a/Bindings/tools.i
+++ b/Bindings/tools.i
@@ -32,4 +32,5 @@
 %include <OpenSim/Tools/CMCTool.h>
 %include <OpenSim/Tools/RRATool.h>
 %include <OpenSim/Tools/AnalyzeTool.h>
+%include <OpenSim/Tools/InverseKinematicsToolBase.h>
 %include <OpenSim/Tools/InverseKinematicsTool.h>

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -123,7 +123,6 @@
 #include "SimbodyEngine/Coordinate.h"
 #include "SimbodyEngine/SpatialTransform.h"
 #include "OpenSense/IMUPlacer.h"
-#include "OpenSense/IMUInverseKinematicsTool.h"
 
 #include "StatesTrajectoryReporter.h"
 
@@ -265,7 +264,6 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameter() );
 
     Object::registerType( IMUPlacer());
-    Object::registerType( IMUInverseKinematicsTool() );
     
     Object::registerType( StatesTrajectoryReporter() );
 

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -286,9 +286,6 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
 
     Object::renameType("MuscleMetabolicPowerProbeUmberger2010_MetabolicMuscleParameterSet",  
         "Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameterSet");
-    // Will remove this before public release but leaving now for testing purposes
-    Object::renameType(
-            "InverseKinematicsStudy", "IMUInverseKinematicsTool");
 
   } catch (const std::exception& e) {
     std::cerr 

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -123,7 +123,6 @@
 #include "StatesTrajectory.h"
 #include "StatesTrajectoryReporter.h"
 #include "OpenSense/OpenSenseUtilities.h"
-#include "OpenSense/IMUInverseKinematicsTool.h"
 
 #include "SimulationUtilities.h"
 

--- a/OpenSim/Tools/IMUInverseKinematicsTool.cpp
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.cpp
@@ -1,6 +1,6 @@
 
 #include "IMUInverseKinematicsTool.h"
-#include "OpenSenseUtilities.h"
+#include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Common/TableSource.h>
@@ -11,8 +11,6 @@
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Simulation/InverseKinematicsSolver.h>
 #include <OpenSim/Simulation/OrientationsReference.h>
-#include "ExperimentalMarker.h"
-#include "ExperimentalFrame.h"
 
 
 using namespace OpenSim;
@@ -21,13 +19,12 @@ using namespace std;
 
 
 IMUInverseKinematicsTool::IMUInverseKinematicsTool()
-{
+        : InverseKinematicsToolBase() {
     constructProperties();
 }
 
 IMUInverseKinematicsTool::IMUInverseKinematicsTool(const std::string& setupFile)
-    : Object(setupFile, true)
-{
+        : InverseKinematicsToolBase(setupFile, true) {
     constructProperties();
     updateFromXMLDocument();
 }
@@ -38,22 +35,11 @@ IMUInverseKinematicsTool::~IMUInverseKinematicsTool()
 
 void IMUInverseKinematicsTool::constructProperties()
 {
-    constructProperty_accuracy(1e-6);
-    constructProperty_constraint_weight(Infinity);
-    Array<double> range{ Infinity, 2};
-    range[0] = -Infinity; // Make range -Infinity to Infinity unless limited by data
-    constructProperty_time_range(range);
-
     constructProperty_sensor_to_opensim_rotations(
             SimTK::Vec3(0));
-
-    constructProperty_model_file("");
-    constructProperty_marker_file("");
     constructProperty_orientations_file("");
-
-    constructProperty_results_directory("");
 }
-
+/**
 void IMUInverseKinematicsTool::
     previewExperimentalData(const TimeSeriesTableVec3& markers,
                 const TimeSeriesTable_<SimTK::Rotation>& orientations) const
@@ -104,7 +90,7 @@ void IMUInverseKinematicsTool::
         previewWorld.getVisualizer().show(state);
     }
 }
-
+*/
 void IMUInverseKinematicsTool::runInverseKinematicsWithOrientationsFromFile(
         Model& model, const std::string& orientationsFileName,
         bool visualizeResults) {

--- a/OpenSim/Tools/IMUInverseKinematicsTool.h
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.h
@@ -35,70 +35,40 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "osimToolsDLL.h"
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Common/ModelDisplayHints.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Simulation/Model/Point.h>
+#include <OpenSim/Tools/InverseKinematicsToolBase.h>
 
 namespace OpenSim {
 
 class Model;
-class IKTaskSet;
 
 //=============================================================================
 //=============================================================================
 /**
  * A Study that performs an Inverse Kinematics analysis with a given model.
  * Inverse kinematics is the solution of internal coordinates that poses
- * the model such that the landmark locations (markers) and/or body rotations 
- * (as measured by IMUs) affixed to the model minimize the weighted least-
- * squares error with observations of analogous markers and IMU orientations
- * in their spatial coordinates. Observations of coordinates can also be
- * included.
+ * the model such that the body rotations (as measured by IMUs) affixed to the model minimize the weighted least-
+ * squares error with observations of IMU orientations
+ * in their spatial coordinates. 
  *
  * @author Ajay Seth
  */
-class OSIMSIMULATION_API IMUInverseKinematicsTool : public Object {
-OpenSim_DECLARE_CONCRETE_OBJECT(IMUInverseKinematicsTool, Object);
+class OSIMTOOLS_API IMUInverseKinematicsTool
+        : public InverseKinematicsToolBase {
+    OpenSim_DECLARE_CONCRETE_OBJECT(
+            IMUInverseKinematicsTool, InverseKinematicsToolBase);
+
 public:
-//==============================================================================
-// PROPERTIES
-//==============================================================================
-    OpenSim_DECLARE_PROPERTY(model_file, std::string,
-        "Name/path to the xml .osim file used to load a model to be analyzed.");
-
-    OpenSim_DECLARE_PROPERTY(marker_file, std::string,
-        "Name/path to a .trc or .sto file of type Vec3 of marker data.");
-
     OpenSim_DECLARE_PROPERTY(orientations_file, std::string,
         "Name/path to a .sto file of sensor frame orientations as quaternions.");
 
     OpenSim_DECLARE_PROPERTY(sensor_to_opensim_rotations, SimTK::Vec3,
             "Space fixed Euler angles (XYZ order) from IMU Space to OpenSim."
             " Default to (0, 0, 0).");
-
-    OpenSim_DECLARE_LIST_PROPERTY_SIZE(time_range, double, 2,
-        "The time range for the study.");
-
-    OpenSim_DECLARE_PROPERTY(constraint_weight, double,
-        "The relative weighting of kinematic constraint errors. By default this "
-        "is Infinity, which means constraints are strictly enforced as part of "
-        "the optimization and are not appended to the objective (cost) function. "
-        "Any other non-zero positive scalar is the penalty factor for constraint "
-        "violations.");
-
-    OpenSim_DECLARE_PROPERTY(accuracy, double,
-        "The accuracy of the solution in absolute terms, i.e. the number of "
-        "significant digits to which the solution can be trusted. Default 1e-6.");
-
-    OpenSim_DECLARE_PROPERTY(results_directory, std::string,
-        "Name of the directory where results are written. Be default this is "
-        "the directory in which the setup file is be  executed.");
-
-private:
-    
-    /** Pointer to the model being investigated. */
-    SimTK::ReferencePtr<Model> _model;
 
 //=============================================================================
 // METHODS
@@ -113,15 +83,14 @@ public:
     //--------------------------------------------------------------------------
     // INTERFACE
     //--------------------------------------------------------------------------
-    bool run(bool visualizeResults=false);
-
+     //--------------------------------------------------------------------------
+    // INTERFACE
+    //--------------------------------------------------------------------------
+    bool run(bool visualizeResults) SWIG_DECLARE_EXCEPTION;
+    bool run() override SWIG_DECLARE_EXCEPTION { 
+        return run(false);
+    };
     //---- Setters and getters for various attributes
-    void setModel(Model& aModel) { _model = &aModel; };
-    void setStartTime(double d) { upd_time_range(0) = d; };
-    double getStartTime() const {return  get_time_range(0); };
-
-    void setEndTime(double d) { upd_time_range(1) = d; };
-    double getEndTime() const {return  get_time_range(1); };
 
     static TimeSeriesTable_<SimTK::Vec3>
         loadMarkersFile(const std::string& markerFile);
@@ -131,9 +100,6 @@ public:
 
 private:
     void constructProperties();
-    // Made private to be used as debugging tool until we have a final place for it.
-    void previewExperimentalData(const TimeSeriesTableVec3& markers,
-        const TimeSeriesTable_<SimTK::Rotation>& orientations) const;
 
 //=============================================================================
 };  // END of class IMUInverseKinematicsTool

--- a/OpenSim/Tools/IMUInverseKinematicsTool.h
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.h
@@ -51,9 +51,9 @@ class Model;
 /**
  * A Study that performs an Inverse Kinematics analysis with a given model.
  * Inverse kinematics is the solution of internal coordinates that poses
- * the model such that the body rotations (as measured by IMUs) affixed to the model minimize the weighted least-
- * squares error with observations of IMU orientations
- * in their spatial coordinates. 
+ * the model such that the body rotations (as measured by IMUs) affixed to the 
+ * model minimize the weighted least-squares error with observations of IMU 
+ * orientations in their spatial coordinates. 
  *
  * @author Ajay Seth
  */
@@ -83,14 +83,10 @@ public:
     //--------------------------------------------------------------------------
     // INTERFACE
     //--------------------------------------------------------------------------
-     //--------------------------------------------------------------------------
-    // INTERFACE
-    //--------------------------------------------------------------------------
     bool run(bool visualizeResults) SWIG_DECLARE_EXCEPTION;
     bool run() override SWIG_DECLARE_EXCEPTION { 
         return run(false);
     };
-    //---- Setters and getters for various attributes
 
     static TimeSeriesTable_<SimTK::Vec3>
         loadMarkersFile(const std::string& markerFile);

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -58,8 +58,7 @@ InverseKinematicsTool::~InverseKinematicsTool()
 /**
  * Default constructor.
  */
-InverseKinematicsTool::InverseKinematicsTool() : Tool()
-{
+InverseKinematicsTool::InverseKinematicsTool() : InverseKinematicsToolBase() {
     constructProperties();
 }
 //_____________________________________________________________________________
@@ -72,7 +71,7 @@ InverseKinematicsTool::InverseKinematicsTool() : Tool()
  * @param aFileName File name of the document.
  */
 InverseKinematicsTool::InverseKinematicsTool(const string &aFileName, bool aLoadModel) :
-    Tool(aFileName, true)
+    InverseKinematicsToolBase(aFileName, true)
 {
     constructProperties();
     updateFromXMLDocument();
@@ -84,18 +83,9 @@ InverseKinematicsTool::InverseKinematicsTool(const string &aFileName, bool aLoad
  */
 void InverseKinematicsTool::constructProperties()
 {
-    constructProperty_model_file("");
-    constructProperty_constraint_weight(Infinity);
-    constructProperty_accuracy(1e-5);
     constructProperty_IKTaskSet(IKTaskSet());
     constructProperty_marker_file("");
     constructProperty_coordinate_file("");
-    Array<double> range{Infinity, 2};
-    range[0] = -Infinity; // Make range -Infinity to Infinity unless limited by
-                          // data
-    constructProperty_time_range(range);
-
-    constructProperty_report_errors(true);
     constructProperty_output_motion_file("");
     constructProperty_report_marker_locations(false);
 }

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -1,5 +1,5 @@
-#ifndef __InverseKinematicsTool_h__
-#define __InverseKinematicsTool_h__
+#ifndef OPENSIM_INVERSE_KINEMATICS_TOOL_H_
+#define OPENSIM_INVERSE_KINEMATICS_TOOL_H_
 /* -------------------------------------------------------------------------- *
  *                     OpenSim:  InverseKinematicsTool.h                      *
  * -------------------------------------------------------------------------- *
@@ -27,13 +27,6 @@
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Tools/IKTaskSet.h>
 #include <OpenSim/Tools/InverseKinematicsToolBase.h>
-
-#ifdef SWIG
-    #ifdef OSIMTOOLS_API
-        #undef OSIMTOOLS_API
-        #define OSIMTOOLS_API
-    #endif
-#endif
 
 namespace OpenSim {
 
@@ -78,7 +71,7 @@ public:
             "Flag indicating whether or not to report model marker locations. "
             "Note, model marker locations are expressed in Ground.");
 
-    //=============================================================================
+//=============================================================================
 // METHODS
 //=============================================================================
     //--------------------------------------------------------------------------
@@ -106,18 +99,7 @@ public:
     const std::string& getCoordinateFileName() const {
         return get_coordinate_file();
     };
-    
-private:
-    void constructProperties();
 
-public:
-    //--------------------------------------------------------------------------
-    // OPERATORS
-    //--------------------------------------------------------------------------
-
-    //--------------------------------------------------------------------------
-    // GET AND SET
-    //--------------------------------------------------------------------------
     IKTaskSet& getIKTaskSet() { return upd_IKTaskSet(); }
 
     //--------------------------------------------------------------------------
@@ -133,9 +115,12 @@ public:
         SimTK::Array_<CoordinateReference>&coordinateReferences) const;
     /** @endcond **/
 
-//=============================================================================
+private:
+    void constructProperties();
+
+    //=============================================================================
 };  // END of class InverseKinematicsTool
 //=============================================================================
 } // namespace
 
-#endif // __InverseKinematicsTool_h__
+#endif // OPENSIM_INVERSE_KINEMATICS_TOOL_H_

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -26,8 +26,7 @@
 #include "osimToolsDLL.h"
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Tools/IKTaskSet.h>
-#include "Tool.h"
-#include <SimTKcommon/internal/ReferencePtr.h> 
+#include <OpenSim/Tools/InverseKinematicsToolBase.h>
 
 #ifdef SWIG
     #ifdef OSIMTOOLS_API
@@ -54,31 +53,10 @@ class CoordinateReference;
  * @author Ajay Seth
  * @version 1.0
  */
-class OSIMTOOLS_API InverseKinematicsTool: public Tool {
-OpenSim_DECLARE_CONCRETE_OBJECT(InverseKinematicsTool, Tool);
-
-//=============================================================================
-// MEMBER VARIABLES
-//=============================================================================
-private:
-    
-    /** Pointer to the model being investigated. */
-    SimTK::ReferencePtr<Model> _model;
+class OSIMTOOLS_API InverseKinematicsTool : public InverseKinematicsToolBase {
+    OpenSim_DECLARE_CONCRETE_OBJECT(InverseKinematicsTool, InverseKinematicsToolBase);
 
 public:
-    OpenSim_DECLARE_PROPERTY(model_file, std::string,
-            "Name/path to the xml .osim file used to load a model to be analyzed.");
-
-    OpenSim_DECLARE_PROPERTY(constraint_weight, double,
-            "The relative weighting of kinematic constraint errors. By default this "
-            "is Infinity, which means constraints are strictly enforced as part of "
-            "the optimization and are not appended to the objective (cost) function. "
-            "Any other non-zero positive scalar is the penalty factor for "
-            "constraint violations.");
-
-    OpenSim_DECLARE_PROPERTY(accuracy, double,
-            "The accuracy of the solution in absolute terms, i.e. the number of "
-            "significant digits to which the solution can be trusted. Default 1e-5.");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(
             IKTaskSet, 
@@ -95,17 +73,6 @@ public:
             "The name of the storage (.sto or .mot) file containing the time "
             "history of coordinate observations. Coordinate values from this file are "
             "included if there is a corresponding model coordinate and task. ");
-
-    OpenSim_DECLARE_LIST_PROPERTY_SIZE(
-            time_range, double, 2, "The time range for the study.");
-
-    OpenSim_DECLARE_PROPERTY(report_errors, bool,
-            "Flag (true or false) indicating whether or not to report marker "
-            "errors from the inverse kinematics solution.");
-
-    OpenSim_DECLARE_PROPERTY(output_motion_file, std::string,
-            "Name of the resulting inverse kinematics motion (.mot) file.");
-
 
     OpenSim_DECLARE_PROPERTY(report_marker_locations, bool,
             "Flag indicating whether or not to report model marker locations. "
@@ -126,13 +93,6 @@ public:
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
 
     //---- Setters and getters for various attributes
-    void setModel(Model& aModel) { _model = &aModel; };
-    void setStartTime(double d) { upd_time_range(0) = d; };
-    double getStartTime() const { return get_time_range(0); };
-
-    void setEndTime(double d) { upd_time_range(1) = d; };
-    double getEndTime() const { return get_time_range(1); };
-
     void setMarkerDataFileName(const std::string& markerDataFileName) {
         upd_marker_file() = markerDataFileName;
     };
@@ -158,10 +118,6 @@ public:
     //--------------------------------------------------------------------------
     // GET AND SET
     //--------------------------------------------------------------------------
-    void setOutputMotionFileName(const std::string aOutputMotionFileName) {
-        upd_output_motion_file() = aOutputMotionFileName;
-    }
-    std::string getOutputMotionFileName() { return get_output_motion_file(); }
     IKTaskSet& getIKTaskSet() { return upd_IKTaskSet(); }
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Tools/InverseKinematicsToolBase.h
+++ b/OpenSim/Tools/InverseKinematicsToolBase.h
@@ -1,5 +1,5 @@
-#ifndef __InverseKinematicsToolBase_h__
-#define __InverseKinematicsToolBase_h__
+#ifndef OPENSIM_INVERSE_KINEMATICS_TOOL_BASE_H_
+#define OPENSIM_INVERSE_KINEMATICS_TOOL_BASE_H_
 /* -------------------------------------------------------------------------- *
  *                     OpenSim:  InverseKinematicsToolBase.h                  *
  * -------------------------------------------------------------------------- *
@@ -24,37 +24,27 @@
  * -------------------------------------------------------------------------- */
 
 #include "osimToolsDLL.h"
-#include <OpenSim/Common/Object.h>
-#include <OpenSim/Tools/IKTaskSet.h>
 #include "Tool.h"
 #include <SimTKcommon/internal/ReferencePtr.h> 
-
-#ifdef SWIG
-    #ifdef OSIMTOOLS_API
-        #undef OSIMTOOLS_API
-        #define OSIMTOOLS_API
-    #endif
-#endif
 
 namespace OpenSim {
 
 class Model;
-class MarkersReference;
-class CoordinateReference;
 
 //=============================================================================
 //=============================================================================
 /**
  * A Tool that performs an Inverse Kinematics analysis with a given model.
  * Inverse kinematics is the solution of internal coordinates that poses
- * the model such that the landmark locations (markers), affixed to the model,
- * minimize the weighted least-squares error with observations of markers 
- * in spatial coordinates. Observations of coordinates can also be included.
+ * the model such that the landmark locations (markers), or orientations of
+ * Sensor (IMUs) affixed to the model, minimize the weighted least-squares 
+ * error with observations of markers in spatial coordinates, or Sensor 
+ * (IMU) orientations. 
  *
  * @author Ayman Habib
  * @version 1.0
  */
-class OSIMTOOLS_API InverseKinematicsToolBase: public Tool {
+class OSIMTOOLS_API InverseKinematicsToolBase : public Tool {
     OpenSim_DECLARE_ABSTRACT_OBJECT(InverseKinematicsToolBase, Tool);
 
 //=============================================================================
@@ -67,7 +57,7 @@ protected:
 
 public:
     OpenSim_DECLARE_PROPERTY(model_file, std::string,
-            "Name/path to the xml .osim file used to load a model to be analyzed.");
+            "Name/path to the xml .osim file.");
 
     OpenSim_DECLARE_PROPERTY(constraint_weight, double,
             "The relative weighting of kinematic constraint errors. By default this "
@@ -85,7 +75,7 @@ public:
 
     OpenSim_DECLARE_PROPERTY(report_errors, bool,
             "Flag (true or false) indicating whether or not to report "
-            "errors from the inverse kinematics solution.");
+            "errors from the inverse kinematics solution. Default is true.");
 
     OpenSim_DECLARE_PROPERTY(output_motion_file, std::string,
             "Name of the resulting inverse kinematics motion (.mot) file.");
@@ -114,36 +104,27 @@ public:
 
     void setEndTime(double d) { upd_time_range(1) = d; };
     double getEndTime() const { return get_time_range(1); };
-    
+
+    void setOutputMotionFileName(const std::string aOutputMotionFileName) {
+        upd_output_motion_file() = aOutputMotionFileName;
+    }
+    std::string getOutputMotionFileName() { return get_output_motion_file(); }
+
 private:
     void constructProperties() {
         constructProperty_model_file("");
         constructProperty_constraint_weight(SimTK::Infinity);
         constructProperty_accuracy(1e-5);
         Array<double> range{SimTK::Infinity, 2};
-        range[0] = -SimTK::Infinity; // Make range -Infinity to Infinity unless
-                                     // limited
-                              // by data
+        // Make range -Infinity to Infinity unless limited by data
+        range[0] = -SimTK::Infinity; 
         constructProperty_time_range(range);
         constructProperty_report_errors(true);
     };
-
-public:
-    //--------------------------------------------------------------------------
-    // OPERATORS
-    //--------------------------------------------------------------------------
-
-    //--------------------------------------------------------------------------
-    // GET AND SET
-    //--------------------------------------------------------------------------
-    void setOutputMotionFileName(const std::string aOutputMotionFileName) {
-        upd_output_motion_file() = aOutputMotionFileName;
-    }
-    std::string getOutputMotionFileName() { return get_output_motion_file(); }
 
 //=============================================================================
 };  // END of class InverseKinematicsToolBase
 //=============================================================================
 } // namespace
 
-#endif // __InverseKinematicsToolBase_h__
+#endif // OPENSIM_INVERSE_KINEMATICS_TOOL_BASE_H_

--- a/OpenSim/Tools/InverseKinematicsToolBase.h
+++ b/OpenSim/Tools/InverseKinematicsToolBase.h
@@ -1,0 +1,149 @@
+#ifndef __InverseKinematicsToolBase_h__
+#define __InverseKinematicsToolBase_h__
+/* -------------------------------------------------------------------------- *
+ *                     OpenSim:  InverseKinematicsToolBase.h                  *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2020 Stanford University and the Authors                *
+ * Author(s): Ayman Habib                                                     *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "osimToolsDLL.h"
+#include <OpenSim/Common/Object.h>
+#include <OpenSim/Tools/IKTaskSet.h>
+#include "Tool.h"
+#include <SimTKcommon/internal/ReferencePtr.h> 
+
+#ifdef SWIG
+    #ifdef OSIMTOOLS_API
+        #undef OSIMTOOLS_API
+        #define OSIMTOOLS_API
+    #endif
+#endif
+
+namespace OpenSim {
+
+class Model;
+class MarkersReference;
+class CoordinateReference;
+
+//=============================================================================
+//=============================================================================
+/**
+ * A Tool that performs an Inverse Kinematics analysis with a given model.
+ * Inverse kinematics is the solution of internal coordinates that poses
+ * the model such that the landmark locations (markers), affixed to the model,
+ * minimize the weighted least-squares error with observations of markers 
+ * in spatial coordinates. Observations of coordinates can also be included.
+ *
+ * @author Ayman Habib
+ * @version 1.0
+ */
+class OSIMTOOLS_API InverseKinematicsToolBase: public Tool {
+    OpenSim_DECLARE_ABSTRACT_OBJECT(InverseKinematicsToolBase, Tool);
+
+//=============================================================================
+// MEMBER VARIABLES
+//=============================================================================
+protected:
+    
+    /** Pointer to the model being investigated. */
+    SimTK::ReferencePtr<Model> _model;
+
+public:
+    OpenSim_DECLARE_PROPERTY(model_file, std::string,
+            "Name/path to the xml .osim file used to load a model to be analyzed.");
+
+    OpenSim_DECLARE_PROPERTY(constraint_weight, double,
+            "The relative weighting of kinematic constraint errors. By default this "
+            "is Infinity, which means constraints are strictly enforced as part of "
+            "the optimization and are not appended to the objective (cost) function. "
+            "Any other non-zero positive scalar is the penalty factor for "
+            "constraint violations.");
+
+    OpenSim_DECLARE_PROPERTY(accuracy, double,
+            "The accuracy of the solution in absolute terms, i.e. the number of "
+            "significant digits to which the solution can be trusted. Default 1e-5.");
+
+    OpenSim_DECLARE_LIST_PROPERTY_SIZE(
+            time_range, double, 2, "The time range for the study.");
+
+    OpenSim_DECLARE_PROPERTY(report_errors, bool,
+            "Flag (true or false) indicating whether or not to report "
+            "errors from the inverse kinematics solution.");
+
+    OpenSim_DECLARE_PROPERTY(output_motion_file, std::string,
+            "Name of the resulting inverse kinematics motion (.mot) file.");
+
+    //=============================================================================
+// METHODS
+//=============================================================================
+    //--------------------------------------------------------------------------
+    // CONSTRUCTION
+    //--------------------------------------------------------------------------
+public:
+    virtual ~InverseKinematicsToolBase(){};
+    InverseKinematicsToolBase() { 
+        constructProperties(); 
+    }
+    InverseKinematicsToolBase(const std::string& aFileName,
+            bool aLoadModel = true) SWIG_DECLARE_EXCEPTION : 
+            Tool(aFileName, aLoadModel) {
+        constructProperties();
+    }
+ 
+    //---- Setters and getters for various attributes
+    void setModel(Model& aModel) { _model = &aModel; };
+    void setStartTime(double d) { upd_time_range(0) = d; };
+    double getStartTime() const { return get_time_range(0); };
+
+    void setEndTime(double d) { upd_time_range(1) = d; };
+    double getEndTime() const { return get_time_range(1); };
+    
+private:
+    void constructProperties() {
+        constructProperty_model_file("");
+        constructProperty_constraint_weight(SimTK::Infinity);
+        constructProperty_accuracy(1e-5);
+        Array<double> range{SimTK::Infinity, 2};
+        range[0] = -SimTK::Infinity; // Make range -Infinity to Infinity unless
+                                     // limited
+                              // by data
+        constructProperty_time_range(range);
+        constructProperty_report_errors(true);
+    };
+
+public:
+    //--------------------------------------------------------------------------
+    // OPERATORS
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    // GET AND SET
+    //--------------------------------------------------------------------------
+    void setOutputMotionFileName(const std::string aOutputMotionFileName) {
+        upd_output_motion_file() = aOutputMotionFileName;
+    }
+    std::string getOutputMotionFileName() { return get_output_motion_file(); }
+
+//=============================================================================
+};  // END of class InverseKinematicsToolBase
+//=============================================================================
+} // namespace
+
+#endif // __InverseKinematicsToolBase_h__

--- a/OpenSim/Tools/RegisterTypes_osimTools.cpp
+++ b/OpenSim/Tools/RegisterTypes_osimTools.cpp
@@ -34,6 +34,8 @@
 //#include "PerturbationTool.h"
 #include "AnalyzeTool.h"
 #include "InverseKinematicsTool.h"
+#include "IMUInverseKinematicsTool.h"
+
 #include "InverseDynamicsTool.h"
 
 #include "GenericModelMaker.h"
@@ -101,6 +103,7 @@ OSIMTOOLS_API void RegisterTypes_osimTools()
 
     Object::registerType( SMC_Joint() );
     Object::registerType( InverseKinematicsTool() );
+    Object::registerType( IMUInverseKinematicsTool());
     Object::registerType( InverseDynamicsTool() );
     // Old versions
     Object::RenameType("rdCMC_Joint",   "CMC_Joint");


### PR DESCRIPTION
Fixes issue #2625 

### Brief summary of changes
Merge InverseKinematicsTool and IMUInverseKinematicsTool into one class hierarchy removing all code duplications. The class IMUInverseKinematicsTool had to be moved to the tools library (instead of simulation)

### Testing I've completed
Ran test suite including testIK (Marker based test cases) and testOpenSense (IMUInverseKinematicsTool usage)

### Looking for feedback on...
Naming, potential cross-usage

### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2708)
<!-- Reviewable:end -->
