### PR TITLE
Rename Moco header guards

### DIFF
--- a/Bindings/OpenSimHeaders_moco.h
+++ b/Bindings/OpenSimHeaders_moco.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_OPENSIM_HEADERS_MOCO_H_
-#define MOCO_OPENSIM_HEADERS_MOCO_H_
+#ifndef OPENSIM_OPENSIM_HEADERS_MOCO_H_
+#define OPENSIM_OPENSIM_HEADERS_MOCO_H_
 /* This header is only used with SWIG to create bindings.
  */
 
@@ -43,4 +43,4 @@
 #include <OpenSim/Moco/ModelOperators.h>
 #include <OpenSim/Moco/osimMocoDLL.h>
 
-#endif // MOCO_OPENSIM_HEADERS_MOCO_H_
+#endif // OPENSIM_OPENSIM_HEADERS_MOCO_H_

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/MocoCustomEffortGoal.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/MocoCustomEffortGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCUSTOMEFFORTGOAL_H
 #define OPENSIM_MOCOCUSTOMEFFORTGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoCustomEffortGoal.h                                       *
+ * OpenSim: MocoCustomEffortGoal.h                                            *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/MocoCustomEffortGoal.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/MocoCustomEffortGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCUSTOMEFFORTGOAL_H
-#define MOCO_MOCOCUSTOMEFFORTGOAL_H
+#ifndef OPENSIM_MOCOCUSTOMEFFORTGOAL_H
+#define OPENSIM_MOCOCUSTOMEFFORTGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoCustomEffortGoal.h                                       *
  * -------------------------------------------------------------------------- *
@@ -45,4 +45,4 @@ protected:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCUSTOMEFFORTGOAL_H
+#endif // OPENSIM_MOCOCUSTOMEFFORTGOAL_H

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
 #define OPENSIM_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: RegisterTypes_osimMocoCustomEffortGoal.h                     *
+ * OpenSim: RegisterTypes_osimMocoCustomEffortGoal.h                          *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
-#define MOCO_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
+#ifndef OPENSIM_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
+#define OPENSIM_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: RegisterTypes_osimMocoCustomEffortGoal.h                     *
  * -------------------------------------------------------------------------- *
@@ -33,4 +33,4 @@ private:
     void registerDllClasses();
 };
 
-#endif // MOCO_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H
+#endif // OPENSIM_REGISTERTYPES_OSIMMOCOCUSTOMEFFORTGOAL_H

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/osimMocoCustomEffortGoalDLL.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/osimMocoCustomEffortGoalDLL.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_OSIMMOCOCUSTOMEFFORTGOALDLL_H
-#define MOCO_OSIMMOCOCUSTOMEFFORTGOALDLL_H
+#ifndef OPENSIM_OSIMMOCOCUSTOMEFFORTGOALDLL_H
+#define OPENSIM_OSIMMOCOCUSTOMEFFORTGOALDLL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: osimMocoCustomEffortGoalDLL.h                                *
  * -------------------------------------------------------------------------- *
@@ -28,4 +28,4 @@
     #endif
 #endif
 
-#endif // MOCO_OSIMMOCOCUSTOMEFFORTGOALDLL_H
+#endif // OPENSIM_OSIMMOCOCUSTOMEFFORTGOALDLL_H

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/osimMocoCustomEffortGoalDLL.h
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/osimMocoCustomEffortGoalDLL.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_OSIMMOCOCUSTOMEFFORTGOALDLL_H
 #define OPENSIM_OSIMMOCOCUSTOMEFFORTGOALDLL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: osimMocoCustomEffortGoalDLL.h                                *
+ * OpenSim: osimMocoCustomEffortGoalDLL.h                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/About.h
+++ b/OpenSim/Moco/About.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCO_ABOUT_H_
 #define OPENSIM_MOCO_ABOUT_H_
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: About.h                                                      *
+ * OpenSim: About.h                                                           *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/DeGrooteFregly2016MuscleStandalone.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/DeGrooteFregly2016MuscleStandalone.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
 #define OPENSIM_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: DeGrooteFregly2016MuscleStandalone.h                         *
+ * OpenSim: DeGrooteFregly2016MuscleStandalone.h                              *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/DeGrooteFregly2016MuscleStandalone.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/DeGrooteFregly2016MuscleStandalone.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
-#define MOCO_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
+#ifndef OPENSIM_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
+#define OPENSIM_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: DeGrooteFregly2016MuscleStandalone.h                         *
  * -------------------------------------------------------------------------- *
@@ -348,4 +348,4 @@ private:
     double _fiber_width = NaN;
 };
 
-#endif // MOCO_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_
+#endif // OPENSIM_DEGROOTEFREGLY2016MUSCLESTANDALONE_H_

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/GlobalStaticOptimization.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/GlobalStaticOptimization.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_GLOBALSTATICOPTIMIZATION_H
-#define MOCO_GLOBALSTATICOPTIMIZATION_H
+#ifndef OPENSIM_GLOBALSTATICOPTIMIZATION_H
+#define OPENSIM_GLOBALSTATICOPTIMIZATION_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: GlobalStaticOptimization.h                                   *
  * -------------------------------------------------------------------------- *
@@ -84,4 +84,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_GLOBALSTATICOPTIMIZATION_H
+#endif // OPENSIM_GLOBALSTATICOPTIMIZATION_H

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/GlobalStaticOptimization.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/GlobalStaticOptimization.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_GLOBALSTATICOPTIMIZATION_H
 #define OPENSIM_GLOBALSTATICOPTIMIZATION_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: GlobalStaticOptimization.h                                   *
+ * OpenSim: GlobalStaticOptimization.h                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGO.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGO.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_INDYGO_H
-#define MOCO_INDYGO_H
+#ifndef OPENSIM_INDYGO_H
+#define OPENSIM_INDYGO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: INDYGO.h                                                     *
  * -------------------------------------------------------------------------- *
@@ -237,4 +237,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_INDYGO_H
+#endif // OPENSIM_INDYGO_H

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGO.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGO.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_INDYGO_H
 #define OPENSIM_INDYGO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: INDYGO.h                                                     *
+ * OpenSim: INDYGO.h                                                          *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGOProblemInternal.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGOProblemInternal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_INDYGOPROBLEMINTERNAL_H
 #define OPENSIM_INDYGOPROBLEMINTERNAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: INDYGOProblemInternal.cpp                                    *
+ * OpenSim: INDYGOProblemInternal.cpp                                         *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGOProblemInternal.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/INDYGOProblemInternal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_INDYGOPROBLEMINTERNAL_H
-#define MOCO_INDYGOPROBLEMINTERNAL_H
+#ifndef OPENSIM_INDYGOPROBLEMINTERNAL_H
+#define OPENSIM_INDYGOPROBLEMINTERNAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: INDYGOProblemInternal.cpp                                    *
  * -------------------------------------------------------------------------- *
@@ -637,4 +637,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_INDYGOPROBLEMINTERNAL_H
+#endif // OPENSIM_INDYGOPROBLEMINTERNAL_H

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolver.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_INVERSEMUSCLESOLVER_H
 #define OPENSIM_INVERSEMUSCLESOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: InverseMuscleSolver.h                                        *
+ * OpenSim: InverseMuscleSolver.h                                             *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolver.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_INVERSEMUSCLESOLVER_H
-#define MOCO_INVERSEMUSCLESOLVER_H
+#ifndef OPENSIM_INVERSEMUSCLESOLVER_H
+#define OPENSIM_INVERSEMUSCLESOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: InverseMuscleSolver.h                                        *
  * -------------------------------------------------------------------------- *
@@ -240,4 +240,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_INVERSEMUSCLESOLVER_H
+#endif // OPENSIM_INVERSEMUSCLESOLVER_H

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolverMotionData.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolverMotionData.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_INVERSEMUSCLESOLVERMOTIONDATA_H
 #define OPENSIM_INVERSEMUSCLESOLVERMOTIONDATA_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: InverseMuscleSolverMotionData.h                              *
