### PR TITLE
Fixed a critical bug in InducedAccelerations which prevents analysis to run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
+====
+Bug Fixes
+---------
+- Fixed a critical bug in Induced Accelerations Analysis which prevents analysis to run when external forces are present
+
 v4.2
 ====
 - Add the ActivationCoordinateActuator component, which is a CoordinateActuator with simple activation dynamics (PR #2699).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
-====
-Bug Fixes
----------
-- Fixed a critical bug in Induced Accelerations Analysis which prevents analysis to run when external forces are present
 
 v4.2
 ====
@@ -29,6 +25,7 @@ v4.2
 - The new Matlab examplePointMass.m shows how to build and simulate a point-mass model.
 - Fix OpenSense calibration algorithm to handle models facing an arbitrary direction. The calibration algorithm now aligns one axis of the provided Orientation Sensor data with the x-axis of the base segment (e.g. pelvis) of the model in default pose.
 - For PrescribedController, the controls_file column labels can now be absolute paths to actuators (previously, the column labels were required to be actuator names).
+- Fixed a critical bug in Induced Accelerations Analysis which prevents analysis to run when external forces are present ([PR #2847](https://github.com/opensim-org/opensim-core/pull/2808)).
 
 v4.1
 ====

--- a/OpenSim/Analyses/InducedAccelerations.cpp
+++ b/OpenSim/Analyses/InducedAccelerations.cpp
@@ -963,23 +963,16 @@ Array<bool> InducedAccelerations::applyContactConstraintAccordingToExternalForce
             point = exf->getPointAtTime(t);
             // point should be expressed in the "applied to" body for consistency across all constraints
             if(exf->getPointExpressedInBodyName() != exf->getAppliedToBodyName()){
-                int appliedToBodyIndex = _model->getBodySet().getIndex(exf->getAppliedToBodyName());
-                if(appliedToBodyIndex < 0){
-                    log_warn("ExternalForce applied_to_body '{}' not found.",
-                             exf->getAppliedToBodyName());
-                }
 
-                int expressedInBodyIndex = _model->getBodySet().getIndex(exf->getPointExpressedInBodyName());
-                if(expressedInBodyIndex < 0){
-                    log_warn("ExternalForce point_expressed_in_body '{}' not found.",
-                             exf->getPointExpressedInBodyName());
-                }
+                const PhysicalFrame* appliedToBody = _model->findComponent<PhysicalFrame>(exf->getAppliedToBodyName());
+                const PhysicalFrame* expressedInBody = _model->findComponent<PhysicalFrame>(exf->getPointExpressedInBodyName());
 
-                const Body &appliedToBody = _model->getBodySet().get(appliedToBodyIndex);
-                const Body &expressedInBody = _model->getBodySet().get(expressedInBodyIndex);
+
+                OPENSIM_THROW_IF_FRMOBJ(appliedToBody == nullptr, Exception, "ExternalForce's appliedToBody " + exf->getAppliedToBodyName() + " not found.");
+                OPENSIM_THROW_IF_FRMOBJ(expressedInBody == nullptr, Exception, "ExternalForce's pointExpressedInBodyName " + exf->getPointExpressedInBodyName() + " not found.");
 
                 _model->getMultibodySystem().realize(s, SimTK::Stage::Velocity);
-                point = expressedInBody.findStationLocationInAnotherFrame(s, point, appliedToBody);
+                point = expressedInBody->findStationLocationInAnotherFrame(s, point, *appliedToBody);
             }
 
             _constraintSet.get(i).setContactPointForInducedAccelerations(s, point);

--- a/OpenSim/Analyses/InducedAccelerationsSolver.cpp
+++ b/OpenSim/Analyses/InducedAccelerationsSolver.cpp
@@ -345,23 +345,15 @@ Array<bool> InducedAccelerationsSolver::
             point = exf->getPointAtTime(t);
             // point should be expressed in the "applied to" body for consistency across all constraints
             if(exf->getPointExpressedInBodyName() != exf->getAppliedToBodyName()){
-                int appliedToBodyIndex = getModel().getBodySet().getIndex(exf->getAppliedToBodyName());
-                if(appliedToBodyIndex < 0){
-                    log_warn("ExternalForce applied_to_body '{}' not found.",
-                            exf->getAppliedToBodyName());
-                }
+                
+                const PhysicalFrame* appliedToBody = getModel().findComponent<PhysicalFrame>(exf->getAppliedToBodyName());
+                const PhysicalFrame* expressedInBody = getModel().findComponent<PhysicalFrame>(exf->getPointExpressedInBodyName());
 
-                int expressedInBodyIndex = getModel().getBodySet().getIndex(exf->getPointExpressedInBodyName());
-                if(expressedInBodyIndex < 0) {
-                    log_warn("ExternalForce point_expressed_in_body '{}' not found.",
-                             exf->getPointExpressedInBodyName());
-                }
-
-                const Body &appliedToBody = getModel().getBodySet().get(appliedToBodyIndex);
-                const Body &expressedInBody = getModel().getBodySet().get(expressedInBodyIndex);
-
+                OPENSIM_THROW_IF_FRMOBJ(appliedToBody == nullptr, Exception, "ExternalForce's appliedToBody " + exf->getAppliedToBodyName() + " not found.");
+                OPENSIM_THROW_IF_FRMOBJ(expressedInBody == nullptr, Exception, "ExternalForce's pointExpressedInBodyName " + exf->getPointExpressedInBodyName() + " not found.");
+                
                 getModel().getMultibodySystem().realize(s, SimTK::Stage::Velocity);
-                point = expressedInBody.findStationLocationInAnotherFrame(s, point, appliedToBody);
+                point = expressedInBody->findStationLocationInAnotherFrame(s, point, *appliedToBody);
             }
 
             _replacementConstraints[i].setContactPointForInducedAccelerations(s, point);


### PR DESCRIPTION
Fixes issue #2689

### Brief summary of changes
Added extra check for external force if it's expressed in or applied to "ground" and transformed the force to respective frame.

### Testing I've completed
I successfully compiled the changes and tested for Induced Accelerations with External Loads analysis.


### CHANGELOG.md
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2847)
<!-- Reviewable:end -->
