### PR TITLE
Moved OpenSim::Component::getSystem() implementation into header

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1540,12 +1540,6 @@ void Component::extendRealizeAcceleration(const SimTK::State& s) const
     }
 }
 
-const SimTK::MultibodySystem& Component::getSystem() const
-{
-    OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
-    return _system.getRef();
-}
-
 SimTK::MultibodySystem& Component::updSystem() const
 {
     OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -550,7 +550,13 @@ public:
      * Throws an Exception if the System has not been created or the Component
      * has not added itself to the System.
      * @see hasSystem().  */
-    const SimTK::MultibodySystem& getSystem() const;
+    const SimTK::MultibodySystem& getSystem() const
+    {
+        // This method is inlined because it is called *a lot* at runtime
+
+        OPENSIM_THROW_IF_FRMOBJ(!hasSystem(), ComponentHasNoSystem);
+        return _system.getRef();
+    }
 
     /**
     * Check if this component has an underlying MultibodySystem.


### PR DESCRIPTION
This is a micro-commit that inlines `Component::getSystem`, by moving the implementation into the header.

I would not normally inline functions--the benefits are usually overstated when compared with the compile-time increases--but, in this case, `getSystem` is called *a lot* internally in OpenSim, so this tiny change should improve perf by 1 % (small gains, really, but it's 1 % for doing basically nothing).

An example of a valgrind call graph that I'd see when measuring things would be this:

![image](https://user-images.githubusercontent.com/4730570/90634982-7c45c700-e220-11ea-9071-661c1c800a53.png)

Where `getSystem` is called 115M times over a typical FD simulation (ToyDropLanding). Measuring this change under my usual profiling rig shows some tiny changes:

|                  Test Name | lhs [secs] | σ [secs] | rhs [secs] | σ [secs] | Speedup |
| -------------------------- | ---------- | -------- | ---------- | -------- | ------- |
|                   Gait2354 |       0.26 |     0.00 |       0.26 |     0.00 |    1.00 |
|             ToyDropLanding |      11.33 |     0.00 |      11.25 |     0.00 |    1.01 |
|   ToyDropLanding_nomuscles |       0.43 |     0.00 |       0.43 |     0.00 |    1.01 |
|            passive_dynamic |       4.64 |     0.00 |       4.61 |     0.00 |    1.01 |
| passive_dynamic_noanalysis |       3.00 |     0.00 |       3.01 |     0.00 |    1.00 |
|                      Arm26 |       0.26 |     0.00 |       0.26 |     0.00 |    1.01 |
|             RajagopalModel |      13.37 |     0.01 |      13.11 |     0.01 |    1.02 |

But I'd take these with a pinch of salt because it's close to the measurement noise.

Either way, we inline *a lot* of other stuff that isn't called nearly as often, so I'm hoping this change is not sacrosanct, given the measurements.


---

- Enables inlining of the function call by other compilation units

- OpenSim::Component::getSystem() is one of the most heavily-called
  functions in OpenSim. For example, an FD simulation of ToyDropLanding
  calls this function >100M times, accounting for ~0.5-1 % of CPU
  usage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2863)
<!-- Reviewable:end -->
