### PR TITLE
Fix linker flags for building Python package for conda.

### DIFF
--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -133,8 +133,28 @@ macro(OpenSimAddPythonModule)
             "${PYTHON_INCLUDE_PATH}"
             "${PYTHON_NUMPY_INCLUDE_DIR}")
     
-    target_link_libraries(${_libname}
-        osimTools osimExampleComponents ${PYTHON_LIBRARIES})
+    # On macOS, the python interpreter might link to the python library 
+    # statically, in which case we do not want to link dynamically to the
+    # python library. This situation occurs with Anaconda's python.
+    # In this situation, we must add a linker flag to mark all undefined
+    # symbols as having to be looked up at runtime, and we ignore
+    # PYTHON_LIBRARIES.
+    # https://github.com/opensim-org/opensim-core/issues/2771
+    # https://stackoverflow.com/questions/25421479/clang-and-undefined-symbols-when-building-a-library
+    # https://github.com/lisitsyn/shogun/commit/961f6109c2a8abab4941bcdde1a19dfe70c440f1
+    # https://github.com/shogun-toolbox/shogun/issues/4068
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+        "import sysconfig; print(sysconfig.get_config_var('LDSHARED'))"
+        OUTPUT_VARIABLE PYTHON_LDSHARED
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if("${PYTHON_LDSHARED}" MATCHES "dynamic_lookup")
+        set_target_properties(${_libname} PROPERTIES LINK_FLAGS
+            "-undefined dynamic_lookup")
+    else()
+        target_link_libraries(${_libname} ${PYTHON_LIBRARIES})
+    endif()
+
+    target_link_libraries(${_libname} osimTools osimExampleComponents)
     
     # Set target properties for various platforms.
     # --------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ v4.2
 ====
 - Add the ActivationCoordinateActuator component, which is a CoordinateActuator with simple activation dynamics (PR #2699).
 - Easily convert Matlab matrices and Python NumPy arrays to and from OpenSim Vectors and Matrices. See Matlab example matrixConversions.m and Python example numpy_conversions.py.
+- Fix a segfault that occurs when using OpenSim's Python Package with
+  Anaconda's Python on a Mac.
 
 v4.1
 ====


### PR DESCRIPTION
Fixes issue #2771 

### Brief summary of changes

This PR brings over a fix I saw elsewhere on GitHub for getting the python package to work with Anaconda's python on Mac.

The diff in this PR provides more background.

### Testing I've completed

On Mac, I built the Python package with Anaconda and ran the python CTest tests.

### CHANGELOG.md (choose one)

- updated...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2773)
<!-- Reviewable:end -->