+ * OpenSim: InverseMuscleSolverMotionData.h                                   *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolverMotionData.h
+++ b/OpenSim/Moco/Archive/InverseMuscleSolver/InverseMuscleSolverMotionData.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_INVERSEMUSCLESOLVERMOTIONDATA_H
-#define MOCO_INVERSEMUSCLESOLVERMOTIONDATA_H
+#ifndef OPENSIM_INVERSEMUSCLESOLVERMOTIONDATA_H
+#define OPENSIM_INVERSEMUSCLESOLVERMOTIONDATA_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: InverseMuscleSolverMotionData.h                              *
  * -------------------------------------------------------------------------- *
@@ -136,4 +136,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_INVERSEMUSCLESOLVERMOTIONDATA_H
+#endif // OPENSIM_INVERSEMUSCLESOLVERMOTIONDATA_H

--- a/OpenSim/Moco/Common/TableProcessor.h
+++ b/OpenSim/Moco/Common/TableProcessor.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_TABLEPROCESSOR_H
 #define OPENSIM_TABLEPROCESSOR_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: TableProcessor.h                                             *
+ * OpenSim: TableProcessor.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Common/TableProcessor.h
+++ b/OpenSim/Moco/Common/TableProcessor.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_TABLEPROCESSOR_H
-#define MOCO_TABLEPROCESSOR_H
+#ifndef OPENSIM_TABLEPROCESSOR_H
+#define OPENSIM_TABLEPROCESSOR_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: TableProcessor.h                                             *
  * -------------------------------------------------------------------------- *
@@ -203,4 +203,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_TABLEPROCESSOR_H
+#endif // OPENSIM_TABLEPROCESSOR_H

--- a/OpenSim/Moco/Components/AccelerationMotion.h
+++ b/OpenSim/Moco/Components/AccelerationMotion.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_ACCELERATIONMOTION_H
 #define OPENSIM_ACCELERATIONMOTION_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: AccelerationMotion.h                                         *
+ * OpenSim: AccelerationMotion.h                                              *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/AccelerationMotion.h
+++ b/OpenSim/Moco/Components/AccelerationMotion.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_ACCELERATIONMOTION_H
-#define MOCO_ACCELERATIONMOTION_H
+#ifndef OPENSIM_ACCELERATIONMOTION_H
+#define OPENSIM_ACCELERATIONMOTION_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: AccelerationMotion.h                                         *
  * -------------------------------------------------------------------------- *
@@ -65,4 +65,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_ACCELERATIONMOTION_H
+#endif // OPENSIM_ACCELERATIONMOTION_H

--- a/OpenSim/Moco/Components/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Moco/Components/DeGrooteFregly2016Muscle.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_DEGROOTEFREGLY2016MUSCLE_H
-#define MOCO_DEGROOTEFREGLY2016MUSCLE_H
+#ifndef OPENSIM_DEGROOTEFREGLY2016MUSCLE_H
+#define OPENSIM_DEGROOTEFREGLY2016MUSCLE_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: DeGrooteFregly2016Muscle.h                                   *
  * -------------------------------------------------------------------------- *
@@ -844,4 +844,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_DEGROOTEFREGLY2016MUSCLE_H
+#endif // OPENSIM_DEGROOTEFREGLY2016MUSCLE_H

--- a/OpenSim/Moco/Components/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Moco/Components/DeGrooteFregly2016Muscle.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_DEGROOTEFREGLY2016MUSCLE_H
 #define OPENSIM_DEGROOTEFREGLY2016MUSCLE_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: DeGrooteFregly2016Muscle.h                                   *
+ * OpenSim: DeGrooteFregly2016Muscle.h                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/DiscreteController.h
+++ b/OpenSim/Moco/Components/DiscreteController.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_DISCRETECONTROLLER_H
 #define OPENSIM_DISCRETECONTROLLER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: DiscreteController.h                                         *
+ * OpenSim: DiscreteController.h                                              *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2020 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/DiscreteController.h
+++ b/OpenSim/Moco/Components/DiscreteController.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_DISCRETECONTROLLER_H
-#define MOCO_DISCRETECONTROLLER_H
+#ifndef OPENSIM_DISCRETECONTROLLER_H
+#define OPENSIM_DISCRETECONTROLLER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: DiscreteController.h                                         *
  * -------------------------------------------------------------------------- *
@@ -45,4 +45,4 @@ protected:
 } // namespace OpenSim
 
 
-#endif // MOCO_DISCRETECONTROLLER_H
+#endif // OPENSIM_DISCRETECONTROLLER_H

--- a/OpenSim/Moco/Components/DiscreteForces.h
+++ b/OpenSim/Moco/Components/DiscreteForces.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_DISCRETEFORCES_H
-#define MOCO_DISCRETEFORCES_H
+#ifndef OPENSIM_DISCRETEFORCES_H
+#define OPENSIM_DISCRETEFORCES_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: DiscreteForces.h                                             *
  * -------------------------------------------------------------------------- *
@@ -56,4 +56,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_DISCRETEFORCES_H
+#endif // OPENSIM_DISCRETEFORCES_H

--- a/OpenSim/Moco/Components/DiscreteForces.h
+++ b/OpenSim/Moco/Components/DiscreteForces.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_DISCRETEFORCES_H
 #define OPENSIM_DISCRETEFORCES_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: DiscreteForces.h                                             *
+ * OpenSim: DiscreteForces.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/ModelFactory.h
+++ b/OpenSim/Moco/Components/ModelFactory.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MODELFACTORY_H
 #define OPENSIM_MODELFACTORY_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: ModelFactory.h                                               *
+ * OpenSim: ModelFactory.h                                                    *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/ModelFactory.h
+++ b/OpenSim/Moco/Components/ModelFactory.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MODELFACTORY_H
-#define MOCO_MODELFACTORY_H
+#ifndef OPENSIM_MODELFACTORY_H
+#define OPENSIM_MODELFACTORY_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: ModelFactory.h                                               *
  * -------------------------------------------------------------------------- *
@@ -96,4 +96,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_MODELFACTORY_H
+#endif // OPENSIM_MODELFACTORY_H

--- a/OpenSim/Moco/Components/MultivariatePolynomialFunction.h
+++ b/OpenSim/Moco/Components/MultivariatePolynomialFunction.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MULTIVARIATEPOLYNOMIAL_FUNCTION_H_
 #define OPENSIM_MULTIVARIATEPOLYNOMIAL_FUNCTION_H_
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MultivariatePolynomialFunction.h                             *
+ * OpenSim: MultivariatePolynomialFunction.h                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017-19 Stanford University and the Authors                  *
  *                                                                            *

--- a/OpenSim/Moco/Components/PositionMotion.h
+++ b/OpenSim/Moco/Components/PositionMotion.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_POSITIONMOTION_H
-#define MOCO_POSITIONMOTION_H
+#ifndef OPENSIM_POSITIONMOTION_H
+#define OPENSIM_POSITIONMOTION_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: PositionMotion.h                                             *
  * -------------------------------------------------------------------------- *
@@ -105,4 +105,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_PRESCRIBEDPOSITIONMOTION_H
+#endif // OPENSIM_PRESCRIBEDPOSITIONMOTION_H

--- a/OpenSim/Moco/Components/PositionMotion.h
+++ b/OpenSim/Moco/Components/PositionMotion.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_POSITIONMOTION_H
 #define OPENSIM_POSITIONMOTION_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: PositionMotion.h                                             *
