### PR TITLE
Logging actuators

### DIFF
--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -38,7 +38,7 @@ static const char HELP[] =
 R"(OpenSim: musculoskeletal modeling and simulation.
 
 Usage:
-  opensim-cmd [--library=<path>]... <command> [<args>...]
+  opensim-cmd [--library=<path>]... [--log=<level>] <command> [<args>...]
   opensim-cmd -h | --help
   opensim-cmd -V | --version
 
@@ -49,6 +49,8 @@ Options:
                  library's extension (e.g., .dll, .so, .dylib). If <path>
                  contains spaces, surround <path> in quotes. You can load
                  multiple plugins by repeating this option.
+  -o <level>, --log <level>  Logging level (off, critical, error, warn, info,
+                 debug, trace). Default: info.
   -h, --help     Show this help description.
   -V, --version  Show the version number.
 
@@ -109,6 +111,12 @@ int main(int argc, const char** argv) {
             // Exit if we couldn't load the library.
             if (!success) return EXIT_FAILURE;
         }
+    }
+
+    // Logging.
+    // --------
+    if (args["--log"]) {
+        Logger::setLevelString(args["--log"].asString());
     }
 
     // Did the user provide a valid command?

--- a/Applications/opensim-cmd/opensim-cmd_info.h
+++ b/Applications/opensim-cmd/opensim-cmd_info.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   If you do not supply any arguments, you get a list of all registered

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   The argument <tool-or-class> can be the name of a Tool

--- a/Applications/opensim-cmd/opensim-cmd_run-tool.h
+++ b/Applications/opensim-cmd/opensim-cmd_run-tool.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   The Tool to run is detected from the setup file you provide. Supported tools

--- a/Applications/opensim-cmd/opensim-cmd_update-file.h
+++ b/Applications/opensim-cmd/opensim-cmd_update-file.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   In an OpenSim XML file, the XML file format version appears as

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -255,7 +255,7 @@ void testLoadPluginLibraries(const std::string& subcommand) {
         expectLib = replaceString(expectLib, "/", "\\");
     #endif
     {
-        StartsWith output("Loaded library " + expectLib);
+        StartsWith output("[info] Loaded library " + expectLib);
         testCommand("-L " + lib + " " + cmd, EXIT_SUCCESS, output);
         testCommand("-L" + lib + " " + cmd, EXIT_SUCCESS, output);
         testCommand("--library " + lib + " " + cmd, EXIT_SUCCESS, output);
@@ -268,14 +268,14 @@ void testLoadPluginLibraries(const std::string& subcommand) {
         // Well, in this case, we just load the same library multiple times.
         testCommand("-L " + lib + " --library " + lib + " " + cmd,
                 EXIT_SUCCESS,
-                StartsWith("Loaded library " + expectLib + "\n"
-                           "Loaded library " + expectLib + "\n"));
+                StartsWith("[info] Loaded library " + expectLib + "\n"
+                           "[info] Loaded library " + expectLib + "\n"));
         testCommand("-L" + lib +
                     " --library=" + lib +
                     " -L " + lib + " " + cmd, EXIT_SUCCESS,
-                StartsWith("Loaded library " + expectLib + "\n"
-                           "Loaded library " + expectLib + "\n"
-                           "Loaded library " + expectLib + "\n"));
+                StartsWith("[info] Loaded library " + expectLib + "\n"
+                           "[info] Loaded library " + expectLib + "\n"
+                           "[info] Loaded library " + expectLib + "\n"));
     }
 }
 
