### PR TITLE
WIP: Exception-safe directiory switching

### DIFF
--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -36,8 +36,8 @@
 %include <OpenSim/Common/Storage.h>
 %template(ArrayStorage) OpenSim::ArrayPtrs<OpenSim::Storage>;
 %include <OpenSim/Common/Units.h>
-%include <OpenSim/Common/IO.h>
 %ignore OpenSim::IO::CwdChanger;
+%include <OpenSim/Common/IO.h>
 %include <OpenSim/Common/Function.h>
 
 %template(SetFunctions) OpenSim::Set<OpenSim::Function, OpenSim::Object>;

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -37,6 +37,7 @@
 %template(ArrayStorage) OpenSim::ArrayPtrs<OpenSim::Storage>;
 %include <OpenSim/Common/Units.h>
 %include <OpenSim/Common/IO.h>
+%ignore OpenSim::IO::CwdChanger;
 %include <OpenSim/Common/Function.h>
 
 %template(SetFunctions) OpenSim::Set<OpenSim::Function, OpenSim::Object>;

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -690,3 +690,48 @@ void IO::eraseEmptyElements(std::vector<std::string>& list)
             ++it;
     }
 }
+
+IO::CwdChanger::CwdChanger() {
+}
+
+IO::CwdChanger::CwdChanger(const std::string& newDir) :
+    _existingDir{getCwd()} {
+
+    chDir(newDir);
+}
+
+IO::CwdChanger IO::CwdChanger::noop() {
+    return CwdChanger{};
+}
+
+IO::CwdChanger IO::CwdChanger::changeTo(const std::string& newDir) {
+    return CwdChanger{newDir};
+}
+
+IO::CwdChanger IO::CwdChanger::changeToParentOf(const std::string& path) {
+    return changeTo(getParentDirectory(path));
+}
+
+// a custom move constructor is necessary because the default move
+// constructor, which effectively calls `this->_existingDir{std::move(tmp._existingDir)}`
+// is specified to leave `tmp._existingDir` in an unspecified state:
+//
+// from: https://en.cppreference.com/w/cpp/string/basic_string/basic_string
+//
+// > Move constructor. Constructs the string with the contents of
+// > other using move semantics. other is left in valid, but
+// > unspecified state
+//
+// `~CwdChanger` requires that `tmp._existingDir.empty() == true`; otherwise,
+// destruction of the temporary will cause a directory change.
+IO::CwdChanger::CwdChanger(IO::CwdChanger&& tmp) :
+    _existingDir{} {
+
+    std::swap(this->_existingDir, tmp._existingDir);
+}
+
+IO::CwdChanger::~CwdChanger() noexcept {
+    if (!_existingDir.empty()) {
+        chDir(_existingDir);
+    }
+}

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -134,6 +134,7 @@ public:
             const std::string& string, const std::string& ending);
     static void eraseEmptyElements(std::vector<std::string>& list);
 
+#ifndef SWIG
     /**
      * A class that:
      *
@@ -200,6 +201,7 @@ public:
          */
         ~CwdChanger() noexcept;
     };
+#endif
 //=============================================================================
 };  // END CLASS IO
 

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -134,7 +134,6 @@ public:
             const std::string& string, const std::string& ending);
     static void eraseEmptyElements(std::vector<std::string>& list);
 
-#ifndef SWIG
     /**
      * A class that:
      *
@@ -201,7 +200,6 @@ public:
          */
         ~CwdChanger() noexcept;
     };
-#endif
 //=============================================================================
 };  // END CLASS IO
 

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -133,6 +133,36 @@ public:
     static bool EndsWithIgnoringCase(
             const std::string& string, const std::string& ending);
     static void eraseEmptyElements(std::vector<std::string>& list);
