### PR TITLE
Replaced uses of chDir with IO::CwdChanger (RAII safety)

### DIFF
--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -736,12 +736,12 @@ IO::CwdChanger& IO::CwdChanger::operator=(CwdChanger&& tmp) {
     return *this;
 }
 
-void IO::CwdChanger::reset() {
+void IO::CwdChanger::restore() {
     chDir(_existingDir);
     _existingDir.clear();
 }
 
-void IO::CwdChanger::release() noexcept {
+void IO::CwdChanger::stay() noexcept {
     _existingDir.clear();
 }
 

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -733,6 +733,7 @@ IO::CwdChanger::CwdChanger(IO::CwdChanger&& tmp) :
 IO::CwdChanger& IO::CwdChanger::operator=(CwdChanger&& tmp) {
     this->_existingDir.clear();
     std::swap(this->_existingDir, tmp._existingDir);
+    return *this;
 }
 
 void IO::CwdChanger::reset() {

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -730,6 +730,20 @@ IO::CwdChanger::CwdChanger(IO::CwdChanger&& tmp) :
     std::swap(this->_existingDir, tmp._existingDir);
 }
 
+IO::CwdChanger& IO::CwdChanger::operator=(CwdChanger&& tmp) {
+    this->_existingDir.clear();
+    std::swap(this->_existingDir, tmp._existingDir);
+}
+
+void IO::CwdChanger::reset() {
+    chDir(_existingDir);
+    _existingDir.clear();
+}
+
+void IO::CwdChanger::release() noexcept {
+    _existingDir.clear();
+}
+
 IO::CwdChanger::~CwdChanger() noexcept {
     if (!_existingDir.empty()) {
         chDir(_existingDir);

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -184,7 +184,25 @@ public:
         CwdChanger(const CwdChanger&) = delete;
         CwdChanger(CwdChanger&& tmp);
         CwdChanger& operator=(const CwdChanger&) = delete;
-        CwdChanger& operator=(CwdChanger&&) = delete;
+        CwdChanger& operator=(CwdChanger&&);
+
+        /**
+         * Prematurely change the current working directory back to its
+         * original location.
+         *
+         * This is functionally equivalent to prematurely destructing the
+         * CwdChanger. After calling CwdChanger::reset(), the now-reset
+         * CwdChanger will become a noop instance that, when it destructs,
+         * will not attempt to change back to the original directory.
+         */
+        void reset();
+
+        /**
+         * Release CwdChanger's control over the current working directory,
+         * such that the CwdChanger instance does not attempt to change
+         * directory on destruction.
+         */
+        void release() noexcept;
 
         /**
          * Destructs a CwdChanger instance.

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -191,18 +191,18 @@ public:
          * original location.
          *
          * This is functionally equivalent to prematurely destructing the
-         * CwdChanger. After calling CwdChanger::reset(), the now-reset
+         * CwdChanger. After calling CwdChanger::restore(), the now-restored
          * CwdChanger will become a noop instance that, when it destructs,
          * will not attempt to change back to the original directory.
          */
-        void reset();
+        void restore();
 
         /**
          * Release CwdChanger's control over the current working directory,
-         * such that the CwdChanger instance does not attempt to change
-         * directory on destruction.
+         * such that the CwdChanger instance does not attempt to change back
+         * to its original directory on destruction.
          */
-        void release() noexcept;
+        void stay() noexcept;
 
         /**
          * Destructs a CwdChanger instance.

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -143,7 +143,7 @@ public:
      * - On destruction: switches the calling process's working directory
      *   back to its original directory.
      */
-    class CwdChanger final {
+    class OSIMCOMMON_API CwdChanger final {
         std::string _existingDir;
 
         /**

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -386,59 +386,44 @@ loadModel(const string &aToolSetupFileName, ForceSet *rOriginalForceSet )
             "No model file was specified (<model_file> element is empty) in "
             "the Tool's Setup file. Consider passing `false` for the "
             "constructor's `aLoadModel` parameter");
-    string saveWorkingDirectory = IO::getCwd();
-    string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);
-    IO::chDir(directoryOfSetupFile);
+
+    auto cwd = IO::CwdChanger::changeToParentOf(aToolSetupFileName);
 
     log_info("AbstractTool {} loading model {}", getName(), _modelFile);
 
-    Model *model = 0;
+    auto model = std::unique_ptr<Model>{new Model{_modelFile}};
+    model->finalizeFromProperties();
 
-    try {
-        model = new Model(_modelFile);
-        model->finalizeFromProperties();
-        if (rOriginalForceSet!=NULL)
-            *rOriginalForceSet = model->getForceSet();
-    } catch(...) { // Properly restore current directory if an exception is thrown
-        IO::chDir(saveWorkingDirectory);
-        throw;
+    if (rOriginalForceSet!=NULL) {
+        *rOriginalForceSet = model->getForceSet();
     }
-    _model = model;
-    IO::chDir(saveWorkingDirectory);
+    _model = model.release();
 }
 
 void AbstractTool::
 updateModelForces(Model& model, const string &aToolSetupFileName, ForceSet *rOriginalForceSet )
 {
-    string saveWorkingDirectory = IO::getCwd();
-    string directoryOfSetupFile = IO::getParentDirectory(aToolSetupFileName);
-    IO::chDir(directoryOfSetupFile);
+    auto cwd = IO::CwdChanger::changeToParentOf(aToolSetupFileName);
 
-    try {
-        if(rOriginalForceSet) *rOriginalForceSet = model.getForceSet();
-
-        // If replacing force set read in from model file, clear it here
-        if (_replaceForceSet){
-            // Can no longer just remove the model's forces.
-            // If the model is connected, then the model will
-            // maintain a list of subcomponents that refer to garbage.
-            model.cleanup();
-            model.updForceSet().setSize(0);
-        }
-
-        // Load force set(s)
-        for(int i=0;i<_forceSetFiles.getSize();i++) {
-            log_info("Adding force object set from {}", _forceSetFiles[i]);
-            ForceSet *forceSet=new ForceSet(_forceSetFiles[i], true);
-            model.updForceSet().append(*forceSet);
-        }
-
-    } catch (...) {
-        IO::chDir(saveWorkingDirectory);
-        throw;
+    if (rOriginalForceSet) {
+        *rOriginalForceSet = model.getForceSet();
     }
 
-    IO::chDir(saveWorkingDirectory);
+    // If replacing force set read in from model file, clear it here
+    if (_replaceForceSet){
+        // Can no longer just remove the model's forces.
+        // If the model is connected, then the model will
+        // maintain a list of subcomponents that refer to garbage.
+        model.cleanup();
+        model.updForceSet().setSize(0);
+    }
+
+    // Load force set(s)
+    for(int i=0; i<_forceSetFiles.getSize(); i++) {
+        log_info("Adding force object set from {}", _forceSetFiles[i]);
+        ForceSet *forceSet=new ForceSet(_forceSetFiles[i], true);
+        model.updForceSet().append(*forceSet);
+    }
 }
 //_____________________________________________________________________________
 /**
@@ -663,51 +648,44 @@ void AbstractTool::removeExternalLoadsFromModel()
             if (iter!= aNode.element_end()){
                 string fileName="";
                 iter->getValueAs(fileName);
-                if (fileName!="" && fileName != "Unassigned"){
-                    string saveWorkingDirectory = IO::getCwd();
-                    string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
-                    IO::chDir(directoryOfSetupFile);
-                    //bool extLoadsFile=false;
-                    try {
-                        SimTK::Xml::Document doc(fileName);
-                        doc.setIndentString("\t");
-                        Xml::Element root = doc.getRootElement();
-                        if (root.getElementTag()=="OpenSimDocument"){
-                            //int curVersion = root.getRequiredAttributeValueAs<int>("Version");
-                            Xml::element_iterator rootIter(root.element_begin("ForceSet"));
-                            if (rootIter!=root.element_end()){
-                                rootIter->setElementTag("ExternalLoads");
-                            }
-                            Xml::element_iterator iter(root.element_begin("ExternalLoads"));
-                            Xml::Element extLoadsElem = *iter;
+                if (fileName!="" && fileName != "Unassigned") {
+                    auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
-                            SimTK::Xml::element_iterator kIter = aNode.element_begin("external_loads_model_kinematics_file");
-                            if (kIter !=aNode.element_end()){
-                                string kinFileName= "";
-                                kIter->getValueAs(kinFileName);
-                                aNode.removeNode(kIter);
-                                // Make sure no node already exist
-                                Xml::element_iterator iter2(extLoadsElem.element_begin("external_loads_model_kinematics_file"));
-                                if (iter2 == extLoadsElem.element_end())
-                                    iter->insertNodeAfter(iter->element_end(), Xml::Element("external_loads_model_kinematics_file", kinFileName));
-                                else
-                                    iter2->setValue(kinFileName);
-                            }
-                            SimTK::Xml::element_iterator fIter = aNode.element_begin("lowpass_cutoff_frequency_for_load_kinematics");
-                            if (fIter !=aNode.element_end()){
-                                SimTK::String freq;
-                                fIter->getValueAs(freq);
-                                Xml::element_iterator iter2(extLoadsElem.element_begin("lowpass_cutoff_frequency_for_load_kinematics"));
-                                if (iter2 == extLoadsElem.element_end())
-                                    iter->insertNodeAfter(iter->element_end(), Xml::Element("lowpass_cutoff_frequency_for_load_kinematics", freq));
-                                else
-                                    iter2->setValue(freq);
-                            }
-                            doc.writeToFile(fileName);
+                    SimTK::Xml::Document doc(fileName);
+                    doc.setIndentString("\t");
+                    Xml::Element root = doc.getRootElement();
+                    if (root.getElementTag()=="OpenSimDocument"){
+                        //int curVersion = root.getRequiredAttributeValueAs<int>("Version");
+                        Xml::element_iterator rootIter(root.element_begin("ForceSet"));
+                        if (rootIter!=root.element_end()){
+                            rootIter->setElementTag("ExternalLoads");
                         }
-                    }
-                    catch(...){
-                        IO::chDir(saveWorkingDirectory);
+                        Xml::element_iterator iter(root.element_begin("ExternalLoads"));
+                        Xml::Element extLoadsElem = *iter;
+
+                        SimTK::Xml::element_iterator kIter = aNode.element_begin("external_loads_model_kinematics_file");
+                        if (kIter !=aNode.element_end()){
+                            string kinFileName= "";
+                            kIter->getValueAs(kinFileName);
+                            aNode.removeNode(kIter);
+                            // Make sure no node already exist
+                            Xml::element_iterator iter2(extLoadsElem.element_begin("external_loads_model_kinematics_file"));
+                            if (iter2 == extLoadsElem.element_end())
+                                iter->insertNodeAfter(iter->element_end(), Xml::Element("external_loads_model_kinematics_file", kinFileName));
+                            else
+                                iter2->setValue(kinFileName);
+                        }
+                        SimTK::Xml::element_iterator fIter = aNode.element_begin("lowpass_cutoff_frequency_for_load_kinematics");
+                        if (fIter !=aNode.element_end()){
+                            SimTK::String freq;
+                            fIter->getValueAs(freq);
+                            Xml::element_iterator iter2(extLoadsElem.element_begin("lowpass_cutoff_frequency_for_load_kinematics"));
+                            if (iter2 == extLoadsElem.element_end())
+                                iter->insertNodeAfter(iter->element_end(), Xml::Element("lowpass_cutoff_frequency_for_load_kinematics", freq));
+                            else
+                                iter2->setValue(freq);
+                        }
+                        doc.writeToFile(fileName);
                     }
                 }
             }
@@ -817,14 +795,12 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
 {
     bool oldFileValid = !(oldFile=="" || oldFile=="Unassigned");
 
-    std::string savedCwd;
-    if(getDocument()) {
-        savedCwd = IO::getCwd();
-        IO::chDir(IO::getParentDirectory(getDocument()->getFileName()));
-    }
-    if (oldFileValid){
+    auto cwd = getDocument() != nullptr
+            ? IO::CwdChanger::changeToParentOf(getDocument()->getFileName())
+            : IO::CwdChanger::noop();
+
+    if (oldFileValid) {
         if(!ifstream(oldFile.c_str(), ios_base::in).good()) {
-            if(getDocument()) IO::chDir(savedCwd);
             string msg =
                 "Object: ERR- Could not open file " + oldFile+ ". It may not exist or you don't have permission to read it.";
             throw Exception(msg,__FILE__,__LINE__);
@@ -844,7 +820,6 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
         for(int i=0; i<9; i++){
             indices[i][0]= labels.findIndex(forceLabels[i]);
             if (indices[i][0]==-1){ // Something went wrong, abort here 
-                if(getDocument()) IO::chDir(savedCwd);
                 string msg =
                     "Object: ERR- Could not find label "+forceLabels[i]+ "in file " + oldFile+ ". Aborting.";
                 throw Exception(msg,__FILE__,__LINE__);
@@ -868,17 +843,14 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
         _externalLoads.setDataFileName(oldFile);
         std::string newName=oldFile.substr(0, oldFile.length()-4)+".xml";
         _externalLoads.print(newName);
-        if(getDocument()) IO::chDir(savedCwd);
         log_cout("Created ForceSet file {} to apply forces from {}.", newName, oldFile);
         return newName;
     }
     else {
-            if(getDocument()) IO::chDir(savedCwd);
             string msg =
                 "Object: ERR- Only one body is specified in " + oldFile+ ".";
             throw Exception(msg,__FILE__,__LINE__);
     }
-    if(getDocument()) IO::chDir(savedCwd);
 }
 
 std::string AbstractTool::getTimeString(const time_t& t) const {

--- a/OpenSim/Simulation/Model/ContactMesh.cpp
+++ b/OpenSim/Simulation/Model/ContactMesh.cpp
@@ -99,25 +99,21 @@ SimTK::ContactGeometry::TriangleMesh* ContactMesh::
     SimTK::PolygonalMesh mesh;
     std::ifstream file;
     assert (_model);
-    const std::string& savedCwd = IO::getCwd();
-    bool restoreDirectory = false;
+
+    auto cwd = IO::CwdChanger::noop();
     if ((_model->getInputFileName()!="")
             && (_model->getInputFileName()!="Unassigned")) {
-        std::string parentDirectory = IO::getParentDirectory(
-                _model->getInputFileName());
-        IO::chDir(parentDirectory);
-        restoreDirectory=true;
+        cwd = IO::CwdChanger::changeToParentOf(_model->getInputFileName());
     }
+
     file.open(filename.c_str());
     if (file.fail()){
-        if (restoreDirectory) IO::chDir(savedCwd);
         throw Exception("Error loading mesh file: "+filename+". "
                 "The file should exist in same folder with model.\n "
                 "Loading is aborted.");
     }
     file.close();
     mesh.loadFile(filename);
-    if (restoreDirectory) IO::chDir(savedCwd);
     _decorativeGeometry.reset(new SimTK::DecorativeMesh(mesh));
     return new SimTK::ContactGeometry::TriangleMesh(mesh);
 }

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -166,9 +166,9 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
                 log_error("Failed to read ExternalLoads data file '{}'.",
                         this->_dataFileName);
                 if (this->getDocument()) {
-                    cwd.reset();
+                    cwd.restore();
                 } else {
-                    cwd.release();
+                    cwd.stay();
                 }
                 throw(ex);
             }

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -158,19 +158,20 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
     auto loadDataFromDirectoryAdjacentToFile =
         [this, &forceData](const std::string& filepath) {
             // Change working directory the ExternalLoads location
-            std::string savedCwd = IO::getCwd();
-            IO::chDir(IO::getParentDirectory(filepath));
+            auto cwd = IO::CwdChanger::changeToParentOf(filepath);
             try {
                 forceData = new Storage(this->_dataFileName);
             }
             catch (const std::exception &ex) {
                 log_error("Failed to read ExternalLoads data file '{}'.",
                         this->_dataFileName);
-                if (this->getDocument())
-                    IO::chDir(savedCwd);
+                if (this->getDocument()) {
+                    cwd.reset();
+                } else {
+                    cwd.release();
+                }
                 throw(ex);
             }
-            IO::chDir(savedCwd);
     };
     if (_dataFileName.length() > 0) {
         if(IO::FileExists(_dataFileName))

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -603,7 +603,7 @@ bool AnalyzeTool::run(bool plotting)
     if (completed && _printResultFiles)
         printResults(getName(),getResultsDir()); // this will create results directory if necessary
 
-    cwd.reset();
+    cwd.restore();
 
     removeExternalLoadsFromModel();
 

--- a/OpenSim/Tools/AnalyzeTool.cpp
+++ b/OpenSim/Tools/AnalyzeTool.cpp
@@ -536,9 +536,11 @@ bool AnalyzeTool::run(bool plotting)
 
     // Do the maneuver to change then restore working directory 
     // so that the parsing code behaves properly if called from a different directory.
-    string saveWorkingDirectory = IO::getCwd();
-    if (getDocument())  // When the tool is created live from GUI it has no file/document association
-        IO::chDir(IO::getParentDirectory(getDocumentFileName()));
+    // When the tool is created live from GUI it has no file/document association
+    auto cwd = getDocument() != nullptr
+            ? IO::CwdChanger::changeToParentOf(getDocumentFileName())
+            : IO::CwdChanger::noop();
+
     // Use the Dynamics Tool API to handle external loads instead of outdated AbstractTool
     /*bool externalLoads = */createExternalLoads(_externalLoadsFileName, *_model);
 
@@ -593,7 +595,6 @@ bool AnalyzeTool::run(bool plotting)
     } catch (const Exception& x) {
         x.print(cout);
         completed = false;
-        IO::chDir(saveWorkingDirectory);
         throw Exception(x.what(),__FILE__,__LINE__);
     }
 
@@ -602,7 +603,7 @@ bool AnalyzeTool::run(bool plotting)
     if (completed && _printResultFiles)
         printResults(getName(),getResultsDir()); // this will create results directory if necessary
 
-    IO::chDir(saveWorkingDirectory);
+    cwd.reset();
 
     removeExternalLoadsFromModel();
 

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -394,9 +394,7 @@ bool CMCTool::run()
     // OUTPUT DIRECTORY
     // Do the maneuver to change then restore working directory 
     // so that the parsing code behaves properly if called from a different directory
-    string saveWorkingDirectory = IO::getCwd();
-    string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
-    IO::chDir(directoryOfSetupFile);
+    auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
     try {
 
@@ -433,7 +431,6 @@ bool CMCTool::run()
     // DESIRED POINTS AND KINEMATICS
     if(_desiredPointsFileName=="" && _desiredKinematicsFileName=="") {
         log_error("A desired points file and desired kinematics file were not specified.");
-        IO::chDir(saveWorkingDirectory);
         return false;
     }
 
@@ -534,7 +531,6 @@ bool CMCTool::run()
      // TASK SET
     if(_taskSetFileName=="") {  
         log_error("A task set was not specified.");
-        IO::chDir(saveWorkingDirectory);         
         return false;        
     }
 
@@ -776,12 +772,10 @@ bool CMCTool::run()
         catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
             x.print(cout);
-            IO::chDir(saveWorkingDirectory);
             return false;
         }
         catch(...) {
             // TODO: eventually might want to allow writing of partial results
-            IO::chDir(saveWorkingDirectory);
             // close open files if we die prematurely (e.g. Opt fail)
             return false;
         }
@@ -835,14 +829,12 @@ bool CMCTool::run()
     catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
         x.print(cout);
-        IO::chDir(saveWorkingDirectory);
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;
     }
     catch(...) {
         // TODO: eventually might want to allow writing of partial results
-        IO::chDir(saveWorkingDirectory);
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;
@@ -879,13 +871,10 @@ bool CMCTool::run()
     } catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
         x.print(cout);
-        IO::chDir(saveWorkingDirectory);
         // close open files if we die prematurely (e.g. Opt fail)
         
         return false;
     }
-
-    IO::chDir(saveWorkingDirectory);
 
     return true;
 }

--- a/OpenSim/Tools/ForwardTool.cpp
+++ b/OpenSim/Tools/ForwardTool.cpp
@@ -309,18 +309,18 @@ bool ForwardTool::run()
     } catch(const std::exception& x) {
         log_error("ForwardTool::run() caught an exception: \n {}", x.what());
         completed = false;
-        cwd.reset();
+        cwd.restore();
     }
     catch (...) { // e.g. may get InterruptedException
         log_error("ForwardTool::run() caught an exception.");
         completed = false;
-        cwd.reset();
+        cwd.restore();
     }
     // PRINT RESULTS
     string fileName;
     if(_printResultFiles) printResultsInternal();
 
-    cwd.reset();
+    cwd.restore();
 
     removeAnalysisSetFromModel();
     return completed;

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -407,7 +407,7 @@ bool InverseDynamicsTool::run()
 
         IO::makeDir(getResultsDir());
         Storage::printResult(&genForceResults, _outputGenForceFileName, getResultsDir(), -1, ".sto");
-        cwd.reset();
+        cwd.restore();
 
         // if body forces to be reported for specified joints
         if(nj >0){

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -255,9 +255,7 @@ bool InverseDynamicsTool::run()
         log_info("Running tool {}...", getName());
         // Do the maneuver to change then restore working directory 
         // so that the parsing code behaves properly if called from a different directory.
-        string saveWorkingDirectory = IO::getCwd();
-        string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
-        IO::chDir(directoryOfSetupFile);
+        auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
         /*bool externalLoads = */createExternalLoads(_externalLoadsFileName, *_model);
         // Initialize the model's underlying computational system and get its default state.
@@ -301,7 +299,6 @@ bool InverseDynamicsTool::run()
             }
         }
         else{
-            IO::chDir(saveWorkingDirectory);
             throw Exception("InverseDynamicsTool: no coordinate file found, "
                 " or setCoordinateValues() was not called.");
         }
