### PR TITLE
Fix memory issue with Logger::addSink in Java

### DIFF
--- a/Bindings/Java/swig/java_common.i
+++ b/Bindings/Java/swig/java_common.i
@@ -198,6 +198,24 @@ using namespace SimTK;
   }
 %}
 
+%typemap(javacode) OpenSim::LogSink %{
+  public void markAdopted() {
+      if (swigCPtr != 0) {
+          if (swigCMemOwn) swigCMemOwn = false;
+      }
+  }
+%}
+// This method takes ownership of the passed-in object; make sure the bindings
+// don't try to handle ownership.
+%javamethodmodifiers OpenSim::Logger::addSink "private";
+%rename OpenSim::Logger::addSink private_addSink;
+%typemap(javacode) OpenSim::Logger %{
+  public static void addSink(LogSink sink) {
+      sink.markAdopted();
+      private_addSink(sink);
+  }
+%}
+
 %import "java_simbody.i"
 
 %include <Bindings/common.i>

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -13,6 +13,7 @@
 
 %shared_ptr(OpenSim::LogSink);
 %include <OpenSim/Common/LogSink.h>
+%ignore OpenSim::Logger::getInstance();
 %include <OpenSim/Common/Logger.h>
 
 %include <OpenSim/Common/Array.h>


### PR DESCRIPTION
### Brief summary of changes

I was tested `Logger.addSink(JavaLogSink())` in Matlab and got a segfault (double free). This PR avoids the double-free.

### Testing I've completed

Ensured I did not get a segfault in Matlab when closing Matlab.

### CHANGELOG.md (choose one)

- no need to update because...part of a feature

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2754)
<!-- Reviewable:end -->
