### PR TITLE
Shorten usage and remove options for now to allow regex to digest it.

### DIFF
--- a/Applications/opensim-cmd/opensim-cmd_viz.h
+++ b/Applications/opensim-cmd/opensim-cmd_viz.h
@@ -67,7 +67,20 @@ Examples:
   opensim-cmd viz -g C:/MyGeometry data orientations.sto -m arm.osim
   opensim-cmd --library C:\Plugins\osimMyCustomForce.dll viz model arm.osim
 )";
+/* Block below was removed from help text to address bug in VisualStudio handling of regular expressions opensim-core issue #2807
 
+Description of options:
+  g, geometry  Search for geometry mesh files in this path.
+  m, model     If visualizing orientation data and --layout is 'model',
+               the orientation data will be visualized according to the default
+               pose of this model.
+  a, layout    If visualizing orientation data, this option specifies the layout
+               of x-y-z triads as either in a 'line' (the default), in a
+               'circle', or according to the default pose of a 'model'. If the
+               value is 'model', then the --model option must be provided.
+  r, rotate    If visualizing orientation data, this option specifies the space
+               fixed Euler angles to apply to data specified in radians.
+*/
 
 SimTK::Vec3 parseRotationsString(const std::string& rotationString) {
     SimTK::Vec3 returnVec3{0};

--- a/Applications/opensim-cmd/opensim-cmd_viz.h
+++ b/Applications/opensim-cmd/opensim-cmd_viz.h
@@ -34,11 +34,8 @@ static const char HELP_VIZ[] =
 R"(Show a model, motion, or marker/orientation data with the Simbody Visualizer.
 
 Usage:
-  opensim-cmd [options]... viz [--geometry=<path>]
-                                model <model-file> [<states-file>]
-  opensim-cmd [options]... viz [--geometry=<path>]
-                                data <data-file> [--model=<model-file>]
-                                [--layout=<layout>] [--rotate=<rotations>]
+  opensim-cmd [options]... viz [--geometry=<path>] model <model-file> [<states-file>]
+  opensim-cmd [options]... viz [--geometry=<path>] data <data-file> [--model=<model-file>] [--layout=<layout>] [--rotate=<rotations>]
   opensim-cmd viz -h | --help
 
 Options:
@@ -60,18 +57,6 @@ Description of subcommands:
          TimeSeriesTableQuaternion, then the data are visualized as body
          orientations using x-y-z triads, and the --model and --layout
          flags can be used.
-
-Description of options:
-  g, geometry  Search for geometry mesh files in this path.
-  m, model     If visualizing orientation data and --layout is 'model',
-               the orientation data will be visualized according to the default
-               pose of this model.
-  a, layout    If visualizing orientation data, this option specifies the layout
-               of x-y-z triads as either in a 'line' (the default), in a
-               'circle', or according to the default pose of a 'model'. If the
-               value is 'model', then the --model option must be provided.
-  r, rotate    If visualizing orientation data, this option specifies the space
-               fixed Euler angles to apply to data specified in radians.
 Examples:
   opensim-cmd viz model lowerlimb.osim
   opensim-cmd viz --geometry C:/MyGeometry model lowerlimb.osim

--- a/Applications/opensim-cmd/opensim-cmd_viz.h
+++ b/Applications/opensim-cmd/opensim-cmd_viz.h
@@ -57,6 +57,7 @@ Description of subcommands:
          TimeSeriesTableQuaternion, then the data are visualized as body
          orientations using x-y-z triads, and the --model and --layout
          flags can be used.
+
 Examples:
   opensim-cmd viz model lowerlimb.osim
   opensim-cmd viz --geometry C:/MyGeometry model lowerlimb.osim


### PR DESCRIPTION
Fixes issue #2807

### Brief summary of changes
By trial and error, removed chunks of documentation parts to avoid regex exception at runtime on windows

### Testing I've completed
Ran tests, ran command in issue report live

### Looking for feedback on...
Is this enough documentation, what minimal additions would be enough for users

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2816)
<!-- Reviewable:end -->
