### PR TITLE
PrescribedController's controls_file column labels can now be actuator paths

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -232,7 +232,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Install packages
-      run: sudo apt-get install --yes liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools swig
+      run: sudo apt-get update && sudo apt-get install --yes liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools swig
 
     - name: Cache dependencies
       id: cache-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ v4.2
   - Previously, it would return `false` if its parent `Model`'s `Model::getAllControllersEnabled` returned `false`
   - The previous behavior would mean that `Controller::setEnabled(true); return Controller::isEnabled();` could return `false`
 - The new Matlab examplePointMass.m shows how to build and simulate a point-mass model.
-
+- For PrescribedController, the controls_file column labels can now be absolute paths to actuators (previously, the column labels were required to be actuator names).
 
 v4.1
 ====

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -1,7 +1,5 @@
 #ifndef OPENSIM_PRESCRIBED_CONTROLLER_H_
 #define OPENSIM_PRESCRIBED_CONTROLLER_H_
-
-
 /* -------------------------------------------------------------------------- *
  *                      OpenSim:  PrescribedController.h                      *
  * -------------------------------------------------------------------------- *
@@ -58,7 +56,8 @@ public:
     /** (Optional) prescribed controls from a storage file  */
     OpenSim_DECLARE_OPTIONAL_PROPERTY(controls_file, std::string,
         "Controls storage (.sto) file containing controls for individual "
-        "actuators in the model. Column labels must match actuator names.");
+        "actuators in the model. Column labels must match actuator names or "
+        "absolute paths.");
 
     /** (Optional) interpolation method for controls in storage.  */
     OpenSim_DECLARE_OPTIONAL_PROPERTY(interpolation_method, int,

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -56,8 +56,9 @@ public:
     /** (Optional) prescribed controls from a storage file  */
     OpenSim_DECLARE_OPTIONAL_PROPERTY(controls_file, std::string,
         "Controls storage (.sto) file containing controls for individual "
-        "actuators in the model. Column labels must match actuator names or "
-        "absolute paths.");
+        "actuators in the model. Each column label must be either the name "
+        "of an actuator in the model's ForceSet or the absolute path to an "
+        "actuator anywhere in the model.");
 
     /** (Optional) interpolation method for controls in storage.  */
     OpenSim_DECLARE_OPTIONAL_PROPERTY(interpolation_method, int,


### PR DESCRIPTION
### Brief summary of changes

On `master`, `PrescribedController`'s `controls_file` column labels must be actuator names. With this PR, the column labels can alternatively be absolute paths to actuators.

### Testing I've completed

On a separate branch related to Moco (`DGF_with_Analyses`), I created an example (exampleHangingMuscle) that successfully uses `PrescribedController` with a controls_file whose column labels include an absolute path to an actuator (rather than just the actuator name).

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2836)
<!-- Reviewable:end -->
