### PR TITLE
Fixed CacheVariable getter failing runtime assertion in debug mode

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1500,7 +1500,7 @@ public:
     template<class T>
     SimTK::CacheEntryIndex getCacheVariableIndex(const CacheVariable<T>& cv) const {
         // cheap: index previously initialized, just return that
-        if (cv.maybeUninitIndex != SimTK::InvalidIndex) {
+        if (cv.maybeUninitIndex.isValid()) {
             return cv.maybeUninitIndex;
         }
 
@@ -3161,7 +3161,7 @@ private:
        }
 
        SimTK::CacheEntryIndex index() const {
-           if (this->maybeUninitIndex != SimTK::InvalidIndex) {
+           if (this->maybeUninitIndex.isValid()) {
                return this->maybeUninitIndex;
            } else {
                OPENSIM_THROW(Exception, "StoredCacheVariable::get: failed because this->index == SimTK::InvalidIndex: this can happen if Component::extendRealizeTopology has not been called");


### PR DESCRIPTION
This fixes an assertion error that can happen when running the tests with a `Debug` build. It happens because SimTK's indexes perform a "is valid" check on both elements of an equality comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2850)
<!-- Reviewable:end -->