@@ -293,7 +293,7 @@ void testRunTool() {
     testCommand("run-tool", EXIT_FAILURE,
             StartsWith("Arguments did not match expected patterns"));
     testCommand("run-tool putes.xml", EXIT_FAILURE,
-            StartsWith("SimTK Exception thrown at"));
+            StartsWith("[error] SimTK Exception thrown at"));
     // We use print-xml to create a setup file that we can try to run.
     // (We are not really trying to test print-xml right now.)
     testCommand("print-xml cmc testruntool_cmc_setup.xml", EXIT_SUCCESS,

--- a/OpenSim/Actuators/ActivationCoordinateActuator.h
+++ b/OpenSim/Actuators/ActivationCoordinateActuator.h
@@ -29,18 +29,20 @@
 
 namespace OpenSim {
 
-/// Similar to CoordinateActuator (simply produces a generalized force) but
-/// with first-order linear activation dynamics. This actuator has one state
-/// variable, `activation`, with \f$ \dot{a} = (x - a) / \tau \f$, where
-/// \f$ a \f$ is activation, \f$ x \f$ is excitation, and \f$ \tau \f$ is the
-/// activation time constant (there is no separate deactivation time constant).
-/// The statebounds_activation output is used in Moco to set default values for
-/// the activation state variable.
-/// <b>Default %Property Values</b>
-/// @verbatim
-/// activation_time_constant: 0.01
-/// default_activation: 0.5
-/// @endverbatim
+/**
+Similar to CoordinateActuator (simply produces a generalized force) but
+with first-order linear activation dynamics. This actuator has one state
+variable, `activation`, with \f$ \dot{a} = (x - a) / \tau \f$, where
+\f$ a \f$ is activation, \f$ x \f$ is excitation, and \f$ \tau \f$ is the
+activation time constant (there is no separate deactivation time constant).
+The statebounds_activation output is used in Moco to set default values for
+the activation state variable.
+<b>Default %Property Values</b>
+@verbatim
+activation_time_constant: 0.01
+default_activation: 0.5
+@endverbatim
+ */
 class OSIMACTUATORS_API ActivationCoordinateActuator
         : public CoordinateActuator {
     OpenSim_DECLARE_CONCRETE_OBJECT(ActivationCoordinateActuator,
@@ -51,8 +53,7 @@ public:
         "(units: seconds; default: 0.01 seconds).");
 
     OpenSim_DECLARE_PROPERTY(default_activation, double,
-        "Value of activation in the default state returned by initSystem() "
-        "(default: 0.5).");
+        "Value of activation in the default state (default: 0.5).");
 
     OpenSim_DECLARE_OUTPUT(statebounds_activation, SimTK::Vec2,
         getBoundsActivation, SimTK::Stage::Model);

--- a/OpenSim/Analyses/StaticOptimization.cpp
+++ b/OpenSim/Analyses/StaticOptimization.cpp
@@ -474,7 +474,9 @@ record(const SimTK::State& s)
     //double duration = (double)(stop.QuadPart-start.QuadPart)/(double)frequency.QuadPart;
     //cout << "optimizer time = " << (duration*1.0e3) << " milliseconds" << endl;
 
-    target.printPerformance(sWorkingCopy, &_parameters[0]);
+    if (Logger::shouldLog(Logger::Level::Info)) {
+        target.printPerformance(sWorkingCopy, &_parameters[0]);
+    }
 
     //update defaults for use in the next step
 

--- a/OpenSim/Analyses/StaticOptimizationTarget.cpp
+++ b/OpenSim/Analyses/StaticOptimizationTarget.cpp
@@ -313,9 +313,8 @@ printPerformance(const SimTK::State& s, double *parameters)
     objectiveFunc(SimTK::Vector(getNumParameters(),parameters,true),true,p);
     SimTK::Vector constraints(getNumConstraints());
     constraintFunc(SimTK::Vector(getNumParameters(),parameters,true),true,constraints);
-    cout << endl;
-    cout << "time = " << s.getTime() <<" Performance = " << p << 
-    " Constraint violation = " << sqrt(~constraints*constraints) << endl;
+    log_cout("time = {} Performance = {} Constraint violation = {}",
+            s.getTime(), p, sqrt(~constraints*constraints));
 }
 
 //______________________________________________________________________________

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1610,11 +1610,10 @@ public:
         }
 
         if (numSubcomponents == 0) {
-            std::cout << "Component '" << getName()
-                      << "' has no subcomponents." << std::endl;
+            log_cout("Component '{}' has no subcomponents.", getName());
             return;
         }
-        maxlen += 4; //padding
+        maxlen += 6; //padding
 
         std::string className = SimTK::NiceTypeName<C>::namestr();
         // Remove "OpenSim::", etc. if it exists.
@@ -1623,24 +1622,24 @@ public:
             className = className.substr(colonPos+1,
                                          className.length()-colonPos);
 
-        std::cout << "Class name and absolute path name for descendants of '"
-                  << getName() << "' that are of type " << className << ":\n"
-                  << std::endl;
+        log_cout("Class name and absolute path name for descendants of '{}'"
+                 "that are of type {}:\n", getName(), className);
 
-        std::cout << std::string(maxlen-concreteClassName.length(), ' ')
-                  << "[" << concreteClassName << "]"
-                  << "  " << getAbsolutePathString() << std::endl;
+        log_cout("{:>{}}  {}", concreteClassName, maxlen,
+                getAbsolutePathString());
 
         // Step through compList again to print.
         for (const C& thisComp : compList) {
             const std::string thisClass = thisComp.getConcreteClassName();
-            std::cout << std::string(maxlen-thisClass.length(), ' ') << "["
-                      << thisClass << "]  ";
             auto path = thisComp.getAbsolutePath();
-            std::cout << std::string((path.getNumPathLevels() - 1) * 4, ' ')
-                      << "/" << path.getComponentName() << std::endl;
+            log_cout(fmt::format(
+                    "{:>{}}  {}/{}",
+                    fmt::format("[{}]", thisClass),
+                    maxlen,
+                    std::string((path.getNumPathLevels() - 1) * 4, ' '),
+                    path.getComponentName()));
         }
