### PR TITLE
Fix ZenHub badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,7 +1258,7 @@ Example: If opensim_install is in your home directory:
 [travisci]: https://travis-ci.org/opensim-org/opensim-core
 [buildstatus_image_appveyor]: https://ci.appveyor.com/api/projects/status/i4wxnmx9jlk69kge/branch/master?svg=true
 [appveyorci]: https://ci.appveyor.com/project/opensim-org/opensim-core/branch/master
-[zenhub_image]: https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png
+[zenhub_image]: https://dxssrr2j0sq4w.cloudfront.net/3.2.0/img/external/zenhub-badge.png
 [zenhub]: https://zenhub.com
 
 [running_gif]: doc/images/opensim_running.gif


### PR DESCRIPTION

### Brief summary of changes

The ZenHub badge in the README was no longer displaying properly. I updated the link to the badge image.

### Testing I've completed

Previewed the README to ensure the badge shows properly now.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2817)
<!-- Reviewable:end -->