+
+    // A class that, on construction, switches the calling process's current
+    // working directory to the supplied directory. On destruction, it switches
+    // the calling process's working directory back to its original directory.
+    class CwdChanger final {
+        std::string _existingDir;
+    public:
+        static CwdChanger noop() {
+            return CwdChanger{};
+        }
+        CwdChanger() {
+            // noop ctor: enables conditional directory switching:
+            //    CwdChanger c = changeDir ? CwdChanger{"new/dir"} : CwdChanger{};
+        }
+        CwdChanger(const std::string& newDir) : _existingDir{IO::getCwd()} {
+            chDir(newDir);
+        }
+        CwdChanger(const CwdChanger&) = delete;
+        CwdChanger(CwdChanger&& tmp) {
+	    std::swap(_existingDir, tmp._existingDir);
+	    tmp._existingDir.clear();
+        }
+        CwdChanger& operator=(const CwdChanger&) = delete;
+        CwdChanger& operator=(CwdChanger&&) = delete;
+        ~CwdChanger() noexcept {
+            if (!_existingDir.empty()) {
+                chDir(_existingDir);
+            }
+        }
+    };
 //=============================================================================
 };  // END CLASS IO
 

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -115,7 +115,7 @@ Object::Object(const string &aFileName, bool aUpdateFromXMLNode)
     // relative to that directory. Make sure we switch back properly in case
     // of an exception.
     if (aUpdateFromXMLNode) {
-        IO::CwdChanger cwdInXMLDir{IO::getParentDirectory(aFileName)};
+        IO::CwdChanger cwd = IO::CwdChanger::changeToParentOf(aFileName);
         updateFromXMLNode(myNode, _document->getDocumentVersion());
     }
 }
@@ -1364,7 +1364,7 @@ print(const string &aFileName) const
     {
         // Temporarily change current directory so that inlined files
         // are written to correct relative directory
-        IO::CwdChanger cwdInXMLDir{IO::getParentDirectory(aFileName)};
+        IO::CwdChanger cwd = IO::CwdChanger::changeToParentOf(aFileName);
         std::unique_ptr<XMLDocument> newDoc{new XMLDocument()};
         if (_document != nullptr) {
             newDoc->copyDefaultObjects(*_document);
@@ -1603,7 +1603,7 @@ makeObjectFromFile(const std::string &aFileName)
         // Here file is deemed legit, chdir to where the file lives
         // here and restore at the end so offline objects are handled
         // properly
-        IO::CwdChanger cwdInXmlDir{IO::getParentDirectory(aFileName)};
+        IO::CwdChanger cwd = IO::CwdChanger::changeToParentOf(aFileName);
         newObject->_document = doc;
         if (newFormat) {
             newObject->updateFromXMLNode(*doc->getRootElement().element_begin(), doc->getDocumentVersion());
@@ -1657,9 +1657,7 @@ void Object::updateFromXMLDocument()
     assert(_document != nullptr);
 
     SimTK::Xml::Element e = _document->getRootDataElement();
-    IO::CwdChanger cwdInDirOfXMLFile{
-        IO::getParentDirectory(_document->getFileName())
-    };
+    IO::CwdChanger cwd = IO::CwdChanger::changeToParentOf(_document->getFileName());
     updateFromXMLNode(e, _document->getDocumentVersion());
 }
 

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -115,16 +115,8 @@ Object::Object(const string &aFileName, bool aUpdateFromXMLNode)
     // relative to that directory. Make sure we switch back properly in case
     // of an exception.
     if (aUpdateFromXMLNode) {
-        const string saveWorkingDirectory = IO::getCwd();
-        const string directoryOfXMLFile = IO::getParentDirectory(aFileName);
-        IO::chDir(directoryOfXMLFile);
-        try {
-            updateFromXMLNode(myNode, _document->getDocumentVersion());
-        } catch (...) {
-            IO::chDir(saveWorkingDirectory);
-            throw; // re-issue the exception
-        }
-        IO::chDir(saveWorkingDirectory);
+        IO::CwdChanger cwdInXMLDir{IO::getParentDirectory(aFileName)};
+        updateFromXMLNode(myNode, _document->getDocumentVersion());
     }
 }
 //_____________________________________________________________________________
@@ -1365,33 +1357,24 @@ print(const string &aFileName) const
         try {
             warnBeforePrint();
         } catch (...) {}
-    }
-    else
+    } else {
         warnBeforePrint();
-    // Temporarily change current directory so that inlined files are written to correct relative directory
-    std::string savedCwd = IO::getCwd();
-    IO::chDir(IO::getParentDirectory(aFileName));
-    try {
-        XMLDocument* oldDoc = NULL;
-        if (_document != NULL){
-            oldDoc = _document;
-        }
-        _document = new XMLDocument();
-        if (oldDoc){
-            _document->copyDefaultObjects(*oldDoc);
-            delete oldDoc;
-            oldDoc = 0;
-        }
-        SimTK::Xml::Element e = _document->getRootElement(); 
-        updateXMLNode(e);
-    } catch (const Exception &ex) {
-        // Important to catch exceptions here so we can restore current working directory...
-        // And then we can re-throw the exception
-        IO::chDir(savedCwd);
-        throw(ex);
     }
-    IO::chDir(savedCwd);
-    if(_document==NULL) return false;
+
+    {
+        // Temporarily change current directory so that inlined files
+        // are written to correct relative directory
+        IO::CwdChanger cwdInXMLDir{IO::getParentDirectory(aFileName)};
+        std::unique_ptr<XMLDocument> newDoc{new XMLDocument()};
+        if (_document != nullptr) {
+            newDoc->copyDefaultObjects(*_document);
+            delete _document;
+        }
+        _document = newDoc.release();
+        SimTK::Xml::Element e = _document->getRootElement();
+        updateXMLNode(e);
+    }
+
     _document->print(aFileName);
     return true;
 }