+ * OpenSim: PositionMotion.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/Components/StationPlaneContactForce.h
+++ b/OpenSim/Moco/Components/StationPlaneContactForce.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_STATIONPLANECONTACTFORCE_H
-#define MOCO_STATIONPLANECONTACTFORCE_H
+#ifndef OPENSIM_STATIONPLANECONTACTFORCE_H
+#define OPENSIM_STATIONPLANECONTACTFORCE_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: StationPlaneContactForce.h                                   *
  * -------------------------------------------------------------------------- *
@@ -312,4 +312,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_STATIONPLANECONTACTFORCE_H
+#endif // OPENSIM_STATIONPLANECONTACTFORCE_H

--- a/OpenSim/Moco/Components/StationPlaneContactForce.h
+++ b/OpenSim/Moco/Components/StationPlaneContactForce.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_STATIONPLANECONTACTFORCE_H
 #define OPENSIM_STATIONPLANECONTACTFORCE_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: StationPlaneContactForce.h                                   *
+ * OpenSim: StationPlaneContactForce.h                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoBounds.h
+++ b/OpenSim/Moco/MocoBounds.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOBOUNDS_H
 #define OPENSIM_MOCOBOUNDS_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoBounds.h                                                 *
+ * OpenSim: MocoBounds.h                                                      *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoBounds.h
+++ b/OpenSim/Moco/MocoBounds.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOBOUNDS_H
-#define MOCO_MOCOBOUNDS_H
+#ifndef OPENSIM_MOCOBOUNDS_H
+#define OPENSIM_MOCOBOUNDS_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoBounds.h                                                 *
  * -------------------------------------------------------------------------- *
@@ -132,4 +132,4 @@ OpenSim_DECLARE_CONCRETE_OBJECT(MocoFinalBounds, MocoBounds);
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOBOUNDS_H
+#endif // OPENSIM_MOCOBOUNDS_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCFunction.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCFunction.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCFUNCTION_H
 #define OPENSIM_CASOCFUNCTION_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoCasOCFunction.h                                          *
+ * OpenSim: MocoCasOCFunction.h                                               *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCFunction.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCFunction.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCFUNCTION_H
-#define MOCO_CASOCFUNCTION_H
+#ifndef OPENSIM_CASOCFUNCTION_H
+#define OPENSIM_CASOCFUNCTION_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoCasOCFunction.h                                          *
  * -------------------------------------------------------------------------- *
