### PR TITLE
Fix ComponentPath when running in MSVC with debug mode

### DIFF
--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -152,19 +152,27 @@ void testComponentPath() {
     // Test if getParentPathStr() returns correct string
     ASSERT(numberedAbsPath.getParentPathString() == numberedAbsPathParentStr);
 
-    ASSERT(CP{""}.getNumPathLevels() == 0);
-    ASSERT(CP{"/"}.getNumPathLevels() == 0);
-    ASSERT(CP{"/a"}.getNumPathLevels() == 1);
-    ASSERT(CP{"/a/"}.getNumPathLevels() == 1);
-    ASSERT(CP{"/a/b"}.getNumPathLevels() == 2);
-    ASSERT(CP{"/a/b/"}.getNumPathLevels() == 2);
-    ASSERT(CP{"/a/b/c"}.getNumPathLevels() == 3);
-    ASSERT(CP{"a"}.getNumPathLevels() == 1);
-    ASSERT(CP{"a/b"}.getNumPathLevels() == 2);
-    ASSERT(CP{"../"}.getNumPathLevels() == 1);
-    ASSERT(CP{".."}.getNumPathLevels() == 1);
-    ASSERT(CP{"a/.."}.getNumPathLevels() == 0);
-    ASSERT(CP{"/a/.."}.getNumPathLevels() == 0);
+    // test number of path levels behaves sanely
+    {
+        static const std::pair<std::string, int> expectedNumPathLevels[] = {
+                {"", 0},
+                {"/", 0},
+                {"a", 1},
+                {"/a", 1},
+                {"/a/", 1},
+                {"a/b", 2},
+                {"/a/b", 2},
+                {"/a/b/", 2},
+                {"/a/b/c", 3},
+                {"../", 1},
+                {"a/..", 0},
+                {"/a/..", 0},
+        };
+
+        for (auto p : expectedNumPathLevels) {
+            ASSERT(CP{p.first}.getNumPathLevels() == p.second);
+        }
+    }
 
     // Loop through all levels of the subtree and see if names match
     for (size_t ind = 0; ind < levels.size(); ++ind) {
@@ -183,6 +191,11 @@ void testComponentPath() {
     for (size_t ind = 0; ind < levels.size(); ++ind) {
         ASSERT(numberedRelPath.getSubcomponentNameAtLevel(ind) == levels[ind]);
     }
+
+    // ensure isAbsolute is sane for vector inputs
+    ASSERT(CP{std::vector<std::string>{}, true}.isAbsolute());
+    ASSERT(CP{std::vector<std::string>{""}, true}.isAbsolute());
+    ASSERT(CP{std::vector<std::string>{"a", "b"}, true}.isAbsolute());
 
     // general tests to ensure it normalizes a variety of paths correctly
     {

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -154,7 +154,7 @@ void testComponentPath() {
 
     // test number of path levels behaves sanely
     {
-        static const std::pair<std::string, int> expectedNumPathLevels[] = {
+        static const std::pair<std::string, size_t> expectedNumPathLevels[] = {
                 {"", 0},
                 {"/", 0},
                 {"a", 1},


### PR DESCRIPTION
Proposed fix for #2866 

@aymanhab noticed that OpenSim `master` tests are currently broken when building with MSVC in debug mode. The reason they are broken is because my implementation of ComponentPath, which was merged in PR #2844 , relied on behavior like:

```c++
std::string s = "";
assert(s.front() == '\0');
assert(*s.begin() == '\0');
assert(*s.rbegin() == '\0');
```

Which is classed as undefined behavior by MSVC. It has assertions for detecting when code tries to do things like this. Those assertions are explained here:

https://docs.microsoft.com/en-us/cpp/standard-library/debug-iterator-support?view=vs-2019

The reason why I figured this kind of code is valid is because C++11 specifically redefined that `std::string` must be a contiguous sequence of `charT`, followed by a value-initialized terminator (`char()`, which `== '\0'`). Cppreference mentions this in *some* of the docs:

> https://en.cppreference.com/w/cpp/string/basic_string/data
> (until C++11) The returned array is not required to be null-terminated. If empty() returns true, the pointer is a non-null pointer that should not be dereferenced. 
> (since C++11) The returned array is null-terminated, that is, data() and c_str() perform the same function. If empty() returns true, the pointer points to a single null character. 

And that, specifically, `operator[]` returns a nul terminator:

> https://en.cppreference.com/w/cpp/string/basic_string/operator_at
> (since C++11) If pos == size(), a reference to the character with value CharT() (the null character) is returned. For the first (non-const) version, the behavior is undefined if this character is modified to any value other than CharT() .

But does not specify this behavior for functions like `.front()` (which *speficially* says that the return value is undefined if the string is empty), and it does not specify this behavior when dereferencing the iterators, which is what MSVC is (probably, rightly) whining about. 

Because I'm busy/lazy, one solution I tried was to just:

```c++
// ComponentPath.cpp
#define _ITERATOR_DEBUG_LEVEL 0 
```

But that causes other compile errors (effectively, MSVC, VS, etc. start thinking that I'm trying to link object files created with different flags and dies). It is also hacky as hell, so I decided to do this "properly", by reimplementing the `ComponentPath` algorithms to specifically use access patterns that are correct in C++11, such as:

```c++
char* begin = &str[0];  // can be `.data()` in C++17
char* end = &str[str.size()];

while (begin != end) {
    if (begin[1] == '\0') {
        // lookahead is NUL, do something
    }
    ++begin;
}
```

This effectively shifts the implementation to be more C-like, than C++-like, because the algorithms now traverse C-string pointers etc. To combat that, I spent a fair bit of time trying to simplify the tricker bits into helper functions, or a more readable form, and the proposed fix--I believe--is as easy to follow as the version that relied on C++ iterators

(moreso imho, but I like C, and pinapple on pizzas, so :shrug:)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2870)
<!-- Reviewable:end -->