@@ -1601,47 +1584,42 @@ makeObjectFromFile(const std::string &aFileName)
     /**
      * Open the file and get the type of the root element
      */
-    try{
-        XMLDocument *doc = new XMLDocument(aFileName);
+    try {
+        XMLDocument* doc = new XMLDocument(aFileName);
         // Here we know the fie exists and is good, chdir to where the file lives
         string rootName = doc->getRootTag();
-        bool newFormat=false;
-        if (rootName == "OpenSimDocument"){ // New format, get child node instead
-            rootName = doc->getRootElement().element_begin()->getElementTag();
-            newFormat=true;
-        }
-        Object* newObject = newInstanceOfType(rootName);
-        if(!newObject) throw Exception("Unrecognized XML element '"+rootName+"' and root of file '"+aFileName+"'",__FILE__,__LINE__);
-        // Here file is deemed legit, chdir to where the file lives here and restore at the end so offline objects are handled properly
-        const string saveWorkingDirectory = IO::getCwd();
-        const string directoryOfXMLFile = IO::getParentDirectory(aFileName);
-        IO::chDir(directoryOfXMLFile);
-        //cout << "File name = "<< aFileName << "Cwd is now "<< directoryOfXMLFile << endl;
-        try {
-            newObject->_document=doc;
-            if (newFormat)
-                newObject->updateFromXMLNode(*doc->getRootElement().element_begin(), doc->getDocumentVersion());
-            else { 
-                SimTK::Xml::Element e = doc->getRootElement();
-                newObject->updateFromXMLNode(e, 10500);
-            }
-        } catch (...) {
-            IO::chDir(saveWorkingDirectory);
-            throw; // re-issue the exception
-        }
-        IO::chDir(saveWorkingDirectory);
-        return (newObject);
-    }
 
-    catch(const std::exception& x) {
+        bool newFormat = false;
+        if (rootName == "OpenSimDocument") { // New format, get child node instead
+            rootName = doc->getRootElement().element_begin()->getElementTag();
+            newFormat = true;
+        }
+
+        Object* newObject = newInstanceOfType(rootName);
+        if(newObject == nullptr) {
+            throw Exception("Unrecognized XML element '"+rootName+"' and root of file '"+aFileName+"'",__FILE__,__LINE__);
+        }
+
+        // Here file is deemed legit, chdir to where the file lives
+        // here and restore at the end so offline objects are handled
+        // properly
+        IO::CwdChanger cwdInXmlDir{IO::getParentDirectory(aFileName)};
+        newObject->_document = doc;
+        if (newFormat) {
+            newObject->updateFromXMLNode(*doc->getRootElement().element_begin(), doc->getDocumentVersion());
+        } else {
+            SimTK::Xml::Element e = doc->getRootElement();
+            newObject->updateFromXMLNode(e, 10500);
+        }
+
+        return newObject;
+    } catch(const std::exception& x) {
         log_error(x.what());
         return nullptr;
-    }
-    catch(...){ // Document couldn't be opened, or something went really bad
+    } catch(...) {
+        // Document couldn't be opened, or something went really bad
         return nullptr;
     }
-    assert(!"Shouldn't be here");
-    return nullptr;
 }
 
 void Object::makeObjectNamesConsistentWithProperties()