@@ -315,4 +315,4 @@ class MultibodySystemImplicit : public Function {
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCFUNCTION_H
+#endif // OPENSIM_CASOCFUNCTION_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCHermiteSimpson.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCHermiteSimpson.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCHERMITESIMPSON_H
 #define OPENSIM_CASOCHERMITESIMPSON_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: CasOCHermiteSimpson.h                                        *
+ * OpenSim: CasOCHermiteSimpson.h                                             *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCHermiteSimpson.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCHermiteSimpson.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCHERMITESIMPSON_H
-#define MOCO_CASOCHERMITESIMPSON_H
+#ifndef OPENSIM_CASOCHERMITESIMPSON_H
+#define OPENSIM_CASOCHERMITESIMPSON_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: CasOCHermiteSimpson.h                                        *
  * -------------------------------------------------------------------------- *
@@ -78,4 +78,4 @@ private:
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCHERMITESIMPSON_H
+#endif // OPENSIM_CASOCHERMITESIMPSON_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCIterate.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCIterate.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCITERATE_H
-#define MOCO_CASOCITERATE_H
+#ifndef OPENSIM_CASOCITERATE_H
+#define OPENSIM_CASOCITERATE_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: CasOCIterate.h                                               *
  * -------------------------------------------------------------------------- *
@@ -78,4 +78,4 @@ struct Solution : public Iterate {
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCITERATE_H
+#endif // OPENSIM_CASOCITERATE_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCIterate.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCIterate.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCITERATE_H
 #define OPENSIM_CASOCITERATE_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: CasOCIterate.h                                               *
+ * OpenSim: CasOCIterate.h                                                    *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCPROBLEM_H
 #define OPENSIM_CASOCPROBLEM_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: CasOCProblem.h                                               *
+ * OpenSim: CasOCProblem.h                                                    *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCPROBLEM_H
-#define MOCO_CASOCPROBLEM_H
+#ifndef OPENSIM_CASOCPROBLEM_H
+#define OPENSIM_CASOCPROBLEM_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: CasOCProblem.h                                               *
  * -------------------------------------------------------------------------- *
@@ -640,4 +640,4 @@ private:
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCPROBLEM_H
+#endif // OPENSIM_CASOCPROBLEM_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCSOLVER_H
 #define OPENSIM_CASOCSOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoCasOCSolver.h                                            *
+ * OpenSim: MocoCasOCSolver.h                                                 *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCSOLVER_H
-#define MOCO_CASOCSOLVER_H
+#ifndef OPENSIM_CASOCSOLVER_H
+#define OPENSIM_CASOCSOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoCasOCSolver.h                                            *
  * -------------------------------------------------------------------------- *
@@ -200,4 +200,4 @@ private:
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCSOLVER_H
+#endif // OPENSIM_CASOCSOLVER_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCTRANSCRIPTION_H
 #define OPENSIM_CASOCTRANSCRIPTION_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: CasOCTranscription.h                                         *
+ * OpenSim: CasOCTranscription.h                                              *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCTRANSCRIPTION_H
-#define MOCO_CASOCTRANSCRIPTION_H
+#ifndef OPENSIM_CASOCTRANSCRIPTION_H
+#define OPENSIM_CASOCTRANSCRIPTION_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: CasOCTranscription.h                                         *
  * -------------------------------------------------------------------------- *
@@ -401,4 +401,4 @@ private:
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCTRANSCRIPTION_H
+#endif // OPENSIM_CASOCTRANSCRIPTION_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTrapezoidal.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTrapezoidal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_CASOCTRAPEZOIDAL_H
-#define MOCO_CASOCTRAPEZOIDAL_H
+#ifndef OPENSIM_CASOCTRAPEZOIDAL_H
+#define OPENSIM_CASOCTRAPEZOIDAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: CasOCTrapezoidal.h                                           *
  * -------------------------------------------------------------------------- *
@@ -48,4 +48,4 @@ private:
 
 } // namespace CasOC
 
-#endif // MOCO_CASOCTRAPEZOIDAL_H
+#endif // OPENSIM_CASOCTRAPEZOIDAL_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTrapezoidal.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTrapezoidal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_CASOCTRAPEZOIDAL_H
 #define OPENSIM_CASOCTRAPEZOIDAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: CasOCTrapezoidal.h                                           *
+ * OpenSim: CasOCTrapezoidal.h                                                *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCASADISOLVER_H
-#define MOCO_MOCOCASADISOLVER_H
+#ifndef OPENSIM_MOCOCASADISOLVER_H
+#define OPENSIM_MOCOCASADISOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoCasADiSolver.h                                           *
  * -------------------------------------------------------------------------- *
@@ -233,4 +233,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCASADISOLVER_H
+#endif // OPENSIM_MOCOCASADISOLVER_H

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCASADISOLVER_H
 #define OPENSIM_MOCOCASADISOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoCasADiSolver.h                                           *
+ * OpenSim: MocoCasADiSolver.h                                                *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCASOCPROBLEM_H
 #define OPENSIM_MOCOCASOCPROBLEM_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoCasOCProblem.h                                           *
+ * OpenSim: MocoCasOCProblem.h                                                *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCASOCPROBLEM_H
-#define MOCO_MOCOCASOCPROBLEM_H
+#ifndef OPENSIM_MOCOCASOCPROBLEM_H
+#define OPENSIM_MOCOCASOCPROBLEM_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoCasOCProblem.h                                           *
  * -------------------------------------------------------------------------- *
@@ -764,4 +764,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCASOCPROBLEM_H
+#endif // OPENSIM_MOCOCASOCPROBLEM_H

--- a/OpenSim/Moco/MocoConstraint.h
+++ b/OpenSim/Moco/MocoConstraint.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONSTRAINT_H
 #define OPENSIM_MOCOCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoConstraint.h                                             *
+ * OpenSim: MocoConstraint.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoConstraint.h
+++ b/OpenSim/Moco/MocoConstraint.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONSTRAINT_H
-#define MOCO_MOCOCONSTRAINT_H
+#ifndef OPENSIM_MOCOCONSTRAINT_H
+#define OPENSIM_MOCOCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoConstraint.h                                             *
  * -------------------------------------------------------------------------- *
@@ -238,4 +238,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONSTRAINT_H
+#endif // OPENSIM_MOCOCONSTRAINT_H

--- a/OpenSim/Moco/MocoConstraintInfo.h
+++ b/OpenSim/Moco/MocoConstraintInfo.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONSTRAINTINFO_H
-#define MOCO_MOCOCONSTRAINTINFO_H
+#ifndef OPENSIM_MOCOCONSTRAINTINFO_H
+#define OPENSIM_MOCOCONSTRAINTINFO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoConstraintInfo.h                                         *
  * -------------------------------------------------------------------------- *
@@ -135,4 +135,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONSTRAINTINFO_H
+#endif // OPENSIM_MOCOCONSTRAINTINFO_H

--- a/OpenSim/Moco/MocoConstraintInfo.h
+++ b/OpenSim/Moco/MocoConstraintInfo.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONSTRAINTINFO_H
 #define OPENSIM_MOCOCONSTRAINTINFO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoConstraintInfo.h                                         *
+ * OpenSim: MocoConstraintInfo.h                                              *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoControlBoundConstraint.h
+++ b/OpenSim/Moco/MocoControlBoundConstraint.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONTROLBOUNDCONSTRAINT_H
 #define OPENSIM_MOCOCONTROLBOUNDCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoControlBoundConstraint.h                                 *
+ * OpenSim: MocoControlBoundConstraint.h                                      *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoControlBoundConstraint.h
+++ b/OpenSim/Moco/MocoControlBoundConstraint.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONTROLBOUNDCONSTRAINT_H
-#define MOCO_MOCOCONTROLBOUNDCONSTRAINT_H
+#ifndef OPENSIM_MOCOCONTROLBOUNDCONSTRAINT_H
+#define OPENSIM_MOCOCONTROLBOUNDCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoControlBoundConstraint.h                                 *
  * -------------------------------------------------------------------------- *
@@ -112,4 +112,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONTROLBOUNDCONSTRAINT_H
+#endif // OPENSIM_MOCOCONTROLBOUNDCONSTRAINT_H

--- a/OpenSim/Moco/MocoDirectCollocationSolver.h
+++ b/OpenSim/Moco/MocoDirectCollocationSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCODIRECTCOLLOCATIONSOLVER_H
-#define MOCO_MOCODIRECTCOLLOCATIONSOLVER_H
+#ifndef OPENSIM_MOCODIRECTCOLLOCATIONSOLVER_H
+#define OPENSIM_MOCODIRECTCOLLOCATIONSOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoDirectCollocationSolver.h                                *
  * -------------------------------------------------------------------------- *
@@ -171,4 +171,4 @@ protected:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCODIRECTCOLLOCATIONSOLVER_H
+#endif // OPENSIM_MOCODIRECTCOLLOCATIONSOLVER_H

--- a/OpenSim/Moco/MocoDirectCollocationSolver.h
+++ b/OpenSim/Moco/MocoDirectCollocationSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCODIRECTCOLLOCATIONSOLVER_H
 #define OPENSIM_MOCODIRECTCOLLOCATIONSOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoDirectCollocationSolver.h                                *
+ * OpenSim: MocoDirectCollocationSolver.h                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoFrameDistanceConstraint.h
+++ b/OpenSim/Moco/MocoFrameDistanceConstraint.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOFRAMEDISTANCECONSTRAINT_H
-#define MOCO_MOCOFRAMEDISTANCECONSTRAINT_H
+#ifndef OPENSIM_MOCOFRAMEDISTANCECONSTRAINT_H
+#define OPENSIM_MOCOFRAMEDISTANCECONSTRAINT_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoFrameDistanceConstraint.h                                *
  * -------------------------------------------------------------------------- *
@@ -149,4 +149,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOFRAMEDISTANCECONSTRAINT_H
+#endif // OPENSIM_MOCOFRAMEDISTANCECONSTRAINT_H

--- a/OpenSim/Moco/MocoFrameDistanceConstraint.h
+++ b/OpenSim/Moco/MocoFrameDistanceConstraint.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOFRAMEDISTANCECONSTRAINT_H
 #define OPENSIM_MOCOFRAMEDISTANCECONSTRAINT_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoFrameDistanceConstraint.h                                *
+ * OpenSim: MocoFrameDistanceConstraint.h                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOACCELERATIONTRACKINGGOAL_H
-#define MOCO_MOCOACCELERATIONTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOACCELERATIONTRACKINGGOAL_H
+#define OPENSIM_MOCOACCELERATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoAccelerationTrackingGoal.h                               *
  * -------------------------------------------------------------------------- *
@@ -144,4 +144,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOACCELERATIONTRACKINGGOAL_H
+#endif // OPENSIM_MOCOACCELERATIONTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoAccelerationTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOACCELERATIONTRACKINGGOAL_H
 #define OPENSIM_MOCOACCELERATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoAccelerationTrackingGoal.h                               *
+ * OpenSim: MocoAccelerationTrackingGoal.h                                    *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOANGULARVELOCITYTRACKINGGOAL_H
-#define MOCO_MOCOANGULARVELOCITYTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOANGULARVELOCITYTRACKINGGOAL_H
+#define OPENSIM_MOCOANGULARVELOCITYTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoAngularVelocityTrackingGoal.h                            *
  * -------------------------------------------------------------------------- *
@@ -177,4 +177,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOANGULARVELOCITYTRACKINGGOAL_H
+#endif // OPENSIM_MOCOANGULARVELOCITYTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoAngularVelocityTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOANGULARVELOCITYTRACKINGGOAL_H
 #define OPENSIM_MOCOANGULARVELOCITYTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoAngularVelocityTrackingGoal.h                            *
+ * OpenSim: MocoAngularVelocityTrackingGoal.h                                 *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONTACTTRACKINGGOAL_H
-#define MOCO_MOCOCONTACTTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOCONTACTTRACKINGGOAL_H
+#define OPENSIM_MOCOCONTACTTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoContactTrackingGoal.h                                    *
  * -------------------------------------------------------------------------- *
@@ -272,4 +272,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONTACTTRACKINGGOAL_H
+#endif // OPENSIM_MOCOCONTACTTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONTACTTRACKINGGOAL_H
 #define OPENSIM_MOCOCONTACTTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoContactTrackingGoal.h                                    *
+ * OpenSim: MocoContactTrackingGoal.h                                         *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2020 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoControlGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoControlGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONTROLGOAL_H
 #define OPENSIM_MOCOCONTROLGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoControlGoal.h                                            *
+ * OpenSim: MocoControlGoal.h                                                 *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoControlGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoControlGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONTROLGOAL_H
-#define MOCO_MOCOCONTROLGOAL_H
+#ifndef OPENSIM_MOCOCONTROLGOAL_H
+#define OPENSIM_MOCOCONTROLGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoControlGoal.h                                            *
  * -------------------------------------------------------------------------- *
@@ -123,4 +123,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONTROLGOAL_H
+#endif // OPENSIM_MOCOCONTROLGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoControlTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoControlTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOCONTROLTRACKINGGOAL_H
 #define OPENSIM_MOCOCONTROLTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoControlTrackingGoal.h                                    *
+ * OpenSim: MocoControlTrackingGoal.h                                         *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2020 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoControlTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoControlTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOCONTROLTRACKINGGOAL_H
-#define MOCO_MOCOCONTROLTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOCONTROLTRACKINGGOAL_H
+#define OPENSIM_MOCOCONTROLTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoControlTrackingGoal.h                                    *
  * -------------------------------------------------------------------------- *
@@ -248,4 +248,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOCONTROLTRACKINGGOAL_H
+#endif // OPENSIM_MOCOCONTROLTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOGOAL_H
-#define MOCO_MOCOGOAL_H
+#ifndef OPENSIM_MOCOGOAL_H
+#define OPENSIM_MOCOGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoGoal.h                                                   *
  * -------------------------------------------------------------------------- *
@@ -449,4 +449,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOGOAL_H
+#endif // OPENSIM_MOCOGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOGOAL_H
 #define OPENSIM_MOCOGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoGoal.h                                                   *
+ * OpenSim: MocoGoal.h                                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoInitialActivationGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialActivationGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOINITIALACTIVATIONGOAL_H
-#define MOCO_MOCOINITIALACTIVATIONGOAL_H
+#ifndef OPENSIM_MOCOINITIALACTIVATIONGOAL_H
+#define OPENSIM_MOCOINITIALACTIVATIONGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoInitialActivationGoal.h                                  *
  * -------------------------------------------------------------------------- *
@@ -53,4 +53,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOINITIALACTIVATIONGOAL_H
+#endif // OPENSIM_MOCOINITIALACTIVATIONGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoInitialActivationGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialActivationGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOINITIALACTIVATIONGOAL_H
 #define OPENSIM_MOCOINITIALACTIVATIONGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoInitialActivationGoal.h                                  *
+ * OpenSim: MocoInitialActivationGoal.h                                       *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoInitialForceEquilibriumGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialForceEquilibriumGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
-#define MOCO_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
+#ifndef OPENSIM_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
+#define OPENSIM_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoInitialForceEquilibriumGoal.h                            *
  * -------------------------------------------------------------------------- *
@@ -57,4 +57,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
+#endif // OPENSIM_MOCOINITIALFORCEEQUILIBRIUMGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoInitialForceEquilibriumGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialForceEquilibriumGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
 #define OPENSIM_MOCOINITIALFORCEEQUILIBRIUMGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoInitialForceEquilibriumGoal.h                            *
+ * OpenSim: MocoInitialForceEquilibriumGoal.h                                 *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoInitialVelocityEquilibriumDGFGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialVelocityEquilibriumDGFGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
-#define MOCO_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
+#ifndef OPENSIM_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
+#define OPENSIM_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoInitialVelocityEquilibriumDGFGoal.h                      *
  * -------------------------------------------------------------------------- *
@@ -59,4 +59,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
+#endif // OPENSIM_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoInitialVelocityEquilibriumDGFGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoInitialVelocityEquilibriumDGFGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
 #define OPENSIM_MOCOINITIALVELOCITYEQUILIBRIUMDGFGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoInitialVelocityEquilibriumDGFGoal.h                      *
+ * OpenSim: MocoInitialVelocityEquilibriumDGFGoal.h                           *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOJOINTREACTIONGOAL_H
 #define OPENSIM_MOCOJOINTREACTIONGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoJointReactionGoal.h                                      *
+ * OpenSim: MocoJointReactionGoal.h                                           *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOJOINTREACTIONGOAL_H
-#define MOCO_MOCOJOINTREACTIONGOAL_H
+#ifndef OPENSIM_MOCOJOINTREACTIONGOAL_H
+#define OPENSIM_MOCOJOINTREACTIONGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoJointReactionGoal.h                                      *
  * -------------------------------------------------------------------------- *
@@ -140,4 +140,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOJOINTREACTIONGOAL_H
+#endif // OPENSIM_MOCOJOINTREACTIONGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoMarkerFinalGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoMarkerFinalGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOMARKERFINALGOAL_H
-#define MOCO_MOCOMARKERFINALGOAL_H
+#ifndef OPENSIM_MOCOMARKERFINALGOAL_H
+#define OPENSIM_MOCOMARKERFINALGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoMarkerFinalGoal.h                                        *
  * -------------------------------------------------------------------------- *
@@ -70,4 +70,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOMARKERFINALGOAL_H
+#endif // OPENSIM_MOCOMARKERFINALGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoMarkerFinalGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoMarkerFinalGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOMARKERFINALGOAL_H
 #define OPENSIM_MOCOMARKERFINALGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoMarkerFinalGoal.h                                        *
+ * OpenSim: MocoMarkerFinalGoal.h                                             *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoMarkerTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoMarkerTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOMARKERTRACKINGGOAL_H
 #define OPENSIM_MOCOMARKERTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoMarkerTrackingGoal.h                                     *
+ * OpenSim: MocoMarkerTrackingGoal.h                                          *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoMarkerTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoMarkerTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOMARKERTRACKINGGOAL_H
-#define MOCO_MOCOMARKERTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOMARKERTRACKINGGOAL_H
+#define OPENSIM_MOCOMARKERTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoMarkerTrackingGoal.h                                     *
  * -------------------------------------------------------------------------- *
@@ -107,4 +107,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOMARKERTRACKINGGOAL_H
+#endif // OPENSIM_MOCOMARKERTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOORIENTATIONTRACKINGGOAL_H
 #define OPENSIM_MOCOORIENTATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoOrientationTrackingGoal.h                                *
+ * OpenSim: MocoOrientationTrackingGoal.h                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOORIENTATIONTRACKINGGOAL_H
-#define MOCO_MOCOORIENTATIONTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOORIENTATIONTRACKINGGOAL_H
+#define OPENSIM_MOCOORIENTATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoOrientationTrackingGoal.h                                *
  * -------------------------------------------------------------------------- *
@@ -180,4 +180,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOORIENTATIONTRACKINGGOAL_H
+#endif // OPENSIM_MOCOORIENTATIONTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOOUTPUTGOAL_H
 #define OPENSIM_MOCOOUTPUTGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoOutputGoal.h                                             *
+ * OpenSim: MocoOutputGoal.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOOUTPUTGOAL_H
-#define MOCO_MOCOOUTPUTGOAL_H
+#ifndef OPENSIM_MOCOOUTPUTGOAL_H
+#define OPENSIM_MOCOOUTPUTGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoOutputGoal.h                                             *
  * -------------------------------------------------------------------------- *
@@ -79,4 +79,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOOUTPUTGOAL_H
+#endif // OPENSIM_MOCOOUTPUTGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoPeriodicityGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoPeriodicityGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOPERIODICITYGOAL_H
-#define MOCO_MOCOPERIODICITYGOAL_H
+#ifndef OPENSIM_MOCOPERIODICITYGOAL_H
+#define OPENSIM_MOCOPERIODICITYGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoPeriodicityGoal.h                                        *
  * -------------------------------------------------------------------------- *
@@ -144,4 +144,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOPERIODICITYGOAL_H
+#endif // OPENSIM_MOCOPERIODICITYGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoPeriodicityGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoPeriodicityGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOPERIODICITYGOAL_H
 #define OPENSIM_MOCOPERIODICITYGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoPeriodicityGoal.h                                        *
+ * OpenSim: MocoPeriodicityGoal.h                                             *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017-19 Stanford University and the Authors                  *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoStateTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoStateTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSTATETRACKINGGOAL_H
 #define OPENSIM_MOCOSTATETRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoStateTrackingGoal.h                                      *
+ * OpenSim: MocoStateTrackingGoal.h                                           *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoStateTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoStateTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSTATETRACKINGGOAL_H
-#define MOCO_MOCOSTATETRACKINGGOAL_H
+#ifndef OPENSIM_MOCOSTATETRACKINGGOAL_H
+#define OPENSIM_MOCOSTATETRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoStateTrackingGoal.h                                      *
  * -------------------------------------------------------------------------- *
@@ -166,4 +166,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSTATETRACKINGGOAL_H
+#endif // OPENSIM_MOCOSTATETRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoSumSquaredStateGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoSumSquaredStateGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSUMSQUAREDSTATEGOAL_H
 #define OPENSIM_MOCOSUMSQUAREDSTATEGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoSumSquaredStateGoal.h                                    *
+ * OpenSim: MocoSumSquaredStateGoal.h                                         *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoGoal/MocoSumSquaredStateGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoSumSquaredStateGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSUMSQUAREDSTATEGOAL_H
-#define MOCO_MOCOSUMSQUAREDSTATEGOAL_H
+#ifndef OPENSIM_MOCOSUMSQUAREDSTATEGOAL_H
+#define OPENSIM_MOCOSUMSQUAREDSTATEGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoSumSquaredStateGoal.h                                    *
  * -------------------------------------------------------------------------- *
@@ -122,4 +122,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSUMSQUAREDSTATEGOAL_H
+#endif // OPENSIM_MOCOSUMSQUAREDSTATEGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOTRANSLATIONTRACKINGGOAL_H
-#define MOCO_MOCOTRANSLATIONTRACKINGGOAL_H
+#ifndef OPENSIM_MOCOTRANSLATIONTRACKINGGOAL_H
+#define OPENSIM_MOCOTRANSLATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTranslationTrackingGoal.h                                *
  * -------------------------------------------------------------------------- *
@@ -175,4 +175,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOTRANSLATIONTRACKINGGOAL_H
+#endif // OPENSIM_MOCOTRANSLATIONTRACKINGGOAL_H

--- a/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOTRANSLATIONTRACKINGGOAL_H
 #define OPENSIM_MOCOTRANSLATIONTRACKINGGOAL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoTranslationTrackingGoal.h                                *
+ * OpenSim: MocoTranslationTrackingGoal.h                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoInverse.h
+++ b/OpenSim/Moco/MocoInverse.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOINVERSE_H
 #define OPENSIM_MOCOINVERSE_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoInverse.h                                                *
+ * OpenSim: MocoInverse.h                                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoInverse.h
+++ b/OpenSim/Moco/MocoInverse.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOINVERSE_H
-#define MOCO_MOCOINVERSE_H
+#ifndef OPENSIM_MOCOINVERSE_H
+#define OPENSIM_MOCOINVERSE_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoInverse.h                                                *
  * -------------------------------------------------------------------------- *
@@ -151,4 +151,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOINVERSE_H
+#endif // OPENSIM_MOCOINVERSE_H

--- a/OpenSim/Moco/MocoParameter.h
+++ b/OpenSim/Moco/MocoParameter.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOPARAMETER_H
 #define OPENSIM_MOCOPARAMETER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoParameter.h                                              *
+ * OpenSim: MocoParameter.h                                                   *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoParameter.h
+++ b/OpenSim/Moco/MocoParameter.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOPARAMETER_H
-#define MOCO_MOCOPARAMETER_H
+#ifndef OPENSIM_MOCOPARAMETER_H
+#define OPENSIM_MOCOPARAMETER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoParameter.h                                              *
  * -------------------------------------------------------------------------- *
@@ -175,4 +175,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOPARAMETER_H
+#endif // OPENSIM_MOCOPARAMETER_H

--- a/OpenSim/Moco/MocoProblem.h
+++ b/OpenSim/Moco/MocoProblem.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOPROBLEM_H
 #define OPENSIM_MOCOPROBLEM_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoProblem.h                                                *
+ * OpenSim: MocoProblem.h                                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoProblem.h
+++ b/OpenSim/Moco/MocoProblem.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOPROBLEM_H
-#define MOCO_MOCOPROBLEM_H
+#ifndef OPENSIM_MOCOPROBLEM_H
+#define OPENSIM_MOCOPROBLEM_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoProblem.h                                                *
  * -------------------------------------------------------------------------- *
@@ -544,4 +544,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOPROBLEM_H
+#endif // OPENSIM_MOCOPROBLEM_H

--- a/OpenSim/Moco/MocoProblemInfo.h
+++ b/OpenSim/Moco/MocoProblemInfo.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOPROBLEMINFO_H
 #define OPENSIM_MOCOPROBLEMINFO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoProblemInfo.h                                            *
+ * OpenSim: MocoProblemInfo.h                                                 *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoProblemInfo.h
+++ b/OpenSim/Moco/MocoProblemInfo.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOPROBLEMINFO_H
-#define MOCO_MOCOPROBLEMINFO_H
+#ifndef OPENSIM_MOCOPROBLEMINFO_H
+#define OPENSIM_MOCOPROBLEMINFO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoProblemInfo.h                                            *
  * -------------------------------------------------------------------------- *
@@ -31,4 +31,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOPROBLEMINFO_H
+#endif // OPENSIM_MOCOPROBLEMINFO_H

--- a/OpenSim/Moco/MocoProblemRep.h
+++ b/OpenSim/Moco/MocoProblemRep.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOPROBLEMREP_H
 #define OPENSIM_MOCOPROBLEMREP_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoProblemRep.h                                             *
+ * OpenSim: MocoProblemRep.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoProblemRep.h
+++ b/OpenSim/Moco/MocoProblemRep.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOPROBLEMREP_H
-#define MOCO_MOCOPROBLEMREP_H
+#ifndef OPENSIM_MOCOPROBLEMREP_H
+#define OPENSIM_MOCOPROBLEMREP_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoProblemRep.h                                             *
  * -------------------------------------------------------------------------- *
@@ -356,4 +356,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOPROBLEMREP_H
+#endif // OPENSIM_MOCOPROBLEMREP_H

--- a/OpenSim/Moco/MocoSolver.h
+++ b/OpenSim/Moco/MocoSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSOLVER_H
 #define OPENSIM_MOCOSOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoSolver.h                                                 *
+ * OpenSim: MocoSolver.h                                                      *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoSolver.h
+++ b/OpenSim/Moco/MocoSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSOLVER_H
-#define MOCO_MOCOSOLVER_H
+#ifndef OPENSIM_MOCOSOLVER_H
+#define OPENSIM_MOCOSOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoSolver.h                                                 *
  * -------------------------------------------------------------------------- *
@@ -128,4 +128,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSOLVER_H
+#endif // OPENSIM_MOCOSOLVER_H

--- a/OpenSim/Moco/MocoStudy.h
+++ b/OpenSim/Moco/MocoStudy.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSTUDY_H
 #define OPENSIM_MOCOSTUDY_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoStudy.h                                                   *
+ * OpenSim: MocoStudy.h                                                       *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoStudy.h
+++ b/OpenSim/Moco/MocoStudy.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSTUDY_H
-#define MOCO_MOCOSTUDY_H
+#ifndef OPENSIM_MOCOSTUDY_H
+#define OPENSIM_MOCOSTUDY_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoStudy.h                                                   *
  * -------------------------------------------------------------------------- *
@@ -179,4 +179,4 @@ OSIMMOCO_API MocoCasADiSolver& MocoStudy::initSolver<MocoCasADiSolver>();
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSTUDY_H
+#endif // OPENSIM_MOCOSTUDY_H

--- a/OpenSim/Moco/MocoStudyFactory.h
+++ b/OpenSim/Moco/MocoStudyFactory.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSTUDYUTILITIES_H
-#define MOCO_MOCOSTUDYUTILITIES_H
+#ifndef OPENSIM_MOCOSTUDYUTILITIES_H
+#define OPENSIM_MOCOSTUDYUTILITIES_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoStudyFactory.h                                           *
  * -------------------------------------------------------------------------- *
@@ -40,4 +40,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSTUDYUTILITIES_H
+#endif // OPENSIM_MOCOSTUDYUTILITIES_H

--- a/OpenSim/Moco/MocoStudyFactory.h
+++ b/OpenSim/Moco/MocoStudyFactory.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSTUDYUTILITIES_H
 #define OPENSIM_MOCOSTUDYUTILITIES_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoStudyFactory.h                                           *
+ * OpenSim: MocoStudyFactory.h                                                *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoTool.h
+++ b/OpenSim/Moco/MocoTool.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOTOOL_H
 #define OPENSIM_MOCOTOOL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoTool.h                                                   *
+ * OpenSim: MocoTool.h                                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoTool.h
+++ b/OpenSim/Moco/MocoTool.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOTOOL_H
-#define MOCO_MOCOTOOL_H
+#ifndef OPENSIM_MOCOTOOL_H
+#define OPENSIM_MOCOTOOL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTool.h                                                   *
  * -------------------------------------------------------------------------- *
@@ -111,4 +111,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOTOOL_H
+#endif // OPENSIM_MOCOTOOL_H

--- a/OpenSim/Moco/MocoTrack.h
+++ b/OpenSim/Moco/MocoTrack.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOTRACK_H
-#define MOCO_MOCOTRACK_H
+#ifndef OPENSIM_MOCOTRACK_H
+#define OPENSIM_MOCOTRACK_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTrack.h                                                  *
  * -------------------------------------------------------------------------- *
@@ -284,4 +284,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOTRACK_H
+#endif // OPENSIM_MOCOTRACK_H

--- a/OpenSim/Moco/MocoTrack.h
+++ b/OpenSim/Moco/MocoTrack.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOTRACK_H
 #define OPENSIM_MOCOTRACK_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoTrack.h                                                  *
+ * OpenSim: MocoTrack.h                                                       *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoTrajectory.h
+++ b/OpenSim/Moco/MocoTrajectory.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOTRAJECTORY_H
 #define OPENSIM_MOCOTRAJECTORY_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoTrajectory.h                                             *
+ * OpenSim: MocoTrajectory.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoTrajectory.h
+++ b/OpenSim/Moco/MocoTrajectory.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOTRAJECTORY_H
-#define MOCO_MOCOTRAJECTORY_H
+#ifndef OPENSIM_MOCOTRAJECTORY_H
+#define OPENSIM_MOCOTRAJECTORY_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTrajectory.h                                             *
  * -------------------------------------------------------------------------- *
@@ -855,4 +855,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOTRAJECTORY_H
+#endif // OPENSIM_MOCOTRAJECTORY_H

--- a/OpenSim/Moco/MocoTropterSolver.h
+++ b/OpenSim/Moco/MocoTropterSolver.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOTROPTERSOLVER_H
-#define MOCO_MOCOTROPTERSOLVER_H
+#ifndef OPENSIM_MOCOTROPTERSOLVER_H
+#define OPENSIM_MOCOTROPTERSOLVER_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTropterSolver.h                                          *
  * -------------------------------------------------------------------------- *
@@ -176,4 +176,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOTROPTERSOLVER_H
+#endif // OPENSIM_MOCOTROPTERSOLVER_H

--- a/OpenSim/Moco/MocoTropterSolver.h
+++ b/OpenSim/Moco/MocoTropterSolver.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOTROPTERSOLVER_H
 #define OPENSIM_MOCOTROPTERSOLVER_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoTropterSolver.h                                          *
+ * OpenSim: MocoTropterSolver.h                                               *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOUTILITIES_H
-#define MOCO_MOCOUTILITIES_H
+#ifndef OPENSIM_MOCOUTILITIES_H
+#define OPENSIM_MOCOUTILITIES_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoUtilities.h                                              *
  * -------------------------------------------------------------------------- *
@@ -807,4 +807,4 @@ SimTK::Real solveBisection(
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOUTILITIES_H
+#endif // OPENSIM_MOCOUTILITIES_H

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOUTILITIES_H
 #define OPENSIM_MOCOUTILITIES_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoUtilities.h                                              *
+ * OpenSim: MocoUtilities.h                                                   *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoVariableInfo.h
+++ b/OpenSim/Moco/MocoVariableInfo.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOVARIABLEINFO_H
-#define MOCO_MOCOVARIABLEINFO_H
+#ifndef OPENSIM_MOCOVARIABLEINFO_H
+#define OPENSIM_MOCOVARIABLEINFO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoProblem.h                                                *
  * -------------------------------------------------------------------------- *
@@ -82,4 +82,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOVARIABLEINFO_H
+#endif // OPENSIM_MOCOVARIABLEINFO_H

--- a/OpenSim/Moco/MocoVariableInfo.h
+++ b/OpenSim/Moco/MocoVariableInfo.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOVARIABLEINFO_H
 #define OPENSIM_MOCOVARIABLEINFO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoProblem.h                                                *
+ * OpenSim: MocoProblem.h                                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/MocoWeightSet.h
+++ b/OpenSim/Moco/MocoWeightSet.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOWEIGHTSET_H
-#define MOCO_MOCOWEIGHTSET_H
+#ifndef OPENSIM_MOCOWEIGHTSET_H
+#define OPENSIM_MOCOWEIGHTSET_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoWeightSet.h                                              *
  * -------------------------------------------------------------------------- *
@@ -62,4 +62,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOWEIGHTSET_H
+#endif // OPENSIM_MOCOWEIGHTSET_H

--- a/OpenSim/Moco/MocoWeightSet.h
+++ b/OpenSim/Moco/MocoWeightSet.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOWEIGHTSET_H
 #define OPENSIM_MOCOWEIGHTSET_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoWeightSet.h                                              *
+ * OpenSim: MocoWeightSet.h                                                   *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/ModelOperators.h
+++ b/OpenSim/Moco/ModelOperators.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MODELOPERATORS_H
-#define MOCO_MODELOPERATORS_H
+#ifndef OPENSIM_MODELOPERATORS_H
+#define OPENSIM_MODELOPERATORS_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: ModelOperators.h                                             *
  * -------------------------------------------------------------------------- *
@@ -332,4 +332,4 @@ public:
 
 } // namespace OpenSim
 
-#endif // MOCO_MODELOPERATORS_H
+#endif // OPENSIM_MODELOPERATORS_H

--- a/OpenSim/Moco/ModelOperators.h
+++ b/OpenSim/Moco/ModelOperators.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MODELOPERATORS_H
 #define OPENSIM_MODELOPERATORS_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: ModelOperators.h                                             *
+ * OpenSim: ModelOperators.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/ModelProcessor.h
+++ b/OpenSim/Moco/ModelProcessor.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MODELPROCESSOR_H
-#define MOCO_MODELPROCESSOR_H
+#ifndef OPENSIM_MODELPROCESSOR_H
+#define OPENSIM_MODELPROCESSOR_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: ModelProcessor.h                                             *
  * -------------------------------------------------------------------------- *
@@ -156,4 +156,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MODELPROCESSOR_H
+#endif // OPENSIM_MODELPROCESSOR_H

--- a/OpenSim/Moco/ModelProcessor.h
+++ b/OpenSim/Moco/ModelProcessor.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MODELPROCESSOR_H
 #define OPENSIM_MODELPROCESSOR_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: ModelProcessor.h                                             *
+ * OpenSim: ModelProcessor.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/RegisterTypes_osimMoco.h
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_REGISTERTYPES_OSIMMOCO_H
 #define OPENSIM_REGISTERTYPES_OSIMMOCO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: RegisterTypes_osimMoco.h                                     *
+ * OpenSim: RegisterTypes_osimMoco.h                                          *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/RegisterTypes_osimMoco.h
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_REGISTERTYPES_OSIMMOCO_H
-#define MOCO_REGISTERTYPES_OSIMMOCO_H
+#ifndef OPENSIM_REGISTERTYPES_OSIMMOCO_H
+#define OPENSIM_REGISTERTYPES_OSIMMOCO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: RegisterTypes_osimMoco.h                                     *
  * -------------------------------------------------------------------------- *
@@ -33,4 +33,4 @@ private:
     void registerDllClasses();
 };
 