@@ -410,7 +407,7 @@ bool InverseDynamicsTool::run()
 
         IO::makeDir(getResultsDir());
         Storage::printResult(&genForceResults, _outputGenForceFileName, getResultsDir(), -1, ".sto");
-        IO::chDir(saveWorkingDirectory);
+        cwd.reset();
 
         // if body forces to be reported for specified joints
         if(nj >0){
@@ -419,7 +416,6 @@ bool InverseDynamicsTool::run()
 
             IO::makeDir(getResultsDir());
             Storage::printResult(&bodyForcesResults, _outputBodyForcesAtJointsFileName, getResultsDir(), -1, ".sto");
-            IO::chDir(saveWorkingDirectory);
         }
 
         removeExternalLoadsFromModel();

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -124,9 +124,7 @@ bool InverseKinematicsTool::run()
 
         // Do the maneuver to change then restore working directory so that the
         // parsing code behaves properly if called from a different directory.
-        string saveWorkingDirectory = IO::getCwd();
-        string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
-        IO::chDir(directoryOfSetupFile);
+        auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
         // Define reporter for output
         kinematicsReporter = new Kinematics();
@@ -292,8 +290,6 @@ bool InverseKinematicsTool::run()
 
             delete modelMarkerLocations;
         }
-
-        IO::chDir(saveWorkingDirectory);
 
         success = true;
 

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -390,33 +390,25 @@ bool MarkerPlacer::processModel(Model* aModel,
     _outputStorage->getStateVector(0)->setTime(s.getTime());
 
     if(_printResultFiles) {
-        std::string savedCwd = IO::getCwd();
-        IO::chDir(aPathToSubject);
+        auto cwd = IO::CwdChanger::changeTo(aPathToSubject);
 
-        try { // writing can throw an exception
-            if (_outputModelFileNameProp.isValidFileName()) {
-                aModel->print(aPathToSubject + _outputModelFileName);
-                log_info("Wrote model file '{}' from model {}.", 
-                    _outputModelFileName, aModel->getName());
-            }
-
-            if (_outputMarkerFileNameProp.isValidFileName()) {
-                aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
-                log_info("Wrote marker file '{}' from model {}.", 
-                    _outputMarkerFileName, aModel->getName());
-            }
-
-            if (_outputMotionFileNameProp.isValidFileName()) {
-                _outputStorage->print(aPathToSubject + _outputMotionFileName,
-                    "w", "File generated from solving marker data for model "
-                    + aModel->getName());
-            }
-        } // catch the exception so we can reset the working directory
-        catch (std::exception& ex) {
-            IO::chDir(savedCwd);
-            OPENSIM_THROW_FRMOBJ(Exception, ex.what());
+        if (_outputModelFileNameProp.isValidFileName()) {
+            aModel->print(aPathToSubject + _outputModelFileName);
+            log_info("Wrote model file '{}' from model {}.",
+                _outputModelFileName, aModel->getName());
         }
-        IO::chDir(savedCwd);
+
+        if (_outputMarkerFileNameProp.isValidFileName()) {
+            aModel->writeMarkerFile(aPathToSubject + _outputMarkerFileName);
+            log_info("Wrote marker file '{}' from model {}.",
+                _outputMarkerFileName, aModel->getName());
+        }
+
+        if (_outputMotionFileNameProp.isValidFileName()) {
+            _outputStorage->print(aPathToSubject + _outputMotionFileName,
+                "w", "File generated from solving marker data for model "
+                + aModel->getName());
+        }
     }
 
     return true;

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -314,26 +314,19 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
         aModel->scale(s, theScaleSet, _preserveMassDist, aSubjectMass);
 
         if(_printResultFiles) {
-            std::string savedCwd = IO::getCwd();
-            IO::chDir(aPathToSubject);
-            try { // writing can throw an exception
-                if (_outputModelFileNameProp.isValidFileName()) {
-                    if (aModel->print(_outputModelFileName))
-                        log_info("Wrote model file '{}' from model.",
-                            _outputModelFileName, aModel->getName());
-                }
+            auto cwd = IO::CwdChanger::changeTo(aPathToSubject);
 
-                if (_outputScaleFileNameProp.isValidFileName()) {
-                    if (theScaleSet.print(_outputScaleFileName))
-                        log_info("Wrote scale file '{}' for model {}.", 
-                            _outputScaleFileName, aModel->getName());
-                }
-            } // catch the exception so we can reset the working directory
-            catch (std::exception& ex) {
-                IO::chDir(savedCwd);
-                OPENSIM_THROW_FRMOBJ(Exception, ex.what());
+            if (_outputModelFileNameProp.isValidFileName()) {
+                if (aModel->print(_outputModelFileName))
+                    log_info("Wrote model file '{}' from model.",
+                        _outputModelFileName, aModel->getName());
             }
-            IO::chDir(savedCwd);
+
+            if (_outputScaleFileNameProp.isValidFileName()) {
+                if (theScaleSet.print(_outputScaleFileName))
+                    log_info("Wrote scale file '{}' for model {}.",
+                        _outputScaleFileName, aModel->getName());
+            }
         }
     }
     catch (const Exception& x) {

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -817,14 +817,14 @@ bool RRATool::run()
     catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
         log_error(x.what());
-        cwd.reset();
+        cwd.restore();
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;
     }
     catch(...) {
         // TODO: eventually might want to allow writing of partial results
-        cwd.reset();
+        cwd.restore();
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -355,9 +355,7 @@ bool RRATool::run()
     // OUTPUT DIRECTORY
     // Do the maneuver to change then restore working directory 
     // so that the parsing code behaves properly if called from a different directory
-    string saveWorkingDirectory = IO::getCwd();
-    string directoryOfSetupFile = IO::getParentDirectory(getDocumentFileName());
-    IO::chDir(directoryOfSetupFile);
+    auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
     try {
 
@@ -399,8 +397,7 @@ bool RRATool::run()
     // DESIRED POINTS AND KINEMATICS
     if(_desiredPointsFileName=="" && _desiredKinematicsFileName=="") {
         log_error("A desired points file and desired kinematics file were not "
-                  "specified.");;
-        IO::chDir(saveWorkingDirectory);
+                  "specified.");
         return false;
     }
 
@@ -500,8 +497,7 @@ bool RRATool::run()
 
      // TASK SET
     if(_taskSetFileName=="") {           
-        log_error("A task set was not specified.");         
-        IO::chDir(saveWorkingDirectory);         
+        log_error("A task set was not specified.");
         return false;        
     }
 
@@ -537,7 +533,6 @@ bool RRATool::run()
                 delete qStore;
                 delete uStore;
                 writeAdjustedModel();
-                IO::chDir(saveWorkingDirectory);
                 return true;
             }
         }
@@ -764,12 +759,10 @@ bool RRATool::run()
         catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
             log_error(x.what());
-            IO::chDir(saveWorkingDirectory);
             return false;
         }
         catch(...) {
             // TODO: eventually might want to allow writing of partial results
-            IO::chDir(saveWorkingDirectory);
             // close open files if we die prematurely (e.g. Opt fail)
             return false;
         }
