### PR TITLE
Fix SWIG warnings

### DIFF
--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -13,7 +13,6 @@
 
 %shared_ptr(OpenSim::LogSink);
 %shared_ptr(OpenSim::StringLogSink);
-%ignore OpenSim::StringLogSink;
 %include <OpenSim/Common/LogSink.h>
 %ignore OpenSim::Logger::getInstance();
 %include <OpenSim/Common/Logger.h>

--- a/OpenSim/Common/APDMDataReader.h
+++ b/OpenSim/Common/APDMDataReader.h
@@ -46,11 +46,7 @@ public:
     APDMDataReader(const APDMDataReaderSettings& settings) {
         _settings = settings;
     }
-    APDMDataReader(const APDMDataReader&)            = default;
-    APDMDataReader(APDMDataReader&&)                 = default;
-    APDMDataReader& operator=(const APDMDataReader&) = default;
-    APDMDataReader& operator=(APDMDataReader&&)      = default;
-    virtual ~APDMDataReader()                   = default;
+    virtual ~APDMDataReader() = default;
 
     APDMDataReader* clone() const override;
 

--- a/OpenSim/Common/APDMDataReaderSettings.h
+++ b/OpenSim/Common/APDMDataReaderSettings.h
@@ -50,11 +50,7 @@ public:
         updateFromXMLDocument();
     };
 
