### PR TITLE
Put Stopwatch in OpenSim namespace

### DIFF
--- a/OpenSim/Common/Stopwatch.h
+++ b/OpenSim/Common/Stopwatch.h
@@ -23,6 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+namespace OpenSim {
+
 /// Record and report elapsed real time ("clock" or "wall" time) in seconds.
 class Stopwatch {
 public:
@@ -85,5 +87,6 @@ private:
     long long m_startTime;
 };
 
+} // namespace OpenSim
 
 #endif // OPENSIM_STOPWATCH_H_


### PR DESCRIPTION
### Brief summary of changes

Put `Stopwatch` in the `OpenSim` namespace.

### CHANGELOG.md (choose one)

- no need to update because...minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2820)
<!-- Reviewable:end -->