-#endif // MOCO_REGISTERTYPES_OSIMMOCO_H
+#endif // OPENSIM_REGISTERTYPES_OSIMMOCO_H

--- a/OpenSim/Moco/Test/Testing.h
+++ b/OpenSim/Moco/Test/Testing.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_TESTING_H
-#define MOCO_TESTING_H
+#ifndef OPENSIM_TESTING_H
+#define OPENSIM_TESTING_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: testing.h                                                    *
  * -------------------------------------------------------------------------- *
@@ -144,4 +144,4 @@ do {                                                                         \
     OpenSim_CATCH_MATRIX_INTERNAL(CHECK, actual, expected, tol, margin);     \
 } while (0)
 
-#endif // MOCO_TESTING_H
+#endif // OPENSIM_TESTING_H

--- a/OpenSim/Moco/Test/Testing.h
+++ b/OpenSim/Moco/Test/Testing.h
@@ -1,7 +1,7 @@
-#ifndef OPENSIM_TESTING_H
-#define OPENSIM_TESTING_H
+#ifndef OPENSIM_MOCO_TESTING_H
+#define OPENSIM_MOCO_TESTING_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: testing.h                                                    *
+ * OpenSim: testing.h                                                         *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *
@@ -144,4 +144,4 @@ do {                                                                         \
     OpenSim_CATCH_MATRIX_INTERNAL(CHECK, actual, expected, tol, margin);     \
 } while (0)
 
