### PR TITLE
Test muscles initialization

### DIFF
--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -119,7 +119,7 @@ static const bool testEquilibriumMillard2012AccelerationMuscle = true;
     @param minNormTendonStrain (recommend default : -0.5)
         The desired minimum normalized tendon strain at the shortest path length
         tested. For example if a value of -2.3 is used here it means that the
-        shortest tendon length will be close to ltSlk*(1 + etIso*(2.3)) where
+        shortest tendon length will be close to ltSlk*(1 + etIso*(-2.3)) where
         ltSlk is the tendon slack length and etIso is the tendon strain at one
         norm force.
 
@@ -1473,7 +1473,7 @@ void runMuscleEquilibriumArchitectureAndStateSweep(const Muscle &aMuscleModel,
                                   const EquilibriumTestSettings& settings)
 {
     // Use a copy of the muscle model passed in to add path points later
-    Muscle *aMuscle(aMuscleModel.clone());
+    std::unique_ptr<Muscle> aMuscle(aMuscleModel.clone());
 
     double optimalFiberLength = aMuscle->getOptimalFiberLength();
 
@@ -1508,7 +1508,7 @@ void runMuscleEquilibriumArchitectureAndStateSweep(const Muscle &aMuscleModel,
             pennationAngle = settings.minPennationAngle +j*pennationAngleDelta;
             aMuscle->setPennationAngleAtOptimalFiberLength(pennationAngle);
 
-            runMuscleEquilibriumStateSweep(*aMuscle,minActivation,
+            runMuscleEquilibriumStateSweep(*aMuscle.get(),minActivation,
                 maxActivation,tendonStrainAtOneNormForce,settings);
         }
     }


### PR DESCRIPTION
Fixes issue #2686 

### Brief summary of changes

- Function runMuscleInitializationSweep has been added: it tests the initialization method for a Muscle object across a dense mesh across activation, path length, and path speed. 
- The settings for runMuscleInitializationSweep are currently globally set and are defined in the struct InitializationTestSettings.
- Because the numerical problems of initialization are related to the tendon slack length the function runMuscleInitializationSweep is applied across the tendon slack lengths listed in NormTendonLengths.
- I have added detailed documentation for runMuscleInitializationSweep and InitializationTestSettings but not with doxygen braces since this is not API code.

### Testing I've completed

This test has been applied to the muscle models that are actively maintained: Thelen200Muscle, Millard2012EquilibriumMuscle, Millard2012AccelerationMuscle. They all fail the test but for different reasons:

- Thelen2003Muscle: fails due to the bad mix of a Newton method + curves that are not C2 continuous.
- Millard2012EquilibriumMuscle: fails because it always returns a solution with a fiber velocity of zero. This is happening because of a flag that is permanently set to false (line 431 in Millard2012EquilbriumMuscleh). However the problem is deeper: even when the computeFIberEquilibrium method is set to compute fiber velocity the method fails.
- Millard2012AccelerationMuscle: fails because the method tries to evaluate a fiber length that is shorter than the minimum length (defined by the pennation model in this case). The initialization method is simply not respecting the lower bound.

### Looking for feedback on...

On two aspects from one or all of: @chrisdembia, @carmichaelong , and  @aseth1 :

1. Is this code acceptable? If not please tell me what needs some attention.
2. Planned fixes for the Muscle models:

- Remove the Newton method that is currently used in all of these models.
- Option 1: Slow & simple: use a bisection method to get to the final tolerance. This will take about 30 iterations for a fiso*1e-8 solution.
- Option 2: Faster: use bisection to get to an initial tolerance of 1e-3*fiso (10 iterations). Try Newton for a fixed number of iterations. If this improves, continue to tolerance (6 iterations). If it does not, bring the solution to tolerance using bisection (for another 20 iterations).
- Ensure that the lower bound on fiber length is respected, and the fiber velocity is less than the maximum value (exceeding this causes the gradient to go to zero).

### CHANGELOG.md (choose one)

- I haven't updated this: should I?

The Doxygen for this PR cannot be viewed: this is test code, not API code. I have documented the new function extensively but it is not enclosed with doxygen's /**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2729)
<!-- Reviewable:end -->
