### PR TITLE
CMake error if SWIG version is too great.

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -2,8 +2,9 @@ if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
     # We require 3.0.8 for the reason mentioned here (for Python 3):
     # https://github.com/tensorflow/tensorflow/issues/830
     find_package(SWIG 3.0.8 REQUIRED)
-    if(NOT (SWIG_VERSION VERSION_LESS "4.0.0"))
-        message(FATAL_ERROR "SWIG version must be less than 4.0.0.")
+    if(NOT (SWIG_VERSION VERSION_LESS "4.0.0") AND BUILD_JAVA_WRAPPING)
+        message(FATAL_ERROR
+                "SWIG version 4.0.0 and greater not yet supported for Java bindings.")
     endif()
 endif()
 

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -2,6 +2,9 @@ if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
     # We require 3.0.8 for the reason mentioned here (for Python 3):
     # https://github.com/tensorflow/tensorflow/issues/830
     find_package(SWIG 3.0.8 REQUIRED)
+    if(NOT (SWIG_VERSION VERSION_LESS "4.0.0"))
+        message(FATAL_ERROR "SWIG version must be less than 4.0.0.")
+    endif()
 endif()
 
 # Flags are both Python and Java bindings will use.


### PR DESCRIPTION
### Brief summary of changes

opensim-core does not yet support SWIG 4, and multiple people have tried building from source using SWIG 4 and run into a Java compiler error. While we figure out a fix, this PR alerts builders that they cannot use SWIG 4.

### Testing I've completed

Ensured that if CMake finds SWIG 4.0.1, then CMake generates this new error.

### CHANGELOG.md (choose one)

- no need to update because...not user-facing
- updated...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2784)
<!-- Reviewable:end -->
