### PR TITLE
Added OPENSIM_EXCEPTION and refactored other exception-throwing macro…

### DIFF
--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -47,52 +47,78 @@ namespace OpenSim {
 
 class Object;
 
-
 /** @name Macros to throw OpenSim exceptions
 The purpose of these macros is to aid with consistent message formatting,
 include file/line/function information in all messages, and to make it easier
 for developers to produce good messages.
 @{                                                                            */
-/**  
-@relates OpenSim::Exception                                                   */
-#define OPENSIM_THROW(EXCEPTION, ...)                                \
-    throw EXCEPTION{__FILE__, __LINE__, __func__, __VA_ARGS__};
 
-/** This macro checks the given condition and throws the given exception if the
-condition is true. Here's an example that throws an exception if some result is
-incorrect, and passes `result` and `5` to the constructor of the
-`ResultIsIncorrect` exception:
-@code
-auto result = getSomeResult();
-OPENSIM_THROW_IF(result != 5, ResultIsIncorrect, result, 5);
-@endcode
-@relates OpenSim::Exception                                                   */
-// These macros also allow us to add more details (e.g. class name) later easily.
-// Note -- Extra braces enclosing "if" are to avoid problems when these macros 
-// are called within if-else statements like:
-//           if(<some condition>)
-//               OPENSIM_THROW_IF(<arguments>)
-//           else
-//               <some statements>
-#define OPENSIM_THROW_IF(CONDITION, EXCEPTION, ...)                  \
-    {                                                                \
-    if(CONDITION)                                                    \
-        OPENSIM_THROW(EXCEPTION, __VA_ARGS__)                        \
+/**
+ * Constructs EXCEPTION in-place. The provided args (...) are forwarded after
+ * forwarding the filename, line, and function name of the caller.
+ *
+ * @relates OpenSim::Exception
+ */
+#define OPENSIM_EXCEPTION(EXCEPTION, ...) \
+    EXCEPTION{__FILE__, __LINE__, __func__, __VA_ARGS__};
+
+/**
+ * Throws EXCEPTION
+ *
+ * This is equivalent to:
+ *
+ *     throw OPENSIM_EXCEPTION(EXCEPTION, ...);
+ */
+#define OPENSIM_THROW(EXCEPTION, ...) \
+    throw OPENSIM_EXCEPTION(EXCEPTION, __VA_ARGS__);
+
+/**
+ * Throws EXCEPTION if CONDITION evaluates to `true`.
+ *
+ * This is equivalent to:
+ *
+ *     if (CONDITION) {
+ *         throw OPENSIM_EXCEPTION(EXCEPTION, ...);
+ *     }
+ *
+ * Implementation note:
+ * The macro implementation is brace-enclosed to avoid problems
+ * when using it in single-statement forms. e.g.:
+ *
+ *     if (c)
+ *         OPENSIM_THROW_IF(...);
+ *     else
+ *         foo();
+ *
+ * (the semicolon is what might cause a problem)
+ */
+#define OPENSIM_THROW_IF(CONDITION, EXCEPTION, ...) \
+    { \
+        if (CONDITION) { \
+            throw OPENSIM_EXCEPTION(EXCEPTION, __VA_ARGS__); \
+        } \
     }
 
-/** Macro to throw from within an Object. This macro picks up implicit pointer
-to the object and uses it to print information.                               */
-#define OPENSIM_THROW_FRMOBJ(EXCEPTION, ...)                         \
-    throw EXCEPTION{__FILE__, __LINE__, __func__, *this, __VA_ARGS__};
+/**
+ * Throws EXCEPTION from within an Object.
+ *
+ * This is equivalent to:
+ *
+ *     throw OPENSIM_EXCEPTION(EXCEPTION, *this, ...);
+ */
+#define OPENSIM_THROW_FRMOBJ(EXCEPTION, ...) \
+    throw OPENSIM_EXCEPTION(EXCEPTION, *this, __VA_ARGS__);
 
-/** Macro to throw from within an Object if a condition evaluates to TRUE. This 
-macro picks up implicit pointer to the object and uses it to print 
-information.                                                                  */
-#define OPENSIM_THROW_IF_FRMOBJ(CONDITION, EXCEPTION, ...)           \
-    {                                                                \
-    if(CONDITION)                                                    \
-        OPENSIM_THROW_FRMOBJ(EXCEPTION, __VA_ARGS__)                 \
-    }
+/**
+ * Throws EXCEPTION from within an Object if CONDITION evaluates to `true`
+ *
+ * This is equivalent to:
+ *
+ *     OPENSIM_THROW_IF(CONDITION, EXCEPTION, *this, ...);
+ */
+#define OPENSIM_THROW_IF_FRMOBJ(CONDITION, EXCEPTION, ...) \
+    OPENSIM_THROW_IF(CONDITION, EXCEPTION, *this, __VA_ARGS__)
+
 /** @}                                                                        */
 
 


### PR DESCRIPTION
Minor addition + refactor. 

- This adds `OPENSIM_EXCEPTION` as an additional macro in `Exceptions.h`
- Existing macros are still available. This is not a breaking change
- Minor refactor to the macros in `Exception.h`, making the documentation somewhat shorter, and much more literal, in its explanation of the existing macro's functionality

The motivation for adding `OPENSIM_EXCEPTION` is to enable developers to decide whether they want the control structures (`throw`/`if`) in the function's body or in a macro. A macro is (arguably) more convenient, and may facilitate future feature additions (e.g. doing things *before* throwing). Putting it in the function body is simpler (for any devs who are unfamilar with the macros) but requires more typing.

Effectively, this enables a stylistic choice:

```c++
// existing, and current
OPENSIM_THROW(E, ...);
OPENSIM_THROW_IF(cond, E, ...);

// proposed alternative
throw OPENSIM_EXCEPTION(E, ...);
if (cond) {
    throw OPENSIM_EXCEPTION(E, ...);
}
```

Where some developers (e.g. me) prefer the latter, because it directly shows all branches + control changes in the function, which makes comprehending larger functions easier (imho):

```c++
O* f() {
    // some resource that may leak, so a dev is going to have
    // to carefully pay attention to `if`, `throw`, `switch`, `return`, etc.
    // (assuming other functions are noexcept)
    O* o = new O();
    if (c) {
        // do stuff
        if (c2) {
            log_something();
            OPENSIM_THROW_IF(throw_on_c2_err, E, ...);  // conditional jump
        } else OPENSIM_THROW(E, ...);  // unconditional jump, if some other condition is not met
    }
    // if you think this macro is silly, consider what OPENSIM_EXCEPTION
    // is facilitating
    OPENSIM_RETURN_IF(c3, o);

    // other stuff

    return o;
}
```

vs.

```c++
O* f() {
    // some resource that may leak, so a dev is going to have
    // to carefully pay attention to `if`, `throw`, `switch`, `return`, etc.
    // (assuming other functions are noexcept)
    O* o = new O();
    if (c) {
        // do stuff
        if (c2) {
            log_something();
            if (throw_on_c2_err) {
                throw OPENSIM_EXCEPTION(E, ...);
            }
        } else throw OPENSIM_EXCEPTION(E, ...);
    }

    if (c3) {
        return o;
    }

    // other stuff

    return o;
}
```

The second is longer, because of the extra typing, but I'd argue it's easier to read. Again, entirely opinion, but macro-izing control structures is effectively the same as saying "well, we *usually* end a paragraph with a fullstop followed by a newline, so why not introduce 'fsnewline' into the language?". Sometimes that's necessary (e.g. complex state machines that use macro-ized `goto`s to incrementally read input) but most of the time I prefer simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2841)
<!-- Reviewable:end -->
