### PR TITLE
Refactored Component::extendRealizeTopology to use for range loops

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1410,51 +1410,35 @@ getStateVariableNamesAddedByComponent() const
 void Component::extendRealizeTopology(SimTK::State& s) const
 {
     const SimTK::Subsystem& subSys = getSystem().getDefaultSubsystem();
-    
-    Component *mutableThis = const_cast<Component*>(this);
 
     // Allocate Modeling Option
-    if(_namedModelingOptionInfo.size()>0){
-        std::map<std::string, ModelingOptionInfo>::iterator it;
-        for (it = (mutableThis->_namedModelingOptionInfo).begin(); 
-             it !=_namedModelingOptionInfo.end(); ++it)
-        {
-            ModelingOptionInfo& moi = it->second;
-            moi.index = subSys.allocateDiscreteVariable
-               (s, SimTK::Stage::Instance, new SimTK::Value<int>(0));
-        }
+    for (auto& kv : _namedModelingOptionInfo) {
+        ModelingOptionInfo& moi = kv.second;
+        moi.index = subSys.allocateDiscreteVariable(
+                s, SimTK::Stage::Instance, new SimTK::Value<int>(0));
     }
 
     // Allocate Continuous State Variables
-    if(_namedStateVariableInfo.size()>0){
-        SimTK::Vector zInit(1, 0.0);
-        std::map<std::string, StateVariableInfo>::iterator it;
-        for (it = (mutableThis->_namedStateVariableInfo).begin(); 
-             it != _namedStateVariableInfo.end(); ++it)
-        {
-            const StateVariable& sv = *it->second.stateVariable;
-            const AddedStateVariable* asv 
-                = dynamic_cast<const AddedStateVariable *>(&sv);
+    SimTK::Vector zInit(1, 0.0);
+    for (auto& kv : _namedStateVariableInfo) {
+        const StateVariable& sv = *kv.second.stateVariable;
+        const AddedStateVariable* asv =
+                dynamic_cast<const AddedStateVariable*>(&sv);
 
-            if(asv){// add index information for added state variables
-                // make mutable just to update system allocated index ONLY!
-                AddedStateVariable* masv = const_cast<AddedStateVariable*>(asv);
-                masv->setVarIndex(subSys.allocateZ(s, zInit));
-                masv->setSubsystemIndex(getDefaultSubsystem().getMySubsystemIndex());
-            }
+        if (asv) { // add index information for added state variables
+            // make mutable just to update system allocated index ONLY!
+            AddedStateVariable* masv = const_cast<AddedStateVariable*>(asv);
+            masv->setVarIndex(subSys.allocateZ(s, zInit));
+            masv->setSubsystemIndex(
+                    getDefaultSubsystem().getMySubsystemIndex());
         }
     }
 
     // Allocate Discrete State Variables
-    if(_namedDiscreteVariableInfo.size()>0){
-        std::map<std::string, DiscreteVariableInfo>::iterator it;
-        for (it = (mutableThis->_namedDiscreteVariableInfo).begin(); 
-             it != _namedDiscreteVariableInfo.end(); ++it)
-        {
-            DiscreteVariableInfo& dvi = it->second;
-            dvi.index = subSys.allocateDiscreteVariable
-               (s, dvi.invalidatesStage, new SimTK::Value<double>(0.0));
-        }
+    for (auto& kv : _namedDiscreteVariableInfo) {
+        DiscreteVariableInfo& dvi = kv.second;
+        dvi.index = subSys.allocateDiscreteVariable(
+                s, dvi.invalidatesStage, new SimTK::Value<double>(0.0));
     }
 
     // allocate cache entry in the state


### PR DESCRIPTION
Tiny Friday-afternoon refactor of a code section I worked near when implementing the new `CacheVariable<T>` abstraction.

No functional changes: it should behave like-for-like. I've deliberately kept this small so that, once it's through CI, it can just be quickly checked + merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2875)
<!-- Reviewable:end -->