-#endif // OPENSIM_TESTING_H
+#endif // OPENSIM_MOCO_TESTING_H

--- a/OpenSim/Moco/osimMoco.h
+++ b/OpenSim/Moco/osimMoco.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_OSIMMOCO_H
 #define OPENSIM_OSIMMOCO_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: osimMoco.h                                                   *
+ * OpenSim: osimMoco.h                                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/osimMoco.h
+++ b/OpenSim/Moco/osimMoco.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_OSIMMOCO_H
-#define MOCO_OSIMMOCO_H
+#ifndef OPENSIM_OSIMMOCO_H
+#define OPENSIM_OSIMMOCO_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: osimMoco.h                                                   *
  * -------------------------------------------------------------------------- *
@@ -63,4 +63,4 @@
 #include "ModelProcessor.h"
 #include "RegisterTypes_osimMoco.h"
 
-#endif // MOCO_OSIMMOCO_H
+#endif // OPENSIM_OSIMMOCO_H

--- a/OpenSim/Moco/osimMocoDLL.h
+++ b/OpenSim/Moco/osimMocoDLL.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_OSIMMOCODLL_H
-#define MOCO_OSIMMOCODLL_H
+#ifndef OPENSIM_OSIMMOCODLL_H
+#define OPENSIM_OSIMMOCODLL_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: osimMocoDLL.h                                                *
  * -------------------------------------------------------------------------- *