@@ -824,14 +817,14 @@ bool RRATool::run()
     catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
         log_error(x.what());
-        IO::chDir(saveWorkingDirectory);
+        cwd.reset();
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;
     }
     catch(...) {
         // TODO: eventually might want to allow writing of partial results
-        IO::chDir(saveWorkingDirectory);
+        cwd.reset();
         // close open files if we die prematurely (e.g. Opt fail)
         manager.getStateStorage().print(getResultsDir() + "/" + getName() + "_states.sto");
         return false;
@@ -905,13 +898,10 @@ bool RRATool::run()
     } catch(const Exception& x) {
         // TODO: eventually might want to allow writing of partial results
         log_error(x.what());
-        IO::chDir(saveWorkingDirectory);
         // close open files if we die prematurely (e.g. Opt fail)
         
         return false;
     }
-
-    IO::chDir(saveWorkingDirectory);
 
     return true;
 }


### PR DESCRIPTION
This is a side-hustle I have been working on whenever I need a break from other dev.

This PR replaces uses of `IO::chDir` with the new `IO::CwdChanger` abstraction, which cleans up some parts of the codebase. To achieve the rollout, it also adds `.reset()` and `.release()` to `IO::CwdChanger`. Some uses of `.reset()` are probably overly paranoid, but they are there to maintain the same directory-changing semantics as the existing code.

The diff is big in places mostly because I removed some `try {} catch (...) { IO::chDir(originalDir); }` code. This required re-indenting, which touches all lines - the implementation should be mostly untouched, apart from the occasional cleanup near wherever I edited the code (e.g. fixing whitespace, using `unique_ptr` where sane, etc. - I probably need more discipline about not doing this, but :shrug:).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2872)
<!-- Reviewable:end -->
