### PR TITLE
Disable timing test with ezc3d.

### DIFF
--- a/OpenSim/Common/Test/testC3DFileAdapter.cpp
+++ b/OpenSim/Common/Test/testC3DFileAdapter.cpp
@@ -80,7 +80,7 @@ void test(const std::string filename) {
     // The walking C3D files included in this test should not take more
     // than 40ms (BTK) or 200ms (ezc3d) on most hardware.
     // We make the max time 200ms to account for potentially slower CI machines.
-    const long long MaximumLoadTimeInNs = SimTK::secToNs(0.400);
+    const long long MaximumLoadTimeInNs = SimTK::secToNs(0.200);
     
     Stopwatch watch;
     C3DFileAdapter c3dFileAdapter{};
@@ -171,8 +171,9 @@ void test(const std::string filename) {
     loadTime = watch.getElapsedTimeInNs();
     cout << "\tC3DFileAdapter '" << filename << "' read with forces at COP in "
         << watch.formatNs(loadTime) << endl;
-    // on ci-biulds will define SKIP_TIMING as it is unpredictably slow on some machines
-    #if defined(NDEBUG) && !defined(SKIP_TIMING)
+    // on ci-biulds will define SKIP_TIMING as it is unpredictably slow on some
+    // machines
+    #if defined(NDEBUG) && !defined(SKIP_TIMING) && defined(WITH_BTK)
     ASSERT(loadTime < MaximumLoadTimeInNs, __FILE__, __LINE__,
         "Unable to load '" + filename + "' within " +
         to_string(MaximumLoadTimeInNs) + "ns.");

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -56,12 +56,13 @@ endfunction()
 
 # Add a dependency. Arguments:
 #   NAME       -- (Required) Name of the project.
+#   DEFAULT    -- (Required) Default value for SUPERBUILD_${NAME} variable.
 #   URL        -- (Required) git repository to download the sources from.
 #   TAG        -- (Required) git tag to checkout before commencing build.
 #   CMAKE_ARGS -- (Optional) A CMake list of arguments to be passed to CMake 
 #                 while building the project.
 function(AddDependency)
-    set(onevalueargs NAME URL TAG)
+    set(onevalueargs NAME DEFAULT URL TAG)
     set(multiValueArgs CMAKE_ARGS)
     cmake_parse_arguments(DEP "" "${onevalueargs}" "${multiValueArgs}" ${ARGN})
 
@@ -73,7 +74,7 @@ function(AddDependency)
     endif()
 
     # Add a cache entry providing option for user to use (or not) superbuild.
-    set(SUPERBUILD_${DEP_NAME} ON CACHE BOOL 
+    set(SUPERBUILD_${DEP_NAME} ${DEP_DEFAULT} CACHE BOOL
         "Automatically download, configure, build and install ${DEP_NAME}")
 
     if(SUPERBUILD_${DEP_NAME})
@@ -142,23 +143,27 @@ SetDefaultCMakeBuildType()
 ####################### Add dependencies below.
 
 AddDependency(NAME       ezc3d
+              DEFAULT    OFF
               URL        https://github.com/pyomeca/ezc3d.git
               TAG        Release_1.3.2
               CMAKE_ARGS -DBUILD_EXAMPLE:BOOL=OFF)
 
 AddDependency(NAME       BTK
+              DEFAULT    OFF
               # URL        https://github.com/Biomechanical-ToolKit/BTKCore.git
               URL        https://github.com/opensim-org/BTKCore.git
               TAG        6d787d0be223851a8f454f2ee8c7d9e47b84cbbe
               CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
 
 AddDependency(NAME       simbody
+              DEFAULT    ON
               URL        https://github.com/simbody/simbody.git
               TAG        Simbody-3.7
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
 
 AddDependency(NAME       docopt
+              DEFAULT    ON
               URL        https://github.com/docopt/docopt.cpp.git
               TAG        3dd23e3280f213bacefdf5fcb04857bf52e90917)
  


### PR DESCRIPTION
### Brief summary of changes

Remove the C3D timing test for ezc3d.

By default, superbuild no longer builds C3D libraries.

### Testing I've completed

Ran testC3DFileAdapter with BTK and with ezc3d and ensured that the timing test only occurs with BTK.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2727)
<!-- Reviewable:end -->
