### PR TITLE
add missing brackets to log_info

### DIFF
--- a/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
@@ -185,10 +185,10 @@ bool IMUPlacer::run(bool visualizeResults) {
     for (auto& imuName : imuLabels) {
         log_info("Processing {}", imuName);
         if (imuBodiesInGround.find(imuName) != imuBodiesInGround.end()) {
-            log_info("Computed offset for ", imuName);
+            log_info("Computed offset for {}", imuName);
             SimTK::Rotation R_FB =
                     ~imuBodiesInGround[imuName] * rotations[int(imuix)];
-            log_info("Offset is ", R_FB);
+            log_info("Offset is {}", R_FB);
             PhysicalOffsetFrame* imuOffset = nullptr;
             const PhysicalOffsetFrame* mo = nullptr;
             if ((mo = _model->findComponent<PhysicalOffsetFrame>(imuName))) {
@@ -197,7 +197,7 @@ bool IMUPlacer::run(bool visualizeResults) {
                 X.updR() = R_FB;
                 imuOffset->setOffsetTransform(X);
             } else {
-                log_info("Creating offset frame for ", imuName);
+                log_info("Creating offset frame for {}", imuName);
                 OpenSim::Body* body =
                         dynamic_cast<OpenSim::Body*>(bodies[imuix]);
                 SimTK::Vec3 p_FB(0);

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -69,7 +69,7 @@ TimeSeriesTable_<SimTK::Rotation> OpenSenseUtilities::
 void OpenSim::OpenSenseUtilities::rotateOrientationTable(
         OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>&
                 quaternionsTable,
-        const SimTK::Rotation_<double>& rotationMatrix) 
+        const SimTK::Rotation_<double>& rotationMatrix)
 {
     SimTK::Rotation R_XG = rotationMatrix;
 
@@ -112,7 +112,7 @@ OpenSenseUtilities::createOrientationsFileFromMarkers(const std::string& markers
 {
     TimeSeriesTableVec3 table{ markersFile };
 
-    // labels of markers including those <bodyName>O,X,Y that identify the 
+    // labels of markers including those <bodyName>O,X,Y that identify the
     // IMU sensor placement/alignment on the body expressed in Ground
     auto labels = table.getColumnLabels();
 
@@ -205,13 +205,13 @@ SimTK::Vec3 OpenSenseUtilities::computeHeadingCorrection(
             OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>&
                     quaternionsTable,
             const std::string& baseImuName,
-            const SimTK::CoordinateDirection baseHeadingDirection) 
+            const SimTK::CoordinateDirection baseHeadingDirection)
 {
      SimTK::Vec3 rotations{0};
- 
+
     // if a base imu is specified, perform heading correction, otherwise skip
     if (!baseImuName.empty()) {
-        
+
         // Base will rotate to match <base>_imu, so we must first remove the
         // base rotation from the other IMUs to get their orientation with
         // respect to individual model bodies and thereby compute correct
@@ -225,7 +225,7 @@ SimTK::Vec3 OpenSenseUtilities::computeHeadingCorrection(
             OPENSIM_THROW(Exception, "No column with base IMU name '" +
                                              baseImuName + "' found.");
         }
-        
+
         auto startRow = quaternionsTable.getRowAtIndex(0);
         Rotation base_R = Rotation(startRow.getElt(0, int(pix)));
 
@@ -239,16 +239,16 @@ SimTK::Vec3 OpenSenseUtilities::computeHeadingCorrection(
         SimTK::Real angularDifference = acos(~pelvisHeading * groundX);
         // Compute the sign of the angular correction.
         SimTK::Vec3 xproduct = (groundX % pelvisHeading);
-        if (xproduct.get(2) > 0) { 
-            angularDifference *= -1; 
+        if (xproduct.get(2) > 0) {
+            angularDifference *= -1;
         }
-        
+
         log_info("Heading correction computed to be {} degs about ground Y.",
             angularDifference * SimTK_RADIAN_TO_DEGREE);
 
         rotations = SimTK::Vec3( 0, angularDifference,  0);
 
-    } 
+    }
     else
         OPENSIM_THROW(Exception,
                 "Heading correction attempted without base imu specification. Aborting.'");


### PR DESCRIPTION
@aymanhab, I was looking at OpenSense files and I think there are a few brackets missing in the `log_infos` to have the outputs printed out. This PR adds them, feel free to ignore if not needed.

### Brief summary of changes

Added missing brackets to `log_info` + blank spaces automatically removed.

### Testing I've completed

No needed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because very minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2815)
<!-- Reviewable:end -->
