### PR TITLE
Improve CMake/installation for Moco examples

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "opensim-models"]
-	path = opensim-models
-	url = https://github.com/opensim-org/opensim-models

--- a/Bindings/Java/Matlab/CMakeLists.txt
+++ b/Bindings/Java/Matlab/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 # Install.
 # --------
-install(DIRECTORY examples/ DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Examples")
+install(DIRECTORY examples/ DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 install(DIRECTORY Hopper_Device DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 install(DIRECTORY Utilities DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
 install(DIRECTORY OpenSenseExample DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}")
@@ -74,12 +74,12 @@ file(COPY "examples/Moco/exampleSquatToStand/squatToStand_3dof9musc.osim"
         DESTINATION
         "${CMAKE_BINARY_DIR}/Examples/Moco/exampleSquatToStand")
 
-file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-        "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleSquatToStand/Geometry")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleMarkerTracking10DOF/Geometry")
+# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
+#         "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
+# install(FILES ${GEOMETRY}
+#         DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleSquatToStand/Geometry")
+# install(FILES ${GEOMETRY}
+#         DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleMarkerTracking10DOF/Geometry")
 
 
 # The configureOpenSim.m script contains paths into the OpenSim installation

--- a/Bindings/Java/Matlab/CMakeLists.txt
+++ b/Bindings/Java/Matlab/CMakeLists.txt
@@ -74,14 +74,6 @@ file(COPY "examples/Moco/exampleSquatToStand/squatToStand_3dof9musc.osim"
         DESTINATION
         "${CMAKE_BINARY_DIR}/Examples/Moco/exampleSquatToStand")
 
-# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-#         "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
-# install(FILES ${GEOMETRY}
-#         DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleSquatToStand/Geometry")
-# install(FILES ${GEOMETRY}
-#         DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleMarkerTracking10DOF/Geometry")
-
-
 # The configureOpenSim.m script contains paths into the OpenSim installation
 # that may be different on different platforms, so we configure it with CMake
 # variables.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,7 +673,7 @@ if(${OPENSIM_C3D_PARSER} STREQUAL "ezc3d")
     find_package(ezc3d REQUIRED HINTS "${ezc3d_hint}")
     add_definitions(-DWITH_EZC3D)
     OpenSimCopyDependencyDLLsForWin(DEP_NAME ezc3d
-            DEP_BIN_DIR"${ezc3d_LIBRARY_DIR}/../bin"
+            DEP_BIN_DIR "${ezc3d_LIBRARY_DIR}/../bin"
             )
     if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
         OpenSimInstallDependencyLibraries(ezc3d "${ezc3d_LIBRARY_DIR}/../"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,9 @@ if(${OPENSIM_C3D_PARSER} STREQUAL "ezc3d")
     endif()
     find_package(ezc3d REQUIRED HINTS "${ezc3d_hint}")
     add_definitions(-DWITH_EZC3D)
-    OpenSimCopyDependencyDLLsForWin(ezc3d "${ezc3d_LIBRARY_DIR}/../")
+    OpenSimCopyDependencyDLLsForWin(DEP_NAME ezc3d
+            DEP_BIN_DIR"${ezc3d_LIBRARY_DIR}/../bin"
+            )
     if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
         OpenSimInstallDependencyLibraries(ezc3d "${ezc3d_LIBRARY_DIR}/../"
             "${ezc3d_LIBRARY_DIR}" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
@@ -691,7 +693,8 @@ elseif(${OPENSIM_C3D_PARSER} STREQUAL "BTK")
                  HINTS "${OPENSIM_DEPENDENCIES_DIR}/BTK/share/btk-0.4dev")
     include(${BTK_USE_FILE})
     add_definitions(-DWITH_BTK)
-    OpenSimCopyDependencyDLLsForWin(BTK ${BTK_INSTALL_PREFIX})
+    OpenSimCopyDependencyDLLsForWin(DEP_NAME BTK
+            DEP_BIN_DIR ${BTK_INSTALL_PREFIX}/bin)
     if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
         OpenSimInstallDependencyLibraries(BTK "${BTK_INSTALL_PREFIX}"
             "${BTK_LIBRARY_DIRS}" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
@@ -777,7 +780,8 @@ endif()
 # so that the tests and examples can run without modifying the PATH
 # (that is, put Simbody's dll's in the same directory as OpenSim's
 # executables and libraries).
-OpenSimCopyDependencyDLLsForWin(Simbody "${Simbody_BIN_DIR}")
+OpenSimCopyDependencyDLLsForWin(DEP_NAME Simbody
+        DEP_BIN_DIR "${Simbody_BIN_DIR}")
 if(WIN32)
     add_dependencies(Copy_Simbody_DLLs Simbody_CONFIG_check)
 endif()
@@ -799,9 +803,8 @@ set_package_properties(casadi PROPERTIES
         PURPOSE "Differentiation and optimizer interface.")
 get_filename_component(CASADI_BIN_DIR "${casadi_DIR}/../" ABSOLUTE)
 # Copy CasADi into our installation.
-MocoCopyDLLs(DEP_NAME casadi
-        DEP_BIN_DIR "${CASADI_BIN_DIR}" INSTALL_DLLS "${CMAKE_INSTALL_BINDIR}")
-if(NOT WIN32)
+OpenSimCopyDependencyDLLsForWin(DEP_NAME casadi DEP_BIN_DIR "${CASADI_BIN_DIR}")
+if(OPENSIM_COPY_DEPENDENCIES AND NOT WIN32)
     # MocoCopyDLLs() only copies DLLs for Windows, but we still need
     # the CasADi shared libraries on other platforms.
     install(DIRECTORY "${CASADI_CMAKE_DIR}/../../../"

--- a/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
@@ -1,19 +1,23 @@
 cmake_minimum_required(VERSION 3.2)
-project(OpenSimMoco_@_example_name@)
+project(OpenSim_@_example_name@)
 
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(OpenSimMoco REQUIRED HINTS
-    "${CMAKE_SOURCE_DIR}/@_moco_install_hint@")
-include("${OpenSimMoco_USE_FILE}")
+find_package(OpenSim REQUIRED HINTS
+    "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")
+include("${OpenSim_USE_FILE}")
 
 foreach(exe @_example_executables@)
     add_executable(${exe} ${exe}.cpp)
-    target_link_libraries(${exe} osimMoco)
+    target_link_libraries(${exe}
+            osimTools osimExampleComponents osimMoco)
 
     # For Windows: make sure DLLs for dependencies are available.
-    MocoCopyDLLs(DEP_NAME OpenSimMoco DEP_BIN_DIR "${OpenSimMoco_BIN_DIR}")
+    OpenSimCopyDependencyDLLsForWin(DEP_NAME OpenSim
+            DEP_BIN_DIR "${OpenSim_BIN_DIR}")
     if(WIN32)
-        add_dependencies(${exe} Copy_OpenSimMoco_DLLs)
+        add_dependencies(${exe} Copy_OpenSim_DLLs)
     endif()
 endforeach()
+
+file(COPY @OSIMEX_RESOURCES@ DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
@@ -7,18 +7,8 @@ set(EXAMPLE_2D_WALKING_FILES
 OpenSimAddExampleCXX(NAME example2DWalking SUBDIR Moco
     RESOURCES "${EXAMPLE_2D_WALKING_FILES}")
 
-# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-#         "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
-# file(COPY ${GEOMETRY}
-#         DESTINATION
-#         "${CMAKE_BINARY_DIR}/Examples/Moco/example2DWalking/Geometry")
-# install(FILES ${GEOMETRY}
-#         DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example2DWalking/Geometry")
-
 file(COPY ${EXAMPLE_2D_WALKING_FILES}
         DESTINATION
         "${CMAKE_BINARY_DIR}/Bindings/Java/Matlab/examples/Moco/example2DWalking")
 install(FILES ${EXAMPLE_2D_WALKING_FILES}
     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example2DWalking")
-# install(FILES ${GEOMETRY}
-#     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example2DWalking/Geometry")

--- a/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
@@ -4,21 +4,21 @@ set(EXAMPLE_2D_WALKING_FILES
         referenceGRF.sto
         referenceGRF.xml)
 
-OpenSimAddExampleCXX(NAME example2DWalking
+OpenSimAddExampleCXX(NAME example2DWalking SUBDIR Moco
     RESOURCES "${EXAMPLE_2D_WALKING_FILES}")
 
-file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-        "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
-file(COPY ${GEOMETRY}
-        DESTINATION
-        "${CMAKE_BINARY_DIR}/Examples/Moco/example2DWalking/Geometry")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example2DWalking/Geometry")
+# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
+#         "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
+# file(COPY ${GEOMETRY}
+#         DESTINATION
+#         "${CMAKE_BINARY_DIR}/Examples/Moco/example2DWalking/Geometry")
+# install(FILES ${GEOMETRY}
+#         DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example2DWalking/Geometry")
 
 file(COPY ${EXAMPLE_2D_WALKING_FILES}
         DESTINATION
         "${CMAKE_BINARY_DIR}/Bindings/Java/Matlab/examples/Moco/example2DWalking")
 install(FILES ${EXAMPLE_2D_WALKING_FILES}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/example2DWalking")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/example2DWalking/Geometry")
+    DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example2DWalking")
+# install(FILES ${GEOMETRY}
+#     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example2DWalking/Geometry")

--- a/OpenSim/Examples/Moco/example3DWalking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/example3DWalking/CMakeLists.txt
@@ -10,15 +10,6 @@ OpenSimAddExampleCXX(NAME example3DWalking SUBDIR Moco
         EXECUTABLES exampleMocoTrack exampleMocoInverse
         RESOURCES "${EXAMPLE_MOCO_TRACK_FILES}")
 
-# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-#     "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
-
-# file(COPY ${GEOMETRY}
-#         DESTINATION
-#         "${CMAKE_BINARY_DIR}/Examples/Moco/example3DWalking/Geometry")
-# install(FILES ${GEOMETRY}
-#         DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example3DWalking/Geometry")
-
 file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION "${CMAKE_BINARY_DIR}/Moco/Sandbox/sandboxMocoTrack")
 
@@ -27,13 +18,9 @@ file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         "${CMAKE_BINARY_DIR}/Bindings/Java/Matlab/examples/Moco/example3DWalking")
 install(FILES ${EXAMPLE_MOCO_TRACK_FILES}
     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example3DWalking")
-# install(FILES ${GEOMETRY}
-#     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example3DWalking/Geometry")
 
 file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION
         "${CMAKE_BINARY_DIR}/Bindings/Python/examples/Moco/example3DWalking")
 install(FILES ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/Moco/example3DWalking")
-# install(FILES ${GEOMETRY}
-#         DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/Moco/example3DWalking/Geometry")

--- a/OpenSim/Examples/Moco/example3DWalking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/example3DWalking/CMakeLists.txt
@@ -6,18 +6,18 @@ set(EXAMPLE_MOCO_TRACK_FILES
         marker_trajectories.trc
         electromyography.sto)
 
-OpenSimAddExampleCXX(NAME example3DWalking
+OpenSimAddExampleCXX(NAME example3DWalking SUBDIR Moco
         EXECUTABLES exampleMocoTrack exampleMocoInverse
         RESOURCES "${EXAMPLE_MOCO_TRACK_FILES}")
 
-file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
-    "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
+# file(GLOB GEOMETRY "${CMAKE_SOURCE_DIR}/opensim-models/Geometry/*"
+#     "${CMAKE_SOURCE_DIR}/opensim-models/Models/RajagopalModel/Geometry/*")
 
-file(COPY ${GEOMETRY} 
-        DESTINATION
-        "${CMAKE_BINARY_DIR}/Examples/Moco/example3DWalking/Geometry")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example3DWalking/Geometry")
+# file(COPY ${GEOMETRY}
+#         DESTINATION
+#         "${CMAKE_BINARY_DIR}/Examples/Moco/example3DWalking/Geometry")
+# install(FILES ${GEOMETRY}
+#         DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}/example3DWalking/Geometry")
 
 file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION "${CMAKE_BINARY_DIR}/Moco/Sandbox/sandboxMocoTrack")
@@ -26,14 +26,14 @@ file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION
         "${CMAKE_BINARY_DIR}/Bindings/Java/Matlab/examples/Moco/example3DWalking")
 install(FILES ${EXAMPLE_MOCO_TRACK_FILES}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/example3DWalking")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/example3DWalking/Geometry")
+    DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example3DWalking")
+# install(FILES ${GEOMETRY}
+#     DESTINATION "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/example3DWalking/Geometry")
 
 file(COPY ${EXAMPLE_MOCO_TRACK_FILES}
         DESTINATION
         "${CMAKE_BINARY_DIR}/Bindings/Python/examples/Moco/example3DWalking")
 install(FILES ${EXAMPLE_MOCO_TRACK_FILES}
-        DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/example3DWalking")
-install(FILES ${GEOMETRY}
-        DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/example3DWalking/Geometry")
+        DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/Moco/example3DWalking")
+# install(FILES ${GEOMETRY}
+#         DESTINATION "${OPENSIM_INSTALL_PYTHONEXDIR}/Moco/example3DWalking/Geometry")

--- a/OpenSim/Examples/Moco/exampleCustomImplicitAuxiliaryDynamics/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleCustomImplicitAuxiliaryDynamics/CMakeLists.txt
@@ -1,1 +1,1 @@
-OpenSimAddExampleCXX(NAME exampleCustomImplicitAuxiliaryDynamics)
+OpenSimAddExampleCXX(NAME exampleCustomImplicitAuxiliaryDynamics SUBDIR Moco)

--- a/OpenSim/Examples/Moco/exampleMarkerTracking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleMarkerTracking/CMakeLists.txt
@@ -1,1 +1,1 @@
-OpenSimAddExampleCXX(NAME exampleMarkerTracking)
+OpenSimAddExampleCXX(NAME exampleMarkerTracking SUBDIR Moco)

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/CMakeLists.txt
@@ -1,1 +1,1 @@
-OpenSimAddPluginExampleCXX(NAME MocoCustomEffortGoal)
+OpenSimAddPluginExampleCXX(NAME MocoCustomEffortGoal SUBDIR Moco)

--- a/OpenSim/Examples/Moco/exampleSlidingMass/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/CMakeLists.txt
@@ -1,2 +1,2 @@
-OpenSimAddExampleCXX(NAME exampleSlidingMass)
+OpenSimAddExampleCXX(NAME exampleSlidingMass SUBDIR Moco)
 

--- a/OpenSim/Examples/Moco/exampleSlidingMassAdvanced/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleSlidingMassAdvanced/CMakeLists.txt
@@ -1,1 +1,1 @@
-OpenSimAddExampleCXX(NAME exampleSlidingMassAdvanced)
+OpenSimAddExampleCXX(NAME exampleSlidingMassAdvanced SUBDIR Moco)

--- a/OpenSim/Examples/Moco/exampleTracking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/exampleTracking/CMakeLists.txt
@@ -1,1 +1,1 @@
-OpenSimAddExampleCXX(NAME exampleTracking)
+OpenSimAddExampleCXX(NAME exampleTracking SUBDIR Moco)

--- a/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.2)
-project(OpenSimMoco_@_example_name@)
+project(OpenSim_@_example_name@)
 
 set(CMAKE_CXX_STANDARD 11)
 
-find_package(OpenSimMoco REQUIRED HINTS
-    "${CMAKE_SOURCE_DIR}/@_moco_install_hint@")
-include("${OpenSimMoco_USE_FILE}")
+find_package(OpenSim REQUIRED HINTS
+    "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")
+include("${OpenSim_USE_FILE}")
 
 add_library(osim@_example_name@ SHARED
         @_example_name@.h
@@ -14,7 +14,8 @@ add_library(osim@_example_name@ SHARED
         RegisterTypes_osim@_example_name@.h
         RegisterTypes_osim@_example_name@.cpp
         )
-target_link_libraries(osim@_example_name@ osimMoco)
+target_link_libraries(osim@_example_name@
+        osimTools osimExampleComponents osimMoco)
 
 string(TOUPPER @_example_name@ example_name_upper)
 set_target_properties(osim@_example_name@ PROPERTIES
@@ -25,7 +26,10 @@ add_executable(example@_example_name@ example@_example_name@.cpp)
 target_link_libraries(example@_example_name@ osim@_example_name@)
 
 # For Windows: make sure DLLs for dependencies are available.
-MocoCopyDLLs(DEP_NAME OpenSimMoco DEP_BIN_DIR "${OpenSimMoco_BIN_DIR}")
+OpenSimCopyDependencyDLLsForWin(DEP_NAME OpenSim
+        DEP_BIN_DIR "${OpenSim_BIN_DIR}")
 if(WIN32)
-    add_dependencies(osim@_example_name@ Copy_OpenSimMoco_DLLs)
+    add_dependencies(osim@_example_name@ Copy_OpenSim_DLLs)
 endif()
+
+file(COPY @OSIMEX_RESOURCES@ DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -595,7 +595,7 @@ endfunction()
 function(OpenSimCopyDependencyDLLsForWin)
     # On Windows, copy dlls into the OpenSim binary directory.
     set(options)
-    set(oneValueArgs DEP_NAME DEP_BIN_DIR INSTALL_DLLS)
+    set(oneValueArgs DEP_NAME DEP_BIN_DIR)
     set(multiValueArgs)
     cmake_parse_arguments(OSIMCOPY
             "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -434,11 +434,14 @@ endfunction()
 # with a CMakeLists that can find the OpenSim installation and build the
 # example.
 #
+# If SUBDIR is provided, the example is installed into this subdirectory of the
+# C++ Examples folder.
+#
 # This function can only be used from the source distribution of OpenSim
 # (e.g., not via the UseOpenSim.cmake file in a binary distribution).
 function(OpenSimAddExampleCXX)
     set(options)
-    set(oneValueArgs NAME)
+    set(oneValueArgs NAME SUBDIR)
     set(multiValueArgs RESOURCES EXECUTABLES)
     cmake_parse_arguments(OSIMEX
             "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -457,16 +460,17 @@ function(OpenSimAddExampleCXX)
 
     # Install files so that users can build the example.
     # We do not install pre-built binaries of the examples.
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            DESTINATION ${OPENSIM_INSTALL_CPPEXDIR}
+    set(_example_install_dir
+            ${OPENSIM_INSTALL_CPPEXDIR}/${OSIMEX_SUBDIR}/${OSIMEX_NAME})
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+            DESTINATION "${_example_install_dir}"
             PATTERN "CMakeLists.txt" EXCLUDE)
 
-    set(_example_install_dir ${OPENSIM_INSTALL_CPPEXDIR}/${OSIMEX_NAME})
     # These next two variables are to be configured below (they are not used
     # here, but within ExampleCMakeListsToInstall.txt.in).
     set(_example_name ${OSIMEX_NAME})
     set(_example_executables ${OSIMEX_EXECUTABLES})
-    file(RELATIVE_PATH _moco_install_hint
+    file(RELATIVE_PATH _opensim_install_hint
             "${CMAKE_INSTALL_PREFIX}/${_example_install_dir}"
             "${CMAKE_INSTALL_PREFIX}")
     configure_file(
@@ -484,16 +488,19 @@ endfunction()
 # Add a target to the OpenSim project for building an example containing a
 # plugin library and an executable.
 # The directory containing the CMakeLists.txt invoking this macro must have 3
-# source files: <MAIN>.h and <MAIN>.cpp are used to create the plugin, and
-# and exampleMAIN.cpp is compiled into an executable that uses the plugin.
+# source files: ${NAME}.h and ${NAME}.cpp are used to create the plugin, and
+# and example${NAME}.cpp is compiled into an executable that uses the plugin.
 # This function also installs the example file with a CMakeLists that can find
 # the OpenSim installation and build the example.
+#
+# If SUBDIR is provided, the example is installed into this subdirectory of the
+# C++ Examples folder.
 #
 # This function can only be used from the source distribution of OpenSim
 # (e.g., not via the UseOpenSim.cmake file in a binary distribution).
 function(OpenSimAddPluginExampleCXX)
     set(options)
-    set(oneValueArgs NAME)
+    set(oneValueArgs NAME SUBDIR)
     set(multiValueArgs RESOURCES)
     cmake_parse_arguments(OSIMEX
             "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -521,16 +528,16 @@ function(OpenSimAddPluginExampleCXX)
     target_link_libraries(example${OSIMEX_NAME} osim${OSIMEX_NAME})
     file(COPY ${OSIMEX_RESOURCES} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            DESTINATION ${OPENSIM_INSTALL_CPPEXDIR}/Plugins
+    set(_example_install_dir
+            ${OPENSIM_INSTALL_CPPEXDIR}/${OSIMEX_SUBDIR}/Plugins/example${OSIMEX_NAME})
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+            DESTINATION "${_example_install_dir}"
             PATTERN "CMakeLists.txt" EXCLUDE)
 
-    set(_example_install_dir
-            ${OPENSIM_INSTALL_CPPEXDIR}/Plugins/example${OSIMEX_NAME})
     # These next two variables are to be configured below (they are not used
     # here, but within ExampleCMakeListsToInstall.txt.in).
     set(_example_name ${OSIMEX_NAME})
-    file(RELATIVE_PATH _moco_install_hint
+    file(RELATIVE_PATH _opensim_install_hint
             "${CMAKE_INSTALL_PREFIX}/${_example_install_dir}"
             "${CMAKE_INSTALL_PREFIX}")
     configure_file(
@@ -577,60 +584,26 @@ function(OpenSimInstallDependencyLibraries PREFIX DEP_LIBS_DIR_WIN
 endfunction()
 
 
-# Function to copy DLL files from dependency install directory into OpenSim 
-# build and install directories. This is a Windows specific function enabled 
-# only for Windows platform. Intention is to allow runtime loader to find all 
-# the required DLLs without need for editing PATH variable.
-function(OpenSimCopyDependencyDLLsForWin DEP_NAME DEP_INSTALL_DIR)
-    # On Windows, copy dlls into OpenSim binary directory.
-    if(WIN32)
-        file(GLOB_RECURSE DLLS ${DEP_INSTALL_DIR}/*.dll)
-        if(NOT DLLS)
-            message(FATAL_ERROR "Zero DLLs found in directory "
-                                "${DEP_INSTALL_DIR}.")
-        endif()
-        set(DEST_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
-        foreach(DLL IN LISTS DLLS)
-            get_filename_component(DLL_NAME ${DLL} NAME)
-            list(APPEND DLLS_DEST "${DEST_DIR}/${DLL_NAME}")
-            add_custom_command(OUTPUT "${DEST_DIR}/${DLL_NAME}"
-                COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
-                COMMAND ${CMAKE_COMMAND} -E copy ${DLL} ${DEST_DIR}
-                DEPENDS ${DLL}
-                COMMENT "Copying DLL from ${DEP_INSTALL_DIR}/${DLL_NAME} to ${DEST_DIR}.")
-        endforeach()
-        add_custom_target(Copy_${DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
-        set_target_properties(Copy_${DEP_NAME}_DLLs PROPERTIES
-            PROJECT_LABEL "Copy ${DEP_NAME} DLLs")
-        if(OPENSIM_COPY_DEPENDENCIES)
-            install(FILES ${DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
-        endif()
-    endif()
-endfunction()
-
 # Copy DLL files from a dependency's installation into the
-# build directory. This is a Windows-specific function enabled 
+# build and install directories. This is a Windows-specific function enabled
 # only on Windows. The intention is to allow the runtime loader to find all 
 # the required DLLs without editing the PATH environment variable.
 # Arguments:
 #   DEP_NAME: Name of the dependency (used to name a custom target)
 #   DEP_BIN_DIR: The directory in the dependency containing DLLs to copy.
-#   INSTALL_DLLS (optional): If provided, then the dependency's DLLs are
-#     installed into ${INSTALL_DLLS}.
 # This is based on a similar function in OpenSimMacros.cmake.
-# TODO: Combine with the function above.
-function(MocoCopyDLLs)
-    # On Windows, copy dlls into the Tropter binary directory.
+function(OpenSimCopyDependencyDLLsForWin)
+    # On Windows, copy dlls into the OpenSim binary directory.
     set(options)
     set(oneValueArgs DEP_NAME DEP_BIN_DIR INSTALL_DLLS)
     set(multiValueArgs)
-    cmake_parse_arguments(MOCOCOPY
+    cmake_parse_arguments(OSIMCOPY
             "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     if(WIN32)
-        file(GLOB DLLS ${MOCOCOPY_DEP_BIN_DIR}/*.dll)
+        file(GLOB DLLS ${OSIMCOPY_DEP_BIN_DIR}/*.dll)
         if(NOT DLLS)
             message(FATAL_ERROR "Zero DLLs found in directory "
-                                "${MOCOCOPY_DEP_BIN_DIR}.")
+                                "${OSIMCOPY_DEP_BIN_DIR}.")
         endif()
         set(DEST_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
         foreach(DLL IN LISTS DLLS)
@@ -640,13 +613,13 @@ function(MocoCopyDLLs)
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
                 COMMAND ${CMAKE_COMMAND} -E copy ${DLL} ${DEST_DIR}
                 DEPENDS ${DLL}
-                COMMENT "Copying ${DLL_NAME} from ${MOCOCOPY_DEP_BIN_DIR} to ${DEST_DIR}.")
+                COMMENT "Copying ${DLL_NAME} from ${OSIMCOPY_DEP_BIN_DIR} to ${DEST_DIR}.")
         endforeach()
-        add_custom_target(Copy_${MOCOCOPY_DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
-        set_target_properties(Copy_${MOCOCOPY_DEP_NAME}_DLLs PROPERTIES
-            PROJECT_LABEL "Copy ${MOCOCOPY_DEP_NAME} DLLs" FOLDER "Moco")
-        if(MOCOCOPY_INSTALL_DLLS)
-            install(FILES ${DLLS} DESTINATION ${MOCOCOPY_INSTALL_DLLS})
+        add_custom_target(Copy_${OSIMCOPY_DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
+        set_target_properties(Copy_${OSIMCOPY_DEP_NAME}_DLLs PROPERTIES
+            PROJECT_LABEL "Copy ${OSIMCOPY_DEP_NAME} DLLs")
+        if(OPENSIM_COPY_DEPENDENCIES)
+            install(FILES ${DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
         endif()
     endif()
 endfunction()

--- a/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
+++ b/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
@@ -59,25 +59,25 @@ endmacro()
 
 install_name_tool_change(osimMoco adolc.2 "@ADOLC_DIR@/lib64")
 
-install_name_tool_add_rpath(casadi.3.5)
+install_name_tool_add_rpath(casadi.3.6)
 get_filename_component(CASADI_LIBDIR "@CASADI_LIBRARY_DIRS@" ABSOLUTE)
-install_name_tool_delete_rpath(casadi.3.5 "${CASADI_LIBDIR}")
+install_name_tool_delete_rpath(casadi.3.6 "${CASADI_LIBDIR}")
 
 
-install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.5 "${libquadmath_dir}")
+install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.6 "${libquadmath_dir}")
 # The library may still have an RPATH like /usr/local/Cellar/gcc/9.1.0/lib/gcc/9/gcc/x86_64-apple-darwin18/9.1.0
 # but it's hard to detect this, and it should be fine to leave it.
-# install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.5 /usr/local/Cellar/gcc/8.2.0/lib/gcc/8/gcc/x86_64-apple-darwin18.0.0/8.2.0)
+# install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.6 /usr/local/Cellar/gcc/8.2.0/lib/gcc/8/gcc/x86_64-apple-darwin18.0.0/8.2.0)
 
 
-install_name_tool_change(casadi_nlpsol_ipopt.3.5 ipopt.1 "@IPOPT_LIBDIR@")
-install_name_tool_change(casadi_nlpsol_ipopt.3.5 coinmumps.1 "@IPOPT_LIBDIR@")
-install_name_tool_change(casadi_nlpsol_ipopt.3.5 coinmetis.1 "@IPOPT_LIBDIR@")
-install_name_tool_change_gfortran(casadi_nlpsol_ipopt.3.5)
-install_name_tool_change_quadmath(casadi_nlpsol_ipopt.3.5)
-install_name_tool_add_rpath(casadi_nlpsol_ipopt.3.5)
-install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.5 "${CASADI_LIBDIR}")
-install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.5 "@IPOPT_LIBDIR@")
+install_name_tool_change(casadi_nlpsol_ipopt.3.6 ipopt.1 "@IPOPT_LIBDIR@")
+install_name_tool_change(casadi_nlpsol_ipopt.3.6 coinmumps.1 "@IPOPT_LIBDIR@")
+install_name_tool_change(casadi_nlpsol_ipopt.3.6 coinmetis.1 "@IPOPT_LIBDIR@")
+install_name_tool_change_gfortran(casadi_nlpsol_ipopt.3.6)
+install_name_tool_change_quadmath(casadi_nlpsol_ipopt.3.6)
+install_name_tool_add_rpath(casadi_nlpsol_ipopt.3.6)
+install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.6 "${CASADI_LIBDIR}")
+install_name_tool_delete_rpath(casadi_nlpsol_ipopt.3.6 "@IPOPT_LIBDIR@")
 
 
 


### PR DESCRIPTION


### Brief summary of changes

- Remove opensim-models submodule (users will be expected to have a geometry folder.
- Fix layout of examples in the installation.
- Remove redundant CMake function `MocoCopyDLLs()` from `OpenSimMacros.cmake`.
- Improve the functionality of the CMake functions that generated installed C++/CMake examples.

### Testing I've completed

- On Mac, I examined the layout of the installation and ensured that various C++ examples could build successfully from the install tree.

### CHANGELOG.md (choose one)

- no need to update because...Moco is not yet in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2823)
<!-- Reviewable:end -->
