### PR TITLE
Address mismatch in Analyses about degrees vs radians

### DIFF
--- a/OpenSim/Analyses/Actuation.cpp
+++ b/OpenSim/Analyses/Actuation.cpp
@@ -234,9 +234,9 @@ constructDescription()
     strcat(descrip, "from the model.\n");
 
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/Actuation.cpp
+++ b/OpenSim/Analyses/Actuation.cpp
@@ -234,12 +234,9 @@ constructDescription()
     strcat(descrip, "from the model.\n");
 
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if (getInDegrees()) {
-        strcat(descrip, "\nAngles are in degrees.");
-    }
-    else {
-        strcat(descrip, "\nAngles are in radians.");
-    }
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -197,9 +197,9 @@ constructDescription()
     strcat(descrip, "\nAngular velocities and accelerations are given about");
     strcat(descrip, " the body-local axes.\n");
     strcat(descrip, "\nUnits are S.I. units (seconds, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -184,25 +184,23 @@ constructDescription()
     char descrip[1024];
     char tmp[MAXLEN];
 
-    strcpy(descrip,"\nThis file contains the kinematics ");
-    strcat(descrip,"(positions and orientations,\n");
-    strcat(descrip,"velocities and angular velocities, or");
-    strcat(descrip," accelerations and angular accelerations)\n");
-    strcat(descrip,"of the centers of mass");
-    sprintf(tmp," of the body segments in model %s.\n",
+    strcpy(descrip, "\nThis file contains the kinematics ");
+    strcat(descrip, "(positions and orientations,\n");
+    strcat(descrip, "velocities and angular velocities, or");
+    strcat(descrip, " accelerations and angular accelerations)\n");
+    strcat(descrip, "of the centers of mass");
+    sprintf(tmp, " of the body segments in model %s.\n",
         _model->getName().c_str());
-    strcat(descrip,tmp);
-    strcat(descrip,"\nBody segment orientations are described using");
-    strcat(descrip," body-fixed X-Y-Z Euler angles.\n");
-    strcat(descrip,"\nAngular velocities and accelerations are given about");
-    strcat(descrip," the body-local axes.\n");
-    strcat(descrip,"\nUnits are S.I. units (seconds, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcat(descrip, tmp);
+    strcat(descrip, "\nBody segment orientations are described using");
+    strcat(descrip, " body-fixed X-Y-Z Euler angles.\n");
+    strcat(descrip, "\nAngular velocities and accelerations are given about");
+    strcat(descrip, " the body-local axes.\n");
+    strcat(descrip, "\nUnits are S.I. units (seconds, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/ForceReporter.cpp
+++ b/OpenSim/Analyses/ForceReporter.cpp
@@ -176,19 +176,17 @@ void ForceReporter::constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nThis file contains the forces exerted on a model ");
-    strcat(descrip,"during a simulation.\n");
+    strcpy(descrip, "\nThis file contains the forces exerted on a model ");
+    strcat(descrip, "during a simulation.\n");
 
-    strcat(descrip,"\nA force is a generalized force, meaning that");
-    strcat(descrip," it can be either a force (N) or a torque (Nm).\n");
+    strcat(descrip, "\nA force is a generalized force, meaning that");
+    strcat(descrip, " it can be either a force (N) or a torque (Nm).\n");
 
-    strcat(descrip,"\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/ForceReporter.cpp
+++ b/OpenSim/Analyses/ForceReporter.cpp
@@ -183,9 +183,9 @@ void ForceReporter::constructDescription()
     strcat(descrip, " it can be either a force (N) or a torque (Nm).\n");
 
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/InducedAccelerations.cpp
+++ b/OpenSim/Analyses/InducedAccelerations.cpp
@@ -228,11 +228,10 @@ void InducedAccelerations::constructDescription()
 
     descrip = "\nThis file contains accelerations of coordinates or bodies.\n";
     descrip += "\nUnits are S.I. units (seconds, meters, Newtons, ...)";
-    if(getInDegrees()) {
-        descrip += "\nAngles are in degrees.";
-    } else {
-        descrip += "\nAngles are in radians.";
-    }
+    descrip += "\nIf header above indicates 'inDegrees=yes' above, ";
+    descrip += "then angles are in degrees, ";
+    descrip += "otherwise angles are in radians.";
+
     descrip += "\n\n";
 
     setDescription(descrip);

--- a/OpenSim/Analyses/InducedAccelerations.cpp
+++ b/OpenSim/Analyses/InducedAccelerations.cpp
@@ -228,9 +228,9 @@ void InducedAccelerations::constructDescription()
 
     descrip = "\nThis file contains accelerations of coordinates or bodies.\n";
     descrip += "\nUnits are S.I. units (seconds, meters, Newtons, ...)";
-    descrip += "\nIf header above indicates 'inDegrees=yes' above, ";
-    descrip += "then angles are in degrees, ";
-    descrip += "otherwise angles are in radians.";
+    descrip += "\nIf the header above contains a line with ";
+    descrip += "'inDegrees', this indicates whether rotational values ";
+    descrip +=  "are in degrees (yes) or radians (no).";
 
     descrip += "\n\n";
 

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -222,13 +222,11 @@ constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcpy(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -223,9 +223,9 @@ constructDescription()
     char descrip[1024];
 
     strcpy(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/MuscleAnalysis.cpp
+++ b/OpenSim/Analyses/MuscleAnalysis.cpp
@@ -182,9 +182,9 @@ void MuscleAnalysis::constructDescription()
         " moment arms, etc).");
 
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/MuscleAnalysis.cpp
+++ b/OpenSim/Analyses/MuscleAnalysis.cpp
@@ -177,17 +177,15 @@ void MuscleAnalysis::constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nThis analysis gathers basic information about muscles ");
-    strcat(descrip,"during a simulation (e.g., forces, tendon lengths,"
+    strcpy(descrip, "\nThis analysis gathers basic information about muscles ");
+    strcat(descrip, "during a simulation (e.g., forces, tendon lengths,"
         " moment arms, etc).");
 
-    strcat(descrip,"\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
     setDescription(descrip);
 }
 //_____________________________________________________________________________

--- a/OpenSim/Analyses/ProbeReporter.cpp
+++ b/OpenSim/Analyses/ProbeReporter.cpp
@@ -163,17 +163,15 @@ void ProbeReporter::constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nThis file contains the probes on a model ");
-    strcat(descrip,"during a simulation.\n");
+    strcpy(descrip, "\nThis file contains the probes on a model ");
+    strcat(descrip, "during a simulation.\n");
 
-    strcat(descrip,"\nThe units used are dependent on the type of probe component");
+    strcat(descrip, "\nThe units used are dependent on the type of probe component");
 
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/ProbeReporter.cpp
+++ b/OpenSim/Analyses/ProbeReporter.cpp
@@ -168,9 +168,9 @@ void ProbeReporter::constructDescription()
 
     strcat(descrip, "\nThe units used are dependent on the type of probe component");
 
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Analyses/StatesReporter.cpp
+++ b/OpenSim/Analyses/StatesReporter.cpp
@@ -156,15 +156,13 @@ constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nThis file contains the states of a model ");
-    strcat(descrip,"during a simulation.\n");
-    strcat(descrip,"\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcpy(descrip, "\nThis file contains the states of a model ");
+    strcat(descrip, "during a simulation.\n");
+    strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }

--- a/OpenSim/Analyses/StatesReporter.cpp
+++ b/OpenSim/Analyses/StatesReporter.cpp
@@ -159,9 +159,9 @@ constructDescription()
     strcpy(descrip, "\nThis file contains the states of a model ");
     strcat(descrip, "during a simulation.\n");
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
@@ -95,11 +95,9 @@ constructDescription()
 
     descrip = "\nThis file contains body positions (of origin) and orientations.\n";
     descrip += "\nUnits are S.I. units (seconds, meters, Newtons, ...)";
-    if(getInDegrees()) {
-        descrip += "\nAngles are in degrees.";
-    } else {
-        descrip += "\nAngles are in radians.";
-    }
+    descrip += "\nIf header above indicates 'inDegrees=yes' above, ";
+    descrip += "then angles are in degrees, ";
+    descrip += "otherwise angles are in radians.";
     descrip += "\n\n";
 
     setDescription(descrip);

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/AnalysisPlugin_Template.cpp
@@ -95,9 +95,9 @@ constructDescription()
 
     descrip = "\nThis file contains body positions (of origin) and orientations.\n";
     descrip += "\nUnits are S.I. units (seconds, meters, Newtons, ...)";
-    descrip += "\nIf header above indicates 'inDegrees=yes' above, ";
-    descrip += "then angles are in degrees, ";
-    descrip += "otherwise angles are in radians.";
+    descrip += "\nIf the header above contains a line with ";
+    descrip += "'inDegrees', this indicates whether rotational values ";
+    descrip += "are in degrees (yes) or radians (no).";
     descrip += "\n\n";
 
     setDescription(descrip);

--- a/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
@@ -177,9 +177,9 @@ constructDescription()
     strcpy(descrip, "\nThis file contains expression evaluation ");
     strcat(descrip, "during a simulation.\n");
     strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
-    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
-    strcat(descrip, "then angles are in degrees, ");
-    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\nIf the header above contains a line with ");
+    strcat(descrip, "'inDegrees', this indicates whether rotational values ");
+    strcat(descrip, "are in degrees (yes) or radians (no).");
     strcat(descrip, "\n\n");
 
     setDescription(descrip);

--- a/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/SymbolicExpressionReporter.cpp
@@ -174,15 +174,13 @@ constructDescription()
 {
     char descrip[1024];
 
-    strcpy(descrip,"\nThis file contains expression evaluation ");
-    strcat(descrip,"during a simulation.\n");
-    strcat(descrip,"\nUnits are S.I. units (second, meters, Newtons, ...)");
-    if(getInDegrees()) {
-        strcat(descrip,"\nAngles are in degrees.");
-    } else {
-        strcat(descrip,"\nAngles are in radians.");
-    }
-    strcat(descrip,"\n\n");
+    strcpy(descrip, "\nThis file contains expression evaluation ");
+    strcat(descrip, "during a simulation.\n");
+    strcat(descrip, "\nUnits are S.I. units (second, meters, Newtons, ...)");
+    strcat(descrip, "\nIf header above indicates 'inDegrees=yes' above, ");
+    strcat(descrip, "then angles are in degrees, ");
+    strcat(descrip, "otherwise angles are in radians.");
+    strcat(descrip, "\n\n");
 
     setDescription(descrip);
 }


### PR DESCRIPTION
Fixes issue #2761 

### Brief summary of changes
Description for Analyses are set during construction, which often called `getInDegrees()`, however users can then change the flag afterwards (before `Storage` prints out the header)

### Testing I've completed
None (aside from the standard current tests). No current tests seem to exercise the Analyses rigorously, but unsure what to do with that when we are moving away from Analyses?

### Looking for feedback on...
- Any test that would make you feel confident about this PR?
- The description now does not depend on `getInDegrees()` but does still assume a header will be written. Is this okay for now?

### CHANGELOG.md (choose one)
Not updated, but happy to do so if reviewers think it's big enough to put in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2775)
<!-- Reviewable:end -->
