### PR TITLE
Tweak logging for tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v4.2
 ====
 - Add the ActivationCoordinateActuator component, which is a CoordinateActuator with simple activation dynamics (PR #2699).
 - Easily convert Matlab matrices and Python NumPy arrays to and from OpenSim Vectors and Matrices. See Matlab example matrixConversions.m and Python example numpy_conversions.py.
+- Users have more control over which messages are logged. Messages are now logged to opensim.log instead of out.log and err.log. Users can control logging levels via `Logger::setLevel()`.
 
 v4.1
 ====

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -935,3 +935,11 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
     }
     if(getDocument()) IO::chDir(savedCwd);
 }
+
+std::string AbstractTool::getTimeString(const time_t& t) const {
+    const auto time = localtime(&t);
+    std::string str(asctime(time));
+    // Remove newline.
+    str.pop_back();
+    return str;
+}

--- a/OpenSim/Simulation/Model/AbstractTool.h
+++ b/OpenSim/Simulation/Model/AbstractTool.h
@@ -374,6 +374,13 @@ public:
 
     void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber) override;
     virtual void loadQStorage (const std::string& statesFileName, Storage& rQStore) const;
+
+protected:
+
+    /// Obtain a string of the provided time using asctime(). This function
+    /// removes the newline that asctime() includes at the end of the string.
+    std::string getTimeString(const time_t& t) const;
+
 //=============================================================================
 };  // END of class AbstractTool
 

--- a/OpenSim/Tools/CMC.cpp
+++ b/OpenSim/Tools/CMC.cpp
@@ -718,11 +718,10 @@ computeControls(SimTK::State& s, ControlSet &controlSet)
     double tiReal = s.getTime(); 
     double tfReal = _tf; 
 
-    log_info("CMC::computeControls, t = {}:", tiReal);
+    log_info("CMC::computeControls, t = {}", tiReal);
     if(_verbose) { 
         log_info(" -- step size = {}, target time = {}", _targetDT, _tf);
     }
-    log_info("");
 
     // SET CORRECTIONS 
     int nq = _model->getNumCoordinates();

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -760,15 +760,13 @@ bool CMCTool::run()
 
     // Initial auxiliary states
     time_t startTime,finishTime;
