### PR TITLE
DeGrooteFregly2016Muscle::computeActuation(): setActuation()

### DIFF
--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -255,6 +255,7 @@ void DeGrooteFregly2016Muscle::computeStateVariableDerivatives(
 
 double DeGrooteFregly2016Muscle::computeActuation(const SimTK::State& s) const {
     const auto& mdi = getMuscleDynamicsInfo(s);
+    setActuation(s, mdi.tendonForce);
     return mdi.tendonForce;
 }
 


### PR DESCRIPTION
### Brief summary of changes

Adding `setActuation()` inside `computeActuation()` in the DGF muscle increases the consistency of the DGF muscle with the Thelen and Millard muscles. Without `setActuation()`, a MuscleAnalysis produces NaNs for multiple quantities, including fiber force.

### Testing I've completed

I've already made this change in the `moco` branch, in the copy of the DGF muscle in Moco that we will eventually throw out. On the `moco` branch, there's an example `exampleHangingMuscle.py` that uses the DGF muscle with a MuscleAnalysis, and I tested that such a MuscleAnalysis correctly reports fiber force.

### CHANGELOG.md (choose one)

- no need to update because...already updated on the `moco` branch: https://github.com/opensim-org/opensim-core/commit/07ad76721799159c8399fdb0f7c67443f7e7c312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2846)
<!-- Reviewable:end -->
