### PR TITLE
logging for applications

### DIFF
--- a/Applications/Analyze/analyze.cpp
+++ b/Applications/Analyze/analyze.cpp
@@ -58,7 +58,7 @@ int main(int argc,char **argv)
       analyze -S SetupFileName -> opensim-cmd run-tool SetupFileName
       analyze -PS              -> opensim-cmd print-xml analyze
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // PARSE COMMAND LINE
     int i;
@@ -88,7 +88,8 @@ int main(int argc,char **argv)
             Object::setSerializeAllDefaults(true);
             tool->print("default_Setup_Analyze.xml");
             Object::setSerializeAllDefaults(false);
-            cout << "Created file default_Setup_Analyze.xml with default setup" << endl;
+            log_info("Created file default_Setup_Analyze.xml with default "
+                     "setup");
             return(0);
 
         // IDENTIFY SETUP FILE
@@ -117,7 +118,7 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\nforward.exe: ERROR- A setup file must be specified.\n";
+        log_error("analyze.exe: ERROR- A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }
@@ -127,15 +128,14 @@ int main(int argc,char **argv)
     LoadOpenSimLibrary("osimActuators");
 
     // CONSTRUCT
-    cout<<"Constructing tool from setup file "<<setupFileName<<".\n\n";
+    log_info("Constructing tool from setup file {}", setupFileName);
     AnalyzeTool analyze(setupFileName);
 
     // PRINT MODEL INFORMATION
     // Model& model = analyze.getModel();
-    cout<<"-----------------------------------------------------------------------\n";
-    cout<<"Loaded library\n";
-    cout<<"-----------------------------------------------------------------------\n";
-    cout<<"-----------------------------------------------------------------------\n\n";
+    log_info("--------------------------------------------------------------");
+    log_info("Loaded library");
+    log_info("--------------------------------------------------------------");
 
     // start timing
     std::clock_t startTime = std::clock();
@@ -143,13 +143,14 @@ int main(int argc,char **argv)
     // RUN
     analyze.run();
 
-    std::cout << "Analyze compute time = " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n" << endl;
+    auto timeInMilliseconds = 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC;
+    log_info("Analyze compute time = {} ms", timeInMilliseconds);
 
     //----------------------------
     // Catch any thrown exceptions
     //----------------------------
     } catch(const std::exception& x) {
-        cout << "Exception in analyze: " << x.what() << endl;
+        log_error("Exception in analyze: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/Analyze/analyze.cpp
+++ b/Applications/Analyze/analyze.cpp
@@ -118,7 +118,7 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("analyze.exe: ERROR- A setup file must be specified.", argv[0]);
+        log_error("analyze.exe: A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/CMC/cmc.cpp
+++ b/Applications/CMC/cmc.cpp
@@ -115,7 +115,7 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("{}: ERROR- A setup file must be specified.", argv[0]);
+        log_error("{}: A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/CMC/cmc.cpp
+++ b/Applications/CMC/cmc.cpp
@@ -59,7 +59,7 @@ int main(int argc,char **argv)
       cmc -S SetupFileName -> opensim-cmd run-tool SetupFileName
       cmc -PS              -> opensim-cmd print-xml cmc
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // PARSE COMMAND LINE
     int i;
@@ -88,7 +88,7 @@ int main(int argc,char **argv)
             Object::setSerializeAllDefaults(true);
             investigation->print("default_Setup_CMC.xml");
             Object::setSerializeAllDefaults(false);
-            cout << "Created file default_Setup_CMC.xml with default setup" << endl;
+            log_info("Created file default_Setup_CMC.xml with default setup");
             return(0);
 
         // IDENTIFY SETUP FILE
@@ -115,23 +115,22 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\n"<<argv[0]<<": ERROR- A setup file must be specified.\n";
+        log_error("{}: ERROR- A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }
 
     // CONSTRUCT
-    cout<<"Constructing investigation from setup file "<<setupFileName<<".\n"<<endl;
+    log_info("Constructing investigation from setup file {}", setupFileName);
     CMCTool cmcgait(setupFileName);
 
     // PRINT MODEL INFORMATION
     Model& model = cmcgait.getModel();
-    cout<<"-----------------------------------------------------------------------\n";
-    cout<<"Loaded library\n";
-    cout<<"-----------------------------------------------------------------------\n";
+    log_info("--------------------------------------------------------------");
+    log_info("Loaded library");
+    log_info("--------------------------------------------------------------");
     model.finalizeFromProperties();
     model.printBasicInfo();
-    cout<<"-----------------------------------------------------------------------\n\n";
 
 
     // RUN
@@ -142,7 +141,7 @@ int main(int argc,char **argv)
     // Catch any thrown exceptions
     //----------------------------
     } catch(const std::exception& x) {
-        cout << "Exception in CMC: " << x.what() << endl;
+        log_error("Exception in CMC: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/Forward/forward.cpp
+++ b/Applications/Forward/forward.cpp
@@ -124,7 +124,7 @@ int main(int argc,char **argv)
     }
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("forward.exe: ERROR- A setup file must be specified.");
+        log_error("forward.exe: A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/Forward/forward.cpp
+++ b/Applications/Forward/forward.cpp
@@ -65,7 +65,7 @@ int main(int argc,char **argv)
       forward -S SetupFileName -> opensim-cmd run-tool SetupFileName
       forward -PS              -> opensim-cmd print-xml forward
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
 
     // PARSE COMMAND LINE
@@ -95,7 +95,8 @@ int main(int argc,char **argv)
             Object::setSerializeAllDefaults(true);
             tool.print("default_Setup_Forward.xml");
             Object::setSerializeAllDefaults(false);
-            cout << "Created file default_Setup_Forward.xml with default setup" << endl;
+            log_info("Created file default_Setup_Forward.xml with default "
+                     "setup");
             return(0);
 
         // IDENTIFY SETUP FILE
@@ -123,7 +124,7 @@ int main(int argc,char **argv)
     }
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\nforward.exe: ERROR- A setup file must be specified.\n";
+        log_error("forward.exe: ERROR- A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }
@@ -134,13 +135,13 @@ int main(int argc,char **argv)
     LoadOpenSimLibrary("osimActuators");
 
     // CONSTRUCT
-    cout<<"Constructing tool from setup file "<<setupFileName<<".\n\n";
+    log_info("Constructing tool from setup file {}", setupFileName);
     ForwardTool forward(setupFileName);
 
     // PRINT MODEL INFORMATION
     // Model& model = forward.getModel();
 
-    cout<<"-----------------------------------------------------------------------"<<endl;
+    log_info("--------------------------------------------------------------");
 
     // start timing
     std::clock_t startTime = std::clock();
@@ -148,13 +149,14 @@ int main(int argc,char **argv)
     // RUN
     forward.run();
 
-    std::cout << "Forward simulation time = " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n" << endl;
+    auto timeInMilliseconds = 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC;
+    log_info("Forward simulation time = {} ms", timeInMilliseconds);
 
     //----------------------------
     // Catch any thrown exceptions
     //----------------------------
     } catch(const std::exception& x) {
-        cout << "Exception in forward: " << x.what() << endl;
+        log_error("Exception in forward: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/ID/id.cpp
+++ b/Applications/ID/id.cpp
@@ -121,7 +121,7 @@ int main(int argc,char **argv)
     }
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("id.exe: ERROR- A setup file must be specified.");
+        log_error("id.exe: A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/ID/id.cpp
+++ b/Applications/ID/id.cpp
@@ -62,7 +62,7 @@ int main(int argc,char **argv)
       id -S SetupFileName -> opensim-cmd run-tool SetupFileName
       id -PS              -> opensim-cmd print-xml id
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
 
     // PARSE COMMAND LINE
@@ -92,7 +92,8 @@ int main(int argc,char **argv)
             Object::setSerializeAllDefaults(true);
             tool->print("default_Setup_InverseDynamics.xml");
             Object::setSerializeAllDefaults(false);
-            cout << "Created file default_Setup_InverseDynamics.xml with default setup" << endl;
+            log_info("Created file default_Setup_InverseDynamics.xml with "
+                     "default setup");
             return(0);
 
         // IDENTIFY SETUP FILE
@@ -120,19 +121,18 @@ int main(int argc,char **argv)
     }
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\nid.exe: ERROR- A setup file must be specified.\n";
+        log_error("id.exe: ERROR- A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }
     // CONSTRUCT
-    cout<<"Constructing tool from setup file "<<setupFileName<<".\n\n";
+    log_info("Constructing tool from setup file {}", setupFileName);
     InverseDynamicsTool id(setupFileName);
 
 
-    cout<<"-----------------------------------------------------------------------"<<endl;
-    cout<<"Starting Inverse Dynamics\n";
-    cout<<"-----------------------------------------------------------------------"<<endl;
-    cout<<"-----------------------------------------------------------------------"<<endl<<endl;
+    log_info("--------------------------------------------------------------");
+    log_info("Starting Inverse Dynamics");
+    log_info("--------------------------------------------------------------");
 
     // start timing
     std::clock_t startTime = std::clock();
@@ -140,13 +140,14 @@ int main(int argc,char **argv)
     // RUN
     id.run();
 
-    std::cout << "Inverse dynamics compute time = " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n" << endl;
+    auto timeInMilliseconds = 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC;
+    log_info("Inverse dynamics compute time = {} ms", timeInMilliseconds);
 
     //----------------------------
     // Catch any thrown exceptions
     //----------------------------
     } catch(const std::exception& x) {
-        cout << "Exception in ID: " << x.what() << endl;
+        log_error("Exception in ID: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -132,7 +132,7 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("ik.exe: ERROR- A setup file must be specified.");
+        log_error("ik.exe: A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -66,7 +66,7 @@ int main(int argc,char **argv)
       ik -S SetupFileName -> opensim-cmd run-tool SetupFileName
       ik -PS              -> opensim-cmd print-xml ik
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // PARSE COMMAND LINE
     string option = "";
@@ -101,7 +101,8 @@ int main(int argc,char **argv)
                 Object::setSerializeAllDefaults(true);
                 tool->print("default_Setup_IK.xml");
                 Object::setSerializeAllDefaults(false);
-                cout << "Created file default_Setup_IK.xml with default setup" << endl;
+                log_info("Created file default_Setup_IK.xml with default "
+                         "setup");
                 return 0;
 
             // PRINT PROPERTY INFO
@@ -121,7 +122,8 @@ int main(int argc,char **argv)
 
             // UNRECOGNIZED
             } else {
-                cout << "Unrecognized option" << option << "on command line... Ignored" << endl;
+                log_warn("Unrecognized option {} on command line... Ignored", 
+                         option);
                 PrintUsage(argv[0], cout);
                 return(0);
             }
@@ -130,13 +132,13 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\nik.exe: ERROR- A setup file must be specified.\n";
+        log_error("ik.exe: ERROR- A setup file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }
 
     // CONSTRUCT
-    cout<<"Constructing tool from setup file "<<setupFileName<<".\n\n";
+    log_info("Constructing tool from setup file {}.", setupFileName);
     InverseKinematicsTool ik(setupFileName);
 
     // start timing
@@ -145,14 +147,14 @@ int main(int argc,char **argv)
     // RUN
     ik.run();
 
-    std::cout << "IK compute time = " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n";
-
+    auto timeInMilliseconds = 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC;
+    log_info("IK compute time = {} ms", timeInMilliseconds);
 
     //----------------------------
     // Catch any thrown exceptions
     //----------------------------
     } catch(const std::exception& x) {
-        cout << "Exception in IK: " << x.what() << endl;
+        log_error("Exception in IK: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/RRA/rra.cpp
+++ b/Applications/RRA/rra.cpp
@@ -112,7 +112,7 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        log_error("{}: ERROR- A setup file must be specified.", argv[0]);
+        log_error("{}: A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }

--- a/Applications/RRA/rra.cpp
+++ b/Applications/RRA/rra.cpp
@@ -56,7 +56,7 @@ int main(int argc,char **argv)
       rra -S SetupFileName -> opensim-cmd run-tool SetupFileName
       rra -PS              -> opensim-cmd print-xml rra
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // PARSE COMMAND LINE
     int i;
@@ -85,7 +85,7 @@ int main(int argc,char **argv)
             Object::setSerializeAllDefaults(true);
             investigation->print("default_Setup_RRA.xml");
             Object::setSerializeAllDefaults(false);
-            cout << "Created file default_Setup_RRA.xml with default setup" << endl;
+            log_info("Created file default_Setup_RRA.xml with default setup");
             return(0);
 
         // IDENTIFY SETUP FILE
@@ -112,22 +112,21 @@ int main(int argc,char **argv)
 
     // ERROR CHECK
     if(setupFileName=="") {
-        cout<<"\n\n"<<argv[0]<<": ERROR- A setup file must be specified.\n";
+        log_error("{}: ERROR- A setup file must be specified.", argv[0]);
         PrintUsage(argv[0], cout);
         return(-1);
     }
 
     // CONSTRUCT
-    cout<<"Constructing investigation from setup file "<<setupFileName<<".\n\n";
+    log_info("Constructing investigation from setup file {}.", setupFileName);
     RRATool rra(setupFileName);
 
     // PRINT MODEL INFORMATION
     Model& model = rra.getModel();
-    cout<<"-----------------------------------------------------------------------\n";
-    cout<<"Loaded library\n";
-    cout<<"-----------------------------------------------------------------------\n";
+    log_info("---------------------------------------------------------------");
+    log_info("Loaded library");
+    log_info("---------------------------------------------------------------");
     model.printBasicInfo();
-    cout<<"-----------------------------------------------------------------------\n\n";
 
     // RUN
     rra.run();

--- a/Applications/Scale/scale.cpp
+++ b/Applications/Scale/scale.cpp
@@ -62,7 +62,7 @@ int main(int argc,char **argv)
       scale -S SetupFileName -> opensim-cmd run-tool SetupFileName
       scale -PS              -> opensim-cmd print-xml scale
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // SET OUTPUT FORMATTING
     IO::SetDigitsPad(4);
@@ -107,7 +107,8 @@ int main(int argc,char **argv)
                     Object::setSerializeAllDefaults(true);
                     subject->print("default_Setup_Scale.xml");
                     Object::setSerializeAllDefaults(false);
-                    cout << "Created file default_Setup_Scale.xml with default setup" << endl;
+                    log_info("Created file default_Setup_Scale.xml with "
+                             "default setup");
                     return(0);
 
                 // PRINT PROPERTY INFO
@@ -127,7 +128,8 @@ int main(int argc,char **argv)
 
                 // Unrecognized
                 } else {
-                    cout << "Unrecognized option " << option << " on command line... Ignored" << endl;
+                    log_error("Unrecognized option {} on command line... "
+                              "Ignored", option);
                     PrintUsage(argv[0], cout);
                     return(0);
                 }

--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -96,7 +96,10 @@ int main(int argc, char **argv)
                 }
                 else if ((option == "-ReadXsens") || (option == "-RX")) {
                     if (argc < 4) {
-                        cout << "Both the directory containing Xsens data files and the reader settings file are necessary to read Xsens data. Please retry with these inputs." << endl;
+                        log_error("Both the directory containing Xsens data "
+                                  "files and the reader settings file are "
+                                  "necessary to read Xsens data. Please retry "
+                                  "with these inputs.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }
@@ -104,12 +107,15 @@ int main(int argc, char **argv)
                     std::string settingsFile{ argv[i + 2] };
                     TimeSeriesTable_<SimTK::Quaternion> rotationsTable =
                                                         readRotationsFromXSensFiles(directory, settingsFile);
-                    cout << "Done." << endl;
+                    log_info("Done.");
                     return 0;
                 }
                 else if ((option == "-ReadAPDM") || (option == "-RA")) {
                     if (argc < 4) {
-                        cout << "Both the data file (.csv) with APDM formatted data and the reader settings file are necessary to read APDM data. Please retry with these inputs." << endl;
+                        log_error("Both the data file (.csv) with APDM "
+                                  "formatted data and the reader settings "
+                                  "file are necessary to read APDM data. "
+                                  "Please retry with these inputs.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }
@@ -117,24 +123,27 @@ int main(int argc, char **argv)
                     std::string settingsFile{ argv[i + 2] };
                     TimeSeriesTable_<SimTK::Quaternion> rotationsTable =
                         readRotationsFromAPDMFile(dataFile, settingsFile);
-                    cout << "Done." << endl;
+                    log_info("Done.");
                     return 0;
                 }
                 else if ((option == "-Transform") || (option == "-T")) {
                     if (argc < 3) {
-                        cout << "Marker file is needed for this option. Please fix and retry." << endl;
+                        log_error("Marker file is needed for this option. "
+                                  "Please fix and retry.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }                   
                     std::string markerFile{ argv[i + 1] };
                     TimeSeriesTable_<SimTK::Quaternion> quaternions =
                         OpenSenseUtilities::createOrientationsFileFromMarkers(markerFile);
-                    cout << "Done." << endl;
+                    log_info("Done.");
                     return 0;
                 }
                 else if ((option == "-AddIMUs") || (option == "-A")) {
                     if (argc < 4) {
-                        cout << "Both a model (.osim) file and marker data (e.g. .trc) file are necessary to add IMU frames to the model based-on marker data." << endl;
+                        log_error("Both a model (.osim) file and marker data "
+                                  "(e.g. .trc) file are necessary to add IMU "
+                                  "frames to the model based-on marker data.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }
@@ -142,12 +151,13 @@ int main(int argc, char **argv)
                     std::string markersFile{ argv[i + 2] };
                     addImuFramesFromMarkers(modelFile, markersFile);
 
-                    cout << "Done." << endl;
+                    log_info("Done.");
                     return 0;
                 }
                 else if ((option == "-Calibrate") || (option == "-C")) {
                     if (argc < 3) {
-                        cout << "Calibration specification file is needed. Please fix and retry." << endl;
+                        log_error("Calibration specification file is needed. "
+                                  "Please fix and retry.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }
@@ -159,15 +169,17 @@ int main(int argc, char **argv)
                     if (imuPlacer.get_output_model_file().empty()) {
                         auto filename =
                                 model.getName() + "_calibrated" + ".osim";
-                        cout << "Wrote calibrated model to file: '" << filename << "'." << endl;
+                        log_info("Wrote calibrated model to file: {}.",
+                                 filename);
                         model.print(filename);
                     }
-                    cout << "Done." << endl;
+                    log_info("Done.");
                     return 0;
                 }
                 else if ((option == "-InverseKinematics") || (option == "-IK")) {
                     if (argc < 3) {
-                        cout << "An inverse kinematics settings (.xml) file was expected but no file was provided." << endl;
+                        log_error("An inverse kinematics settings (.xml) file "
+                                  "was expected but no file was provided.");
                         PrintUsage(argv[0], cout);
                         exit(-1);
                     }
@@ -178,9 +190,11 @@ int main(int argc, char **argv)
                     IMUInverseKinematicsTool *imuIKTool = new IMUInverseKinematicsTool();
                     imuIKTool->setName("new");
                     Object::setSerializeAllDefaults(true);
-                    imuIKTool->print("new_Setup_IMUInverseKinematicsTool.xml");
+                    std::string setupFile = 
+                        "new_Setup_IMUInverseKinematicsTool.xml";
+                    imuIKTool->print(setupFile);
                     Object::setSerializeAllDefaults(false);
-                    cout << "Created file new_Setup_IMUInverseKinematicsTool.xml with default setup." << endl;
+                    log_info("Created file {} with default setup.", setupFile);
                     return 0;
 
                     // PRINT PROPERTY INFO
@@ -204,7 +218,8 @@ int main(int argc, char **argv)
                     // UNRECOGNIZED
                 }
                 else {
-                    cout << "Unrecognized option" << option << "on command line... Ignored" << endl;
+                    log_warn("Unrecognized option {} on command line... "
+                              "Ignored", option);
                     PrintUsage(argv[0], cout);
                     return(0);
                 }
@@ -213,13 +228,13 @@ int main(int argc, char **argv)
 
         // ERROR CHECK
         if (setupFileName == "") {
-            cout << "\n\nopensense.exe: ERROR- A setup file must be specified.\n";
+            log_error("opensense.exe: ERROR- A setup file must be specified.");
             PrintUsage(argv[0], cout);
             return(-1);
         }
 
         // CONSTRUCT
-        cout << "Constructing tool from setup file " << setupFileName << ".\n\n";
+        log_info("Constructing tool from setup file {}.", setupFileName);
         IMUInverseKinematicsTool ik(setupFileName);
 
         // start timing
@@ -228,15 +243,15 @@ int main(int argc, char **argv)
         // RUN
         ik.run();
 
-        std::cout << "opensense compute time = " << 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC << "ms\n";
-
+        auto timeInMilliseconds = 1.e3*(std::clock() - startTime) / CLOCKS_PER_SEC;
+        log_info("opensense compute time = {} ms", timeInMilliseconds);
 
         //----------------------------
         // Catch any thrown exceptions
         //----------------------------
     }
     catch (const std::exception& x) {
-        cout << "Exception in opensense: " << x.what() << endl;
+        log_error("Exception in opensense: {}", x.what());
         return -1;
     }
     //----------------------------

--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
 
         // ERROR CHECK
         if (setupFileName == "") {
-            log_error("opensense.exe: ERROR- A setup file must be specified.");
+            log_error("opensense.exe: A setup file must be specified.");
             PrintUsage(argv[0], cout);
             return(-1);
         }

--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -114,7 +114,7 @@ int main(int argc, const char** argv) {
     // Did the user provide a valid command?
     // -------------------------------------
     if (!args["<command>"]) {
-        std::cout << "No command provided." << std::endl;
+        log_error("No command provided.");
         return EXIT_FAILURE;
     }
 
@@ -122,8 +122,8 @@ int main(int argc, const char** argv) {
     const auto& command = args["<command>"].asString();
 
     if (commands.count(command) == 0) {
-        std::cout << "'" << command << "' is not an opensim-cmd command. "
-            << "See 'opensim-cmd --help'." << std::endl;
+        log_error("'{}' is not an opensim-cmd command. "
+                  "See 'opensim-cmd --help'.", command);
         return EXIT_FAILURE;
     }
 
@@ -134,7 +134,7 @@ int main(int argc, const char** argv) {
 
 
     } catch (const std::exception& e) {
-        std::cerr << e.what() << std::endl;
+        log_error(e.what());
         return EXIT_FAILURE;
     }
 

--- a/Applications/opensim-cmd/opensim-cmd_info.h
+++ b/Applications/opensim-cmd/opensim-cmd_info.h
@@ -28,8 +28,6 @@
 #include <docopt.h>
 #include "parse_arguments.h"
 
-#include <OpenSim/OpenSim.h>
-
 static const char HELP_INFO[] =
 R"(Show description of properties in an OpenSim class.
 

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -28,8 +28,6 @@
 #include <docopt.h>
 #include "parse_arguments.h"
 
-#include <OpenSim/OpenSim.h>
-
 static const char HELP_PRINT_XML[] =
 R"(Print a template XML file for a Tool or class.
 
@@ -119,7 +117,7 @@ int print_xml(int argc, const char** argv) {
                 "Did you intend to load a plugin (with --library)?");
     }
 
-    std::cout << "Printing '" << outputFile << "'." << std::endl;
+    log_info("Printing '{}'.", outputFile);
     Object::setSerializeAllDefaults(true);
     obj->print(outputFile);
     Object::setSerializeAllDefaults(false);

--- a/Applications/opensim-cmd/opensim-cmd_run-tool.h
+++ b/Applications/opensim-cmd/opensim-cmd_run-tool.h
@@ -28,8 +28,6 @@
 #include <docopt.h>
 #include "parse_arguments.h"
 
-#include <OpenSim/OpenSim.h>
-
 static const char HELP_RUN_TOOL[] = 
 R"(Run a tool (e.g., Inverse Kinematics) from an XML setup file.
 
@@ -85,8 +83,7 @@ int run_tool(int argc, const char** argv) {
         // We must use the concrete class constructor, as it loads the model
         // (this also preserves the behavior of the previous command line
         // tools).
-        std::cout << "Preparing to run " << tool->getConcreteClassName() << "."
-                  << std::endl;
+        log_info("Preparing to run {}.", tool->getConcreteClassName());
         std::unique_ptr<AbstractTool> concreteTool;
         if        (dynamic_cast<RRATool*>(tool)) {
             concreteTool.reset(new RRATool(setupFile));
@@ -97,9 +94,9 @@ int run_tool(int argc, const char** argv) {
         } else if (dynamic_cast<AnalyzeTool*>(tool)) {
             concreteTool.reset(new AnalyzeTool(setupFile));
         } else {
-            std::cout << "Detected an AbstractTool that is not RRA, "
-                "CMC, Forward, or Analyze; custom tools may not get "
-                "constructed properly." << std::endl;
+            log_warn("Detected an AbstractTool that is not RRA, "
+                     "CMC, Forward, or Analyze; custom tools may not get "
+                     "constructed properly.");
             concreteTool.reset(tool->clone());
         }
         const bool success = concreteTool->run();
@@ -107,15 +104,13 @@ int run_tool(int argc, const char** argv) {
         else return EXIT_FAILURE;
     } else if (auto* tool = dynamic_cast<Tool*>(obj.get())) {
         // Tool.
-        std::cout << "Preparing to run " << tool->getConcreteClassName() << "."
-                  << std::endl;
+        log_info("Preparing to run {}.", tool->getConcreteClassName());
         const bool success = tool->run();
         if (success) return EXIT_SUCCESS;
         else return EXIT_FAILURE;
     } else if (auto* scale = dynamic_cast<ScaleTool*>(obj.get())) {
         // ScaleTool.
-        std::cout << "Preparing to run " << scale->getConcreteClassName() << "."
-                  << std::endl;
+        log_info("Preparing to run {}.", scale->getConcreteClassName());
         const bool success = scale->run();
         if (success) return EXIT_SUCCESS;
         else return EXIT_FAILURE;

--- a/Applications/opensim-cmd/opensim-cmd_update-file.h
+++ b/Applications/opensim-cmd/opensim-cmd_update-file.h
@@ -28,8 +28,6 @@
 #include <docopt.h>
 #include "parse_arguments.h"
 
-#include <OpenSim/OpenSim.h>
-
 static const char HELP_UPDATE_FILE[] =
 R"(Update an .osim, .xml (e.g., setup) or .sto file to this version's format.
 
@@ -73,25 +71,23 @@ int update_file(int argc, const char** argv) {
 
     // .osim or .xml file.
     if (extension == ".osim" || extension == ".xml") {
-        std::cout << "Loading input file '" << inputFile << "'." << std::endl;
+        log_info("Loading input file '{}'.", inputFile);
         const auto* obj = Object::makeObjectFromFile(inputFile);
         if (!obj) {
             throw Exception(
                     "Could not make object from file '" + inputFile + "'.\n"
                     "Did you intend to load a plugin (with --library)?");
         }
-        std::cout << "Printing updated file to '" << outputFile << "'."
-                  << std::endl;
+        log_info("Printing updated file to '{}.", outputFile);
         obj->print(outputFile);
         return EXIT_SUCCESS;
     }
 
     // .sto file.
     if (extension == ".sto") {
-        std::cout << "Loading input file '" << inputFile << "'." << std::endl;
+        log_info("Loading input file '{}'.", inputFile);
         Storage stg(inputFile);
-        std::cout << "Printing updated file to '" << outputFile << "'."
-                  << std::endl;
+        log_info("Printing updated file to '{}.", outputFile);
         stg.print(outputFile);
         return EXIT_SUCCESS;
     }

--- a/Applications/opensim-cmd/opensim-cmd_update-file.h
+++ b/Applications/opensim-cmd/opensim-cmd_update-file.h
@@ -78,7 +78,7 @@ int update_file(int argc, const char** argv) {
                     "Could not make object from file '" + inputFile + "'.\n"
                     "Did you intend to load a plugin (with --library)?");
         }
-        log_info("Printing updated file to '{}.", outputFile);
+        log_info("Printing updated file to '{}'.", outputFile);
         obj->print(outputFile);
         return EXIT_SUCCESS;
     }
@@ -87,7 +87,7 @@ int update_file(int argc, const char** argv) {
     if (extension == ".sto") {
         log_info("Loading input file '{}'.", inputFile);
         Storage stg(inputFile);
-        log_info("Printing updated file to '{}.", outputFile);
+        log_info("Printing updated file to '{}'.", outputFile);
         stg.print(outputFile);
         return EXIT_SUCCESS;
     }

--- a/Applications/opensim-cmd/parse_arguments.h
+++ b/Applications/opensim-cmd/parse_arguments.h
@@ -25,6 +25,8 @@
 
 #include <docopt.h>
 
+#include <OpenSim/OpenSim.h>
+
 namespace OpenSim {
 
 // This implementation was copied from docopt.cpp; the only difference is that
@@ -41,18 +43,18 @@ parse_arguments(std::string const& doc,
     try {
         return docopt_parse(doc, argv, help, !version.empty(), options_first);
     } catch (DocoptExitHelp const&) {
-        std::cout << doc << std::endl;
+        log_cout(doc);
         std::exit(0);
     } catch (DocoptExitVersion const&) {
-        std::cout << version << std::endl;
+        log_cout(version);
         std::exit(0);
     } catch (DocoptLanguageError const& error) {
-        std::cerr << "Docopt usage string could not be parsed." << std::endl;
-        std::cerr << error.what() << std::endl;
+        log_error("Docopt usage string could not be parsed.");
+        log_error(error.what());
         std::exit(-1);
     } catch (DocoptArgumentError const& error) {
-        std::cerr << error.what() << "." << std::endl;
-        std::cerr << "Use --help to get more information." << std::endl;
+        log_error(error.what());
+        log_error("Use --help to get more information.");
         std::exit(-1);
     }
 }

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -112,6 +112,15 @@ public:
     const std::string prefix;
 };
 
+class ContainsSubstring {
+public:
+    ContainsSubstring(std::string substr) : substr(substr) {}
+    bool check(const std::string& str) const {
+        return str.find(substr) != std::string::npos;
+    }
+    const std::string substr;
+};
+
 // Checks that the command produces exactly the expected output.
 void checkCommandOutput(const std::string& arguments,
         const std::string& output,
@@ -135,6 +144,19 @@ void checkCommandOutput(const std::string& arguments,
         std::string msg = "When testing arguments '" + arguments +
             "' got the following output:\n" + output +
             "\nExpected it to start with:\n" + expectedOutput.prefix;
+        throw std::runtime_error(msg);
+    }
+}
+
+// Checks that the command output ends with a given string.
+void checkCommandOutput(const std::string& arguments,
+        const std::string& output,
+        const ContainsSubstring& expectedOutput) {
+    if (!expectedOutput.check(output)) {
+        std::string msg = "When testing arguments '" + arguments +
+                          "' got the following output:\n" + output +
+                          "\nExpected it to contain:\n" +
+                          expectedOutput.substr;
         throw std::runtime_error(msg);
     }
 }
@@ -189,12 +211,13 @@ void testNoCommand() {
     // Library option.
     // ===============
     // Syntax errors.
-    testCommand("-L", EXIT_FAILURE, StartsWith("-L requires an argument"));
+    testCommand("-L", EXIT_FAILURE, 
+            ContainsSubstring("-L requires an argument"));
     testCommand("--library", EXIT_FAILURE, 
-            StartsWith("--library requires an argument"));
+            ContainsSubstring("--library requires an argument"));
     // Must specify a command; can't only list a library to load.
     {
-        StartsWith output("Arguments did not match expected patterns");
+        ContainsSubstring output("Arguments did not match expected patterns");
         // All of these are otherwise valid options for specify libraries to
         // load.
         testCommand("-L x", EXIT_FAILURE, output);
@@ -207,9 +230,10 @@ void testNoCommand() {
 
     // Unrecognized command.
     // =====================
+    std::string str_bleepbloop("'bleepbloop' is not an opensim-cmd command. "
+                               "See 'opensim-cmd --help'.\n");
     testCommand("bleepbloop", EXIT_FAILURE, 
-            "'bleepbloop' is not an opensim-cmd command. "
-            "See 'opensim-cmd --help'.\n");
+            ContainsSubstring(str_bleepbloop));
 }
 
 // http://stackoverflow.com/questions/5343190/how-do-i-replace-all-instances-of-a-string-with-another-string
@@ -291,32 +315,33 @@ void testRunTool() {
     // Error messages.
     // ===============
     testCommand("run-tool", EXIT_FAILURE,
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("run-tool putes.xml", EXIT_FAILURE,
             StartsWith("[error] SimTK Exception thrown at"));
     // We use print-xml to create a setup file that we can try to run.
     // (We are not really trying to test print-xml right now.)
     testCommand("print-xml cmc testruntool_cmc_setup.xml", EXIT_SUCCESS,
-            "Printing 'testruntool_cmc_setup.xml'.\n");
+            ContainsSubstring("Printing 'testruntool_cmc_setup.xml'.\n"));
     // This fails because this setup file doesn't have much in it.
     testCommand("run-tool testruntool_cmc_setup.xml", EXIT_FAILURE,
             std::regex(RE_ANY + "(No model file was specified)" + RE_ANY));
     // Similar to the previous two commands, except for scaling
     // (since ScaleTool goes through a different branch of the code).
     testCommand("print-xml scale testruntool_scale_setup.xml", EXIT_SUCCESS,
-            "Printing 'testruntool_scale_setup.xml'.\n");
+            ContainsSubstring("Printing 'testruntool_scale_setup.xml'.\n"));
     // This fails because this setup file doesn't have much in it.
     testCommand("run-tool testruntool_scale_setup.xml", EXIT_FAILURE,
-            std::regex("(Preparing to run ScaleTool.)" + RE_ANY +
+            std::regex(RE_ANY + "(Preparing to run ScaleTool.)" + RE_ANY +
                        "(Processing subject default)" + RE_ANY));
     // Now we'll try loading a valid OpenSim XML file that is *not* a Tool
     // setup file, and we get a helpful error.
     // (We are not really trying to test print-xml right now.)
     testCommand("print-xml Model testruntool_Model.xml", EXIT_SUCCESS,
-            "Printing 'testruntool_Model.xml'.\n");
+            ContainsSubstring("Printing 'testruntool_Model.xml'.\n"));
     testCommand("run-tool testruntool_Model.xml", EXIT_FAILURE,
-            "The provided file 'testruntool_Model.xml' does not define "
-            "an OpenSim Tool. Did you intend to load a plugin?\n");
+            ContainsSubstring("The provided file 'testruntool_Model.xml' "
+                              "does not define an OpenSim Tool. "
+                              "Did you intend to load a plugin?\n"));
 
     // Library option.
     // ===============
@@ -335,33 +360,35 @@ void testPrintXML() {
     // Error messages.
     // ===============
     testCommand("print-xml", EXIT_FAILURE,
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("print-xml x y z", EXIT_FAILURE,
-            StartsWith("Unexpected argument: print-xml, x, y, z"));
+            ContainsSubstring("Unexpected argument: print-xml, x, y, z"));
     testCommand("print-xml bleepbloop", EXIT_FAILURE,
-        "There is no tool or registered concrete class named 'bleepbloop'.\n"
-        "Did you intend to load a plugin (with --library)?\n");
+            ContainsSubstring("There is no tool or registered concrete class "
+                              "named 'bleepbloop'.\nDid you intend to load a "
+                              "plugin (with --library)?\n"));
     testCommand("print-xml bleepbloop y", EXIT_FAILURE,
-        "There is no tool or registered concrete class named 'bleepbloop'.\n"
-        "Did you intend to load a plugin (with --library)?\n");
+            ContainsSubstring("There is no tool or registered concrete class "
+                              "named 'bleepbloop'.\nDid you intend to load a "
+                              "plugin (with --library)?\n"));
 
     // Successful input.
     // =================
     testCommand("print-xml cmc", EXIT_SUCCESS,
-            "Printing 'default_Setup_CMCTool.xml'.\n");
+            ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
     testCommand("print-xml Millard2012EquilibriumMuscle", EXIT_SUCCESS,
-            "Printing 'default_Millard2012EquilibriumMuscle.xml'.\n");
+            ContainsSubstring("Printing 'default_Millard2012EquilibriumMuscle.xml'.\n"));
     testCommand("print-xml cmc default_cmc_setup.xml", EXIT_SUCCESS,
-            "Printing 'default_cmc_setup.xml'.\n");
+            ContainsSubstring("Printing 'default_cmc_setup.xml'.\n"));
 
     // Tool names are case-insensitive.
     // ================================
     testCommand("print-xml CmC", EXIT_SUCCESS,
-            "Printing 'default_Setup_CMCTool.xml'.\n");
+            ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
     testCommand("print-xml FORwarD", EXIT_SUCCESS,
-            "Printing 'default_Setup_ForwardTool.xml'.\n");
+            ContainsSubstring("Printing 'default_Setup_ForwardTool.xml'.\n"));
     testCommand("print-xml Analyze default_analyze_setup.xml", EXIT_SUCCESS,
-            "Printing 'default_analyze_setup.xml'.\n");
+            ContainsSubstring("Printing 'default_analyze_setup.xml'.\n"));
 
     // Library option.
     // ===============
@@ -380,13 +407,14 @@ void testInfo() {
     // Error messages.
     // ===============
     testCommand("info x", EXIT_FAILURE,
-            "No registered class with name 'x'. "
-            "Did you intend to load a plugin?\n");
+            ContainsSubstring("No registered class with name 'x'. "
+                              "Did you intend to load a plugin?\n"));
     testCommand("info x y", EXIT_FAILURE,
-            "No registered class with name 'x'. "
-            "Did you intend to load a plugin?\n");
+            ContainsSubstring("No registered class with name 'x'. "
+                              "Did you intend to load a plugin?\n"));
     testCommand("info Body y", EXIT_FAILURE,
-            "No property with name 'y' found in class 'Body'.\n");
+            ContainsSubstring("No property with name 'y' found in "
+                              "class 'Body'.\n"));
 
     // Successful input.
     // =================
@@ -394,7 +422,7 @@ void testInfo() {
     testCommand("info PathSpring", EXIT_SUCCESS,
             StartsWith("\nPROPERTIES FOR PathSpring"));
     testCommand("info Body mass", EXIT_SUCCESS,
-            "\nBody.mass\nThe mass of the body (kg)\n");
+            ContainsSubstring("\nBody.mass\nThe mass of the body (kg)\n"));
 
     // Library option.
     // ===============
@@ -415,31 +443,32 @@ void testUpdateFile() {
 
     // Syntax errors.
     testCommand("update-file", EXIT_FAILURE,
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("update-file x", EXIT_FAILURE, 
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("update-file x.doc", EXIT_FAILURE, 
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("update-file x.xml", EXIT_FAILURE, 
-            StartsWith("Arguments did not match expected patterns"));
+            ContainsSubstring("Arguments did not match expected patterns"));
     testCommand("update-file x y", EXIT_FAILURE, 
-            "Input file 'x' does not have an extension.\n");
+            ContainsSubstring("Input file 'x' does not have an extension.\n"));
     testCommand("update-file x.doc y", EXIT_FAILURE, 
-            "Input file 'x.doc' has an unrecognized extension.\n");
+            ContainsSubstring("Input file 'x.doc' has an unrecognized "
+                              "extension.\n"));
 
     // File does not exist.
     testCommand("update-file x.xml y", EXIT_FAILURE, 
-            std::regex("(?:Loading input file 'x.xml')" + RE_ANY +
+            std::regex(RE_ANY + "(?:Loading input file 'x.xml')" + RE_ANY +
                        "(?:Could not make object from file 'x.xml'.\n" + 
                        "Did you intend to load a plugin (with --library)?)" +
                        RE_ANY));
     testCommand("update-file x.osim y", EXIT_FAILURE, 
-            std::regex("(?:Loading input file 'x.osim')" + RE_ANY +
+            std::regex(RE_ANY + "(?:Loading input file 'x.osim')" + RE_ANY +
                        "(?:Could not make object from file 'x.osim'.\n" +
                        "Did you intend to load a plugin (with --library)?)" +
                        RE_ANY));
     testCommand("update-file x.sto y", EXIT_FAILURE, 
-            std::regex("(Loading input file 'x.sto')" + RE_ANY +
+            std::regex(RE_ANY + "(Loading input file 'x.sto')" + RE_ANY +
                        "(Storage: Failed to open file 'x.sto')" + RE_ANY));
 
     // Successful input.
@@ -447,11 +476,13 @@ void testUpdateFile() {
     // We use print-xml to create a file that we can try to update.
     // (We are not really trying to test print-xml right now.)
     testCommand("print-xml Model testupdatefile_Model.osim", EXIT_SUCCESS,
-            "Printing 'testupdatefile_Model.osim'.\n");
+            ContainsSubstring("Printing 'testupdatefile_Model.osim'.\n"));
     testCommand("update-file testupdatefile_Model.osim "
                 "testupdatefile_Model_updated.osim", EXIT_SUCCESS,
-            "Loading input file 'testupdatefile_Model.osim'.\n"
-            "Printing updated file to 'testupdatefile_Model_updated.osim'.\n");
+                std::regex(RE_ANY + "(Loading input file "
+                           "'testupdatefile_Model.osim'.\n)" + 
+                           RE_ANY + "(Printing updated file to "
+                           "'testupdatefile_Model_updated.osim'.\n)" + RE_ANY));
 
     // Library option.
     // ===============

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -105,20 +105,20 @@ CommandOutput system_output(std::string command) {
 
 class StartsWith {
 public:
-    StartsWith(std::string prefix) : prefix(prefix) {}
+    StartsWith(std::string prefix) : prefixStr(prefix) {}
     bool check(const std::string& str) const {
-        return std::equal(prefix.begin(), prefix.end(), str.begin());
+        return std::equal(prefixStr.begin(), prefixStr.end(), str.begin());
     }
-    const std::string prefix;
+    const std::string prefixStr;
 };
 
 class ContainsSubstring {
 public:
-    ContainsSubstring(std::string substr) : substr(substr) {}
+    ContainsSubstring(std::string substr) : substring(substr) {}
     bool check(const std::string& str) const {
-        return str.find(substr) != std::string::npos;
+        return str.find(substring) != std::string::npos;
     }
-    const std::string substr;
+    const std::string substring;
 };
 
 // Checks that the command produces exactly the expected output.
@@ -143,7 +143,8 @@ void checkCommandOutput(const std::string& arguments,
     if (!expectedOutput.check(output)) {
         std::string msg = "When testing arguments '" + arguments +
             "' got the following output:\n" + output +
-            "\nExpected it to start with:\n" + expectedOutput.prefix;
+                          "\nExpected it to start with:\n" +
+                          expectedOutput.prefixStr;
         throw std::runtime_error(msg);
     }
 }
@@ -156,7 +157,7 @@ void checkCommandOutput(const std::string& arguments,
         std::string msg = "When testing arguments '" + arguments +
                           "' got the following output:\n" + output +
                           "\nExpected it to contain:\n" +
-                          expectedOutput.substr;
+                          expectedOutput.substring;
         throw std::runtime_error(msg);
     }
 }

--- a/Applications/versionUpdate/versionUpdate.cpp
+++ b/Applications/versionUpdate/versionUpdate.cpp
@@ -48,7 +48,7 @@ int main(int argc,char **argv)
     DEPRECATED:    versionUpdate inputFileName outputFileName
     REPLACED WITH: opensim-cmd update-file inputFileName outputFileName
     )";
-    std::cout << deprecationNotice << std::endl;
+    log_warn(deprecationNotice);
 
     // PARSE COMMAND LINE
     string option = "";
@@ -62,7 +62,8 @@ int main(int argc,char **argv)
     outputFileName = (argc == 2)?(outputFileName=inputFileName): string(argv[2]);
     // ERROR CHECK
     if(inputFileName=="") {
-        cout<<"\n\versionUpdate.exe: ERROR- An input file must be specified.\n";
+        log_error("versionUpdate.exe: ERROR- An input file must be "
+                  "specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }
@@ -70,7 +71,8 @@ int main(int argc,char **argv)
     string::size_type extSep = inputFileName.rfind(".");
 
     if (extSep == string::npos) {
-        cout<<"\n\versionUpdate.exe: ERROR- Unknown file type encountered. File extension must be specified.\n";
+        log_error("versionUpdate.exe: ERROR- Unknown file type encountered. "
+                  "File extension must be specified.");
         PrintUsage(argv[0], cout);
         return 1;// if '_fileName' contains path information...
     }
@@ -81,7 +83,8 @@ int main(int argc,char **argv)
         return (0);
     }
     if (extension != ".xml" && extension != ".osim") {
-        cout<<"\n\versionUpdate.exe: ERROR- Unknown file type encountered. Only .xml, .osim and .sto files are supported.\n";
+        log_error("versionUpdate.exe: ERROR- Unknown file type encountered. "
+                  "Only .xml, .osim and .sto files are supported.");
         PrintUsage(argv[0], cout);
         return 1;// if '_fileName' contains path information...
     }

--- a/Applications/versionUpdate/versionUpdate.cpp
+++ b/Applications/versionUpdate/versionUpdate.cpp
@@ -62,8 +62,7 @@ int main(int argc,char **argv)
     outputFileName = (argc == 2)?(outputFileName=inputFileName): string(argv[2]);
     // ERROR CHECK
     if(inputFileName=="") {
-        log_error("versionUpdate.exe: ERROR- An input file must be "
-                  "specified.");
+        log_error("versionUpdate.exe: An input file must be specified.");
         PrintUsage(argv[0], cout);
         return(-1);
     }
@@ -71,7 +70,7 @@ int main(int argc,char **argv)
     string::size_type extSep = inputFileName.rfind(".");
 
     if (extSep == string::npos) {
-        log_error("versionUpdate.exe: ERROR- Unknown file type encountered. "
+        log_error("versionUpdate.exe: Unknown file type encountered. "
                   "File extension must be specified.");
         PrintUsage(argv[0], cout);
         return 1;// if '_fileName' contains path information...
@@ -83,7 +82,7 @@ int main(int argc,char **argv)
         return (0);
     }
     if (extension != ".xml" && extension != ".osim") {
-        log_error("versionUpdate.exe: ERROR- Unknown file type encountered. "
+        log_error("versionUpdate.exe: Unknown file type encountered. "
                   "Only .xml, .osim and .sto files are supported.");
         PrintUsage(argv[0], cout);
         return 1;// if '_fileName' contains path information...

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1428,19 +1428,28 @@ PrintPropertyInfo(ostream &aOStream,
                   const string &aClassName, const string &aPropertyName,
                   bool printFlagInfo)
 {
+    std::stringstream ss;
+
     if(aClassName=="") {
         // NO CLASS
         int size = _registeredTypes.getSize();
-        aOStream<<"REGISTERED CLASSES ("<<size<<")\n";
+        ss<<"REGISTERED CLASSES ("<<size<<")\n";
         Object *obj;
         for(int i=0;i<size;i++) {
             obj = _registeredTypes.get(i);
             if(obj==NULL) continue;
-            aOStream<<obj->getConcreteClassName()<<endl;
+            ss<<obj->getConcreteClassName()<<endl;
         }
         if (printFlagInfo) {
-            aOStream<<"\n\nUse '-PropertyInfo ClassName' to list the properties of a particular class.\n\n";
+            ss<<"\n\nUse '-PropertyInfo ClassName' to list the properties of a particular class.\n\n";
         }
+
+        if (aOStream.rdbuf() == std::cout.rdbuf()) {
+            log_cout(ss.str());
+        } else {
+            aOStream << ss.str() << std::endl;
+        }
+
         return true;
     }
 
@@ -1448,9 +1457,16 @@ PrintPropertyInfo(ostream &aOStream,
     const Object* object = getDefaultInstanceOfType(aClassName);
     if(object==NULL) {
         if (printFlagInfo) {
-            aOStream<<"\nA class with the name '"<<aClassName<<"' was not found.\n";
-            aOStream<<"\nUse '-PropertyInfo' without specifying a class name to print a listing of all registered classes.\n";
+            ss<<"\nA class with the name '"<<aClassName<<"' was not found.\n";
+            ss<<"\nUse '-PropertyInfo' without specifying a class name to print a listing of all registered classes.\n";
         }
+
+        if (aOStream.rdbuf() == std::cout.rdbuf()) {
+            log_cout(ss.str());
+        } else {
+            aOStream << ss.str() << std::endl;
+        }
+
         return false;
     }
 
@@ -1462,7 +1478,7 @@ PrintPropertyInfo(ostream &aOStream,
         int propertySetSize = propertySet.getSize();
         int propertyTableSize = object->_propertyTable.getNumProperties();
         int size = propertySetSize + propertyTableSize;
-        aOStream<<"\nPROPERTIES FOR "<<aClassName<<" ("<<size<<")\n";
+        ss<<"\nPROPERTIES FOR "<<aClassName<<" ("<<size<<")\n";
         string comment;
         int i;
         for(i=0;i<propertyTableSize;i++) {
@@ -1470,13 +1486,13 @@ PrintPropertyInfo(ostream &aOStream,
                 &object->_propertyTable.getAbstractPropertyByIndex(i);
             if(abstractProperty==NULL) continue;
             if(aPropertyName=="") {
-                aOStream<<i+1<<". "<<abstractProperty->getName()<<endl;
+                ss<<i+1<<". "<<abstractProperty->getName()<<endl;
             } else {
-                aOStream<<"\n"<<i+1<<". "<<abstractProperty->getName()<<"\n";
+                ss<<"\n"<<i+1<<". "<<abstractProperty->getName()<<"\n";
                 comment = abstractProperty->getComment();
                 if(!comment.empty()) {
                     string formattedComment = IO::formatText(comment,"\t",80);
-                    aOStream<<"\t"<<formattedComment<<"\n";
+                    ss<<"\t"<<formattedComment<<"\n";
                 }
             }
         }
@@ -1485,25 +1501,32 @@ PrintPropertyInfo(ostream &aOStream,
             prop = object->_propertySet.get(i-propertyTableSize);
             if(prop==NULL) continue;
             if(aPropertyName=="") {
-                aOStream<<i+1<<". "<<prop->getName()<<endl;
+                ss<<i+1<<". "<<prop->getName()<<endl;
             } else {
-                aOStream<<"\n"<<i+1<<". "<<prop->getName()<<"\n";
+                ss<<"\n"<<i+1<<". "<<prop->getName()<<"\n";
                 comment = prop->getComment();
                 if(!comment.empty()) {
                     string formattedComment = IO::formatText(comment,"\t",80);
-                    aOStream<<"\t"<<formattedComment<<"\n";
+                    ss<<"\t"<<formattedComment<<"\n";
                 }
             }
         }
 
         if (printFlagInfo) {
-            aOStream << "\n\nUse '-PropertyInfo ClassName.PropertyName' to print "
+            ss << "\n\nUse '-PropertyInfo ClassName.PropertyName' to print "
                 "info for a particular property.\n";
             if(aPropertyName!="*") {
-                aOStream << "Use '-PropertyInfo ClassName.*' to print info for all "
+                ss << "Use '-PropertyInfo ClassName.*' to print info for all "
                     "properties in a class.\n";
             }
         }
+
+        if (aOStream.rdbuf() == std::cout.rdbuf()) {
+            log_cout(ss.str());
+        } else {
+            aOStream << ss.str() << std::endl;
+        }
+
         return true;
     }
 
@@ -1511,9 +1534,15 @@ PrintPropertyInfo(ostream &aOStream,
     try {
         prop = propertySet.get(aPropertyName);
         // OUTPUT
-        //aOStream<<"\nPROPERTY INFO FOR "<<aClassName<<"\n";
-        aOStream << "\n" << aClassName << "." << aPropertyName << "\n"
+        ss << "\n" << aClassName << "." << aPropertyName << "\n"
                  << prop->getComment() << "\n";
+
+        if (aOStream.rdbuf() == std::cout.rdbuf()) {
+            log_cout(ss.str());
+        } else {
+            aOStream << ss.str() << std::endl;
+        }
+
         return true;
     } catch(...) {
         try {
@@ -1523,18 +1552,31 @@ PrintPropertyInfo(ostream &aOStream,
                         "' class '" + aClassName + "'.");
             }
             // OUTPUT
-            //aOStream<<"\nPROPERTY INFO FOR "<<aClassName<<"\n";
-            aOStream << "\n" <<aClassName << "." << aPropertyName <<"\n"
+            ss << "\n" <<aClassName << "." << aPropertyName <<"\n"
                      << abstractProperty->getComment()<<"\n";
+
+            if (aOStream.rdbuf() == std::cout.rdbuf()) {
+                log_cout(ss.str());
+            } else {
+                aOStream << ss.str() << std::endl;
+            }
+
             return true;
         } catch (...) {
             if (printFlagInfo) {
-                aOStream << "\nPrintPropertyInfo: no property with the name "
+                ss << "\nPrintPropertyInfo: no property with the name "
                     << aPropertyName;
-                aOStream << " was found in class " << aClassName << ".\n";
-                aOStream << "Omit the property name to get a listing of all "
+                ss << " was found in class " << aClassName << ".\n";
+                ss << "Omit the property name to get a listing of all "
                     "properties in a class.\n";
             }
+
+            if (aOStream.rdbuf() == std::cout.rdbuf()) {
+                log_cout(ss.str());
+            } else {
+                aOStream << ss.str() << std::endl;
+            }
+
             return false;
         }
     }


### PR DESCRIPTION
Part of #36

### Brief summary of changes
Use spdlog in Applications folder.

### Testing I've completed
Ran some of the executables without arguments, saw a different behavior in the help section with the `[warning]` tag:
```
[2020-05-13 10:25:30.305] [warning]
    THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.
```
The `opensim.log` file was empty.

### Looking for feedback on...
- What other testing would be good to do?
- There is heavy usage of `PrintUsage()` and `Object::PrintPropertyInfo()`. Should I deal with those too? If so, in a new PR?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2769)
<!-- Reviewable:end -->