-    struct tm *localTime;
     double elapsedTime;
     if( s.getNZ() > 0) { // If there are actuator states (i.e. muscles dynamics)
         log_info("-----------------------------------------------------------------");
         log_info("Computing initial values for muscles states (activation, length):");
         log_info("-----------------------------------------------------------------");
         time(&startTime);
-        localTime = localtime(&startTime);
-        log_info(" -- Start time = {}", asctime(localTime));
+        log_info(" -- Start time = {}", getTimeString(startTime));
         log_info("-----------------------------------------------------------------");
         log_info("");
 
@@ -793,11 +791,9 @@ bool CMCTool::run()
         log_info("----------------------------------");
         log_info("Finished computing initial states:");
         log_info("----------------------------------");
-        localTime = localtime(&startTime);
-        log_info(" -- Start time = {}", asctime(localTime));            
-        localTime = localtime(&finishTime);
-        log_info(" -- Finish time = {}", asctime(localTime));
-        elapsedTime = difftime(finishTime,startTime);
+        log_info(" -- Start time = {}", getTimeString(startTime));
+        log_info(" -- Finish time = {}", getTimeString(finishTime));
+        elapsedTime = difftime(finishTime, startTime);
         log_info(" -- Elapsed time = {} seconds.", elapsedTime);
         log_info("----------------------------------");
         log_info("");
@@ -819,8 +815,7 @@ bool CMCTool::run()
     s.updTime() = _ti;
     controller->setTargetTime( _ti );
     time(&startTime);
-    localTime = localtime(&startTime);
-    log_info(" -- Start time = {}", asctime(localTime));
+    log_info(" -- Start time = {}", getTimeString(startTime));
     log_info("--------------------------------------------");
     log_info("");
 
@@ -859,11 +854,9 @@ bool CMCTool::run()
     if( _verbose ){
       log_info(" -- States = {}", s.getY()); 
     }
-    localTime = localtime(&startTime);
-    log_info(" -- Start time = {}", asctime(localTime));
-    localTime = localtime(&finishTime);
-    log_info(" -- Finish time = {}", asctime(localTime));
-    elapsedTime = difftime(finishTime,startTime);
+    log_info(" -- Start time = {}", getTimeString(startTime));
+    log_info(" -- Finish time = {}", getTimeString(finishTime));
+    elapsedTime = difftime(finishTime, startTime);
     log_info(" -- Elapsed time = {} seconds.", elapsedTime);
     log_info("-------------------------------------------");
     log_info("");

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -223,7 +223,7 @@ bool InverseKinematicsTool::run()
 
                 log_info("Frame {} (t = {}):\t total squared error = {}, "
                          "marker error: RMS = {}, max = {} ({})", 
-                    i, s.getTime(), totalSquaredMarkerError, 
+                    i, s.getTime(), totalSquaredMarkerError, rms,
                     sqrt(maxSquaredMarkerError), 
                     ikSolver.getMarkerNameForIndex(worst));
             }

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -369,7 +369,9 @@ bool MarkerPlacer::processModel(Model* aModel,
     }
     log_info("Frame at (t = {}):\t total squared error = {}, "
              "marker error: RMS = {}, max = {} ({})",
-            s.getTime(), totalSquaredMarkerError, sqrt(maxSquaredMarkerError),
+            s.getTime(), totalSquaredMarkerError,
+            sqrt(totalSquaredMarkerError/nm),
+            sqrt(maxSquaredMarkerError),
             ikSol.getMarkerNameForIndex(worst));
     /* Now move the non-fixed markers on the model so that they are coincident
      * with the measured markers in the static pose. The model is already in

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -748,15 +748,13 @@ bool RRATool::run()
 
     // Initial auxiliary states
     time_t startTime,finishTime;
-    struct tm *localTime;
     double elapsedTime;
     if( s.getNZ() > 0) { // If there are actuator states (i.e. muscles dynamics)
         log_info("-----------------------------------------------------------------");
         log_info("Computing initial values for muscles states (activation, length):");
         log_info("-----------------------------------------------------------------");
         time(&startTime);
-        localTime = localtime(&startTime);
-        log_info(" -- Start time = {}", asctime(localTime));
+        log_info(" -- Start time = {}", getTimeString(startTime));
         log_info("-----------------------------------------------------------------");
         log_info("");
 
@@ -781,12 +779,10 @@ bool RRATool::run()
         log_info("----------------------------------");
         log_info("Finished computing initial states:");
         log_info("----------------------------------");
-        localTime = localtime(&startTime);
-        log_info(" -- Start time = {}", asctime(localTime));
-        localTime = localtime(&finishTime);
-        log_info(" -- Finish time = {}", asctime(localTime));
-        elapsedTime = difftime(finishTime,startTime);
-        log_info(" -- Elapsed time = {} seconds.\n", elapsedTime);
+        log_info(" -- Start time = {}", getTimeString(startTime));
+        log_info(" -- Finish time = {}", getTimeString(finishTime));
+        elapsedTime = difftime(finishTime, startTime);
+        log_info(" -- Elapsed time = {} seconds.", elapsedTime);
         log_info("----------------------------------");
         log_info("");
 
@@ -808,8 +804,7 @@ bool RRATool::run()
     s.updTime() = _ti;
     controller->setTargetTime( _ti );
     time(&startTime);
-    localTime = localtime(&startTime);
-    log_info(" -- Start time = {}", asctime(localTime));
+    log_info(" -- Start time = {}", getTimeString(startTime));
     log_info("--------------------------------------------");
     log_info("");
 
@@ -848,12 +843,10 @@ bool RRATool::run()
     if( _verbose ){
       log_info(" -- States = {}", s.getY());
     }
-    localTime = localtime(&startTime);
-    log_info(" -- Start time = {}", asctime(localTime));
-    localTime = localtime(&finishTime);
-    log_info(" -- Finish time = {}", asctime(localTime));
-    elapsedTime = difftime(finishTime,startTime);
-    log_info(" -- Elapsed time = {} seconds.\n", elapsedTime);
+    log_info(" -- Start time = {}", getTimeString(startTime));
+    log_info(" -- Finish time = {}", getTimeString(finishTime));
+    elapsedTime = difftime(finishTime, startTime);
+    log_info(" -- Elapsed time = {} seconds.", elapsedTime);
     log_info("-------------------------------------------");
     log_info("");
 


### PR DESCRIPTION
Fixes issue #36 

### Brief summary of changes

- Removes excess newlines in RRA and CMC logging.
- Fix a bug in the logging of Scale and IK (we were missing an output variable).

### Testing I've completed

Ran the gait2354 pipeline.

### Looking for feedback on...

Do we like the modified logging output? Here's a snippet of the modified output:

```
[info] CMC::computeControls, t = 1.246
[info] CMC::computeControls, t = 1.247
[info] CMC::computeControls, t = 1.248
[info] CMC::computeControls, t = 1.249
[info] -------------------------------------------
[info] Finished tracking the specified kinematics:
[info] -------------------------------------------
[info]  -- Start time = Sat May 23 16:02:58 2020
[info]  -- Finish time = Sat May 23 16:03:07 2020
[info]  -- Elapsed time = 9.0 seconds.
[info] -------------------------------------------
[info] 
[info] Printing results of investigation subject01_walk1_RRA to ResultsRRA
[info] 
```

### CHANGELOG.md (choose one)

- updated...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2776)
<!-- Reviewable:end -->
