### PR TITLE
On Windows with MSVC, avoid generating SWIG files for Python twice

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -88,8 +88,6 @@ jobs:
       run: echo "::set-output name=hash::$(git rev-parse --short HEAD)"
 
     - name: Install opensim-core
-      # TODO: Bindings are rebuilt at this stage because of a bug on Windows
-      # in the macro OpenSimFindSwigFileDependencies().
       run: |
         chdir $env:GITHUB_WORKSPACE\\build
         cmake --build . --config Release --target doxygen -- /maxcpucount:4
@@ -98,14 +96,14 @@ jobs:
         Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.commithash.outputs.hash }}" -Recurse
         7z a "opensim-core-${{ steps.commithash.outputs.hash }}.zip" "opensim-core-${{ steps.commithash.outputs.hash }}"
 
-    # - name: Test Python bindings
-    #   run: |
-    #     $env:PATH = "$env:HOME/opensim-core-install/bin;$env:PATH"
-    #     $env:PATH
-    #     # Move to the installed location of the python package.
-    #     cd ~/opensim-core-install/sdk/python
-    #     # Run python tests.
-    #     python -m unittest discover --start-directory opensim/tests --verbose
+    - name: Test Python bindings
+      run: |
+        $env:PATH += ";$env:HOME/opensim-core-install/bin"
+        $env:PATH
+        # Move to the installed location of the python package.
+        cd ~/opensim-core-install/sdk/python
+        # Run python tests.
+        python -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
       uses: actions/upload-artifact@v2

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -16,7 +16,7 @@ function(OpenSimGenerateJavaWrapper
             ${INPUT_INTERFACE_FILE}
             )
 
-    OpenSimFindSwigFileDependencies(_${NAME}_dependencies ${NAME}
+    OpenSimFindSwigFileDependencies(_${NAME}_dependencies "${NAME} (Java)"
         "${_swig_common_args}"
         )
 

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -78,7 +78,7 @@ macro(OpenSimAddPythonModule)
     # configure step and fills the first argument with a list of the
     # dependencies.
     OpenSimFindSwigFileDependencies(_${OSIMSWIGPY_MODULE}_dependencies
-        ${OSIMSWIGPY_MODULE} "${_swig_common_args}")
+        "${OSIMSWIGPY_MODULE} (Python)" "${_swig_common_args}")
 
     # Run swig.
     add_custom_command(
@@ -192,24 +192,24 @@ macro(OpenSimAddPythonModule)
 
     # Copy files into the build tree python package.
     # ----------------------------------------------
-    # Copy the library file.
     add_custom_command(TARGET ${_libname} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${_libname}>"
             "${OPENSIM_PYTHON_BINARY_DIR}/opensim/$<TARGET_FILE_NAME:${_libname}>"
-        COMMENT "Copying ${_libname} library to python package in build directory."
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py"
+            "${OPENSIM_PYTHON_BINARY_DIR}/opensim/${OSIMSWIGPY_MODULE}.py"
+        COMMENT "Copying ${OSIMSWIGPY_MODULE}.py and ${_libname} to python package in build directory."
         VERBATIM
         )
 
-    # Copy the generated .py file to the per-config python package dir.
-    OpenSimPutFileInPythonPackage(
-        "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py" opensim)
-
-    # Install the library.
-    # --------------------
-    # It's important that we use install(TARGETS) 
+    # Install the python module and compiled library.
+    # -----------------------------------------------
+    # For the shared library, it's important that we use install(TARGETS)
     # because this causes CMake to remove the build-tree RPATH from the library
     # (which is set temporarily for libraries in the build tree).
     install(TARGETS ${_libname} DESTINATION "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${OSIMSWIGPY_MODULE}.py"
+        DESTINATION "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
 
 endmacro()
 

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -515,9 +515,9 @@ macro(OpenSimFindSwigFileDependencies OSIMSWIGDEP_RETURNVAL
     # Clean up the output, since it's in the form of a makefile
     # (and we just want a list of file paths).
     if(${_successfully_got_dependencies} EQUAL 0) # return code 0 is success.
-        # '^.*:' matches the first line of the makefile (the output file path).
+        # '^.*cxx:' matches the first line of the makefile (the output file path).
         # '\\\\' matches a single \ (escape for CMake, and escape for regex).
-        string(REGEX REPLACE "(^.*:|\\\\\n)" "" ${OSIMSWIGDEP_RETURNVAL}
+        string(REGEX REPLACE "(^.*cxx:|\\\\\n)" "" ${OSIMSWIGDEP_RETURNVAL}
             ${_dependencies_makefile})
         # Replace spaces with semicolons to create a list of file paths.
         separate_arguments(${OSIMSWIGDEP_RETURNVAL})


### PR DESCRIPTION
### Brief summary of changes

Fix issues with CMake that causes SWIG to run multiple times when generating the Python bindings.

### Testing I've completed

Locally, I ensured that building the `PythonBindings` target only causes SWIG to be run once (for each module).

### CHANGELOG.md (choose one)

- no need to update because...not user-facing