@@ -28,4 +28,4 @@
     #endif
 #endif
 
-#endif // MOCO_OSIMMOCODLL_H
+#endif // OPENSIM_OSIMMOCODLL_H

--- a/OpenSim/Moco/osimMocoDLL.h
+++ b/OpenSim/Moco/osimMocoDLL.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_OSIMMOCODLL_H
 #define OPENSIM_OSIMMOCODLL_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: osimMocoDLL.h                                                *
+ * OpenSim: osimMocoDLL.h                                                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Moco/tropter/TropterProblem.h
+++ b/OpenSim/Moco/tropter/TropterProblem.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_TROPTERPROBLEM_H
-#define MOCO_TROPTERPROBLEM_H
+#ifndef OPENSIM_TROPTERPROBLEM_H
+#define OPENSIM_TROPTERPROBLEM_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: TropterProblem.h                                             *
  * -------------------------------------------------------------------------- *
@@ -734,4 +734,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_TROPTERPROBLEM_H
+#endif // OPENSIM_TROPTERPROBLEM_H

--- a/OpenSim/Moco/tropter/TropterProblem.h
+++ b/OpenSim/Moco/tropter/TropterProblem.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_TROPTERPROBLEM_H
 #define OPENSIM_TROPTERPROBLEM_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: TropterProblem.h                                             *
