### PR TITLE
[Moco] Introduce OPENSIM_WITH_CASADI CMake variable

### DIFF
--- a/Bindings/Java/Matlab/examples/Moco/exampleSlidingMass.m
+++ b/Bindings/Java/Matlab/examples/Moco/exampleSlidingMass.m
@@ -75,7 +75,7 @@ problem.addGoal(MocoFinalTimeGoal('final_time'));
 
 % Configure the solver.
 % =====================
-solver = study.initTropterSolver();
+solver = study.initCasADiSolver();
 solver.set_num_mesh_intervals(50);
 
 % Now that we've finished setting up the tool, print it to a file.

--- a/Bindings/Java/Matlab/tests/CMakeLists.txt
+++ b/Bindings/Java/Matlab/tests/CMakeLists.txt
@@ -98,7 +98,9 @@ endif()
 OpenSimAddMatlabTest(testOsimList2MatlabCell testOsimList2MatlabCell.m)
 OpenSimAddMatlabTest(testWalkerScripts testWalkerScripts.m)
 
-OpenSimAddMatlabTest(SlidingMass ../Examples/Moco/exampleSlidingMass.m)
+if(OPENSIM_WITH_CASADI)
+    OpenSimAddMatlabTest(SlidingMass ../Examples/Moco/exampleSlidingMass.m)
+endif()
 OpenSimAddMatlabTest(MocoSWIGAdditionalInterface
     testMocoSWIGAdditionalInterface.m)
 OpenSimAddMatlabTest(MocoWorkflow testMocoWorkflow.m)

--- a/Bindings/Java/Matlab/tests/testMocoWorkflow.m
+++ b/Bindings/Java/Matlab/tests/testMocoWorkflow.m
@@ -103,21 +103,23 @@ function testChangingTimeBounds(testCase)
     problem.setControlInfo('/actuator', [-10, 10]);
     problem.addGoal(MocoFinalTimeGoal());
 
-    solver = study.initTropterSolver();
-    solver.set_transcription_scheme('trapezoidal')
-    solver.set_num_mesh_intervals(19);
-    guess = solver.createGuess('random');
-    guess.setTime(opensimMoco.createVectorLinspace(20, 0.0, 3.0));
-    solver.setGuess(guess);
-    solution0 = study.solve();
+    if MocoTropterSolver.isAvailable()
+        solver = study.initTropterSolver();
+        solver.set_transcription_scheme('trapezoidal')
+        solver.set_num_mesh_intervals(19);
+        guess = solver.createGuess('random');
+        guess.setTime(opensimMoco.createVectorLinspace(20, 0.0, 3.0));
+        solver.setGuess(guess);
+        solution0 = study.solve();
 
-    problem.setTimeBounds(0, [5.8, 10]);
-    % Editing the problem does not affect information in the Solver; the
-    % guess still exists.
-    assert(~solver.getGuess().empty());
+        problem.setTimeBounds(0, [5.8, 10]);
+        % Editing the problem does not affect information in the Solver; the
+        % guess still exists.
+        assert(~solver.getGuess().empty());
 
-    solution = study.solve();
-    testCase.assertEqual(solution.getFinalTime(), 5.8);
+        solution = study.solve();
+        testCase.assertEqual(solution.getFinalTime(), 5.8);
+    end
 
 end
 
@@ -131,16 +133,18 @@ function testChangingModel(testCase)
     problem.setStateInfo('/slider/position/value', [0, 1], 0, 1);
     problem.setStateInfo('/slider/position/speed', [-100, 100], 0, 0);
     problem.addGoal(MocoFinalTimeGoal());
-    solver = study.initTropterSolver();
-    solver.set_num_mesh_intervals(20);
-    finalTime0 = study.solve().getFinalTime();
+    if MocoTropterSolver.isAvailable()
+        solver = study.initTropterSolver();
+        solver.set_num_mesh_intervals(20);
+        finalTime0 = study.solve().getFinalTime();
 
-    testCase.assertEqual(finalTime0, 2.00, 'AbsTol', 0.01);
+        testCase.assertEqual(finalTime0, 2.00, 'AbsTol', 0.01);
 
-    body = Body.safeDownCast(model.updComponent('body'));
-    body.setMass(2 * body.getMass());
-    finalTime1 = study.solve().getFinalTime();
-    assert(finalTime1 > 1.1 * finalTime0);
+        body = Body.safeDownCast(model.updComponent('body'));
+        body.setMass(2 * body.getMass());
+        finalTime1 = study.solve().getFinalTime();
+        assert(finalTime1 > 1.1 * finalTime0);
+    end
 end
 
 function testOrder(testCase)
@@ -153,11 +157,13 @@ function testOrder(testCase)
     problem.setStateInfo('/slider/position/speed', [-100, 100], 0, 0);
     problem.addGoal(MocoFinalTimeGoal());
     problem.setModel(createSlidingMassModel());
-    solver = study.initTropterSolver();
-    solver.set_num_mesh_intervals(20);
-    finalTime =  study.solve().getFinalTime();
+    if MocoTropterSolver.isAvailable()
+        solver = study.initTropterSolver();
+        solver.set_num_mesh_intervals(20);
+        finalTime =  study.solve().getFinalTime();
 
-    testCase.assertEqual(finalTime, 2.0, 'AbsTol', 0.01);
+        testCase.assertEqual(finalTime, 2.0, 'AbsTol', 0.01);
+    end
 end
 
 function testChangingGoals(testCase)
@@ -172,9 +178,11 @@ function testChangingGoals(testCase)
     problem.updPhase().addGoal(MocoFinalTimeGoal());
     effort = MocoControlGoal('effort');
     problem.updPhase().addGoal(effort);
-    finalTime0 = study.solve().getFinalTime();
+    if MocoCasADiSolver.isAvailable()
+        finalTime0 = study.solve().getFinalTime();
 
-    % Change the weights of the costs.
-    effort.setWeight(0.1);
-    assert(study.solve().getFinalTime() < 0.8 * finalTime0);
+        % Change the weights of the costs.
+        effort.setWeight(0.1);
+        assert(study.solve().getFinalTime() < 0.8 * finalTime0);
+    end
 end

