### PR TITLE
Convert last remaining cerr in the Analyses folder to use log_error() 

### DIFF
--- a/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
+++ b/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
@@ -58,9 +58,7 @@ OSIMANALYSES_API void RegisterTypes_osimAnalyses()
     Object::RegisterType( OutputReporter() );
 
   } catch (const std::exception& e) {
-    std::cerr 
-        << "ERROR during osimAnalyses Object registration:\n"
-        << e.what() << "\n";
+    log_error("Error during osimAnalyses Object registration: {}", e.what());
   }
 }
 


### PR DESCRIPTION
Related to #36

### Brief summary of changes
Seems like Analyses were already taken care of, but there was one last cerr to convert. 

### Testing I've completed
None, but not sure if necessary.

### CHANGELOG.md (choose one)

- no need to update because...part of a feature.

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2759)
<!-- Reviewable:end -->