+ * OpenSim: TropterProblem.h                                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/MuscleLikeCoordinateActuator.h
+++ b/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/MuscleLikeCoordinateActuator.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MUSCLELIKECOORDINATEACTUATOR_H
-#define MOCO_MUSCLELIKECOORDINATEACTUATOR_H
+#ifndef OPENSIM_MUSCLELIKECOORDINATEACTUATOR_H
+#define OPENSIM_MUSCLELIKECOORDINATEACTUATOR_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MuscleLikeCoordinateActuator.h                               *
  * -------------------------------------------------------------------------- *
@@ -100,6 +100,6 @@ private:
 
 } //namespace Opensim
 
-#endif // MOCO_MUSCLELIKECOORDINATEACTUATOR_H
+#endif // OPENSIM_MUSCLELIKECOORDINATEACTUATOR_H
 
 

--- a/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/MuscleLikeCoordinateActuator.h
+++ b/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/MuscleLikeCoordinateActuator.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MUSCLELIKECOORDINATEACTUATOR_H
 #define OPENSIM_MUSCLELIKECOORDINATEACTUATOR_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MuscleLikeCoordinateActuator.h                               *
+ * OpenSim: MuscleLikeCoordinateActuator.h                                    *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/MocoUserControlCost.h
+++ b/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/MocoUserControlCost.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOUSERCONTROLCOST_H
 #define OPENSIM_MOCOUSERCONTROLCOST_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoUserControlCost.h                                        *
+ * OpenSim: MocoUserControlCost.h                                             *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/MocoUserControlCost.h
+++ b/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/MocoUserControlCost.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOUSERCONTROLCOST_H
-#define MOCO_MOCOUSERCONTROLCOST_H
+#ifndef OPENSIM_MOCOUSERCONTROLCOST_H
+#define OPENSIM_MOCOUSERCONTROLCOST_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoUserControlCost.h                                        *
  * -------------------------------------------------------------------------- *
@@ -87,4 +87,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOUSERCONTROLCOST_H
+#endif // OPENSIM_MOCOUSERCONTROLCOST_H

--- a/OpenSim/Sandbox/Moco/shared/MocoSandboxShared.h
+++ b/OpenSim/Sandbox/Moco/shared/MocoSandboxShared.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_MOCOSANDBOXSHARED_H
-#define MOCO_MOCOSANDBOXSHARED_H
+#ifndef OPENSIM_MOCOSANDBOXSHARED_H
+#define OPENSIM_MOCOSANDBOXSHARED_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoSandboxShared.h                                          *
  * -------------------------------------------------------------------------- *
@@ -171,4 +171,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_MOCOSANDBOXSHARED_H
+#endif // OPENSIM_MOCOSANDBOXSHARED_H

--- a/OpenSim/Sandbox/Moco/shared/MocoSandboxShared.h
+++ b/OpenSim/Sandbox/Moco/shared/MocoSandboxShared.h
@@ -1,7 +1,7 @@
 #ifndef OPENSIM_MOCOSANDBOXSHARED_H
 #define OPENSIM_MOCOSANDBOXSHARED_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoSandboxShared.h                                          *
+ * OpenSim: MocoSandboxShared.h                                               *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2017 Stanford University and the Authors                     *
  *                                                                            *


### PR DESCRIPTION
### Brief summary of changes

This PR makes Moco's header guards consistent with the header guards in the rest of OpenSim.

@nickbianco I know there are lots of files here but I used Find-Replace to make the changes; I don't think the review will be too painful.

### Testing I've completed

Built the source code locally.

### CHANGELOG.md (choose one)

- no need to update because...not user-facing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2819)
<!-- Reviewable:end -->