--- a/Bindings/Java/tests/TestSlidingMass.java
+++ b/Bindings/Java/tests/TestSlidingMass.java
@@ -78,17 +78,19 @@ class TestSlidingMass {
 
     // Configure the solver.
     // =====================
-    MocoTropterSolver ms = study.initTropterSolver();
-    ms.set_num_mesh_intervals(100);
+    if (MocoCasADiSolver.isAvailable()) {
+      MocoCasADiSolver ms = study.initCasADiSolver();
+      ms.set_num_mesh_intervals(100);
 
-    // Now that we've finished setting up the tool, print it to a file.
-    study.print("sliding_mass.omoco");
+      // Now that we've finished setting up the tool, print it to a file.
+      study.print("sliding_mass.omoco");
 
-    // Solve the problem.
-    // ==================
-    MocoSolution solution = study.solve();
+      // Solve the problem.
+      // ==================
+      MocoSolution solution = study.solve();
 
-    solution.write("sliding_mass_solution.sto");
+      solution.write("sliding_mass_solution.sto");
+    }
   }
   public static void main(String[] args) {
     try {

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -315,13 +315,13 @@ set(PYTHON_EXAMPLES_UNITTEST_ARGS
 if(OPENSIM_WITH_CASADI)
     list(APPEND PYTHON_EXAMPLES_UNITTEST_ARGS
             Moco.exampleKinematicConstraints
-            Moco.examplePredictAndTrack
             Moco.exampleSlidingMass
             )
 endif()
 if(OPENSIM_WITH_TROPTER)
     list(APPEND PYTHON_EXAMPLES_UNITTEST_ARGS
             Moco.exampleOptimizeMass
+            Moco.examplePredictAndTrack
             )
 endif()
 # Similar as above, but for the example files. These files aren't named as

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -311,11 +311,19 @@ set(PYTHON_EXAMPLES_UNITTEST_ARGS
         extend_OpenSim_Vec3_class
         posthoc_StatesTrajectory_example
         wiring_inputs_and_outputs_with_TableReporter
-        Moco.exampleKinematicConstraints
-        Moco.exampleOptimizeMass
-        Moco.examplePredictAndTrack
-        Moco.exampleSlidingMass
         )
+if(OPENSIM_WITH_CASADI)
+    list(APPEND PYTHON_EXAMPLES_UNITTEST_ARGS
+            Moco.exampleKinematicConstraints
+            Moco.examplePredictAndTrack
+            Moco.exampleSlidingMass
+            )
+endif()
+if(OPENSIM_WITH_TROPTER)
+    list(APPEND PYTHON_EXAMPLES_UNITTEST_ARGS
+            Moco.exampleOptimizeMass
+            )
+endif()
 # Similar as above, but for the example files. These files aren't named as
 # test_*.py, so we must specify a more general search pattern.
 add_test(NAME python_examples

--- a/Bindings/Python/examples/Moco/examplePredictAndTrack.py
+++ b/Bindings/Python/examples/Moco/examplePredictAndTrack.py
@@ -138,7 +138,7 @@ def solvePrediction():
 
 
     # Configure the solver.
-    solver = study.initCasADiSolver()
+    solver = study.initTropterSolver()
     solver.set_num_mesh_intervals(100)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")
@@ -159,11 +159,11 @@ def solvePrediction():
     study.printToXML("examplePredictAndTrack_predict.omoco")
 
     # Solve the problem.
-    solution = study.solve();
-    solution.write("examplePredictAndTrack_predict_solution.sto");
+    solution = study.solve()
+    solution.write("examplePredictAndTrack_predict_solution.sto")
 
     if visualize:
-        study.visualize(solution);
+        study.visualize(solution)
     return solution
     
 
@@ -232,7 +232,7 @@ def solveStateTracking(stateRef):
     # TODO problem.addGoal(effort)
 
     # Configure the solver.
-    solver = study.initCasADiSolver()
+    solver = study.initTropterSolver()
     solver.set_num_mesh_intervals(50)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")
@@ -287,7 +287,7 @@ def solveMarkerTracking(markersRef, guess):
     # problem.addGoal(effort)
 
     # Configure the solver.
-    solver = study.initCasADiSolver()
+    solver = study.initTropterSolver()
     solver.set_num_mesh_intervals(50)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")

--- a/Bindings/Python/examples/Moco/examplePredictAndTrack.py
+++ b/Bindings/Python/examples/Moco/examplePredictAndTrack.py
@@ -138,7 +138,7 @@ def solvePrediction():
 
 
     # Configure the solver.
-    solver = study.initTropterSolver()
+    solver = study.initCasADiSolver()
     solver.set_num_mesh_intervals(100)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")
@@ -232,7 +232,7 @@ def solveStateTracking(stateRef):
     # TODO problem.addGoal(effort)
 
     # Configure the solver.
-    solver = study.initTropterSolver()
+    solver = study.initCasADiSolver()
     solver.set_num_mesh_intervals(50)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")
@@ -287,7 +287,7 @@ def solveMarkerTracking(markersRef, guess):
     # problem.addGoal(effort)
 
     # Configure the solver.
-    solver = study.initTropterSolver()
+    solver = study.initCasADiSolver()
     solver.set_num_mesh_intervals(50)
     solver.set_verbosity(2)
     solver.set_optim_solver("ipopt")

--- a/Bindings/Python/examples/Moco/exampleSlidingMass.py
+++ b/Bindings/Python/examples/Moco/exampleSlidingMass.py
@@ -74,7 +74,7 @@ problem.addGoal(osim.MocoFinalTimeGoal())
 
 # Configure the solver.
 # =====================
-solver = study.initTropterSolver()
+solver = study.initCasADiSolver()
 solver.set_num_mesh_intervals(100)
 
 # Now that we've finished setting up the study, print it to a file.

--- a/Bindings/Python/swig/python_moco.i
+++ b/Bindings/Python/swig/python_moco.i
@@ -420,12 +420,6 @@ using namespace SimTK;
     ptr._markAdopted()
 %}
 
-%pythonprepend OpenSim::MocoStudy::solve %{
-    if MocoCasADiSolver.safeDownCast(self.updSolver()):
-        solver = MocoCasADiSolver.safeDownCast(self.updSolver())
-        solver.setRunningInPython(True)
-%}
-
 
 // Include all the OpenSim code.
 // =============================

--- a/Bindings/Python/tests/test_moco.py
+++ b/Bindings/Python/tests/test_moco.py
@@ -27,13 +27,13 @@ def createSlidingMassModel():
 
     actu = osim.CoordinateActuator()
     actu.setCoordinate(coord)
-    actu.setName("actuator");
-    actu.setOptimalForce(1);
-    actu.setMinControl(-10);
-    actu.setMaxControl(10);
-    model.addComponent(actu);
+    actu.setName("actuator")
+    actu.setOptimalForce(1)
+    actu.setMinControl(-10)
+    actu.setMaxControl(10)
+    model.addComponent(actu)
 
-    return model;
+    return model
 
 class TestSwigAddtlInterface(unittest.TestCase):
     def test_bounds(self):
@@ -296,21 +296,22 @@ class TestWorkflow(unittest.TestCase):
         problem.setControlInfo("/actuator", [-10, 10])
         problem.addGoal(osim.MocoFinalTimeGoal())
 
-        solver = study.initTropterSolver()
-        solver.set_transcription_scheme("trapezoidal");
-        solver.set_num_mesh_intervals(19)
-        guess = solver.createGuess("random")
-        guess.setTime(osim.createVectorLinspace(20, 0.0, 3.0))
-        solver.setGuess(guess)
-        solution0 = study.solve()
+        if osim.MocoTropterSolver.isAvailable():
+            solver = study.initTropterSolver()
+            solver.set_transcription_scheme("trapezoidal");
+            solver.set_num_mesh_intervals(19)
+            guess = solver.createGuess("random")
+            guess.setTime(osim.createVectorLinspace(20, 0.0, 3.0))
+            solver.setGuess(guess)
+            solution0 = study.solve()
 
-        problem.setTimeBounds(0, [5.8, 10])
-        # Editing the problem does not affect information in the Solver; the
-        # guess still exists.
-        assert(not solver.getGuess().empty())
+            problem.setTimeBounds(0, [5.8, 10])
+            # Editing the problem does not affect information in the Solver; the
+            # guess still exists.
+            assert(not solver.getGuess().empty())
 
-        solution = study.solve()
-        self.assertAlmostEqual(solution.getFinalTime(), 5.8)
+            solution = study.solve()
+            self.assertAlmostEqual(solution.getFinalTime(), 5.8)
 
     def test_changing_model(self):
         study = osim.MocoStudy()
@@ -321,17 +322,18 @@ class TestWorkflow(unittest.TestCase):
         problem.setStateInfo("/slider/position/value", [0, 1], 0, 1)
         problem.setStateInfo("/slider/position/speed", [-100, 100], 0, 0)
         problem.addGoal(osim.MocoFinalTimeGoal())
-        solver = study.initTropterSolver()
-        solver.set_num_mesh_intervals(19)
-        solver.set_transcription_scheme("trapezoidal");
-        finalTime0 = study.solve().getFinalTime()
+        if osim.MocoTropterSolver.isAvailable():
+            solver = study.initTropterSolver()
+            solver.set_num_mesh_intervals(19)
+            solver.set_transcription_scheme("trapezoidal");
+            finalTime0 = study.solve().getFinalTime()
 
-        self.assertAlmostEqual(finalTime0, 2.00, places=2)
+            self.assertAlmostEqual(finalTime0, 2.00, places=2)
 
-        body = model.updComponent("body")
-        body.setMass(2 * body.getMass())
-        finalTime1 = study.solve().getFinalTime()
-        assert(finalTime1 > 1.1 * finalTime0)
+            body = model.updComponent("body")
+            body.setMass(2 * body.getMass())
+            finalTime1 = study.solve().getFinalTime()
+            assert(finalTime1 > 1.1 * finalTime0)
 
     def test_order(self):
         # Can set the cost and model in any order.
@@ -342,11 +344,12 @@ class TestWorkflow(unittest.TestCase):
         problem.setStateInfo("/slider/position/speed", [-100, 100], 0, 0)
         problem.addGoal(osim.MocoFinalTimeGoal())
         problem.setModel(createSlidingMassModel())
-        solver = study.initTropterSolver()
-        solver.set_num_mesh_intervals(19)
-        solver.set_transcription_scheme("trapezoidal");
-        finalTime =  study.solve().getFinalTime()
-        self.assertAlmostEqual(finalTime, 2.0, places=2)
+        if osim.MocoTropterSolver.isAvailable():
+            solver = study.initTropterSolver()
+            solver.set_num_mesh_intervals(19)
+            solver.set_transcription_scheme("trapezoidal")
+            finalTime =  study.solve().getFinalTime()
+            self.assertAlmostEqual(finalTime, 2.0, places=2)
 
     def test_changing_costs(self):
         # Changes to the costs are obeyed.
@@ -359,10 +362,11 @@ class TestWorkflow(unittest.TestCase):
         problem.updPhase().addGoal(osim.MocoFinalTimeGoal())
         effort = osim.MocoControlGoal("effort")
         problem.updPhase().addGoal(effort)
-        solver = study.initTropterSolver()
-        solver.set_transcription_scheme("trapezoidal");
-        finalTime0 = study.solve().getFinalTime()
+        if osim.MocoTropterSolver.isAvailable():
+            solver = study.initTropterSolver()
+            solver.set_transcription_scheme("trapezoidal");
+            finalTime0 = study.solve().getFinalTime()
 
-        # Change the weights of the costs.
-        effort.setWeight(0.1)
-        assert(study.solve().getFinalTime() < 0.8 * finalTime0)
+            # Change the weights of the costs.
+            effort.setWeight(0.1)
+            assert(study.solve().getFinalTime() < 0.8 * finalTime0)

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,10 @@ Moco Change Log
 
 0.5.0 (in development)
 ----------------------
+- 2020-06-22: Moco can be built without CasADi, and the functions
+              MocoCasADiSolver::isAvailable() and 
+              MocoTropterSolver::isAvailable() are added.
+
 - 2020-06-08: Moco uses OpenSim's new message logging system.
 
 - 2020-06-01: Introduce MocoGoal::getStageDependency() to improve efficiency of 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,16 +169,10 @@ mark_as_advanced(OPENSIM_BUILD_INDIVIDUAL_APPS)
 
 # Moco settings.
 # --------------
-option(MOCO_BUILD_EXAMPLES
-    "Build, test, and install Moco C++ examples." ON)
-
-# TODO Rename to OPENSIM_WITH_TROPTER.
-option(MOCO_WITH_TROPTER
-    "Build the tropter optimal control library." ON)
-if(NOT MOCO_WITH_TROPTER)
-    # TODO
-    message(WARNING "MOCO_WITH_TROPTER=OFF is not supported yet.")
-endif()
+option(OPENSIM_WITH_CASADI
+        "Build CasADi support for Moco (MocoCasADiSolver)." ON)
+option(OPENSIM_WITH_TROPTER
+        "Build the tropter optimal control library, for use in MocoTropterSolver." ON)
 
 
 # Configure installation directories across platforms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,12 +84,16 @@ Running Moco tests
 In general, Moco's tests depend on the CasADi and Tropter libraries, whose use
 is determined by the `OPENSIM_WITH_CASADI` and `OPENSIM_WITH_TROPTER` CMake
 variables. The CTests are designed to succeed regardless of the value of these
-CMake variables, through the use of Catch2 tags `[casadi]` and `[tropter]`. For
-example, Moco CTests are run with the argument `~[casadi]` if
-`OPENSIM_WITH_CASADI` is OFF. If the test executables are run without CTest,
-the tests will fail if either `OPENSIM_WITH_CASADI` or `OPENSIM_WITH_TROPTER`
-is false; for the tests to pass, provide the argument(s) `~[casadi]` and/or
-`~[tropter]` (depending on which libraries are available).
+CMake variables: if `OPENSIM_WITH_CASADI` is off, Moco's C++ tests are run with
+arguments `"exclude:*MocoCasADiSolver*" "exclude:[casadi]"`,
+which excludes Catch2 templatized tests using MocoCasADiSolver and other tests
+that are tagged as relying on CasADi (likewise for Tropter).
+If the test executables are run without CTest (e.g., debugging a project in
+Visual Studio), the tests will fail if either `OPENSIM_WITH_CASADI` or
+`OPENSIM_WITH_TROPTER` is false; for the tests to pass, provide the argument(s)
+`"exclude:*MocoCasADiSolver*" "exclude:[casadi]"` and/or
+`"exclude:*MocoTropterSolver*" "exclude:[tropter]"` (depending on which
+libraries are available).
 
 
 Checking for Memory Leaks through GitHub

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Contents:
 - [Ways to Contribute](#ways-to-contribute)
 - [Making a Pull Request](#making-a-pull-request-pr)
 - [Writing tests](#writing-tests)
+- [Running Moco tests](#running-moco-tests)
 - [Checking for Memory Leaks through GitHub](#checking-for-memory-leaks-through-github)
 - [Coding Standards](#coding-standards)
 - [List of Contributors](#list-of-contributors)
@@ -76,6 +77,20 @@ go into the `OpenSim/Tests/shared` directory. You can then use the
 copy the necessary shared files to the proper build directory. *DO NOT CHANGE* files
 that are already in `OpenSim/Tests/shared`; you could inadvertently weaken tests
 that rely on some obscure aspect of the files.
+
+
+Running Moco tests
+------------------
+In general, Moco's tests depend on the CasADi and Tropter libraries, whose use
+is determined by the `OPENSIM_WITH_CASADI` and `OPENSIM_WITH_TROPTER` CMake
+variables. The CTests are designed to succeed regardless of the value of these
+CMake variables, through the use of Catch2 tags `[casadi]` and `[tropter]`. For
+example, Moco CTests are run with the argument `~[casadi]` if
+`OPENSIM_WITH_CASADI` is OFF. If the test executables are run without CTest,
+the tests will fail if either `OPENSIM_WITH_CASADI` or `OPENSIM_WITH_TROPTER`
+is false; for the tests to pass, provide the argument(s) `~[casadi]` and/or
+`~[tropter]` (depending on which libraries are available).
+
 
 Checking for Memory Leaks through GitHub
 ----------------------------------------

--- a/OpenSim/Moco/CMakeLists.txt
+++ b/OpenSim/Moco/CMakeLists.txt
@@ -92,21 +92,6 @@ set(MOCO_SOURCES
         Components/MultivariatePolynomialFunction.h
         MocoCasADiSolver/MocoCasADiSolver.h
         MocoCasADiSolver/MocoCasADiSolver.cpp
-        MocoCasADiSolver/MocoCasOCProblem.h
-        MocoCasADiSolver/MocoCasOCProblem.cpp
-        MocoCasADiSolver/CasOCProblem.h
-        MocoCasADiSolver/CasOCProblem.cpp
-        MocoCasADiSolver/CasOCSolver.h
-        MocoCasADiSolver/CasOCSolver.cpp
-        MocoCasADiSolver/CasOCFunction.h
-        MocoCasADiSolver/CasOCFunction.cpp
-        MocoCasADiSolver/CasOCTranscription.h
-        MocoCasADiSolver/CasOCTranscription.cpp
-        MocoCasADiSolver/CasOCTrapezoidal.h
-        MocoCasADiSolver/CasOCTrapezoidal.cpp
-        MocoCasADiSolver/CasOCHermiteSimpson.h
-        MocoCasADiSolver/CasOCHermiteSimpson.cpp
-        MocoCasADiSolver/CasOCIterate.h
         MocoInverse.cpp
         MocoInverse.h
         MocoTrack.h
@@ -121,16 +106,37 @@ set(MOCO_SOURCES
         MocoStudyFactory.h
         MocoStudyFactory.cpp
         )
-if (MOCO_WITH_TROPTER)
+if(OPENSIM_WITH_CASADI)
+    list(APPEND MOCO_SOURCES
+            MocoCasADiSolver/CasOCProblem.h
+            MocoCasADiSolver/CasOCProblem.cpp
+            MocoCasADiSolver/CasOCSolver.h
+            MocoCasADiSolver/CasOCSolver.cpp
+            MocoCasADiSolver/CasOCFunction.h
+            MocoCasADiSolver/CasOCFunction.cpp
+            MocoCasADiSolver/CasOCTranscription.h
+            MocoCasADiSolver/CasOCTranscription.cpp
+            MocoCasADiSolver/CasOCTrapezoidal.h
+            MocoCasADiSolver/CasOCTrapezoidal.cpp
+            MocoCasADiSolver/CasOCHermiteSimpson.h
+            MocoCasADiSolver/CasOCHermiteSimpson.cpp
+            MocoCasADiSolver/CasOCIterate.h
+            MocoCasADiSolver/MocoCasOCProblem.h
+            MocoCasADiSolver/MocoCasOCProblem.cpp
+            )
+endif()
+if(OPENSIM_WITH_TROPTER)
     list(APPEND MOCO_SOURCES
             tropter/TropterProblem.h
             tropter/TropterProblem.cpp
             )
 endif ()
 add_library(osimMoco SHARED ${MOCO_SOURCES})
-target_link_libraries(osimMoco PUBLIC osimTools
-        PRIVATE casadi)
-if (MOCO_WITH_TROPTER)
+target_link_libraries(osimMoco PUBLIC osimTools)
+if (OPENSIM_WITH_CASADI)
+    target_link_libraries(osimMoco PRIVATE casadi)
+endif()
+if (OPENSIM_WITH_TROPTER)
     target_link_libraries(osimMoco PRIVATE tropter)
 endif ()
 
@@ -141,10 +147,13 @@ target_include_directories(osimMoco INTERFACE
 set_target_properties(osimMoco PROPERTIES
         DEFINE_SYMBOL OSIMMOCO_EXPORTS
         PROJECT_LABEL "Library - osimMoco"
-        FOLDER "Moco"
+        FOLDER "Libraries"
         )
-if (MOCO_WITH_TROPTER)
-    target_compile_definitions(osimMoco PUBLIC MOCO_WITH_TROPTER)
+if (OPENSIM_WITH_CASADI)
+    target_compile_definitions(osimMoco PUBLIC OPENSIM_WITH_CASADI)
+endif ()
+if (OPENSIM_WITH_TROPTER)
+    target_compile_definitions(osimMoco PUBLIC OPENSIM_WITH_TROPTER)
 endif ()
 # TODO: Remove the concept of a separate Moco version.
 target_compile_definitions(osimMoco PRIVATE

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -51,6 +51,14 @@ void MocoCasADiSolver::constructProperties() {
     constructProperty_implicit_auxiliary_derivatives_weight(1.0);
 }
 
+bool MocoCasADiSolver::isAvailable() {
+#ifdef OPENSIM_WITH_CASADI
+    return true;
+#else
+    return false;
+#endif
+}
+
 MocoTrajectory MocoCasADiSolver::createGuess(const std::string& type) const {
 #ifdef OPENSIM_WITH_CASADI
     OPENSIM_THROW_IF_FRMOBJ(

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
@@ -28,6 +28,15 @@ namespace OpenSim {
 
 class MocoCasOCProblem;
 
+class MocoCasADiSolverNotAvailable : public Exception {
+public:
+    MocoCasADiSolverNotAvailable(
+            const std::string& file, int line, const std::string& func)
+            : Exception(file, line, func) {
+        addMessage("MocoCasADiSolver is not available.");
+    }
+};
+
 /// This solver uses the CasADi library (https://casadi.org) to convert the
 /// MocoProblem into a generic nonlinear programming problem. CasADi efficiently
 /// calculcates the derivatives required to solve MocoProblem%s, and may
@@ -203,11 +212,6 @@ public:
 
     /// @}
 
-    /// @cond
-    /// This is used to generate a warning.
-    void setRunningInPython(bool value) const { m_runningInPython = value; }
-    /// @endcond
-
 protected:
     MocoSolution solveImpl() const override;
 
@@ -227,8 +231,6 @@ private:
     MocoTrajectory m_guessFromAPI;
     mutable SimTK::ResetOnCopy<MocoTrajectory> m_guessFromFile;
     mutable SimTK::ReferencePtr<const MocoTrajectory> m_guessToUse;
-
-    mutable bool m_runningInPython = false;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
@@ -169,6 +169,10 @@ public:
 
     MocoCasADiSolver();
 
+    /// Returns true if Moco was compiled with the CasADi library; returns false
+    /// otherwise.
+    static bool isAvailable();
+
     /// @name Specifying an initial guess
     /// @{
 

--- a/OpenSim/Moco/MocoTropterSolver.cpp
+++ b/OpenSim/Moco/MocoTropterSolver.cpp
@@ -34,6 +34,14 @@ void MocoTropterSolver::constructProperties() {
     constructProperty_exact_hessian_block_sparsity_mode();
 }
 
+bool MocoTropterSolver::isAvailable() {
+#ifdef OPENSIM_WITH_TROPTER
+    return true;
+#else
+    return false;
+#endif
+}
+
 std::shared_ptr<const MocoTropterSolver::TropterProblemBase<double>>
 MocoTropterSolver::createTropterProblem() const {
 #ifdef OPENSIM_WITH_TROPTER

--- a/OpenSim/Moco/MocoTropterSolver.cpp
+++ b/OpenSim/Moco/MocoTropterSolver.cpp
@@ -20,8 +20,8 @@
 #include "MocoProblemRep.h"
 #include "MocoUtilities.h"
 
-#ifdef MOCO_WITH_TROPTER
-#    include "tropter/TropterProblem.h"
+#ifdef OPENSIM_WITH_TROPTER
+    #include "tropter/TropterProblem.h"
 #endif
 
 using namespace OpenSim;
@@ -36,7 +36,7 @@ void MocoTropterSolver::constructProperties() {
 
 std::shared_ptr<const MocoTropterSolver::TropterProblemBase<double>>
 MocoTropterSolver::createTropterProblem() const {
-#ifdef MOCO_WITH_TROPTER
+#ifdef OPENSIM_WITH_TROPTER
     checkPropertyInSet(
             *this, getProperty_multibody_dynamics_mode(),
             {"explicit", "implicit"});
@@ -55,7 +55,7 @@ std::unique_ptr<tropter::DirectCollocationSolver<double>>
 MocoTropterSolver::createTropterSolver(
         std::shared_ptr<const MocoTropterSolver::TropterProblemBase<double>>
                 ocp) const {
-#ifdef MOCO_WITH_TROPTER
+#ifdef OPENSIM_WITH_TROPTER
     // Check that a non-negative number of mesh points was provided.
     checkPropertyInRangeOrSet(*this, getProperty_num_mesh_intervals(), 0,
             std::numeric_limits<int>::max(), {});
@@ -210,7 +210,7 @@ MocoTropterSolver::createTropterSolver(
 }
 
 MocoTrajectory MocoTropterSolver::createGuess(const std::string& type) const {
-#ifdef MOCO_WITH_TROPTER
+#ifdef OPENSIM_WITH_TROPTER
     OPENSIM_THROW_IF_FRMOBJ(
             type != "bounds" && type != "random" && type != "time-stepping",
             Exception,
@@ -293,7 +293,7 @@ const MocoTrajectory& MocoTropterSolver::getGuess() const {
 }
 
 void MocoTropterSolver::printOptimizationSolverOptions(std::string solver) {
-#ifdef MOCO_WITH_TROPTER
+#ifdef OPENSIM_WITH_TROPTER
     if (solver == "ipopt") {
         tropter::optimization::IPOPTSolver::print_available_options();
     } else {
@@ -305,7 +305,7 @@ void MocoTropterSolver::printOptimizationSolverOptions(std::string solver) {
 }
 
 MocoSolution MocoTropterSolver::solveImpl() const {
-#ifdef MOCO_WITH_TROPTER
+#ifdef OPENSIM_WITH_TROPTER
     const Stopwatch stopwatch;
 
     OPENSIM_THROW_IF_FRMOBJ(getProblemRep().isPrescribedKinematics(), Exception,

--- a/OpenSim/Moco/MocoTropterSolver.h
+++ b/OpenSim/Moco/MocoTropterSolver.h
@@ -91,6 +91,10 @@ public:
 
     MocoTropterSolver();
 
+    /// Returns true if Moco was compiled with the Tropter library; returns
+    /// false otherwise.
+    static bool isAvailable();
+
     /// @name Specifying an initial guess
     /// @{
 

--- a/OpenSim/Moco/Test/CMakeLists.txt
+++ b/OpenSim/Moco/Test/CMakeLists.txt
@@ -14,7 +14,14 @@ function(MocoAddTest)
     target_link_libraries(${MOCOTEST_NAME} osimMoco ${MOCOTEST_LIB_DEPENDS})
     target_include_directories(${MOCOTEST_NAME}
             PRIVATE "${CMAKE_SOURCE_DIR}/tropter/external/catch")
-    add_test(NAME ${MOCOTEST_NAME} COMMAND ${MOCOTEST_NAME})
+    # Skip tests relying on MocoCasADiSolver if CasADi is not available.
+    if(NOT OPENSIM_WITH_CASADI)
+        set(test_args "${test_args} ~[casadi]")
+    endif()
+    if(NOT OPENSIM_WITH_TROPTER)
+        set(test_args "${test_args} ~[tropter]")
+    endif()
+    add_test(NAME ${MOCOTEST_NAME} COMMAND ${MOCOTEST_NAME} ${test_args})
     # Tests likely run faster if we parallelize the tests rather than the
     # individual problems.
     set_property(TEST ${MOCOTEST_NAME} APPEND PROPERTY

--- a/OpenSim/Moco/Test/CMakeLists.txt
+++ b/OpenSim/Moco/Test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CMakeParseArguments)
 
-# Create an exectuable for the file ${TEST_NAME}.cpp, which depends on
+# Create an executable for the file ${TEST_NAME}.cpp, which depends on
 # libraries ${LIB_DEPENDENCIES}. Also create a CTest test for this executable.
 function(MocoAddTest)
     set(options)
@@ -16,10 +16,12 @@ function(MocoAddTest)
             PRIVATE "${CMAKE_SOURCE_DIR}/tropter/external/catch")
     # Skip tests relying on MocoCasADiSolver if CasADi is not available.
     if(NOT OPENSIM_WITH_CASADI)
-        set(test_args "${test_args} ~[casadi]")
+        list(APPEND test_args "exclude:*MocoCasADiSolver*")
+        list(APPEND test_args "exclude:[casadi]")
     endif()
     if(NOT OPENSIM_WITH_TROPTER)
-        set(test_args "${test_args} ~[tropter]")
+        list(APPEND test_args "exclude:*MocoTropterSolver*")
+        list(APPEND test_args "exclude:[tropter]")
     endif()
     add_test(NAME ${MOCOTEST_NAME} COMMAND ${MOCOTEST_NAME} ${test_args})
     # Tests likely run faster if we parallelize the tests rather than the

--- a/OpenSim/Moco/Test/CMakeLists.txt
+++ b/OpenSim/Moco/Test/CMakeLists.txt
@@ -32,11 +32,11 @@ MocoAddTest(NAME testMocoGoals)
 
 MocoAddTest(NAME testMocoParameters)
 
-MocoAddTest(NAME testImplicit)
+MocoAddTest(NAME testMocoImplicit)
 
 MocoAddTest(NAME testMocoConstraints)
 
-MocoAddTest(NAME testContact)
+MocoAddTest(NAME testMocoContact)
 
 MocoAddTest(NAME testMocoActuators)
 

--- a/OpenSim/Moco/Test/Testing.h
+++ b/OpenSim/Moco/Test/Testing.h
@@ -25,28 +25,6 @@
 // TODO #include <OpenSim/Auxiliary/catch.hpp>
 #include <Vendors/tropter/external/catch/catch.hpp>
 
-#if defined(OPENSIM_WITH_CASADI) && defined(OPENSIM_WITH_TROPTER)
-    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoCasADiSolver, MocoTropterSolver)
-#elif defined(OPENSIM_WITH_CASADI)
-    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoCasADiSolver)
-#elif defined(OPENSIM_WITH_TROPTER)
-    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoTropterSolver)
-#else
-    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoTropterSolver)
-#endif
-
-
-/// TODO
-#if defined(OPENSIM_WITH_CASADI) && defined(OPENSIM_WITH_TROPTER)
-    #define OPENSIM_TEST_CASADI_TROPTER MocoCasADiSolver, MocoTropterSolver
-#elif defined(OPENSIM_WITH_CASADI)
-    #define OPENSIM_TEST_CASADI_TROPTER MocoCasADiSolver
-#elif defined(OPENSIM_WITH_TROPTER)
-    #define OPENSIM_TEST_CASADI_TROPTER MocoTropterSolver
-#else
-    #define OPENSIM_TEST_CASADI_TROPTER
-#endif
-
 
 // Helper functions for comparing vectors.
 // ---------------------------------------

--- a/OpenSim/Moco/Test/Testing.h
+++ b/OpenSim/Moco/Test/Testing.h
@@ -25,6 +25,28 @@
 // TODO #include <OpenSim/Auxiliary/catch.hpp>
 #include <Vendors/tropter/external/catch/catch.hpp>
 
+#if defined(OPENSIM_WITH_CASADI) && defined(OPENSIM_WITH_TROPTER)
+    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoCasADiSolver, MocoTropterSolver)
+#elif defined(OPENSIM_WITH_CASADI)
+    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoCasADiSolver)
+#elif defined(OPENSIM_WITH_TROPTER)
+    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoTropterSolver)
+#else
+    #define TEST_CASE_CASADI_TROPTER(Name, Tags) TEMPLATE_TEST_CASE(Name, Tags, MocoTropterSolver)
+#endif
+
+
+/// TODO
+#if defined(OPENSIM_WITH_CASADI) && defined(OPENSIM_WITH_TROPTER)
+    #define OPENSIM_TEST_CASADI_TROPTER MocoCasADiSolver, MocoTropterSolver
+#elif defined(OPENSIM_WITH_CASADI)
+    #define OPENSIM_TEST_CASADI_TROPTER MocoCasADiSolver
+#elif defined(OPENSIM_WITH_TROPTER)
+    #define OPENSIM_TEST_CASADI_TROPTER MocoTropterSolver
+#else
+    #define OPENSIM_TEST_CASADI_TROPTER
+#endif
+
 
 // Helper functions for comparing vectors.
 // ---------------------------------------

--- a/OpenSim/Moco/Test/testMocoActuators.cpp
+++ b/OpenSim/Moco/Test/testMocoActuators.cpp
@@ -1084,8 +1084,8 @@ Model createHangingMuscleModel(
     return model;
 }
 
-#ifdef OPENSIM_WITH_CASADI
-TEMPLATE_TEST_CASE("Hanging muscle minimum time", "", MocoCasADiSolver) {
+TEMPLATE_TEST_CASE(
+        "Hanging muscle minimum time", "[casadi]", MocoCasADiSolver) {
     auto ignoreActivationDynamics = GENERATE(true, false);
     auto ignoreTendonCompliance = GENERATE(true, false);
     auto isTendonDynamicsExplicit = GENERATE(false);
@@ -1262,7 +1262,6 @@ TEMPLATE_TEST_CASE("Hanging muscle minimum time", "", MocoCasADiSolver) {
         CHECK(error < 0.015);
     }
 }
-#endif
 
 TEST_CASE("ActivationCoordinateActuator") {
     // Create a problem with ACA and ensure the activation bounds are

--- a/OpenSim/Moco/Test/testMocoActuators.cpp
+++ b/OpenSim/Moco/Test/testMocoActuators.cpp
@@ -1084,6 +1084,7 @@ Model createHangingMuscleModel(
     return model;
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE("Hanging muscle minimum time", "", MocoCasADiSolver) {
     auto ignoreActivationDynamics = GENERATE(true, false);
     auto ignoreTendonCompliance = GENERATE(true, false);
@@ -1261,9 +1262,10 @@ TEMPLATE_TEST_CASE("Hanging muscle minimum time", "", MocoCasADiSolver) {
         CHECK(error < 0.015);
     }
 }
+#endif
 
 TEST_CASE("ActivationCoordinateActuator") {
-    // TODO create a problem with ACA and ensure the activation bounds are
+    // Create a problem with ACA and ensure the activation bounds are
     // set as expected.
     auto model = ModelFactory::createSlidingPointMass();
     auto* actu = new ActivationCoordinateActuator();

--- a/OpenSim/Moco/Test/testMocoAnalytic.cpp
+++ b/OpenSim/Moco/Test/testMocoAnalytic.cpp
@@ -54,8 +54,8 @@ SimTK::Matrix expectedSolution(const SimTK::Vector& time) {
     return expectedStatesTrajectory;
 }
 
-TEMPLATE_TEST_CASE("Second order linear min effort", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Second order linear min effort", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     // Kirk 1998, Example 5.1-1, page 198.
 
     Model model;
@@ -100,7 +100,8 @@ TEMPLATE_TEST_CASE("Second order linear min effort", "",
 /// Section 2.4 of Bryson and Ho [1].
 /// Bryson, A. E., Ho, Y.‐C., Applied Optimal Control, Optimization, Estimation,
 /// and Control. New York‐London‐Sydney‐Toronto. John Wiley & Sons. 1975.
-TEMPLATE_TEST_CASE("Linear tangent steering", "", /*MocoTropterSolver, TODO*/
+TEMPLATE_TEST_CASE("Linear tangent steering",
+        "[casadi]", /*MocoTropterSolver, TODO*/
         MocoCasADiSolver) {
     // The problem is parameterized by a, T, and h, with 0 < 4h/(aT^2) < 1.
     const double a = 5;

--- a/OpenSim/Moco/Test/testMocoAnalytic.cpp
+++ b/OpenSim/Moco/Test/testMocoAnalytic.cpp
@@ -54,7 +54,7 @@ SimTK::Matrix expectedSolution(const SimTK::Vector& time) {
     return expectedStatesTrajectory;
 }
 
-TEMPLATE_TEST_CASE("Second order linear min effort", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Second order linear min effort", "",
         MocoCasADiSolver, MocoTropterSolver) {
     // Kirk 1998, Example 5.1-1, page 198.
 

--- a/OpenSim/Moco/Test/testMocoAnalytic.cpp
+++ b/OpenSim/Moco/Test/testMocoAnalytic.cpp
@@ -54,8 +54,8 @@ SimTK::Matrix expectedSolution(const SimTK::Vector& time) {
     return expectedStatesTrajectory;
 }
 
-TEMPLATE_TEST_CASE("Second order linear min effort", "", MocoTropterSolver,
-        MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Second order linear min effort", "",
+        OPENSIM_TEST_CASADI_TROPTER) {
     // Kirk 1998, Example 5.1-1, page 198.
 
     Model model;

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -840,7 +840,7 @@ void testDoublePendulumPrescribedMotion(MocoSolution& couplerSolution,
 }
 
 TEMPLATE_TEST_CASE("DoublePendulum with and without constraint derivatives",
-        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     SECTION("DoublePendulum without constraint derivatives") {
         MocoSolution couplerSol;
         testDoublePendulumCoordinateCoupler<TestType>(
@@ -858,9 +858,8 @@ TEMPLATE_TEST_CASE("DoublePendulum with and without constraint derivatives",
     }
 }
 
-#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("DoublePendulum with and without constraint derivatives",
-        "[implicit]") {
+        "[implicit][casadi]") {
     SECTION("DoublePendulum without constraint derivatives") {
         MocoSolution couplerSol;
         testDoublePendulumCoordinateCoupler<MocoCasADiSolver>(
@@ -877,31 +876,26 @@ TEST_CASE("DoublePendulum with and without constraint derivatives",
                 couplerSol, true, "implicit");
     }
 }
-#endif
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine without constraint derivatives",
-        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumPointOnLine<TestType>(false, "explicit");
 }
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine with constraint derivatives",
-        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumPointOnLine<TestType>(true, "explicit");
 }
 
-#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("DoublePendulumPointOnLine without constraint derivatives",
-        "[implicit]") {
+        "[implicit][casadi]") {
     testDoublePendulumPointOnLine<MocoCasADiSolver>(false, "implicit");
 }
-#endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE(
-        "DoublePendulumPointOnLine with constraint derivatives", "[implicit]") {
+TEST_CASE("DoublePendulumPointOnLine with constraint derivatives",
+        "[implicit][casadi]") {
     testDoublePendulumPointOnLine<MocoCasADiSolver>(true, "implicit");
 }
-#endif
 
 class EqualControlConstraint : public MocoPathConstraint {
     OpenSim_DECLARE_CONCRETE_OBJECT(EqualControlConstraint, MocoPathConstraint);
@@ -933,8 +927,8 @@ protected:
 /// Solve an optimal control problem where a double pendulum must reach a
 /// specified final configuration while subject to a constraint that its
 /// actuators must produce an equal control trajectory.
-TEMPLATE_TEST_CASE(
-        "DoublePendulumEqualControl", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("DoublePendulumEqualControl", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     OpenSim::Object::registerType(EqualControlConstraint());
     MocoStudy study;
     study.setName("double_pendulum_equal_control");
@@ -999,10 +993,9 @@ TEMPLATE_TEST_CASE(
 // solving for the mass that allows the point mass to obey the constraint
 // of staying in place. This checks that the parameters are applied to both
 // ModelBase and ModelDisabledConstraints.
-#ifdef OPENSIM_WITH_TROPTER
 TEMPLATE_TEST_CASE(
-        "Parameters are set properly for Base and DisabledConstraints", "",
-        MocoTropterSolver /*, too damn slow: MocoCasADiSolver*/) {
+        "Parameters are set properly for Base and DisabledConstraints",
+        "[tropter]", MocoTropterSolver /*, too damn slow: MocoCasADiSolver*/) {
     Model model;
     auto* body = new Body("b", 0.7, SimTK::Vec3(0), SimTK::Inertia(1));
     model.addBody(body);
@@ -1025,7 +1018,6 @@ TEMPLATE_TEST_CASE(
     MocoSolution solution = study.solve();
     CHECK(solution.getParameter("mass") == Approx(1.0).epsilon(1e-3));
 }
-#endif
 
 class MocoJointReactionComponentGoal : public MocoGoal {
     OpenSim_DECLARE_CONCRETE_OBJECT(MocoJointReactionComponentGoal, MocoGoal);
@@ -1114,17 +1106,15 @@ void testDoublePendulumJointReactionGoal(std::string dynamics_mode) {
 
 TEMPLATE_TEST_CASE(
         "DoublePendulumPointJointReactionGoal with constraint derivatives",
-        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumJointReactionGoal<TestType>("explicit");
 }
 
-#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE("DoublePendulumJointReactionGoal implicit with "
                    "constraint derivatives",
-        "[implicit]", MocoCasADiSolver) {
+        "[implicit][casadi]", MocoCasADiSolver) {
     testDoublePendulumJointReactionGoal<TestType>("implicit");
 }
-#endif
 
 struct AccelerationsAndJointReaction {
     SimTK::Vector udot;
@@ -1165,8 +1155,7 @@ private:
 // separate multipliers. When using implicit dynamics, we provide separate
 // accelerations. This test ensures that these accelerations and multipliers are
 // those that Moco specified, not what Simbody computes.
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
+TEST_CASE("Goals use Moco-defined accelerations and multipliers", "[casadi]") {
     MocoStudy study;
     study.setName("mass_welded");
     MocoProblem& problem = study.updProblem();
@@ -1319,10 +1308,8 @@ TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
     CHECK(Ry == Approx(testData->reaction[1][1]));
     CHECK(Rz == Approx(testData->reaction[1][2]));
 }
-#endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("Multipliers are correct", "") {
+TEST_CASE("Multipliers are correct", "[casadi]") {
     SECTION("Body welded to ground") {
         auto dynamics_mode =
                 GENERATE(as<std::string>{}, "implicit", "explicit");
@@ -1422,13 +1409,11 @@ TEST_CASE("Multipliers are correct", "") {
         OpenSim_CHECK_MATRIX_TOL(lambda, 0.5 * (Fx - Fy), 1e-5);
     }
 }
-#endif
 
 // Ensure that we correctly handle the combination of prescribed kinematics
 // (PositionMotion) and kinematic constraints. This test is similar to the one
 // above except that we prescribe motions for tx and ty.
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("Prescribed kinematics with kinematic constraints", "") {
+TEST_CASE("Prescribed kinematics with kinematic constraints", "[casadi]") {
     Model model = ModelFactory::createPlanarPointMass();
     model.set_gravity(Vec3(0));
     CoordinateCouplerConstraint* constraint = new CoordinateCouplerConstraint();
@@ -1468,10 +1453,9 @@ TEST_CASE("Prescribed kinematics with kinematic constraints", "") {
 
     OpenSim_CHECK_MATRIX_TOL(lambda, 0.5 * (Fx - Fy), 1e-5);
 }
-#endif
 
-TEMPLATE_TEST_CASE(
-        "MocoControlBoundConstraint", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("MocoControlBoundConstraint", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     SECTION("Lower bound only") {
         MocoStudy study;
         auto& problem = study.updProblem();
@@ -1602,8 +1586,8 @@ TEMPLATE_TEST_CASE(
     }
 }
 
-TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     using SimTK::Pi;
 
     // Create a 3D pendulum model with a single body and a marker at the 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -840,7 +840,7 @@ void testDoublePendulumPrescribedMotion(MocoSolution& couplerSolution,
 }
 
 TEMPLATE_TEST_CASE("DoublePendulum with and without constraint derivatives",
-        "[explicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
     SECTION("DoublePendulum without constraint derivatives") {
         MocoSolution couplerSol;
         testDoublePendulumCoordinateCoupler<TestType>(
@@ -858,6 +858,7 @@ TEMPLATE_TEST_CASE("DoublePendulum with and without constraint derivatives",
     }
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("DoublePendulum with and without constraint derivatives",
         "[implicit]") {
     SECTION("DoublePendulum without constraint derivatives") {
@@ -876,26 +877,31 @@ TEST_CASE("DoublePendulum with and without constraint derivatives",
                 couplerSol, true, "implicit");
     }
 }
+#endif
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine without constraint derivatives",
-        "[explicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
     testDoublePendulumPointOnLine<TestType>(false, "explicit");
 }
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine with constraint derivatives",
-        "[explicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
     testDoublePendulumPointOnLine<TestType>(true, "explicit");
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("DoublePendulumPointOnLine without constraint derivatives",
         "[implicit]") {
     testDoublePendulumPointOnLine<MocoCasADiSolver>(false, "implicit");
 }
+#endif
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE(
         "DoublePendulumPointOnLine with constraint derivatives", "[implicit]") {
     testDoublePendulumPointOnLine<MocoCasADiSolver>(true, "implicit");
 }
+#endif
 
 class EqualControlConstraint : public MocoPathConstraint {
     OpenSim_DECLARE_CONCRETE_OBJECT(EqualControlConstraint, MocoPathConstraint);
@@ -928,7 +934,7 @@ protected:
 /// specified final configuration while subject to a constraint that its
 /// actuators must produce an equal control trajectory.
 TEMPLATE_TEST_CASE(
-        "DoublePendulumEqualControl", "", MocoTropterSolver, MocoCasADiSolver) {
+        "DoublePendulumEqualControl", "", OPENSIM_TEST_CASADI_TROPTER) {
     OpenSim::Object::registerType(EqualControlConstraint());
     MocoStudy study;
     study.setName("double_pendulum_equal_control");
@@ -993,6 +999,7 @@ TEMPLATE_TEST_CASE(
 // solving for the mass that allows the point mass to obey the constraint
 // of staying in place. This checks that the parameters are applied to both
 // ModelBase and ModelDisabledConstraints.
+#ifdef OPENSIM_WITH_TROPTER
 TEMPLATE_TEST_CASE(
         "Parameters are set properly for Base and DisabledConstraints", "",
         MocoTropterSolver /*, too damn slow: MocoCasADiSolver*/) {
@@ -1018,6 +1025,7 @@ TEMPLATE_TEST_CASE(
     MocoSolution solution = study.solve();
     CHECK(solution.getParameter("mass") == Approx(1.0).epsilon(1e-3));
 }
+#endif
 
 class MocoJointReactionComponentGoal : public MocoGoal {
     OpenSim_DECLARE_CONCRETE_OBJECT(MocoJointReactionComponentGoal, MocoGoal);
@@ -1106,15 +1114,17 @@ void testDoublePendulumJointReactionGoal(std::string dynamics_mode) {
 
 TEMPLATE_TEST_CASE(
         "DoublePendulumPointJointReactionGoal with constraint derivatives",
-        "[explicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[explicit]", OPENSIM_TEST_CASADI_TROPTER) {
     testDoublePendulumJointReactionGoal<TestType>("explicit");
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE("DoublePendulumJointReactionGoal implicit with "
                    "constraint derivatives",
         "[implicit]", MocoCasADiSolver) {
     testDoublePendulumJointReactionGoal<TestType>("implicit");
 }
+#endif
 
 struct AccelerationsAndJointReaction {
     SimTK::Vector udot;
@@ -1155,6 +1165,7 @@ private:
 // separate multipliers. When using implicit dynamics, we provide separate
 // accelerations. This test ensures that these accelerations and multipliers are
 // those that Moco specified, not what Simbody computes.
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
     MocoStudy study;
     study.setName("mass_welded");
@@ -1308,8 +1319,9 @@ TEST_CASE("Goals use Moco-defined accelerations and multipliers") {
     CHECK(Ry == Approx(testData->reaction[1][1]));
     CHECK(Rz == Approx(testData->reaction[1][2]));
 }
+#endif
 
-
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("Multipliers are correct", "") {
     SECTION("Body welded to ground") {
         auto dynamics_mode =
@@ -1410,10 +1422,12 @@ TEST_CASE("Multipliers are correct", "") {
         OpenSim_CHECK_MATRIX_TOL(lambda, 0.5 * (Fx - Fy), 1e-5);
     }
 }
+#endif
 
 // Ensure that we correctly handle the combination of prescribed kinematics
 // (PositionMotion) and kinematic constraints. This test is similar to the one
 // above except that we prescribe motions for tx and ty.
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("Prescribed kinematics with kinematic constraints", "") {
     Model model = ModelFactory::createPlanarPointMass();
     model.set_gravity(Vec3(0));
@@ -1454,9 +1468,10 @@ TEST_CASE("Prescribed kinematics with kinematic constraints", "") {
 
     OpenSim_CHECK_MATRIX_TOL(lambda, 0.5 * (Fx - Fy), 1e-5);
 }
+#endif
 
 TEMPLATE_TEST_CASE(
-        "MocoControlBoundConstraint", "", MocoTropterSolver, MocoCasADiSolver) {
+        "MocoControlBoundConstraint", "", OPENSIM_TEST_CASADI_TROPTER) {
     SECTION("Lower bound only") {
         MocoStudy study;
         auto& problem = study.updProblem();
@@ -1587,8 +1602,8 @@ TEMPLATE_TEST_CASE(
     }
 }
 
-TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "", MocoTropterSolver, 
-        MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "",
+        OPENSIM_TEST_CASADI_TROPTER) {
     using SimTK::Pi;
 
     // Create a 3D pendulum model with a single body and a marker at the 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -840,7 +840,7 @@ void testDoublePendulumPrescribedMotion(MocoSolution& couplerSolution,
 }
 
 TEMPLATE_TEST_CASE("DoublePendulum with and without constraint derivatives",
-        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[explicit]", MocoCasADiSolver, MocoTropterSolver) {
     SECTION("DoublePendulum without constraint derivatives") {
         MocoSolution couplerSol;
         testDoublePendulumCoordinateCoupler<TestType>(
@@ -878,12 +878,12 @@ TEST_CASE("DoublePendulum with and without constraint derivatives",
 }
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine without constraint derivatives",
-        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[explicit]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumPointOnLine<TestType>(false, "explicit");
 }
 
 TEMPLATE_TEST_CASE("DoublePendulumPointOnLine with constraint derivatives",
-        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[explicit]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumPointOnLine<TestType>(true, "explicit");
 }
 
@@ -927,7 +927,7 @@ protected:
 /// Solve an optimal control problem where a double pendulum must reach a
 /// specified final configuration while subject to a constraint that its
 /// actuators must produce an equal control trajectory.
-TEMPLATE_TEST_CASE("DoublePendulumEqualControl", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("DoublePendulumEqualControl", "",
         MocoCasADiSolver, MocoTropterSolver) {
     OpenSim::Object::registerType(EqualControlConstraint());
     MocoStudy study;
@@ -1106,7 +1106,7 @@ void testDoublePendulumJointReactionGoal(std::string dynamics_mode) {
 
 TEMPLATE_TEST_CASE(
         "DoublePendulumPointJointReactionGoal with constraint derivatives",
-        "[explicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[explicit]", MocoCasADiSolver, MocoTropterSolver) {
     testDoublePendulumJointReactionGoal<TestType>("explicit");
 }
 
@@ -1454,7 +1454,7 @@ TEST_CASE("Prescribed kinematics with kinematic constraints", "[casadi]") {
     OpenSim_CHECK_MATRIX_TOL(lambda, 0.5 * (Fx - Fy), 1e-5);
 }
 
-TEMPLATE_TEST_CASE("MocoControlBoundConstraint", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("MocoControlBoundConstraint", "",
         MocoCasADiSolver, MocoTropterSolver) {
     SECTION("Lower bound only") {
         MocoStudy study;
@@ -1580,13 +1580,14 @@ TEMPLATE_TEST_CASE("MocoControlBoundConstraint", "[casadi][tropter]",
         problem.setControlInfo("/tau0", {-5, 5});
         problem.addGoal<MocoControlGoal>();
         auto* constr = problem.addPathConstraint<MocoControlBoundConstraint>();
+        study.initSolver<TestType>();
         study.solve();
         constr->addControlPath("/tau0");
         study.solve();
     }
 }
 
-TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("MocoFrameDistanceConstraint", "",
         MocoCasADiSolver, MocoTropterSolver) {
     using SimTK::Pi;
 

--- a/OpenSim/Moco/Test/testMocoContact.cpp
+++ b/OpenSim/Moco/Test/testMocoContact.cpp
@@ -521,35 +521,27 @@ MeyerFregly2016Force* createMeyerFregly() {
     return contact;
 }
 
-#ifdef OPENSIM_WITH_TROPTER
-TEST_CASE("testStationPlaneContactForce AckermannVanDenBogert2010Force") {
+TEST_CASE("testStationPlaneContactForce AckermannVanDenBogert2010Force",
+        "[tropter]") {
     testStationPlaneContactForce(createAVDB);
 }
-#endif
 
-#ifdef OPENSIM_WITH_TROPTER
-TEST_CASE("testStationPlaneContactForce EspositoMiller2018Force") {
+TEST_CASE("testStationPlaneContactForce EspositoMiller2018Force", "[tropter]") {
     testStationPlaneContactForce(createEspositoMiller);
 }
-#endif
 
 // TODO does not pass:
-// #ifdef OPENSIM_WITH_TROPTER
-// TEST_CASE("testStationPlaneContactForce MeyerFregly2016Force") {
+// TEST_CASE("testStationPlaneContactForce MeyerFregly2016Force", "[tropter]") {
 //     testStationPlaneContactForce(createMeyerFregly);
 // }
-// # endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("testSmoothSphereHalfSpaceForce") {
+TEST_CASE("testSmoothSphereHalfSpaceForce", "[casadi]") {
     const SimTK::Real equilibriumHeight =
         testSmoothSphereHalfSpaceForce_NormalForce();
     testSmoothSphereHalfSpaceForce_FrictionForce(equilibriumHeight);
 }
-#endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("MocoContactTrackingGoal") {
+TEST_CASE("MocoContactTrackingGoal", "[casadi]") {
 
     // We drop a ball from a prescribed initial height, record the contact
     // force, then solve a trajectory optimization that tracks the recorded
@@ -640,4 +632,3 @@ TEST_CASE("MocoContactTrackingGoal") {
             externalLoadsTimeStepping, "ground_force_r_vy",
             0.5);
 }
-#endif

--- a/OpenSim/Moco/Test/testMocoContact.cpp
+++ b/OpenSim/Moco/Test/testMocoContact.cpp
@@ -17,8 +17,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// TODO add 3D tests (contact models are currently only 2D).
-
 #define CATCH_CONFIG_MAIN
 #include "Testing.h"
 #include <OpenSim/Moco/osimMoco.h>
@@ -523,26 +521,34 @@ MeyerFregly2016Force* createMeyerFregly() {
     return contact;
 }
 
+#ifdef OPENSIM_WITH_TROPTER
 TEST_CASE("testStationPlaneContactForce AckermannVanDenBogert2010Force") {
     testStationPlaneContactForce(createAVDB);
 }
+#endif
 
+#ifdef OPENSIM_WITH_TROPTER
 TEST_CASE("testStationPlaneContactForce EspositoMiller2018Force") {
     testStationPlaneContactForce(createEspositoMiller);
 }
+#endif
 
 // TODO does not pass:
+// #ifdef OPENSIM_WITH_TROPTER
 // TEST_CASE("testStationPlaneContactForce MeyerFregly2016Force") {
 //     testStationPlaneContactForce(createMeyerFregly);
 // }
+// # endif
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("testSmoothSphereHalfSpaceForce") {
     const SimTK::Real equilibriumHeight =
         testSmoothSphereHalfSpaceForce_NormalForce();
     testSmoothSphereHalfSpaceForce_FrictionForce(equilibriumHeight);
 }
+#endif
 
-
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("MocoContactTrackingGoal") {
 
     // We drop a ball from a prescribed initial height, record the contact
@@ -634,3 +640,4 @@ TEST_CASE("MocoContactTrackingGoal") {
             externalLoadsTimeStepping, "ground_force_r_vy",
             0.5);
 }
+#endif

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<Model> createSlidingMassModel() {
 }
 
 /// Test the result of a sliding mass minimum effort problem.
-TEMPLATE_TEST_CASE("Test MocoControlGoal", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Test MocoControlGoal", "",
         MocoCasADiSolver, MocoTropterSolver) {
     const int N = 9;          // mesh intervals
     const int Nc = 2 * N + 1; // collocation points (Hermite-Simpson)
@@ -255,7 +255,7 @@ void testDoublePendulumTracking(MocoStudy study,
             solutionTracking.getStatesTrajectory(), 1e-1);
 }
 
-TEMPLATE_TEST_CASE("Test tracking goals", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Test tracking goals", "", MocoCasADiSolver,
         MocoTropterSolver) {
 
     // Start with double pendulum problem to minimize control effort to create
@@ -361,7 +361,7 @@ TEMPLATE_TEST_CASE("Test tracking goals", "[casadi][tropter]", MocoCasADiSolver,
     }
 }
 
-TEMPLATE_TEST_CASE("Test MocoJointReactionGoal", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Test MocoJointReactionGoal", "",
         MocoCasADiSolver, MocoTropterSolver) {
 
     using SimTK::Inertia;
@@ -672,7 +672,7 @@ public:
         return getModel().getControls(state).normSqr();
     }
 };
-TEMPLATE_TEST_CASE("MocoOutputGoal", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("MocoOutputGoal", "", MocoCasADiSolver,
         MocoTropterSolver) {
     auto createStudy = []() {
         MocoStudy study;

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -50,8 +50,8 @@ std::unique_ptr<Model> createSlidingMassModel() {
 }
 
 /// Test the result of a sliding mass minimum effort problem.
-TEMPLATE_TEST_CASE(
-        "Test MocoControlGoal", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Test MocoControlGoal", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     const int N = 9;          // mesh intervals
     const int Nc = 2 * N + 1; // collocation points (Hermite-Simpson)
     MocoSolution sol1;
@@ -255,7 +255,8 @@ void testDoublePendulumTracking(MocoStudy study,
             solutionTracking.getStatesTrajectory(), 1e-1);
 }
 
-TEMPLATE_TEST_CASE("Test tracking goals", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Test tracking goals", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
 
     // Start with double pendulum problem to minimize control effort to create
     // a controls trajectory to track.
@@ -360,8 +361,8 @@ TEMPLATE_TEST_CASE("Test tracking goals", "", OPENSIM_TEST_CASADI_TROPTER) {
     }
 }
 
-TEMPLATE_TEST_CASE(
-        "Test MocoJointReactionGoal", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Test MocoJointReactionGoal", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
 
     using SimTK::Inertia;
     using SimTK::Vec3;
@@ -493,8 +494,7 @@ public:
     }
 };
 
-#ifdef OPENSIM_WITH_CASADI
-TEMPLATE_TEST_CASE("Endpoint constraints", "", MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Endpoint constraints", "[casadi]", MocoCasADiSolver) {
     // TODO test with Tropter.
 
     MocoStudy study;
@@ -547,10 +547,8 @@ TEMPLATE_TEST_CASE("Endpoint constraints", "", MocoCasADiSolver) {
                 Approx(0).margin(1e-6));
     }
 }
-#endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEMPLATE_TEST_CASE("MocoPeriodicityGoal", "", MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("MocoPeriodicityGoal", "[casadi]", MocoCasADiSolver) {
 
     MocoStudy study;
     auto& problem = study.updProblem();
@@ -599,7 +597,6 @@ TEMPLATE_TEST_CASE("MocoPeriodicityGoal", "", MocoCasADiSolver) {
                 Approx(solution.getControl("/tau0")[0]).margin(1e-6));
     }
 }
-#endif
 
 class MocoControlGoalWithEndpointConstraint : public MocoGoal {
     OpenSim_DECLARE_CONCRETE_OBJECT(
@@ -625,9 +622,8 @@ public:
     }
 };
 
-#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE(
-        "Endpoint constraint with integral", "", MocoCasADiSolver) {
+        "Endpoint constraint with integral", "[casadi]", MocoCasADiSolver) {
 
     Model model;
     const double mass = 1.3169;
@@ -665,7 +661,6 @@ TEMPLATE_TEST_CASE(
     // over the motion must be 0.
     CHECK(solution.getControlsTrajectory().norm() < 1e-3);
 }
-#endif
 
 class MySumSquaredControls : public ModelComponent {
     OpenSim_DECLARE_CONCRETE_OBJECT(MySumSquaredControls, ModelComponent);
@@ -677,7 +672,8 @@ public:
         return getModel().getControls(state).normSqr();
     }
 };
-TEMPLATE_TEST_CASE("MocoOutputGoal", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("MocoOutputGoal", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     auto createStudy = []() {
         MocoStudy study;
         study.setName("sliding_mass");

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -112,7 +112,7 @@ MocoSolution solveDoublePendulumSwingup(const std::string& dynamics_mode) {
 }
 
 TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
-        "[implicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[implicit]", MocoCasADiSolver, MocoTropterSolver) {
     GIVEN("solutions to implicit and explicit problems") {
 
         auto solutionImplicit =
@@ -166,7 +166,7 @@ TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
 }
 
 TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
-        "[implicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "[implicit]", MocoCasADiSolver, MocoTropterSolver) {
     class MyPathConstraint : public MocoPathConstraint {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyPathConstraint, MocoPathConstraint);
         void initializeOnModelImpl(

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -112,7 +112,7 @@ MocoSolution solveDoublePendulumSwingup(const std::string& dynamics_mode) {
 }
 
 TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
-        "[implicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[implicit]", OPENSIM_TEST_CASADI_TROPTER) {
     GIVEN("solutions to implicit and explicit problems") {
 
         auto solutionImplicit =
@@ -166,7 +166,7 @@ TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
 }
 
 TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
-        "[implicit]", MocoTropterSolver, MocoCasADiSolver) {
+        "[implicit]", OPENSIM_TEST_CASADI_TROPTER) {
     class MyPathConstraint : public MocoPathConstraint {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyPathConstraint, MocoPathConstraint);
         void initializeOnModelImpl(
@@ -204,6 +204,7 @@ TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
     }
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE("Combining implicit dynamics with kinematic constraints",
         "[implicit]", /*MocoTropterSolver,*/ MocoCasADiSolver) {
     GIVEN("MocoProblem with a kinematic constraint") {
@@ -234,6 +235,7 @@ TEMPLATE_TEST_CASE("Combining implicit dynamics with kinematic constraints",
         }
     }
 }
+#endif
 
 SCENARIO("Using MocoTrajectory with the implicit dynamics mode",
         "[implicit][trajectory]") {
@@ -403,6 +405,7 @@ TEST_CASE("Implicit auxiliary dynamics") {
         }
     }
 
+#ifdef OPENISM_WITH_CASADI
     SECTION("Direct collocation implicit") {
        MocoStudy study;
        auto& problem = study.updProblem();
@@ -417,6 +420,7 @@ TEST_CASE("Implicit auxiliary dynamics") {
        // Correct answer obtained from Matlab with ode45.
        CHECK(final == Approx(1.732).margin(1e-3));
     }
+#endif
 
     SECTION("MocoTropterSolver does not support implicit auxiliary dynamics") {
         MocoStudy study;

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -112,7 +112,7 @@ MocoSolution solveDoublePendulumSwingup(const std::string& dynamics_mode) {
 }
 
 TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
-        "[implicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[implicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     GIVEN("solutions to implicit and explicit problems") {
 
         auto solutionImplicit =
@@ -166,7 +166,7 @@ TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
 }
 
 TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
-        "[implicit]", OPENSIM_TEST_CASADI_TROPTER) {
+        "[implicit][casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
     class MyPathConstraint : public MocoPathConstraint {
         OpenSim_DECLARE_CONCRETE_OBJECT(MyPathConstraint, MocoPathConstraint);
         void initializeOnModelImpl(
@@ -204,9 +204,8 @@ TEMPLATE_TEST_CASE("Combining implicit dynamics mode with path constraints",
     }
 }
 
-#ifdef OPENSIM_WITH_CASADI
 TEMPLATE_TEST_CASE("Combining implicit dynamics with kinematic constraints",
-        "[implicit]", /*MocoTropterSolver,*/ MocoCasADiSolver) {
+        "[implicit][casadi]", /*MocoTropterSolver,*/ MocoCasADiSolver) {
     GIVEN("MocoProblem with a kinematic constraint") {
         MocoStudy study;
         auto& prob = study.updProblem();
@@ -235,7 +234,6 @@ TEMPLATE_TEST_CASE("Combining implicit dynamics with kinematic constraints",
         }
     }
 }
-#endif
 
 SCENARIO("Using MocoTrajectory with the implicit dynamics mode",
         "[implicit][trajectory]") {

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -82,7 +82,7 @@ MocoStudy createSlidingMassMocoStudy() {
     return study;
 }
 
-TEMPLATE_TEST_CASE("Non-uniform mesh", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Non-uniform mesh", "", MocoCasADiSolver,
         MocoTropterSolver) {
     auto transcriptionScheme =
             GENERATE(as<std::string>{}, "trapezoidal", "hermite-simpson");
@@ -207,7 +207,7 @@ std::unique_ptr<Model> createPendulumModel() {
     return model;
 }
 
-TEMPLATE_TEST_CASE("Solver options", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Solver options", "", MocoCasADiSolver,
         MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -428,7 +428,7 @@ TEST_CASE("Building a problem", "") {
 }
 
 TEMPLATE_TEST_CASE(
-        "Workflow", "[casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "Workflow", "", MocoCasADiSolver, MocoTropterSolver) {
 
     // Default bounds.
     SECTION("Default bounds") {
@@ -702,6 +702,7 @@ TEMPLATE_TEST_CASE(
         problem.setStateInfo("/slider/position/speed", {-100, 100}, 0, 0);
         problem.updPhase().addGoal<MocoFinalTimeGoal>();
         auto effort = problem.updPhase().addGoal<MocoControlGoal>("effort");
+        study.initSolver<TestType>();
         const double finalTime0 = study.solve().getFinalTime();
 
         // Change the weights of the costs.
@@ -738,7 +739,7 @@ TEMPLATE_TEST_CASE(
     //     }
     // }
 }
-TEMPLATE_TEST_CASE("Set infos with regular expression", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Set infos with regular expression", "",
         MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     MocoProblem& problem = study.updProblem();
@@ -783,7 +784,7 @@ TEMPLATE_TEST_CASE("Set infos with regular expression", "[casadi][tropter]",
                           .getLower(),
             4);
 }
-TEMPLATE_TEST_CASE("Disable Actuators", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Disable Actuators", "", MocoCasADiSolver,
         MocoTropterSolver) {
 
     MocoSolution solution;
@@ -847,7 +848,7 @@ TEMPLATE_TEST_CASE("Disable Actuators", "[casadi][tropter]", MocoCasADiSolver,
     CHECK(solution2.getObjective() != Approx(solution.getObjective()));
 }
 
-TEMPLATE_TEST_CASE("State tracking", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("State tracking", "", MocoCasADiSolver,
         MocoTropterSolver) {
     // TODO move to another test file?
     auto makeTool = []() {
@@ -928,7 +929,7 @@ TEMPLATE_TEST_CASE("State tracking", "[casadi][tropter]", MocoCasADiSolver,
 }
 
 TEMPLATE_TEST_CASE(
-        "Guess", "[casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
+        "Guess", "", MocoCasADiSolver, MocoTropterSolver) {
 
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -1305,7 +1306,7 @@ TEMPLATE_TEST_CASE("Guess time-stepping", "[tropter]",
     }
 }
 
-TEMPLATE_TEST_CASE("MocoTrajectory", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("MocoTrajectory", "", MocoCasADiSolver,
         MocoTropterSolver) {
     // Reading and writing.
     {
@@ -1703,7 +1704,7 @@ TEST_CASE("Interpolate", "") {
     SimTK_TEST(SimTK::isNaN(newY[3]));
 }
 
-TEMPLATE_TEST_CASE("Sliding mass", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Sliding mass", "", MocoCasADiSolver,
         MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution solution = study.solve();
@@ -1747,7 +1748,7 @@ TEMPLATE_TEST_CASE("Sliding mass", "[casadi][tropter]", MocoCasADiSolver,
     }
 }
 
-TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "",
         MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     auto& solver = study.initSolver<TestType>();
@@ -1847,12 +1848,10 @@ void testSkippingOverQuaternionSlots(
 }
 
 TEST_CASE("Skip over empty quaternion slots; CasADi.", "[casadi]") {
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "explicit");
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "explicit");
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "explicit");
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "implicit");
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "implicit");
-    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "implicit");
+    auto mode = GENERATE(as<std::string>{}, "explicit", "implicit");
+    testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, mode);
+    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, mode);
+    testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, mode);
 }
 
 TEST_CASE("Skip over empty quaternion slots; Tropter.", "[tropter]") {
@@ -2011,7 +2010,7 @@ TEST_CASE("Solver isAvailable()") {
 
 
 /*
-TEMPLATE_TEST_CASE("Controllers in the model", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("Controllers in the model", "",
         MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     auto& problem = study.updProblem();

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -83,7 +83,7 @@ MocoStudy createSlidingMassMocoStudy() {
 }
 
 TEMPLATE_TEST_CASE(
-        "Non-uniform mesh", "", MocoTropterSolver, MocoCasADiSolver) {
+        "Non-uniform mesh", "", OPENSIM_TEST_CASADI_TROPTER) {
     auto transcriptionScheme =
             GENERATE(as<std::string>{}, "trapezoidal", "hermite-simpson");
     MocoStudy study;
@@ -207,7 +207,7 @@ std::unique_ptr<Model> createPendulumModel() {
     return model;
 }
 
-TEMPLATE_TEST_CASE("Solver options", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Solver options", "", OPENSIM_TEST_CASADI_TROPTER) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
     MocoSolution solDefault = study.solve();
@@ -426,7 +426,7 @@ TEST_CASE("Building a problem", "") {
     }
 }
 
-TEMPLATE_TEST_CASE("Workflow", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Workflow", "", OPENSIM_TEST_CASADI_TROPTER) {
 
     // Default bounds.
     SECTION("Default bounds") {
@@ -736,8 +736,8 @@ TEMPLATE_TEST_CASE("Workflow", "", MocoTropterSolver, MocoCasADiSolver) {
     //     }
     // }
 }
-TEMPLATE_TEST_CASE("Set infos with regular expression", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Set infos with regular expression", "",
+        OPENSIM_TEST_CASADI_TROPTER) {
     MocoStudy study;
     MocoProblem& problem = study.updProblem();
     problem.setModelCopy(OpenSim::ModelFactory::createDoublePendulum());
@@ -782,7 +782,7 @@ TEMPLATE_TEST_CASE("Set infos with regular expression", "", MocoCasADiSolver,
             4);
 }
 TEMPLATE_TEST_CASE(
-        "Disable Actuators", "", MocoCasADiSolver, MocoTropterSolver) {
+        "Disable Actuators", "", OPENSIM_TEST_CASADI_TROPTER) {
 
     MocoSolution solution;
     MocoSolution solution2;
@@ -845,7 +845,7 @@ TEMPLATE_TEST_CASE(
     CHECK(solution2.getObjective() != Approx(solution.getObjective()));
 }
 
-TEMPLATE_TEST_CASE("State tracking", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("State tracking", "", OPENSIM_TEST_CASADI_TROPTER) {
     // TODO move to another test file?
     auto makeTool = []() {
         MocoStudy study;
@@ -924,7 +924,7 @@ TEMPLATE_TEST_CASE("State tracking", "", MocoTropterSolver, MocoCasADiSolver) {
     // TODO error if data does not cover time window.
 }
 
-TEMPLATE_TEST_CASE("Guess", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Guess", "", OPENSIM_TEST_CASADI_TROPTER) {
 
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -1235,6 +1235,7 @@ TEMPLATE_TEST_CASE("Guess", "", MocoTropterSolver, MocoCasADiSolver) {
     // after they get the mutable reference.
 }
 
+#ifdef OPENSIM_WITH_TROPTER
 TEMPLATE_TEST_CASE(
         "Guess time-stepping", "", MocoTropterSolver /*, MocoCasADiSolver*/) {
     // This problem is just a simulation (there are no costs), and so the
@@ -1300,6 +1301,7 @@ TEMPLATE_TEST_CASE(
         SimTK_TEST(guess.getTime()[guess.getNumTimes() - 1] == 6);
     }
 }
+#endif
 
 TEST_CASE("MocoTrajectory") {
     // Reading and writing.
@@ -1698,7 +1700,7 @@ TEST_CASE("Interpolate", "") {
     SimTK_TEST(SimTK::isNaN(newY[3]));
 }
 
-TEMPLATE_TEST_CASE("Sliding mass", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Sliding mass", "", OPENSIM_TEST_CASADI_TROPTER) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution solution = study.solve();
     int numTimes = 20;
@@ -1741,8 +1743,8 @@ TEMPLATE_TEST_CASE("Sliding mass", "", MocoTropterSolver, MocoCasADiSolver) {
     }
 }
 
-TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "", MocoTropterSolver,
-        MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "",
+        OPENSIM_TEST_CASADI_TROPTER) {
     MocoStudy study;
     auto& solver = study.initSolver<TestType>();
     THEN("problem solves without error, solution trajectories are empty.") {
@@ -1842,19 +1844,23 @@ void testSkippingOverQuaternionSlots(
 
 TEST_CASE("Skip over empty quaternion slots", "") {
 
+#ifdef OPENSIM_WITH_TROPTER
     testSkippingOverQuaternionSlots<MocoTropterSolver>(
             false, false, "explicit");
     testSkippingOverQuaternionSlots<MocoTropterSolver>(true, false, "explicit");
     testSkippingOverQuaternionSlots<MocoTropterSolver>(true, true, "explicit");
     testSkippingOverQuaternionSlots<MocoTropterSolver>(
             false, false, "implicit");
+#endif
 
+#ifdef OPENSIM_WITH_CASADI
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "implicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "implicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "implicit");
+#endif
 }
 
 TEST_CASE("MocoPhase::bound_activation_from_excitation") {
@@ -1991,7 +1997,7 @@ TEST_CASE("Objective breakdown") {
 
 /*
 TEMPLATE_TEST_CASE("Controllers in the model", "",
-        MocoCasADiSolver, MocoTropterSolver) {
+        OPENSIM_TEST_CASADI_TROPTER) {
     MocoStudy study;
     auto& problem = study.updProblem();
     auto model = createSlidingMassModel();

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -82,8 +82,8 @@ MocoStudy createSlidingMassMocoStudy() {
     return study;
 }
 
-TEMPLATE_TEST_CASE(
-        "Non-uniform mesh", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Non-uniform mesh", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     auto transcriptionScheme =
             GENERATE(as<std::string>{}, "trapezoidal", "hermite-simpson");
     MocoStudy study;
@@ -207,7 +207,8 @@ std::unique_ptr<Model> createPendulumModel() {
     return model;
 }
 
-TEMPLATE_TEST_CASE("Solver options", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Solver options", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
     MocoSolution solDefault = study.solve();
@@ -426,7 +427,8 @@ TEST_CASE("Building a problem", "") {
     }
 }
 
-TEMPLATE_TEST_CASE("Workflow", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE(
+        "Workflow", "[casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
 
     // Default bounds.
     SECTION("Default bounds") {
@@ -736,8 +738,8 @@ TEMPLATE_TEST_CASE("Workflow", "", OPENSIM_TEST_CASADI_TROPTER) {
     //     }
     // }
 }
-TEMPLATE_TEST_CASE("Set infos with regular expression", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Set infos with regular expression", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     MocoProblem& problem = study.updProblem();
     problem.setModelCopy(OpenSim::ModelFactory::createDoublePendulum());
@@ -781,8 +783,8 @@ TEMPLATE_TEST_CASE("Set infos with regular expression", "",
                           .getLower(),
             4);
 }
-TEMPLATE_TEST_CASE(
-        "Disable Actuators", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Disable Actuators", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
 
     MocoSolution solution;
     MocoSolution solution2;
@@ -845,7 +847,8 @@ TEMPLATE_TEST_CASE(
     CHECK(solution2.getObjective() != Approx(solution.getObjective()));
 }
 
-TEMPLATE_TEST_CASE("State tracking", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("State tracking", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     // TODO move to another test file?
     auto makeTool = []() {
         MocoStudy study;
@@ -924,7 +927,8 @@ TEMPLATE_TEST_CASE("State tracking", "", OPENSIM_TEST_CASADI_TROPTER) {
     // TODO error if data does not cover time window.
 }
 
-TEMPLATE_TEST_CASE("Guess", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE(
+        "Guess", "[casadi][tropter]", MocoCasADiSolver, MocoTropterSolver) {
 
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -1235,9 +1239,8 @@ TEMPLATE_TEST_CASE("Guess", "", OPENSIM_TEST_CASADI_TROPTER) {
     // after they get the mutable reference.
 }
 
-#ifdef OPENSIM_WITH_TROPTER
-TEMPLATE_TEST_CASE(
-        "Guess time-stepping", "", MocoTropterSolver /*, MocoCasADiSolver*/) {
+TEMPLATE_TEST_CASE("Guess time-stepping", "[tropter]",
+        MocoTropterSolver /*, MocoCasADiSolver*/) {
     // This problem is just a simulation (there are no costs), and so the
     // forward simulation guess should reduce the number of iterations to
     // converge, and the guess and solution should also match our own
@@ -1301,9 +1304,9 @@ TEMPLATE_TEST_CASE(
         SimTK_TEST(guess.getTime()[guess.getNumTimes() - 1] == 6);
     }
 }
-#endif
 
-TEST_CASE("MocoTrajectory") {
+TEMPLATE_TEST_CASE("MocoTrajectory", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     // Reading and writing.
     {
         const std::string fname = "testMocoInterface_testMocoTrajectory.sto";
@@ -1324,7 +1327,7 @@ TEST_CASE("MocoTrajectory") {
     {
         const std::string fname =
                 "testMocoInterface_testMocoSolutionSuccess.sto";
-        MocoStudy study = createSlidingMassMocoStudy();
+        MocoStudy study = createSlidingMassMocoStudy<TestType>();
         auto& solver =
                 dynamic_cast<MocoDirectCollocationSolver&>(study.updSolver());
 
@@ -1700,7 +1703,8 @@ TEST_CASE("Interpolate", "") {
     SimTK_TEST(SimTK::isNaN(newY[3]));
 }
 
-TEMPLATE_TEST_CASE("Sliding mass", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Sliding mass", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution solution = study.solve();
     int numTimes = 20;
@@ -1743,8 +1747,8 @@ TEMPLATE_TEST_CASE("Sliding mass", "", OPENSIM_TEST_CASADI_TROPTER) {
     }
 }
 
-TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Solving an empty MocoProblem", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     auto& solver = study.initSolver<TestType>();
     THEN("problem solves without error, solution trajectories are empty.") {
@@ -1842,25 +1846,22 @@ void testSkippingOverQuaternionSlots(
     }
 }
 
-TEST_CASE("Skip over empty quaternion slots", "") {
-
-#ifdef OPENSIM_WITH_TROPTER
-    testSkippingOverQuaternionSlots<MocoTropterSolver>(
-            false, false, "explicit");
-    testSkippingOverQuaternionSlots<MocoTropterSolver>(true, false, "explicit");
-    testSkippingOverQuaternionSlots<MocoTropterSolver>(true, true, "explicit");
-    testSkippingOverQuaternionSlots<MocoTropterSolver>(
-            false, false, "implicit");
-#endif
-
-#ifdef OPENSIM_WITH_CASADI
+TEST_CASE("Skip over empty quaternion slots; CasADi.", "[casadi]") {
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "explicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(false, false, "implicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, false, "implicit");
     testSkippingOverQuaternionSlots<MocoCasADiSolver>(true, true, "implicit");
-#endif
+}
+
+TEST_CASE("Skip over empty quaternion slots; Tropter.", "[tropter]") {
+    testSkippingOverQuaternionSlots<MocoTropterSolver>(
+            false, false, "explicit");
+    testSkippingOverQuaternionSlots<MocoTropterSolver>(true, false, "explicit");
+    testSkippingOverQuaternionSlots<MocoTropterSolver>(true, true, "explicit");
+    testSkippingOverQuaternionSlots<MocoTropterSolver>(
+            false, false, "implicit");
 }
 
 TEST_CASE("MocoPhase::bound_activation_from_excitation") {
@@ -1961,7 +1962,7 @@ TEST_CASE("solveBisection()") {
     }
 }
 
-TEST_CASE("Objective breakdown") {
+TEST_CASE("Objective breakdown", "[casadi]") {
     class MocoConstantGoal : public MocoGoal {
         OpenSim_DECLARE_CONCRETE_OBJECT(MocoConstantGoal, MocoGoal);
     public:
@@ -1994,10 +1995,24 @@ TEST_CASE("Objective breakdown") {
     CHECK(solution.getObjectiveTerm("goal_b") == Approx(0.01 * 7.3));
 }
 
+TEST_CASE("Solver isAvailable()") {
+#ifdef OPENSIM_WITH_CASADI
+    CHECK(MocoCasADiSolver::isAvailable());
+#else
+    CHECK(!MocoCasADiSolver::isAvailable());
+#endif
+
+#ifdef OPENSIM_WITH_TROPTER
+    CHECK(MocoTropterSolver::isAvailable());
+#else
+    CHECK(!MocoTropterSolver::isAvailable());
+#endif
+}
+
 
 /*
-TEMPLATE_TEST_CASE("Controllers in the model", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Controllers in the model", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study;
     auto& problem = study.updProblem();
     auto model = createSlidingMassModel();

--- a/OpenSim/Moco/Test/testMocoInverse.cpp
+++ b/OpenSim/Moco/Test/testMocoInverse.cpp
@@ -62,6 +62,7 @@ TEST_CASE("PrescribedKinematics prescribe() and realize()") {
     CHECK(ydot[1] == Approx(2 * c2));
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics") {
 
     // Make sure that custom dynamics are still handled properly even when
@@ -114,7 +115,9 @@ TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics") {
     OpenSim_CHECK_MATRIX_TOL(solution.getState("/customdynamics/s"),
             0.2 * SimTK::exp(solution.getTime()), 1e-4);
 }
+#endif
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("MocoInverse Rajagopal2016, 18 muscles") {
 
     MocoInverse inverse;
@@ -145,3 +148,4 @@ TEST_CASE("MocoInverse Rajagopal2016, 18 muscles") {
             {{"controls", {}}}) < 1e-2);
     CHECK(std.compareContinuousVariablesRMS(solution, {{"states", {}}}) < 1e-2);
 }
+#endif

--- a/OpenSim/Moco/Test/testMocoInverse.cpp
+++ b/OpenSim/Moco/Test/testMocoInverse.cpp
@@ -62,8 +62,8 @@ TEST_CASE("PrescribedKinematics prescribe() and realize()") {
     CHECK(ydot[1] == Approx(2 * c2));
 }
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics") {
+TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics",
+        "[casadi]") {
 
     // Make sure that custom dynamics are still handled properly even when
     // we are skipping over the kinematic/multibody states. That is, this test
@@ -115,10 +115,8 @@ TEST_CASE("PrescribedKinematics direct collocation auxiliary dynamics") {
     OpenSim_CHECK_MATRIX_TOL(solution.getState("/customdynamics/s"),
             0.2 * SimTK::exp(solution.getTime()), 1e-4);
 }
-#endif
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("MocoInverse Rajagopal2016, 18 muscles") {
+TEST_CASE("MocoInverse Rajagopal2016, 18 muscles", "[casadi]") {
 
     MocoInverse inverse;
     ModelProcessor modelProcessor =
@@ -148,4 +146,3 @@ TEST_CASE("MocoInverse Rajagopal2016, 18 muscles") {
             {{"controls", {}}}) < 1e-2);
     CHECK(std.compareContinuousVariablesRMS(solution, {{"states", {}}}) < 1e-2);
 }
-#endif

--- a/OpenSim/Moco/Test/testMocoParameters.cpp
+++ b/OpenSim/Moco/Test/testMocoParameters.cpp
@@ -72,7 +72,7 @@ protected:
 /// correct trajectory specified by the state bounds and the FinalPositionCost.
 /// This tests the ability for MocoParameter to optimize a simple scalar model
 /// property value.
-TEMPLATE_TEST_CASE("Oscillator mass", "[casadi][tropter]", MocoCasADiSolver,
+TEMPLATE_TEST_CASE("Oscillator mass", "", MocoCasADiSolver,
         MocoTropterSolver) {
     int N = 25;
 
@@ -133,7 +133,7 @@ std::unique_ptr<Model> createOscillatorTwoSpringsModel() {
 /// equivalent stiffness of a single spring that would produce the same 
 /// oscillation trajectory. This tests the ability for MocoParameter to optimize
 /// the value of a model property for two different components.
-TEMPLATE_TEST_CASE("One parameter two springs", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("One parameter two springs", "",
         MocoCasADiSolver, MocoTropterSolver) {
     int N = 25;
 
@@ -212,7 +212,7 @@ protected:
 /// that the body comes to rest, i.e. the body's center of mass becomes aligned
 /// with the pin joint rotation point. This tests the ability of MocoParameter
 /// to optimize an element of a non-scalar model property.
-TEMPLATE_TEST_CASE("See-saw center of mass", "[casadi][tropter]",
+TEMPLATE_TEST_CASE("See-saw center of mass", "",
         MocoCasADiSolver, MocoTropterSolver) {
     int N = 25;
 

--- a/OpenSim/Moco/Test/testMocoParameters.cpp
+++ b/OpenSim/Moco/Test/testMocoParameters.cpp
@@ -72,7 +72,8 @@ protected:
 /// correct trajectory specified by the state bounds and the FinalPositionCost.
 /// This tests the ability for MocoParameter to optimize a simple scalar model
 /// property value.
-TEMPLATE_TEST_CASE("Oscillator mass", "", OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("Oscillator mass", "[casadi][tropter]", MocoCasADiSolver,
+        MocoTropterSolver) {
     int N = 25;
 
     MocoStudy study;
@@ -132,8 +133,8 @@ std::unique_ptr<Model> createOscillatorTwoSpringsModel() {
 /// equivalent stiffness of a single spring that would produce the same 
 /// oscillation trajectory. This tests the ability for MocoParameter to optimize
 /// the value of a model property for two different components.
-TEMPLATE_TEST_CASE("One parameter two springs", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("One parameter two springs", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     int N = 25;
 
     MocoStudy study;
@@ -211,8 +212,8 @@ protected:
 /// that the body comes to rest, i.e. the body's center of mass becomes aligned
 /// with the pin joint rotation point. This tests the ability of MocoParameter
 /// to optimize an element of a non-scalar model property.
-TEMPLATE_TEST_CASE("See-saw center of mass", "",
-        OPENSIM_TEST_CASADI_TROPTER) {
+TEMPLATE_TEST_CASE("See-saw center of mass", "[casadi][tropter]",
+        MocoCasADiSolver, MocoTropterSolver) {
     int N = 25;
 
     MocoStudy study;

--- a/OpenSim/Moco/Test/testMocoParameters.cpp
+++ b/OpenSim/Moco/Test/testMocoParameters.cpp
@@ -25,10 +25,7 @@
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 using namespace OpenSim;
 
-TEST_CASE("(Dummy test to support discovery in Resharper)")
-{
-    REQUIRE(true);
-}
+TEST_CASE("(Dummy test to support discovery in Resharper)") { REQUIRE(true); }
 
 const double STIFFNESS = 100.0; // N/m
 const double MASS = 5.0; // kg
@@ -75,7 +72,7 @@ protected:
 /// correct trajectory specified by the state bounds and the FinalPositionCost.
 /// This tests the ability for MocoParameter to optimize a simple scalar model
 /// property value.
-TEMPLATE_TEST_CASE("Oscillator mass", "", MocoTropterSolver, MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Oscillator mass", "", OPENSIM_TEST_CASADI_TROPTER) {
     int N = 25;
 
     MocoStudy study;
@@ -136,7 +133,7 @@ std::unique_ptr<Model> createOscillatorTwoSpringsModel() {
 /// oscillation trajectory. This tests the ability for MocoParameter to optimize
 /// the value of a model property for two different components.
 TEMPLATE_TEST_CASE("One parameter two springs", "",
-        MocoTropterSolver, MocoCasADiSolver) {
+        OPENSIM_TEST_CASADI_TROPTER) {
     int N = 25;
 
     MocoStudy study;
@@ -215,7 +212,7 @@ protected:
 /// with the pin joint rotation point. This tests the ability of MocoParameter
 /// to optimize an element of a non-scalar model property.
 TEMPLATE_TEST_CASE("See-saw center of mass", "",
-        MocoTropterSolver, MocoCasADiSolver) {
+        OPENSIM_TEST_CASADI_TROPTER) {
     int N = 25;
 
     MocoStudy study;

--- a/OpenSim/Moco/Test/testMocoTrack.cpp
+++ b/OpenSim/Moco/Test/testMocoTrack.cpp
@@ -43,6 +43,7 @@ TEST_CASE("MocoTrack interface") {
     }
 }
 
+#ifdef OPENSIM_WITH_CASADI
 TEST_CASE("MocoTrack gait10dof18musc") {
 
     MocoTrack track;
@@ -66,3 +67,4 @@ TEST_CASE("MocoTrack gait10dof18musc") {
     CHECK(std.compareContinuousVariablesRMS(
             solution, {{"controls",{}}}) < 1e-2);
 }
+#endif

--- a/OpenSim/Moco/Test/testMocoTrack.cpp
+++ b/OpenSim/Moco/Test/testMocoTrack.cpp
@@ -43,8 +43,7 @@ TEST_CASE("MocoTrack interface") {
     }
 }
 
-#ifdef OPENSIM_WITH_CASADI
-TEST_CASE("MocoTrack gait10dof18musc") {
+TEST_CASE("MocoTrack gait10dof18musc", "[casadi]") {
 
     MocoTrack track;
 
@@ -67,4 +66,3 @@ TEST_CASE("MocoTrack gait10dof18musc") {
     CHECK(std.compareContinuousVariablesRMS(
             solution, {{"controls",{}}}) < 1e-2);
 }
-#endif

--- a/Vendors/CMakeLists.txt
+++ b/Vendors/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(lepton)
-if(MOCO_WITH_TROPTER)
+if(OPENSIM_WITH_TROPTER)
     add_subdirectory(tropter)
 endif()


### PR DESCRIPTION
### Brief summary of changes

I added a CMake variable OPENSIM_WITH_CASADI and ensured the Moco tests pass when OPENSIM_WITH_CASADI and/or OPENSIM_WITH_TROPTER are false.

This PR targets the `moco` branch.

### Testing I've completed

Ran CTests with all 4 combinations of OPENSIM_WITH_CASADI and OPENSIM_WITH_TROPTER.

GitHub Actions leaves both of these CMake variables set to ON.

### Looking for feedback on...

- Names of the OPENSIM_WITH_CASADI and OPENSIM_WITH_TROPTER CMake variables.
- Reviewing: I'm thinking that @nickbianco reivews this PR and then others review this PR as part of #2805 ; does this plan make sense?

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2814)
<!-- Reviewable:end -->