-        std::cout << std::endl;
+        log_cout("");
     }
 
     /** Print outputs of this component and optionally, those of all

--- a/OpenSim/Common/DebugUtilities.cpp
+++ b/OpenSim/Common/DebugUtilities.cpp
@@ -20,22 +20,24 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 #include "DebugUtilities.h"
-#include <sstream>
-#include <fstream>
-#include <iostream>
+
+#include "Logger.h"
 #include <cassert>
 #include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 namespace OpenSim {
 namespace DebugUtilities {
 
-void Fatal_Error(const char *msg, const char *function, const char *file, unsigned int line)
-{
-    std::ostringstream string_stream;
-    string_stream << "Fatal Error: " << msg << " (function = " << function << ", file = " << file << ", line = " << line << ")";
-    std::cerr << string_stream.str() << std::endl;
-    throw std::runtime_error(string_stream.str());
+void Fatal_Error(const char* msg, const char* function, const char* file,
+        unsigned int line) {
+    std::string str = fmt::format("Fatal Error: {} (function = {}, file = {}, "
+                                  "line = {})", msg, function, file, line);
+    log_critical(str);
+    throw std::runtime_error(str);
     assert(false);
     exit(1);
 }
@@ -55,7 +57,7 @@ void AddEnvironmentVariablesFromFile(const std::string &aFileName)
     while (getline(input,line)) {
         if(line.find("export") != std::string::npos) {
             std::string env=line.substr(7);
-            std::cout << "Setting environment '" << env << "'" << std::endl;
+            log_info("Setting environment '{}'", env);
 #ifdef _WIN32
             _putenv(env.c_str());
 #else

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -27,12 +27,13 @@
 
 
 // INCLUDES
-#include <time.h>
+#include "IO.h"
+
+#include "Logger.h"
+#include <climits>
 #include <math.h>
 #include <string>
-#include <climits>
-
-#include "IO.h"
+#include <time.h>
 #if defined(__linux__) || defined(__APPLE__)
     #include <sys/stat.h>
     #include <sys/types.h>
@@ -434,8 +435,8 @@ OpenFile(const string &aFileName,const string &aMode)
     // OPEN THE FILE
     fp = fopen(aFileName.c_str(),aMode.c_str());
     if(fp==NULL) {
-        printf("IO.OpenFile(const string&,const string&): failed to open %s\n",
-         aFileName.c_str());
+        log_error("IO.OpenFile(const string&,const string&): "
+                  "failed to open {}.", aFileName);
         return(NULL);
     }
 
@@ -450,7 +451,8 @@ OpenInputFile(const string &aFileName,ios_base::openmode mode)
 {
     ifstream *fs = new ifstream(aFileName.c_str(), ios_base::in | mode);
     if(!fs || !(*fs)) {
-        printf("IO.OpenInputFile(const string&,openmode mode): failed to open %s\n", aFileName.c_str());
+        log_error("IO.OpenInputFile(const string&,openmode mode): "
+                  "failed to open {}.", aFileName);
         return(NULL);
     }
 
@@ -461,7 +463,8 @@ OpenOutputFile(const string &aFileName,ios_base::openmode mode)
 {
     ofstream *fs = new ofstream(aFileName.c_str(), ios_base::out | mode);
     if(!fs || !(*fs)) {
-        printf("IO.OpenOutputFile(const string&,openmode mode): failed to open %s\n", aFileName.c_str());
+        log_error("IO.OpenOutputFile(const string&,openmode mode): failed to "
+                  "open {}.", aFileName);
         return(NULL);
     }
 

--- a/OpenSim/Common/LoadOpenSimLibrary.cpp
+++ b/OpenSim/Common/LoadOpenSimLibrary.cpp
@@ -22,9 +22,11 @@
  * -------------------------------------------------------------------------- */
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-#include <iostream>
-#include "IO.h"
 #include "LoadOpenSimLibrary.h"
+
+#include "IO.h"
+#include "Logger.h"
+#include <iostream>
 
 using namespace OpenSim;
 using namespace std;
@@ -52,7 +54,7 @@ static void *LoadLibrary(const std::string &name, std::string &actualNameLoaded)
     }
     return lib;
 }
-#define LoadLibraryError() { char* err=dlerror(); if(err) cout<<"dlerror: "<<err<<endl; }
+#define LoadLibraryError() { char* err=dlerror(); if(err) log_error("dlerror: {}", err); }
 
 #else
 
@@ -105,12 +107,12 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
     bool tryDebugThenRelease = false;
 #ifndef NDEBUG
     if(!hasDebugSuffix) {
-        if(verbose) cout << "Will try loading debug library first" << endl;
+        if(verbose) log_info("Will try loading debug library first");
         tryDebugThenRelease = true;
     }
 #else
     if(hasDebugSuffix) {
-        if(verbose) cout << "WARNING: Trying to load a debug library into release osimSimulation" << endl;
+        if(verbose) log_warn("Trying to load a debug library into release osimSimulation");
         tryDebugThenRelease = true;
     }
 #endif
@@ -120,23 +122,29 @@ OpenSim::LoadOpenSimLibrary(const std::string &lpLibFileName, bool verbose)
         string debugLibFileName = fixedLibFileName + debugSuffix + libraryExtension;
         string releaseLibFileName = fixedLibFileName + libraryExtension;
         if ((libraryHandle = LoadLibrary(debugLibFileName,actualNameLoaded))) {
-            if(verbose) cout << "Loaded library " << actualNameLoaded << endl;
+            if(verbose) log_info("Loaded library {}", actualNameLoaded);
         } else {
             LoadLibraryError();
-            if(verbose) cout << "Loading of debug library " << debugLibFileName << " Failed. Trying " << releaseLibFileName << endl;
+            if(verbose) {
+                log_error("Loading of debug library {} failed. Trying {}.",
+                        debugLibFileName, releaseLibFileName);
+            }
             if ((libraryHandle = LoadLibrary(releaseLibFileName,actualNameLoaded))) {
-                if(verbose) cout << "Loaded library " << actualNameLoaded << endl;
+                if(verbose) log_info("Loaded library {}", actualNameLoaded);
             } else {
                 LoadLibraryError();
-                if(verbose) cout << "Failed to load either debug or release library " << releaseLibFileName << endl;
+                if(verbose)
+                    log_error("Failed to load either debug or release "
+                              "library {}.", releaseLibFileName);
             }
         }
     } else {
         if ((libraryHandle = LoadLibrary(actualLibFileName,actualNameLoaded))) {
-            if(verbose) cout << "Loaded library " << actualNameLoaded << endl;
+            if(verbose) log_info("Loaded library {}", actualNameLoaded);
         } else {
             LoadLibraryError();
-            if(verbose) cout << "Failed to load library " << actualLibFileName << endl;
+            if (verbose)
+                log_error("Failed to load library {}", actualLibFileName);
         }
     }
 
