### PR TITLE
Fixed a transpose

### DIFF
--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -32,7 +32,7 @@ class TestDataAdapter(unittest.TestCase):
         try:
             adapter = osim.C3DFileAdapter()
         except AttributeError:
-            # C3D support not available. OpenSim was not compiled with BTK.
+            # C3D support not available. OpenSim was not compiled with ezc3d.
             return
         tables = adapter.read(os.path.join(test_dir, 'walking2.c3d'))
         forces = adapter.getForcesTable(tables)

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -30,12 +30,12 @@ convertToSimtkMatrix(const ezc3d::Matrix& mat) {
 // This can become a lambda function inside extendRead in future.
 SimTK::Matrix_<double>
 convertToSimtkMatrix(const std::vector<ezc3d::Vector3d>& all_vec) {
-    SimTK::Matrix_<double> simtkMat{static_cast<int>(all_vec.size()), 3};
+    SimTK::Matrix_<double> simtkMat{3, static_cast<int>(all_vec.size())};
 
     for(int r = 0; r < all_vec.size(); ++r){
         const ezc3d::Vector3d& vec(all_vec[r]);
         for(int c = 0; c < 3; ++c){
-            simtkMat(r, c) = vec(c);
+            simtkMat(c, r) = vec(c);
         }
     }
 


### PR DESCRIPTION
I cannot locally test for Python, but it seems that the difference with BTK was a transpose in the Matrix. Here is the fix for that!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2750)
<!-- Reviewable:end -->
