### PR TITLE
Add logging flag to opensim-cmd

### DIFF
--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -21,8 +21,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define _REGEX_MAX_STACK_COUNT 20000000
-
 #include "opensim-cmd_run-tool.h"
 #include "opensim-cmd_print-xml.h"
 #include "opensim-cmd_info.h"
@@ -44,14 +42,8 @@ Usage:
   opensim-cmd -V | --version
 
 Options:
-  -L <path>, --library <path>  Load a plugin before executing the requested
-                 command. The <path> to the library can be absolute, or
-                 relative to the current directory. Make sure to include the
-                 library's extension (e.g., .dll, .so, .dylib). If <path>
-                 contains spaces, surround <path> in quotes. You can load
-                 multiple plugins by repeating this option.
-  -o <level>, --log <level>  Logging level (off, critical, error, warn, info,
-                 debug, trace). Default: info.
+  -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
   -h, --help     Show this help description.
   -V, --version  Show the version number.
 
@@ -62,6 +54,17 @@ Available commands:
   update-file  Update an .xml file (.osim or setup) to this version's format.
 
   Pass -h or --help to any of these commands to learn how to use them.
+
+Description of options:
+  L, library  Load a plugin before executing the requested
+              command. The <path> to the library can be absolute, or
+              relative to the current directory. Make sure to include the
+              library's extension (e.g., .dll, .so, .dylib). If <path>
+              contains spaces, surround <path> in quotes. You can load
+              multiple plugins by repeating this option.
+  o, log      Control the verbosity of OpenSim's console output.
+              Levels: off, critical, error, warn, info, debug, trace.
+              Default: info.
 
 Examples:
   opensim-cmd run-tool InverseDynamics_Setup.xml

--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -33,6 +33,11 @@
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/version.h>
 
+// The initial descriptions of the options should not exceed one line.
+// This is to avoid regex errors with MSVC, where parsing HELP with
+// MSVC's regex library causes a stack error if the description for an
+// option is too long.
+
 static const char HELP[] =
 R"(OpenSim: musculoskeletal modeling and simulation.
 

--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -21,13 +21,14 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#define _REGEX_MAX_STACK_COUNT 20000000
+
 #include "opensim-cmd_run-tool.h"
 #include "opensim-cmd_print-xml.h"
 #include "opensim-cmd_info.h"
 #include "opensim-cmd_update-file.h"
 
 #include <iostream>
-
 #include <docopt.h>
 #include "parse_arguments.h"
 
@@ -38,7 +39,7 @@ static const char HELP[] =
 R"(OpenSim: musculoskeletal modeling and simulation.
 
 Usage:
-  opensim-cmd [--library=<path>]... <command> [<args>...]
+  opensim-cmd [--library=<path>]... [--log=<level>] <command> [<args>...]
   opensim-cmd -h | --help
   opensim-cmd -V | --version
 
@@ -49,6 +50,8 @@ Options:
                  library's extension (e.g., .dll, .so, .dylib). If <path>
                  contains spaces, surround <path> in quotes. You can load
                  multiple plugins by repeating this option.
+  -o <level>, --log <level>  Logging level (off, critical, error, warn, info,
+                 debug, trace). Default: info.
   -h, --help     Show this help description.
   -V, --version  Show the version number.
 
@@ -67,7 +70,7 @@ Examples:
   opensim-cmd update-file lowerlimb_v3.3.osim lowerlimb_updated.osim
   opensim-cmd -L C:\Plugins\osimMyCustomForce.dll run-tool CMC_setup.xml
   opensim-cmd --library ../plugins/libosimMyPlugin.so print-xml MyCustomTool
-  opensim-cmd --library=libosimMyCustomForce.dylib info MyCustomForce
+  opensim-cmd --library=libosimMyCustomForce.dylib --log=debug info MyCustomForce
 
 )";
 
@@ -109,6 +112,12 @@ int main(int argc, const char** argv) {
             // Exit if we couldn't load the library.
             if (!success) return EXIT_FAILURE;
         }
+    }
+    
+    // Logging.
+    // --------
+    if (args["--log"]) {
+        Logger::setLevelString(args["--log"].asString());
     }
 
     // Did the user provide a valid command?

--- a/Applications/opensim-cmd/opensim-cmd_info.h
+++ b/Applications/opensim-cmd/opensim-cmd_info.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   If you do not supply any arguments, you get a list of all registered

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   The argument <tool-or-class> can be the name of a Tool

--- a/Applications/opensim-cmd/opensim-cmd_run-tool.h
+++ b/Applications/opensim-cmd/opensim-cmd_run-tool.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   The Tool to run is detected from the setup file you provide. Supported tools

--- a/Applications/opensim-cmd/opensim-cmd_update-file.h
+++ b/Applications/opensim-cmd/opensim-cmd_update-file.h
@@ -39,6 +39,7 @@ Usage:
 
 Options:
   -L <path>, --library <path>  Load a plugin.
+  -o <level>, --log <level>  Logging level.
 
 Description:
   In an OpenSim XML file, the XML file format version appears as

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -156,6 +156,7 @@ void testCommand(const std::string& arguments,
                  const T& expectedOutput) {
     CommandOutput out = system_output(COMMAND + " " + arguments);
 
+    std::cout << out.output << std::endl;
     checkCommandOutput(arguments, out.output, expectedOutput);
 
     const bool returnCodeIsCorrect = (out.returncode == expectedReturnCode);
@@ -175,7 +176,7 @@ void testNoCommand() {
                           "Pass -h or --help" + RE_ANY);
         testCommand("", EXIT_SUCCESS, output);
         testCommand("-h", EXIT_SUCCESS, output);
-        testCommand("-help", EXIT_SUCCESS, output);
+        testCommand("--help", EXIT_SUCCESS, output);
     }
 
     // Version.

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -156,7 +156,6 @@ void testCommand(const std::string& arguments,
                  const T& expectedOutput) {
     CommandOutput out = system_output(COMMAND + " " + arguments);
 
-    std::cout << out.output << std::endl;
     checkCommandOutput(arguments, out.output, expectedOutput);
 
     const bool returnCodeIsCorrect = (out.returncode == expectedReturnCode);


### PR DESCRIPTION
Fixes part of issue #36 

### Brief summary of changes

This PR adds a logging flag to `opensim-cmd`. I was able to avoid the regex stack error with MSVC by moving the description of the option flags

### Testing I've completed

Ran testCommandLineInterface on Windows.

### CHANGELOG.md (choose one)

- no need to update because...part of a feature

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2764)
<!-- Reviewable:end -->