@@ -156,12 +164,12 @@ OpenSim::LoadOpenSimLibraryExact(const std::string& exactPath,
     OPENSIM_PORTABLE_HINSTANCE library = LoadLibrary(fixedPath.c_str());
     if (library) {
         if (verbose) {
-            cout << "Loaded library " << fixedPath << endl;
+            log_info("Loaded library {}", fixedPath);
         }
         return true;
     } else {
         if (verbose) {
-            cout << "Failed to load library " << fixedPath << endl;
+            log_error("Failed to load library {}", fixedPath);
         }
         return false;
     }
@@ -191,7 +199,7 @@ OpenSim::LoadOpenSimLibraries(int argc,char **argv)
             string libraryName = argv[i+1];
             library = LoadOpenSimLibrary(libraryName.c_str(), true);
             if(library==NULL) {
-                cout<<"ERROR- library "<<libraryName<<" could not be loaded.\n" << endl;
+                log_error("library {} could not be loaded.", libraryName);
             } else {
                 i++;
             }

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_LOG_H_
 #define OPENSIM_LOG_H_
 /* -------------------------------------------------------------------------- *
- *                           OpenSim:  Logger.h                                  *
+ *                           OpenSim:  Logger.h                               *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -25,6 +25,7 @@
 #include "osimCommonDLL.h"
 #include <set>
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
 #include <string>
 
 namespace OpenSim {
@@ -130,14 +131,31 @@ public:
         spdlog::trace(fmt, args...);
     }
 
+    /// Use this function to log messages that would normally be sent to
+    /// std::cout. These messages always appear, and are also logged to the
+    /// filesink (addFileSink()) and any sinks added via addSink().
+    /// The main use case for this function is inside of functions whose intent
+    /// is to print information (e.g., Component::printSubcomponentInfo()).
+    template <typename... Args>
+    static void cout(spdlog::string_view_t fmt, const Args&... args) {
+        m_cout_logger->log(spdlog::level::info, fmt, args...);
+    }
+
     /// @}
 
     /// Log messages to a file at the level getLevel().
-    /// If we are already logging messages to the provided file, then this
-    /// function issues a warning and returns.
+    /// OpenSim logs messages to the file opensim.log by default.
+    /// If we are already logging messages to a file, then this
+    /// function issues a warning and returns; invoke removeFileSink() first.
     /// @note This function is not thread-safe. Do not invoke this function
     /// concurrently, or concurrently with addSink() or removeSink().
-    static void addLogFile(const std::string& filepath = "opensim.log");
+    static void addFileSink(const std::string& filepath = "opensim.log");
+
+    /// Remove the filesink if it exists.
+    /// If the filesink was already removed, then this does nothing.
+    /// @note This function is not thread-safe. Do not invoke this function
+    /// concurrently, or concurrently with addSink() or removeSink().
+    static void removeFileSink();
 
     /// Start reporting messages to the provided sink.
     /// @note This function is not thread-safe. Do not invoke this function
@@ -161,43 +179,60 @@ public:
 private:
     /// Initialize spdlog.
     Logger();
+
+    /// This is the logger used in log_cout.
+    static std::shared_ptr<spdlog::logger> m_cout_logger;
+
     static std::shared_ptr<Logger> m_log;
 
-    /// Keep track of file sinks.
-    static std::set<std::string> m_filepaths;
+    /// Keep track of the file sink.
+    static std::shared_ptr<spdlog::sinks::basic_file_sink_mt> m_filesink;
 };
 
 /// @name Logging functions
 /// @{
 
+/// @related Logger
 template <typename... Args>
 void log_critical(spdlog::string_view_t fmt, const Args&... args) {
     Logger::critical(fmt, args...);
 }
 
+/// @related Logger
 template <typename... Args>
 void log_error(spdlog::string_view_t fmt, const Args&... args) {
     Logger::error(fmt, args...);
 }
 
+/// @related Logger
 template <typename... Args>
 void log_warn(spdlog::string_view_t fmt, const Args&... args) {
     Logger::warn(fmt, args...);
 }
 
+/// @related Logger
 template <typename... Args>
 void log_info(spdlog::string_view_t fmt, const Args&... args) {
     Logger::info(fmt, args...);
 }
 
+/// @related Logger
 template <typename... Args>
 void log_debug(spdlog::string_view_t fmt, const Args&... args) {
     Logger::debug(fmt, args...);
 }
 
+/// @related Logger
 template <typename... Args>
 void log_trace(spdlog::string_view_t fmt, const Args&... args) {
     Logger::trace(fmt, args...);
+}
+
+/// @copydoc Logger::cout()
+/// @related Logger
+template <typename... Args>
+void log_cout(spdlog::string_view_t fmt, const Args&... args) {
+    Logger::cout(fmt, args...);
 }
 
 /// @}

--- a/OpenSim/Common/MarkerData.cpp
+++ b/OpenSim/Common/MarkerData.cpp
@@ -113,7 +113,8 @@ MarkerData::MarkerData(const string& aFileName) :
 
    _fileName = aFileName;
 
-    cout << "Loaded marker file " << _fileName << " (" << _numMarkers << " markers, " << _numFrames << " frames)" << endl;
+   log_info("Loaded marker file {} ({} markers, {} frames)",
+           _fileName, _numMarkers, _numFrames);
 }
 
 //_____________________________________________________________________________
@@ -767,8 +768,9 @@ void MarkerData::averageFrames(double aThreshold, double aStartTime, double aEnd
 
             if (pt.isNaN())
             {
-                cout << "___WARNING___: marker " << _markerNames[i] << " is missing in frames " << startUserIndex
-                      << " to " << endUserIndex << ". Coordinates will be set to NAN." << endl;
+                log_warn("Marker {} is missing in frames {} to {}. Coordinate "
+                         "will be set to NAN.", _markerNames[i], startUserIndex,
+                        endUserIndex);
             }
             else if (maxX[i] - minX[i] > aThreshold ||
                       maxY[i] - minY[i] > aThreshold ||
@@ -777,14 +779,14 @@ void MarkerData::averageFrames(double aThreshold, double aStartTime, double aEnd
                 double maxDim = maxX[i] - minX[i];
                 maxDim = MAX(maxDim, (maxY[i] - minY[i]));
                 maxDim = MAX(maxDim, (maxZ[i] - minZ[i]));
-                cout << "___WARNING___: movement of marker " << _markerNames[i] << " in " << _fileName
-                      << " is " << maxDim << " (threshold = " << aThreshold << ")" << endl;
+                log_warn("Movement of marker {} in {} is {} (threshold = {})",
+                        _markerNames[i], _fileName, maxDim, aThreshold);
             }
         }
     }
 
-    cout << "Averaged frames from time " << aStartTime << " to " << aEndTime << " in " << _fileName
-          << " (frames " << startUserIndex << " to " << endUserIndex << ")" << endl;
+    log_info("Averaged frames from time {} to {} in {} (frames {} to {})",
+            aStartTime, aEndTime, _fileName, startUserIndex, endUserIndex);
 
     if (aThreshold > 0.0)
     {

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1592,7 +1592,7 @@ makeObjectFromFile(const std::string &aFileName)
     }
 
     catch(const std::exception& x) {
-        cout << x.what() << endl;
+        log_error(x.what());
         return nullptr;
     }
     catch(...){ // Document couldn't be opened, or something went really bad

--- a/OpenSim/Common/OptimizationTarget.cpp
+++ b/OpenSim/Common/OptimizationTarget.cpp
@@ -153,7 +153,7 @@ printPerformance(double *x)
 {
     double p;
     objectiveFunc(SimTK::Vector(getNumParameters(),x,true),true,p);
-    std::cout << "performance = " << p << std::endl;
+    log_cout("performance = {}", p);
 }
 
 //=============================================================================

--- a/OpenSim/Common/PiecewiseConstantFunction.cpp
+++ b/OpenSim/Common/PiecewiseConstantFunction.cpp
@@ -74,15 +74,17 @@ PiecewiseConstantFunction::PiecewiseConstantFunction(int aN,const double *aX,con
        // NUMBER OF DATA POINTS
        if(aN < 2)
        {
-             printf("PiecewiseConstantFunction: ERROR- there must be 2 or more data points.\n");
-             return;
+           log_error("PiecewiseConstantFunction: there must be 2 or more "
+                     "data points.");
+           return;
        }
 
        // CHECK DATA
        if((aX==NULL)||(aY==NULL))
        {
-             printf("PiecewiseConstantFunction: ERROR- NULL arrays for data points encountered.\n");
-             return;
+           log_error("PiecewiseConstantFunction: NULL arrays for data points "
+                     "encountered.");
+           return;
        }
 
        // INDEPENDENT VALUES (KNOT SEQUENCE)

--- a/OpenSim/Common/PiecewiseLinearFunction.cpp
+++ b/OpenSim/Common/PiecewiseLinearFunction.cpp
@@ -77,14 +77,16 @@ PiecewiseLinearFunction::PiecewiseLinearFunction(int aN,const double *aX,const d
     // NUMBER OF DATA POINTS
     if(aN < 2)
     {
-        printf("PiecewiseLinearFunction: ERROR- there must be 2 or more data points.\n");
+        log_error("PiecewiseLinearFunction: there must be 2 or more data "
+                  "points.");
         return;
     }
 
     // CHECK DATA
     if((aX==NULL)||(aY==NULL))
     {
-        printf("PiecewiseLinearFunction: ERROR- NULL arrays for data points encountered.\n");
+        log_error("PiecewiseLinearFunction: NULL arrays for data points "
+                  "encountered.");
         return;
     }
 

--- a/OpenSim/Common/SimmSpline.cpp
+++ b/OpenSim/Common/SimmSpline.cpp
@@ -78,14 +78,14 @@ SimmSpline::SimmSpline(int aN,const double *aX,const double *aY,
     // NUMBER OF DATA POINTS
     if(aN < 2)
     {
-        printf("SimmSpline: ERROR- there must be 2 or more data points.\n");
+        log_error("SimmSpline: there must be 2 or more data points.");
         return;
     }
 
     // CHECK DATA
     if((aX==NULL)||(aY==NULL))
     {
-        printf("SimmSpline: ERROR- NULL arrays for data points encountered.\n");
+        log_error("SimmSpline: NULL arrays for data points encountered.");
         return;
     }
 

--- a/OpenSim/Common/StateVector.cpp
+++ b/OpenSim/Common/StateVector.cpp
@@ -465,7 +465,7 @@ void StateVector::
 divide(double aValue)
 {
     if(aValue==0.0) {
-        printf("StateVector.divide: ERROR- divide by zero\n");
+        log_error("StateVector.divide: divide by zero.");
         return;
     }
 
@@ -537,7 +537,7 @@ print(FILE *fp) const
 {
     // CHECK FILE POINTER
     if(fp==NULL) {
-        printf("StateVector.print(FILE*): null file pointer.\n");
+        log_error("StateVector.print(FILE*): null file pointer.");
         return(-1);
     }
 
@@ -547,7 +547,7 @@ print(FILE *fp) const
     int n=0,nTotal=0;
     n = fprintf(fp,format,_t);
     if(n<0) {
-        printf("StateVector.print(FILE*): error writing to file.\n");
+        log_error("StateVector.print(FILE*): error writing to file.");
         return(n);
     }
     nTotal += n;
@@ -557,7 +557,7 @@ print(FILE *fp) const
     for(int i=0;i<_data.getSize();i++) {
         n = fprintf(fp,format,_data[i]);
         if(n<0) {
-            printf("StateVector.print(FILE*): error writing to file.\n");
+            log_error("StateVector.print(FILE*): error writing to file.");
             return(n);
         }
         nTotal += n;
@@ -566,7 +566,7 @@ print(FILE *fp) const
     // CARRIAGE RETURN
     n = fprintf(fp,"\n");
     if(n<0) {
-        printf("StateVector.print(FILE*): error writing to file.\n");
+        log_error("StateVector.print(FILE*): error writing to file.");
         return(n);
     }
     nTotal += n;

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -30,6 +30,7 @@ provide an in-memory container for data access and manipulation.              */
 
 #include "OpenSim/Common/DataTable.h"
 #include <SimTKsimbody.h>
+#include "Logger.h"
 
 namespace OpenSim {
 
@@ -453,7 +454,7 @@ public:
         trimToIndices(start_index, last_index);
         // If resulting table is empty, throw
         if (this->getNumRows()==0)
-            std::cout << "WARNING: trimming resulted in an Empty Table" << std::endl;
+            log_warn("Trimming resulted in an empty table.");
     }
     /**
      * trim TimeSeriesTable, keeping rows at newStartTime to the end.

--- a/OpenSim/Common/VectorFunctionUncoupledNxN.h
+++ b/OpenSim/Common/VectorFunctionUncoupledNxN.h
@@ -96,14 +96,18 @@ public:
     //--------------------------------------------------------------------------
     // EVALUATE
     //--------------------------------------------------------------------------
-    virtual void evaluate( const SimTK::State& s, const double *aX, double *rF) { 
-        std::cout << "VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( const SimTK::State&, const double*, double*)" << std::endl;
+    virtual void evaluate( const SimTK::State& s, const double *aX, double *rF) {
+        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
+                  "const SimTK::State&, const double*, double*)");
     }
     virtual void evaluate( const SimTK::State& s, const Array<double> &aX, Array<double> &rF){
-        std::cout << "VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( const SimTK::State&, const Array<double>, Array<double>)" << std::endl;
+        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
+                  "const SimTK::State&, const Array<double>, Array<double>)");
     }
     virtual void evaluate( const SimTK::State& s, const Array<double> &aX, Array<double> &rF, const Array<int> &aDerivWRT){
-        std::cout << "VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( const SimTK::State&, const Array<double>&a, Array<double>&, const Array<int>&)" << std::endl;
+        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
+                     "const SimTK::State&, const Array<double>&a, "
+                     "Array<double>&, const Array<int>&)");
     }
 
 //=============================================================================

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -179,8 +179,9 @@ print(const string &aFileName)
 {
     // Standard Out
     if(aFileName.empty()) {
-        cout << *this;
-        cout << flush;
+        std::stringstream ss;
+        ss << *this;
+        log_cout(ss.str());
     // File
     } else {
         setIndentString("\t");
@@ -312,7 +313,7 @@ bool XMLDocument::isEqualTo(XMLDocument& aOtherDocument, double toleranceForDoub
     SimTK::Array_<SimTK::Xml::Element> elts1 = root1.getAllElements();
     SimTK::Array_<SimTK::Xml::Element> elts2 = root2.getAllElements();
     if (elts1.size() != elts2.size()){
-        cout << "Different number of children at Top level" << endl;
+        log_info("Different number of children at Top level");
         equal = false;
     }
     if (!equal) return false;
@@ -326,8 +327,8 @@ bool XMLDocument::isEqualTo(XMLDocument& aOtherDocument, double toleranceForDoub
             continue;
         equal = isElementEqual(elts1[it], elts2[it], toleranceForDoubles);
         if (!equal){ 
-            cout << elts1[it].getElementTag() << " is different" << endl;  
-            return false; 
+            log_info("{} is different", elts1[it].getElementTag());
+            return false;
         }
     }
     return true;
@@ -343,7 +344,7 @@ bool XMLDocument::isElementEqual(SimTK::Xml::Element& elt1, SimTK::Xml::Element&
     // Handle different # attributes
     if ( (att1 == elt1.attribute_end() && att2 != elt2.attribute_end()) ||
          (att1 != elt1.attribute_end() && att2 == elt2.attribute_end()) ){
-            cout << "Number of attributes is different, element " << elt1.getElementTag() << endl;
+            log_info("Number of attributes is different, element {}", elt1.getElementTag());
             return false;
     }
     bool equal =true;
@@ -352,8 +353,8 @@ bool XMLDocument::isElementEqual(SimTK::Xml::Element& elt1, SimTK::Xml::Element&
         equal = (att1->getName() == att2->getName());
         equal = equal && (att1->getValue() == att2->getValue());
         if (!equal) {
-            cout << "Attribute " << att1->getName() << " is different " << att1->getValue() << 
-            "vs." << att2->getValue() << endl;
+            log_info("Attribute {} is different {} vs. {}", att1->getName(),
+                    att1->getValue(), att2->getValue());
         }
     }
     if (!equal) return false;
@@ -362,26 +363,28 @@ bool XMLDocument::isElementEqual(SimTK::Xml::Element& elt1, SimTK::Xml::Element&
     SimTK::Array_<SimTK::Xml::Element> elts1 = elt1.getAllElements();
     SimTK::Array_<SimTK::Xml::Element> elts2 = elt2.getAllElements();
     if (elts1.size() != elts2.size()){
-        cout << "Different number of children for Element " << elt1.getElementTag() << endl;
+        log_info("Different number of children for Element {}",
+                elt1.getElementTag());
         equal = false;
     }
     if (!equal) return false;
     // Recursively compare Elements unless Value Elements in that case do direct compare
     for(unsigned it = 0; it < elts1.size() && equal; it++){
         SimTK::String elt1Tag = elts1[it].getElementTag();
-        cout << "Compare " << elt1Tag << endl;
+        log_info("Compare {}", elt1Tag);
         SimTK::Xml::element_iterator elt2_iter = elt2.element_begin(elt1Tag);
         if (elt2_iter==elt2.element_end()){
-            cout << "Element " << elt1Tag << " was not found in reference document" << endl;
+            log_info("Element {} was not found in reference document", elt1Tag);
             equal = false;
             break;
         }
         bool value1 = elts1[it].isValueElement();
         bool value2 = elt2_iter->isValueElement();
         equal = (value1 == value2);
-        if (!equal){ 
-            cout << elts1[it].getElementTag() << " is different. One is Value Element the other isn't" << endl;  
-            return false; 
+        if (!equal){
+            log_info("{} is different. One is Value Element the other isn't",
+                     elts1[it].getElementTag());
+            return false;
         }
         if (value1){
             // We should check if this's a double or array of doubles in that case we can getValueAs<double>
@@ -399,14 +402,14 @@ bool XMLDocument::isElementEqual(SimTK::Xml::Element& elt1, SimTK::Xml::Element&
         else    // recur
             equal = isElementEqual(elts1[it], elts2[it], toleranceForDoubles);
         if (!equal){ 
-            cout << elts1[it].getElementTag() << " is different" << endl;  
+            log_info("{} is different", elts1[it].getElementTag());
             SimTK::String pad;
             elts1[it].writeToString(pad);
-            cout << pad << endl;
-            cout << "------------------- vs. ------" << endl;
+            log_info(pad);
+            log_info("------------------- vs. ------");
             elts2[it].writeToString(pad);
-            cout << pad << endl;
-            return equal; 
+            log_info(pad);
+            return equal;
         }
     }
 

--- a/OpenSim/Common/XMLDocument.h
+++ b/OpenSim/Common/XMLDocument.h
@@ -164,7 +164,8 @@ public:
     //--------------------------------------------------------------------------
     // IO
     //--------------------------------------------------------------------------
-    bool print(const std::string &aFileName=NULL);
+    /// If the filename is empty, the file is printed to cout.
+    bool print(const std::string& aFileName = {});
 
 //=============================================================================
 };  // END CLASS XMLDocument

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -266,7 +266,7 @@ void Mesh::extendFinalizeFromProperties() {
                 warningGiven = true;
             }
             if (getDebugLevel() <= 0) { return; }
-            std::cout << "The following locations were tried:\n";
+            std::cout << "The following locations were tried:";
             for (unsigned i = 0; i < attempts.size(); ++i)
                 std::cout << "\n  " << attempts[i];
             std::cout << std::endl;

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1558,7 +1558,8 @@ void Model::printBasicInfo(std::ostream& aOStream) const
     OPENSIM_THROW_IF_FRMOBJ(!isObjectUpToDateWithProperties(), Exception,
         "Model::finalizeFromProperties() must be called first.");
 
-    aOStream
+    std::stringstream ss;
+    ss
         << "\n               MODEL: " << getName()
         << "\n         coordinates: " << countNumComponents<Coordinate>()
         << "\n              forces: " << countNumComponents<Force>()
@@ -1572,15 +1573,22 @@ void Model::printBasicInfo(std::ostream& aOStream) const
         << "\n             markers: " << countNumComponents<Marker>()
         << "\n         controllers: " << countNumComponents<Controller>()
         << "\n  contact geometries: " << countNumComponents<ContactGeometry>()
-        << "\nmisc modelcomponents: " << getMiscModelComponentSet().getSize()
-        << std::endl;
+        << "\nmisc modelcomponents: " << getMiscModelComponentSet().getSize();
+
+    if (aOStream.rdbuf() == std::cout.rdbuf()) {
+        log_cout(ss.str());
+    } else {
+        aOStream << ss.str() << std::endl;
+    }
 }
 
 void Model::printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) const
 {
-    aOStream << "MODEL: " << getName() << std::endl;
+    std::stringstream ss;
 
-    aOStream
+    ss << "MODEL: " << getName() << std::endl;
+
+    ss
         << "\nnumStates = "      << s.getNY()
         << "\nnumCoordinates = " << countNumComponents<Coordinate>()
         << "\nnumSpeeds = "      << countNumComponents<Coordinate>()
@@ -1590,17 +1598,17 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) con
         << "\nnumProbes = "      << countNumComponents<Probe>()
         << std::endl;
 
-    aOStream << "\nANALYSES (total: " << getNumAnalyses() << ")" << std::endl;
+    ss << "\nANALYSES (total: " << getNumAnalyses() << ")" << std::endl;
     for (int i = 0; i < _analysisSet.getSize(); ++i)
-        aOStream << "analysis[" << i << "] = " << _analysisSet.get(i).getName()
+        ss << "analysis[" << i << "] = " << _analysisSet.get(i).getName()
                  << std::endl;
 
-    aOStream << "\nBODIES (total: " << countNumComponents<Body>() << ")"
+    ss << "\nBODIES (total: " << countNumComponents<Body>() << ")"
              << std::endl;
     unsigned bodyNum = 0u;
     for (const auto& body : getComponentList<Body>()) {
         const auto inertia = body.getInertia();
-        aOStream << "body[" << bodyNum << "] = " << body.getName() << ". "
+        ss << "body[" << bodyNum << "] = " << body.getName() << ". "
             << "mass: " << body.get_mass()
             << "\n              moments of inertia:  " << inertia.getMoments()
             << "\n              products of inertia: " << inertia.getProducts()
@@ -1608,53 +1616,59 @@ void Model::printDetailedInfo(const SimTK::State& s, std::ostream& aOStream) con
         ++bodyNum;
     }
 
-    aOStream << "\nJOINTS (total: " << countNumComponents<Joint>() << ")"
+    ss << "\nJOINTS (total: " << countNumComponents<Joint>() << ")"
              << std::endl;
     unsigned jointNum = 0u;
     for (const auto& joint : getComponentList<Joint>()) {
-        aOStream << "joint[" << jointNum << "] = " << joint.getName() << "."
+        ss << "joint[" << jointNum << "] = " << joint.getName() << "."
                  << " parent: " << joint.getParentFrame().getName()
                  << ", child: " << joint.getChildFrame().getName() << std::endl;
         ++jointNum;
     }
 
-    aOStream << "\nACTUATORS (total: " << countNumComponents<Actuator>() << ")"
+    ss << "\nACTUATORS (total: " << countNumComponents<Actuator>() << ")"
              << std::endl;
     unsigned actuatorNum = 0u;
     for (const auto& actuator : getComponentList<Actuator>()) {
-        aOStream << "actuator[" << actuatorNum << "] = " << actuator.getName()
+        ss << "actuator[" << actuatorNum << "] = " << actuator.getName()
                  << std::endl;
         ++actuatorNum;
     }
 
     /*
     int n;
-    aOStream<<"MODEL: "<<getName()<<std::endl;
+    ss<<"MODEL: "<<getName()<<std::endl;
 
     n = getNumBodies();
-    aOStream<<"\nBODIES ("<<n<<")" << std::endl;
-    for(i=0;i<n;i++) aOStream<<"body["<<i<<"] = "<<getFrameName(i)<<std::endl;
+    ss<<"\nBODIES ("<<n<<")" << std::endl;
+    for(i=0;i<n;i++) ss<<"body["<<i<<"] = "<<getFrameName(i)<<std::endl;
 
     n = getNQ();
-    aOStream<<"\nGENERALIZED COORDINATES ("<<n<<")" << std::endl;
-    for(i=0;i<n;i++) aOStream<<"q["<<i<<"] = "<<getCoordinateName(i)<<std::endl;
+    ss<<"\nGENERALIZED COORDINATES ("<<n<<")" << std::endl;
+    for(i=0;i<n;i++) ss<<"q["<<i<<"] = "<<getCoordinateName(i)<<std::endl;
 
     n = getNU();
-    aOStream<<"\nGENERALIZED SPEEDS ("<<n<<")" << std::endl;
-    for(i=0;i<n;i++) aOStream<<"u["<<i<<"] = "<<getSpeedName(i)<<std::endl;
+    ss<<"\nGENERALIZED SPEEDS ("<<n<<")" << std::endl;
+    for(i=0;i<n;i++) ss<<"u["<<i<<"] = "<<getSpeedName(i)<<std::endl;
 
     n = getNA();
-    aOStream<<"\nACTUATORS ("<<n<<")" << std::endl;
-    for(i=0;i<n;i++) aOStream<<"actuator["<<i<<"] = "<<getActuatorName(i)<<std::endl;
+    ss<<"\nACTUATORS ("<<n<<")" << std::endl;
+    for(i=0;i<n;i++) ss<<"actuator["<<i<<"] = "<<getActuatorName(i)<<std::endl;
 
     n = getNP();
-    aOStream<<"\nCONTACTS ("<<n<<")" << std::endl;
+    ss<<"\nCONTACTS ("<<n<<")" << std::endl;
     */
 
     Array<string> stateNames = getStateVariableNames();
-    aOStream << "\nSTATES (total: " << stateNames.getSize() << ")" << std::endl;
+    ss << "\nSTATES (total: " << stateNames.getSize() << ")" << std::endl;
     for (int i = 0; i < stateNames.getSize(); ++i)
-        aOStream << "y[" << i << "] = " << stateNames[i] << std::endl;
+        ss << "y[" << i << "] = " << stateNames[i] << std::endl;
+
+    if (aOStream.rdbuf() == std::cout.rdbuf()) {
+        log_cout(ss.str());
+    } else {
+        aOStream << ss.str() << std::endl;
+    }
 }
 
 //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -973,7 +973,9 @@ public:
     /**
      * Print some basic information about the model.
      *
-     * @param aOStream Output stream.
+     * @param aOStream Output stream. If this is std::cout, then the info is
+     * logged using OpenSim's Logger so that the info is printed to all log
+     * sinks.
      */
     void printBasicInfo(std::ostream& aOStream = std::cout) const;
 
@@ -981,7 +983,9 @@ public:
      * Print detailed information about the model.
      *
      * @param s        the system State.
-     * @param aOStream Output stream.
+     * @param aOStream Output stream. If this is std::cout, then the info is
+     * logged using OpenSim's Logger so that the info is printed to all log
+     * sinks.
      */
     void printDetailedInfo(const SimTK::State& s,
                            std::ostream& aOStream = std::cout) const;


### PR DESCRIPTION
Related to #36 

### Brief summary of changes

- Logging to a file is on by default.
- Add command-line flag to set logging level when using `opensim-cmd`.
- Introduced `log_cout()` for logging messages in `print`-like functions. Such messages are printed regardless of the logging level, and go to all registered sinks, including the file sink. Callers of `print`-like functions can use `Logger::shouldLog()` to determine if the `print`-like function should be called.
- Update logging in the Common library, the Model class, and other files.

### Testing I've completed

- Tested `addFileSink()`, `removeFileSink()` in Python.
- Tested running the `opensim-cmd` tool with different `--log` levels.

### Looking for feedback on...

What do you think about the logic for handling `print`-like functions?

### CHANGELOG.md (choose one)

- no need to update because...part of a feature
