### PR TITLE
Handle situation where logfile can't be created.

### DIFF
--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -145,7 +145,7 @@ bool Logger::shouldLog(Level level) {
 
 void Logger::addFileSink(const std::string& filepath) {
     if (m_filesink) {
-        warn("Already logging to file '{}'; file sink not added. Call "
+        warn("Already logging to file '{}'; log file not added. Call "
              "removeFileSink() first.", m_filesink->filename());
         return;
     }

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -149,19 +149,18 @@ void Logger::addFileSink(const std::string& filepath) {
              "removeFileSink() first.", m_filesink->filename());
         return;
     }
-    // verify if file can be opened at the specified path
-    std::ifstream ifs(filepath);
-
-    if (ifs.is_open()) {
-        ifs.close();
-    } else {
-        // show message:
-         warn("Can't open file '{}' for writing. Log file will not be created. "
-             "Check that you have write permissions to the specified path.", 
-             filepath);
+    // check if file can be opened at the specified path if not return meaningful
+    // warning rather than bubble the exception up.
+    try {
+        m_filesink =
+                std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);
+    }
+    catch (...) {
+        warn("Can't open file '{}' for writing. Log file will not be created. "
+             "Check that you have write permissions to the specified path.",
+                filepath);
         return;
     }
-    m_filesink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);
     addSinkInternal(m_filesink);
 }
 

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -156,7 +156,8 @@ void Logger::addFileSink(const std::string& filepath) {
         ifs.close();
     } else {
         // show message:
-         warn("Can't open file {} for writing. Log file will not be created.", 
+         warn("Can't open file '{}' for writing. Log file will not be created. "
+             "Check that you have write permissions to the specified path.", 
              filepath);
         return;
     }

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -44,7 +44,6 @@ Logger::Logger() {
     m_default_logger->set_pattern("[%l] %v");
     m_cout_logger->set_level(spdlog::level::info);
     m_cout_logger->set_pattern("%v");
-    addFileSink();
     // This ensures log files are updated regularly, instead of only when the
     // program shuts down.
     spdlog::flush_on(spdlog::level::info);
@@ -157,7 +156,8 @@ void Logger::addFileSink(const std::string& filepath) {
         ifs.close();
     } else {
         // show message:
-        std::cout << "Can't open file " << filepath << "Log will not be created." << std::endl;
+         warn("Can't open file {} for writing. Log will not be created.", 
+             filepath);
         return;
     }
     m_filesink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -150,6 +150,16 @@ void Logger::addFileSink(const std::string& filepath) {
              "removeFileSink() first.", m_filesink->filename());
         return;
     }
+    // verify if file can be opened in current folder
+    std::ifstream ifs(filepath);
+
+    if (ifs.is_open()) {
+        ifs.close();
+    } else {
+        // show message:
+        std::cout << "Can't open file " << filepath << "Log will not be created." << std::endl;
+        return;
+    }
     m_filesink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);
     addSinkInternal(m_filesink);
 }

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -150,7 +150,7 @@ void Logger::addFileSink(const std::string& filepath) {
              "removeFileSink() first.", m_filesink->filename());
         return;
     }
-    // verify if file can be opened in current folder
+    // verify if file can be opened at the specified path
     std::ifstream ifs(filepath);
 
     if (ifs.is_open()) {

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -156,7 +156,7 @@ void Logger::addFileSink(const std::string& filepath) {
         ifs.close();
     } else {
         // show message:
-         warn("Can't open file {} for writing. Log will not be created.", 
+         warn("Can't open file {} for writing. Log file will not be created.", 
              filepath);
         return;
     }

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -152,6 +152,7 @@ public:
     /// function issues a warning and returns; invoke removeFileSink() first.
     /// @note This function is not thread-safe. Do not invoke this function
     /// concurrently, or concurrently with addSink() or removeSink().
+    /// @note If filepath can't be opened, no log file is created.
     static void addFileSink(const std::string& filepath = "opensim.log");
 
     /// Remove the filesink if it exists.
@@ -177,6 +178,7 @@ public:
         if (!m_osimLogger) {
             m_osimLogger =
                     std::shared_ptr<OpenSim::Logger>(new OpenSim::Logger());
+            addFileSink();
         }
         return m_osimLogger;
     }


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Handle the case of logfile that can't be opened.

### Testing I've completed
None
### Looking for feedback on...
What should be the behavior on failure? Before this PR, GUI fails to launch, we can have GUI add its own sink in a different folder that GUI decides on (e.g. Resources folder which we know is writable, other folder common to Netbeans, /AppData, ... or under home directory though I don't like sprinkling files all over the file system)
### CHANGELOG.md (choose one)

- no need to update because...
- updated...

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2797)
<!-- Reviewable:end -->