@@ -1676,15 +1654,11 @@ void Object::setObjectIsUpToDateWithProperties()
 
 void Object::updateFromXMLDocument()
 {
-    assert(_document!= 0);
-    
-    SimTK::Xml::Element e = _document->getRootDataElement(); 
-    const string saveWorkingDirectory = IO::getCwd();
-    string parentFileName = _document->getFileName();
-    const string directoryOfXMLFile = IO::getParentDirectory(parentFileName);
-    IO::chDir(directoryOfXMLFile);
+    assert(_document != nullptr);
+
+    SimTK::Xml::Element e = _document->getRootDataElement();
+    IO::CwdChanger cwdInDirOfXMLFile{IO::getParentDirectory(_document->getFileName())};
     updateFromXMLNode(e, _document->getDocumentVersion());
-    IO::chDir(saveWorkingDirectory);
 }
 
 std::string Object::dump() const {

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1657,7 +1657,9 @@ void Object::updateFromXMLDocument()
     assert(_document != nullptr);
 
     SimTK::Xml::Element e = _document->getRootDataElement();
-    IO::CwdChanger cwdInDirOfXMLFile{IO::getParentDirectory(_document->getFileName())};
+    IO::CwdChanger cwdInDirOfXMLFile{
+        IO::getParentDirectory(_document->getFileName())
+    };
     updateFromXMLNode(e, _document->getDocumentVersion());
 }
 


### PR DESCRIPTION
This is just a refactoring idea I'm playing around with on the side. 

Effectively, this PR aims to implement an RAII wrapper for directory switching. The motivation for doing this is to simplify some of the code sections that currently rely on changing the working directory of the caller temporarily (e.g. because XML files can contain relative paths).

Here is a simplified example of a common code pattern in OpenSim (see: [here](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Simulation/Model/AbstractTool.cpp#L413) for a direct example).

```c++
std::string saveWorkingDirectory = IO::getCwd();
std::string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);

IO::chDir(directoryOfSetupFile);  // the calling process now switches

// do stuff

IO::chDir(saveWorkingDirectory);
```

This pattern occurs in *many* places in OpenSim. There are ~85 uses of `chDir`, most of them are part of patterns like this. In principle, it's fine, but it misses out some subtleties, such as when `// do stuff` can throw:

```c++
std::string saveWorkingDirectory = IO::getCwd();
std::string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);

IO::chDir(directoryOfSetupFile);

// bug: the process will still be dir-switched when unwinding
doSomethingPotentiallyExceptionThrowing(); 

// correct
try {
  doSomethingPotentiallyExceptionThrowing(); 
} catch (...) {
  IO::chDir(saveWorkingDirectory);
  throw;
}

IO::chDir(saveWorkingDirectory);
```

Or when the directory switch is conditional (see [here](https://github.com/opensim-org/opensim-core/blob/master/OpenSim/Simulation/Model/AbstractTool.cpp#L873)):

```c++
std::string wd;
if (cond) {
  wd = IO::getCwd();
  IO::chDir(IO::getParentDirectory(someOtherDir));
}

// bug if cond != true
IO::chDir(wd);

 // correct
if (cond) {
  IO::chDir(wd);
}
```

The solution to these problems is to lean on C++'s strong RAII guarantees and lifetime semantics. This PR introduces a new class, currently called `IO::CwdChanger`, which temporarily changes the working directory of the calling process for its lifetime. This behavior is maintained even when unwinding, so the exceptional case becomes this:

```c++
IO::CwdChanger cwdChanger{IO::getParentDirectory(aToolSetupFileName)};
doSomethingPotentiallyExceptionThrowing(); 
// IO::CwdChanger::~CwdChanger automatically switches dir back, even when throwing
```

The class also has a noop case, which makes the class not change the directory on construction or destruction. This might seem dumb, but is useful for the conditional case:

```c++
IO::CwdChanger cwdChanger = cond ? IO::CwdChanger{path} : IO::CwdChanger::noop();
// now the cwd is *either* path, or unchanged
// the destructor implicitly changes back to the original dir 
```

This PR may also include some quality-of-life refactors in the code areas around the usage points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2839)
<!-- Reviewable:end -->
