### PR TITLE
Fix SWIG warning when building Moco bindings.

### DIFF
--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -12,6 +12,7 @@
 %include <OpenSim/Common/Exception.h>
 
 %shared_ptr(OpenSim::LogSink);
+%shared_ptr(OpenSim::StringLogSink);
 %ignore OpenSim::StringLogSink;
 %include <OpenSim/Common/LogSink.h>
 %ignore OpenSim::Logger::getInstance();


### PR DESCRIPTION
### Brief summary of changes

This PR fixes a SWIG warning I saw when building Moco's python bindings:

```
.../opensim-moco/opensim-core/OpenSim/Common/LogSink.h:54: Warning 520: Derived class 'StringLogSink' of 'OpenSim::LogSink' is not similarly marked as a smart pointer.
```

### Testing I've completed

Built Moco's bindings with this fix, and the warning went away.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2796)
<!-- Reviewable:end -->
