### PR TITLE
Added _enabledControllers cache to OpenSim::Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ v4.2
 - Fix a segfault that occurs when using OpenSim's Python Package with Anaconda's Python on a Mac.
 - Expose PropertyHelper class to python bindings to allow editing of objects using the properties interface (useful for editing objects defined in plugins) in python (consistent with Java/Matlab).
 - Whitespace is trimmed when reading table metadata for STO, MOT, and CSV files.
+- Minor performance improvements (5-10 %) for controller-heavy models (PR #2806)
+- `Controller::isEnabled` will now only return whether the particular controller is enabled
+  - Previously, it would return `false` if its parent `Model`'s `Model::getAllControllersEnabled` returned `false`
+  - The previous behavior would mean that `Controller::setEnabled(true); return Controller::isEnabled();` could return `false`
 
 
 v4.1

--- a/OpenSim/Simulation/Control/Controller.cpp
+++ b/OpenSim/Simulation/Control/Controller.cpp
@@ -105,11 +105,7 @@ void Controller::updateFromXMLNode(SimTK::Xml::Element& node,
  */
 bool Controller::isEnabled() const
 {
-    if( getModel().getAllControllersEnabled() ) {
-       return( get_enabled() );
-    } else {
-       return( false );
-    }
+    return get_enabled();
 }
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1925,12 +1925,11 @@ const Vector& Model::getControls(const SimTK::State &s) const
 /** Compute the controls the model */
 void Model::computeControls(const SimTK::State& s, SimTK::Vector &controls) const
 {
-    if (not this->getAllControllersEnabled()) {
+    if (!this->getAllControllersEnabled()) {
         return;
     }
 
-    for (const auto& controllerRefWrapper : this->_enabledControllers) {
-        const Controller& controller = controllerRefWrapper.get();
+    for (const Controller& controller : this->_enabledControllers) {
         controller.computeControls(s, controls);
     }
 }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1141,6 +1141,18 @@ private:
     // initializeState() or initSystem() is called.
     SimTK::State _workingState;
 
+    // A cached list of `Controller`s that were enabled in the model
+    // when `Model::extendConnectToModel(Model&)` was called.
+    //
+    // This only exists to improve performance. At runtime,
+    // `Model::computeControls(...)` may be called many times. Without
+    // this cache, the implementation must repeatably call
+    // `getComponentList<Controller>`, which is expensive because it
+    // uses runtime `dynamic_cast`s to iterate over, and downcast, a
+    // sequence of `Component`s. For controller-heavy models,
+    // pre-caching controllers into this vector can improve perf by
+    // >5%.
+    std::vector<std::reference_wrapper<const Controller>> _enabledControllers{};
 
     //--------------------------------------------------------------------------
     //                              RUN TIME 


### PR DESCRIPTION
This PR is to try and optimize certain (mostly, controller-heavy) simulations, such as the FD sim for `ToyDropLanding`. In those simulations, profilers (`valgrind`/`perf`) reported that ~8 % of CPU time was spent calling `getComponentList`.

The reason that `getComponentList` can have this kind of overhead is because its implementation involves `dynamic_cast`ing (downcasting) every element in a container to determine whether the element is a `Controller` or not (the container's elements are `Component`s). The `computeControls` method can be called many times in a simulation, so this iterate-and-downcast can happen *a lot*.

The proposed fix for this is to cache a `std::vector<Controller const&>` of enabled `Controller`s in the `Model` (`Model::_enabledControllers`) just after the model's connection graph is fully established. At this point in `Model`'s lifecycle, `Controller`s and other subcomponents shouldn't change, so the cache should remain valid during the remainder of the simulation. The cache is used by `computeControls` at runtime.

Overall, this caching change makes *some* simulations 5-10 % faster. Usually the simulations containing a bunch of muscles. Not a huge performance improvement--something I'm desperately searching for in OpenSim ;)--but not a terrible performance improvement for a relatively small change (albeit, a change that increases the complexity of `Model`). 

Overall stats from my current measurement technique, which effectively just runs some FD/IK simulations (the suite is work in progress, and should probably be ran on different hardware, etc. temporary repo [here](https://github.com/adamkewley/throwaway-osim-perf)).

```
source activate && ./comparison
```

repeats = 64
|                  Test Name | master [secs] | σ [secs] | branch [secs] | σ [secs] | Speedup |
| -------------------------- | ------------- | -------- | ------------- | -------- | ------- |
|                   Gait2354 |          0.27 |     0.00 |          0.27 |     0.00 |    0.99 |
|             ToyDropLanding |         15.41 |     0.05 |         14.43 |     0.06 |    1.07 |
|   ToyDropLanding_nomuscles |          0.45 |     0.00 |          0.45 |     0.00 |    1.00 |
|            passive_dynamic |          5.10 |     0.02 |          5.07 |     0.01 |    1.01 |
| passive_dynamic_noanalysis |          3.20 |     0.01 |          3.22 |     0.01 |    1.00 |
|                      Arm26 |          0.31 |     0.00 |          0.29 |     0.00 |    1.07 |
|             RajagopalModel |         15.88 |     0.06 |         15.10 |     0.06 |    1.05 |

---

Commit note:

- Caches all enabled OpenSim::Controllers in a model after
  the model graph is finalized (pre-computation)

- At compute time, used by Model::computeControllers as a
  faster substitute to using getComponentList<T>

- This is purely a performance modification. Benchmarks
  (e.g. on ToyDropLanding, from the OpenSim Tutorials)
  indicate a 5-10 % speedup with this change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2806)
<!-- Reviewable:end -->