-    APDMDataReaderSettings(const APDMDataReaderSettings&)            = default;
-    APDMDataReaderSettings(APDMDataReaderSettings&&)                 = default;
-    APDMDataReaderSettings& operator=(const APDMDataReaderSettings&) = default;
-    APDMDataReaderSettings& operator=(APDMDataReaderSettings&&)      = default;
-    virtual ~APDMDataReaderSettings()                   = default;
+    virtual ~APDMDataReaderSettings() = default;
     
 private:
     void constructProperties() {

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -28,19 +28,16 @@
 #include "TimeSeriesTable.h"
 #include "Event.h"
 
-template<typename> class shrik;
-
 namespace OpenSim {
-    /** C3DFileAdapter reads a C3D file into markers and forces tables of type
-    TimeSeriesTableVec3. The markers table has each column labeled by its
-    corresponding marker name. For the forces table, the data are grouped
-    by sensor (force-plate #) in force, point and moment order, with the
-    respective *f#*, *p#* and *m#* column labels. C3DFileAdpater provides
-    options for expressing the force-plate measurements either as the
-    net force and moments expressed at the ForcePlateOrigin, the
-    CenterOfPressure, or the PointOfWrenchApplication.
-    */
 
+/** C3DFileAdapter reads a C3D file into markers and forces tables of type
+TimeSeriesTableVec3. The markers table has each column labeled by its
+corresponding marker name. For the forces table, the data are grouped
+by sensor (force-plate #) in force, point and moment order, with the
+respective *f#*, *p#* and *m#* column labels. C3DFileAdpater provides
+options for expressing the force-plate measurements either as the
+net force and moments expressed at the ForcePlateOrigin, the
+CenterOfPressure, or the PointOfWrenchApplication. */
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
 public:
     typedef std::vector<Event>                         EventTable; 

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -107,13 +107,6 @@ public:
         PointOfWrenchApplication = 2    ///< 2 : PWA as defined by Shimba, 1984
     };
 
-    C3DFileAdapter()                                 = default;
-    C3DFileAdapter(const C3DFileAdapter&)            = default;
-    C3DFileAdapter(C3DFileAdapter&&)                 = default;
-    C3DFileAdapter& operator=(const C3DFileAdapter&) = default;
-    C3DFileAdapter& operator=(C3DFileAdapter&&)      = default;
-    ~C3DFileAdapter()                                = default;
-
     C3DFileAdapter* clone() const override;
     /**  C3DFileAdpater provides options for expressing the force-plate 
         measurements either as the net force and moments expressed at the 

--- a/OpenSim/Common/XsensDataReader.h
+++ b/OpenSim/Common/XsensDataReader.h
@@ -36,9 +36,10 @@
 
 namespace OpenSim {
 
-/** XsensDataReader is a class that reads files produced by IMU manufacturer Xsens
-    and produces datatables from them. This is intended to help consume IMU outputs.*/
-class OSIMCOMMON_API XsensDataReader : public IMUDataReader{
+/** XsensDataReader is a class that reads files produced by IMU manufacturer
+   Xsens and produces datatables from them. This is intended to help consume IMU
+   outputs.*/
+class OSIMCOMMON_API XsensDataReader : public IMUDataReader {
 public:
     // Default Constructor
     XsensDataReader() = default;
@@ -46,11 +47,7 @@ public:
     XsensDataReader(const XsensDataReaderSettings& settings) {
         _settings = settings;
     }
-    XsensDataReader(const XsensDataReader&)            = default;
-    XsensDataReader(XsensDataReader&&)                 = default;
-    XsensDataReader& operator=(const XsensDataReader&) = default;
-    XsensDataReader& operator=(XsensDataReader&&)      = default;
-    virtual ~XsensDataReader()                   = default;
+    virtual ~XsensDataReader() = default;
 
     XsensDataReader* clone() const override;
 protected:

--- a/OpenSim/Common/XsensDataReaderSettings.h
+++ b/OpenSim/Common/XsensDataReaderSettings.h
@@ -1,6 +1,5 @@
 #ifndef OPENSIM_XSENS_DATA_READER_SETTINGS_H_
 #define OPENSIM_XSENS_DATA_READER_SETTINGS_H_
-
 /* -------------------------------------------------------------------------- *
  *                          OpenSim:  XsensDataReaderSettings.h               *
  * -------------------------------------------------------------------------- *
@@ -26,13 +25,15 @@
 #include "Object.h"
 #include "ExperimentalSensor.h"
 /** @file
-* This file defines class for configuring the reading data files from IMU maker Xsens.
-*/
+ * This file defines class for configuring the reading data files from IMU maker
+ * Xsens.
+ */
 
 namespace OpenSim {
 
-/** XsensDataReaderSettings is a class that reads files produced by IMU manufacturer Xsens
-    and produces datatables from them. This is intended to help consume IMU outputs.*/
+/** XsensDataReaderSettings is a class that reads files produced by IMU
+   manufacturer Xsens and produces datatables from them. This is intended to
+   help consume IMU outputs.*/
 class OSIMCOMMON_API XsensDataReaderSettings : public Object {
 OpenSim_DECLARE_CONCRETE_OBJECT(XsensDataReaderSettings, Object);
 public:
@@ -54,11 +55,7 @@ public:
         updateFromXMLDocument();
     };
 
-    XsensDataReaderSettings(const XsensDataReaderSettings&)            = default;
-    XsensDataReaderSettings(XsensDataReaderSettings&&)                 = default;
-    XsensDataReaderSettings& operator=(const XsensDataReaderSettings&) = default;
-    XsensDataReaderSettings& operator=(XsensDataReaderSettings&&)      = default;
-    virtual ~XsensDataReaderSettings()                   = default;
+    virtual ~XsensDataReaderSettings() = default;
     
 private:
     void constructProperties() {


### PR DESCRIPTION
This is a follow-up to #2796 

### Brief summary of changes

This PR avoids the SWIG warning regarding `StringLogSink` following @aymanhab's suggestion in #2796.

This PR also avoids a few other SWIG warnings due to unnecessary declarations of move/copy constructors.

### Testing I've completed

Ran CTests.

### CHANGELOG.md (choose one)

- no need to update because...minor

The Doxygen for this PR can be viewed at http://myosin.sourceforge.net/?C=N;O=D; click the folder whose name is this PR's number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2798)
<!-- Reviewable:end -->
