### PR TITLE
WIP: Add range loop support to OpenSim::Set and rollout

### DIFF
--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -470,10 +470,9 @@ record(const SimTK::State& s)
         memcpy(&_kin[I+3],&angVec[0],3*sizeof(double));
     }
 
-    if(_recordCenterOfMass) {
+    if (_recordCenterOfMass) {
         double rP[3] = { 0.0, 0.0, 0.0 };
-        for(int i=0;i<bs.getSize();i++) {
-            Body& body = bs.get(i);
+        for (Body& body : bs) {
             const SimTK::Vec3& com = body.get_mass_center();
             vec = body.findStationLocationInGround(s, com);
             // ADD TO WHOLE BODY MASS
@@ -518,10 +517,9 @@ record(const SimTK::State& s)
         memcpy(&_kin[I+3],&angVec[0],3*sizeof(double));
     }
 
-    if(_recordCenterOfMass) {
+    if (_recordCenterOfMass) {
         double rV[3] = { 0.0, 0.0, 0.0 };
-        for(int i=0;i<bs.getSize();i++) {
-            Body& body = bs.get(i);
+        for (Body& body : bs) {
             const SimTK::Vec3& com = body.get_mass_center();
             vec = body.findStationVelocityInGround(s, com);
             rV[0] += body.get_mass() * vec[0];
@@ -567,8 +565,7 @@ record(const SimTK::State& s)
 
     if(_recordCenterOfMass) {
         double rA[3] = { 0.0, 0.0, 0.0 };
-        for(int i=0;i<bs.getSize();i++) {
-            Body& body = bs.get(i);
+        for (Body& body : bs) {
             const SimTK::Vec3& com = body.get_mass_center();
             vec = body.findStationAccelerationInGround(s, com);
             rA[0] += body.get_mass() * vec[0];

--- a/OpenSim/Analyses/InducedAccelerationsSolver.cpp
+++ b/OpenSim/Analyses/InducedAccelerationsSolver.cpp
@@ -105,7 +105,7 @@ const SimTK::Vector& InducedAccelerationsSolver::solve(const SimTK::State& s,
         s_solver.updZ() = s.getZ();
 
         //Make sure all the actuators are on!
-        for(int f=0; f<_modelCopy.getActuators().getSize(); f++){
+        for (int f = 0; f< _modelCopy.getActuators().getSize(); f++) {
             _modelCopy.updActuators().get(f).setAppliesForce(s_solver, true);
         }
 
@@ -177,7 +177,7 @@ const SimTK::Vector& InducedAccelerationsSolver::solve(const SimTK::State& s,
         s_solver.setU(SimTK::Vector(nu,0.0));
 
         // disable other forces
-        for(int f=0; f<_modelCopy.getForceSet().getSize(); f++){
+        for (int f = 0; f < _modelCopy.getForceSet().getSize(); f++){
             _modelCopy.updForceSet()[f].setAppliesForce(s_solver, false);
         }
     }
@@ -189,7 +189,7 @@ const SimTK::Vector& InducedAccelerationsSolver::solve(const SimTK::State& s,
         s_solver.updU() = s.getU();
             
         // zero actuator forces
-        for(int f=0; f<_modelCopy.getActuators().getSize(); f++){
+        for (int f = 0; f< _modelCopy.getActuators().getSize(); f++) {
             _modelCopy.updActuators().get(f).setAppliesForce(s_solver, false);
         }
         // Set the configuration (gen. coords and speeds) of the model.
@@ -200,7 +200,7 @@ const SimTK::Vector& InducedAccelerationsSolver::solve(const SimTK::State& s,
         _modelCopy.updForceSubsystem().setForceIsDisabled(s_solver, _modelCopy.getGravityForce().getForceIndex(), true);
 
         // zero actuator forces
-        for(int f=0; f<_modelCopy.getActuators().getSize(); f++){
+        for (int f = 0; f < _modelCopy.getActuators().getSize(); f++) {
             _modelCopy.updActuators().get(f).setAppliesForce(s_solver, false);
         }
 
@@ -333,7 +333,7 @@ Array<bool> InducedAccelerationsSolver::
     Array<bool> constraintOn(false, _replacementConstraints.getSize());
     double t = s.getTime();
 
-    for(int i=0; i<_forcesToReplace.getSize(); i++){
+    for (int i = 0; i < _forcesToReplace.getSize(); i++) {
         ExternalForce* exf = dynamic_cast<ExternalForce*>(&_forcesToReplace[i]);
         SimTK::Vec3 point, force, gpoint;
 

--- a/OpenSim/Analyses/JointReaction.cpp
+++ b/OpenSim/Analyses/JointReaction.cpp
@@ -550,23 +550,24 @@ record(const SimTK::State& s)
     SimTK::State s_analysis = s;
 
     _model->updMultibodySystem().realize(s_analysis, s.getSystemStage());
-    if(_useForceStorage){
+    if (_useForceStorage) {
         const auto& actuatorSet = _model->getActuators();
         int nA = actuatorSet.getSize();
         Array<double> forces(0,nA);
         _storeActuation->getDataAtTime(s.getTime(),nA,forces);
         int storageIndex = -1;
-        for(int actuatorIndex=0;actuatorIndex<nA;actuatorIndex++)
-        {
+
+        for (const Actuator& a : actuatorSet) {
             //Actuator* act = dynamic_cast<Actuator*>(&_forceSet->get(actuatorIndex));
-            std::string actuatorName = actuatorSet.get(actuatorIndex).getName();
+            std::string actuatorName = a.getName();
             storageIndex = _storeActuation->getStateIndex(actuatorName, 0);
             if(storageIndex == -1){
                 log_warn("The actuator '{}' was not found in the forces file.",
                         actuatorName);
                 break;
             }
-            const ScalarActuator* act = dynamic_cast<const ScalarActuator*>(&actuatorSet[actuatorIndex]);
+
+            const ScalarActuator* act = dynamic_cast<const ScalarActuator*>(&a);
             if (act){
                 act->overrideActuation(s_analysis, true);
                 act->setOverrideActuation(s_analysis, forces[storageIndex]);

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -180,7 +180,7 @@ deleteStorage()
 void Kinematics::
 updateCoordinatesToRecord()
 {
-    if(!_model) {
+    if (!_model) {
         _coordinateIndices.setSize(0);
         _values.setSize(0);
         return;
@@ -188,21 +188,24 @@ updateCoordinatesToRecord()
 
     const CoordinateSet& coordSet = _model->getCoordinateSet();
     _coordinateIndices.setSize(getProperty_coordinates().size());
-    for(int i=0; i<getProperty_coordinates().size(); i++) {
-        if(get_coordinates(i) == "all") {
+    for (int i = 0; i < getProperty_coordinates().size(); i++) {
+        if (get_coordinates(i) == "all") {
             _coordinateIndices.setSize(coordSet.getSize());
-            for(int j=0;j<coordSet.getSize();j++) _coordinateIndices[j]=j;
+            for (int j = 0; j < coordSet.getSize(); j++) {
+                _coordinateIndices[j]=j;
+            }
             break;
         }
         
         int index = coordSet.getIndex(get_coordinates(i));
-        if(index<0) 
+        if (index < 0) {
             throw Exception("Kinematics: ERR- Could not find coordinate named '"+get_coordinates(i)+"'",__FILE__,__LINE__);
+        }
         _coordinateIndices[i] = index;
     }
     _values.setSize(_coordinateIndices.getSize());
 
-    if(_values.getSize()==0) {
+    if (_values.getSize() == 0) {
         log_warn("Kinematics analysis has no coordinates to record values for");
     }
 }

--- a/OpenSim/Analyses/MuscleAnalysis.cpp
+++ b/OpenSim/Analyses/MuscleAnalysis.cpp
@@ -211,8 +211,8 @@ void MuscleAnalysis::allocateStorageObjects()
 
         if(IO::Lowercase(_coordinateList[0]) == "all"){
             _coordinateList.setSize(0);
-            for(int i=0; i < qSet.getSize(); ++i) {
-                _coordinateList.append(qSet[i].getName());
+            for (const Coordinate& c : qSet) {
+                _coordinateList.append(c.getName());
             }
         } 
         else{
@@ -342,12 +342,13 @@ void MuscleAnalysis::allocateStorageObjects()
     ForceSet& fSet = _model->updForceSet();
     _muscleList = _muscleListProp.getValueStrArray();
     int nm = _muscleList.getSize();
-    if((nm==1) && (_muscleList.get(0)=="all")) {
+    if (nm == 1 && _muscleList.get(0) == "all") {
         _muscleList.setSize(0);
-        int nf = fSet.getSize();
-        for(int i=0;i<nf;i++) {
-            Muscle *m = dynamic_cast<Muscle*>(&fSet.get(i));
-            if( m ) _muscleList.append(m->getName());
+        for (Force& f : fSet) {
+            Muscle *m = dynamic_cast<Muscle*>(&f);
+            if (m) {
+                _muscleList.append(m->getName());
+            }
         }
     }
     // POPULATE ACTIVE MUSCLE ARRAY

--- a/OpenSim/Analyses/ProbeReporter.h
+++ b/OpenSim/Analyses/ProbeReporter.h
@@ -151,16 +151,12 @@ protected:
         record(const SimTK::State& s );
 public:
     void disableIntegrationOnlyProbes() {
-        ProbeSet& probes = _model->updProbeSet();
-        int nP = probes.getSize();
+        for (Probe& nextProbe : _model->updProbeSet()) {
+            const std::string& op = nextProbe.getOperation();
 
-        for(int i=0 ; i<nP ; i++) {
-            Probe& nextProbe = (Probe&)probes[i];
-            if (nextProbe.getOperation()=="integrate" || nextProbe.getOperation()=="min" || nextProbe.getOperation()=="max"){
+            if (op == "integrate" || op == "min" || op == "max") {
                 nextProbe.setEnabled(false);
-                log_warn("Disabling probe {} as invalid for non-integration "
-                         "context.",
-                        nextProbe.getName());
+                log_warn("Disabling probe {} as invalid for non-integration context.", nextProbe.getName());
             }
         }
     }

--- a/OpenSim/Common/Set.h
+++ b/OpenSim/Common/Set.h
@@ -295,22 +295,6 @@ void setMemoryOwner(bool aTrueFalse)
     _objects.setMemoryOwner(aTrueFalse);
 }
 
-SetIterator<false, T, C, Set> begin() {
-    return {*this, 0};
-}
-
-SetIterator<true, T, C, Set> begin() const {
-    return {const_cast<Set&>(*this), 0};
-}
-
-SetIterator<false, T, C, Set> end() {
-    return {*this, getSize()};
-}
-
-SetIterator<true, T, C, Set> end() const {
-    return {const_cast<Set&>(*this), getSize()};
-}
-
 #ifndef SWIG
 //_____________________________________________________________________________
 /**
@@ -722,6 +706,22 @@ T& get(const std::string &aName)
 const T& get(const std::string &aName) const
 {
     return( *_objects.get(aName) );
+}
+
+SetIterator<false, T, C, Set> begin() {
+    return {*this, 0};
+}
+
+SetIterator<true, T, C, Set> begin() const {
+    return {const_cast<Set&>(*this), 0};
+}
+
+SetIterator<false, T, C, Set> end() {
+    return {*this, getSize()};
+}
+
+SetIterator<true, T, C, Set> end() const {
+    return {const_cast<Set&>(*this), getSize()};
 }
 #endif
 //_____________________________________________________________________________

--- a/OpenSim/Common/Set.h
+++ b/OpenSim/Common/Set.h
@@ -33,6 +33,7 @@
 
 namespace OpenSim {
 
+#ifndef SWIG
 template<bool isConst, class T, class C, template<class, class> class S>
 class SetIterator final {
     S<T, C>& _data;
@@ -69,6 +70,7 @@ public:
         return *this;
     }
 };
+#endif
 
 //=============================================================================
 //=============================================================================
@@ -293,6 +295,22 @@ void setMemoryOwner(bool aTrueFalse)
     _objects.setMemoryOwner(aTrueFalse);
 }
 
+SetIterator<false, T, C, Set> begin() {
+    return {*this, 0};
+}
+
+SetIterator<true, T, C, Set> begin() const {
+    return {const_cast<Set&>(*this), 0};
+}
+
+SetIterator<false, T, C, Set> end() {
+    return {*this, getSize()};
+}
+
+SetIterator<true, T, C, Set> end() const {
+    return {const_cast<Set&>(*this), getSize()};
+}
+
 #ifndef SWIG
 //_____________________________________________________________________________
 /**
@@ -436,22 +454,6 @@ virtual bool setSize(int aSize)
 int getSize() const
 {
     return( _objects.getSize() );
-}
-
-SetIterator<false, T, C, Set> begin() {
-    return {*this, 0};
-}
-
-SetIterator<true, T, C, Set> begin() const {
-    return {const_cast<Set&>(*this), 0};
-}
-
-SetIterator<false, T, C, Set> end() {
-    return {*this, getSize()};
-}
-
-SetIterator<true, T, C, Set> end() const {
-    return {const_cast<Set&>(*this), getSize()};
 }
 
 //-----------------------------------------------------------------------------

--- a/OpenSim/ExampleComponents/ToyReflexController.cpp
+++ b/OpenSim/ExampleComponents/ToyReflexController.cpp
@@ -108,8 +108,8 @@ void ToyReflexController::computeControls(const State& s,
     //reflex control
     double control = 0;
 
-    for(int i=0; i<actuators.getSize(); ++i){
-        const Muscle *musc = dynamic_cast<const Muscle*>(&actuators[i]);
+    for (const Actuator& a : actuators){
+        const Muscle *musc = dynamic_cast<const Muscle*>(&a);
         speed = musc->getLengtheningSpeed(s);
         // un-normalize muscle's maximum contraction velocity (fib_lengths/sec) 
         max_speed =

--- a/OpenSim/Examples/ControllerExample/ControllerExample.cpp
+++ b/OpenSim/Examples/ControllerExample/ControllerExample.cpp
@@ -302,11 +302,11 @@ int main()
         osimModel.printDetailedInfo( si, std::cout );
 
         // Print out the initial position and velocity states.
-        for( int i = 0; i < modelCoordinateSet.getSize(); i++ ) {
-            std::cout << "Initial " << modelCoordinateSet[i].getName()
-                << " = " << modelCoordinateSet[i].getValue( si )
+        for (const Coordinate& c : modelCoordinateSet) {
+            std::cout << "Initial " << c.getName()
+                << " = " << c.getValue( si )
                 << ", and speed = "
-                << modelCoordinateSet[i].getSpeedValue( si ) << std::endl;
+                << c.getSpeedValue( si ) << std::endl;
         }
 
         // Integrate from initial time to final time.

--- a/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
+++ b/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
@@ -735,8 +735,8 @@ void createLuxoJr(OpenSim::Model& model){
 
     // flip the z coordinates of all path points
     PathPointSet& points = kneeExtensorLeft->updGeometryPath().updPathPointSet();
-    for (int i=0; i<points.getSize(); ++i) {
-        dynamic_cast<PathPoint&>(points[i]).upd_location()[2] *= -1;
+    for (AbstractPathPoint& p : points) {
+        dynamic_cast<PathPoint&>(p).upd_location()[2] *= -1;
     }
 
     kneeExtensorLeft->set_ignore_tendon_compliance(true);
@@ -767,8 +767,8 @@ void createLuxoJr(OpenSim::Model& model){
 
     PathPointSet& pointsLeft = backExtensorLeft->updGeometryPath()
         .updPathPointSet();
-    for (int i=0; i<points.getSize(); ++i) {
-        dynamic_cast<PathPoint&>(pointsLeft[i]).upd_location()[2] *= -1;
+    for (AbstractPathPoint& p : pointsLeft) {
+        dynamic_cast<PathPoint&>(p).upd_location()[2] *= -1;
     }
     backExtensorLeft->set_ignore_tendon_compliance(true);
     model.addForce(backExtensorLeft);

--- a/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
+++ b/OpenSim/Examples/OptimizationExample_Arm26/OptimizationExample.cpp
@@ -131,10 +131,9 @@ int main()
         coords.get("r_shoulder_elev").setValue(si, -1.57079633);
 
         // Set the initial muscle activations and make all tendons rigid.
-        const Set<Muscle> &muscleSet = osimModel.getMuscles();
-        for(int i=0; i<muscleSet.getSize(); ++i) {
-            muscleSet[i].setActivation(si, 0.01);
-            muscleSet[i].setIgnoreTendonCompliance(si, true);
+        for (Muscle& m : osimModel.getMuscles()) {
+            m.setActivation(si, 0.01);
+            m.setIgnoreTendonCompliance(si, true);
         }
     
         // Make sure the muscles states are in equilibrium
@@ -175,7 +174,7 @@ int main()
         cout << "Elapsed time = " << (std::clock()-startTime)/CLOCKS_PER_SEC << "s" << endl;
         
         const Set<Actuator>& actuators = osimModel.getActuators();
-        for(int i=0; i<actuators.getSize(); ++i){
+        for (int i = 0; i < actuators.getSize(); ++i) {
             cout << actuators[i].getName() << " control value = " << controls[i] << endl;
         }
 
@@ -186,8 +185,9 @@ int main()
         // Dump out optimization results to a text file for testing
         ofstream ofile; 
         ofile.open("Arm26_optimization_result"); 
-        for(int i=0; i<actuators.getSize(); ++i)
+        for (int i = 0; i < actuators.getSize(); ++i) {
             ofile << controls[i] << endl;
+        }
         ofile << -f <<endl;
         ofile.close(); 
 

--- a/OpenSim/Examples/SimpleOptimizationExample/SimpleOptimizationExample.cpp
+++ b/OpenSim/Examples/SimpleOptimizationExample/SimpleOptimizationExample.cpp
@@ -60,10 +60,12 @@ class ExampleOptimizationSystem : public OptimizerSystem {
         // Now equilibrate muscles at this configuration
         const Set<Muscle> &muscleSet = osimModel.getMuscles();
         // Make sure other muscle states are initialized the same with 1.0 activation, 0.1 fiberLength followed by equilibrium computation
-        for(int i=0; i< muscleSet.getSize(); i++ ){
-            muscleSet[i].setActivation(s, 1.0);
-            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&muscleSet[i]);
-            if (afl) afl->setFiberLength(s, .1);
+        for (Muscle& m : muscleSet) {
+            m.setActivation(s, 1.0);
+            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&m);
+            if (afl) {
+                afl->setFiberLength(s, .1);
+            }
         }
         // Make sure the muscles states are in equilibrium
         osimModel.equilibrateMuscles(s);
@@ -111,9 +113,9 @@ int main()
 
         // Set the initial muscle activations 
         const Set<Muscle> &muscleSet = osimModel.getMuscles();
-        for(int i=0; i< muscleSet.getSize(); i++ ){
-            muscleSet[i].setActivation(si, 1.0);
-            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&muscleSet[i]);
+        for (Muscle& m : muscleSet) {
+            m.setActivation(si, 1.0);
+            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&m);
             afl->setFiberLength(si, .1);
         }
         OpenSim::Coordinate& elbowFlexCoord = osimModel.updCoordinateSet().get("r_elbow_flex");

--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -99,8 +99,7 @@ void AssemblySolver::setupGoals(SimTK::State &s)
     const CoordinateSet& modelCoordSet = getModel().getCoordinateSet();
 
     // Restrict solution to set range of any of the coordinates that are clamped
-    for(int i=0; i<modelCoordSet.getSize(); ++i){
-        const Coordinate& coord = modelCoordSet[i];
+    for(const Coordinate& coord : modelCoordSet){
         if(coord.getClamped(s)){
             _assembler->restrictQ(coord.getBodyIndex(), 
                 MobilizerQIndex(coord.getMobilizerQIndex()),
@@ -214,10 +213,11 @@ void AssemblySolver::assemble(SimTK::State &state)
         // Get model coordinates
         const CoordinateSet& modelCoordSet = getModel().getCoordinateSet();
         // Make sure the locks in original state are restored
-        for(int i=0; i< modelCoordSet.getSize(); ++i){
-            bool isLocked = modelCoordSet[i].getLocked(state);
-            if(isLocked)
-                modelCoordSet[i].setLocked(state, isLocked);
+        for (Coordinate& c : modelCoordSet) {
+            bool isLocked = c.getLocked(state);
+            if (isLocked) {
+                c.setLocked(state, isLocked);
+            }
         }
         // TODO: Useful to include through debug message/log in the future
         log_debug("ASSEMBLED CONFIGURATION (acc={} tol={} normerr={}, maxerr={}, cost={})",

--- a/OpenSim/Simulation/Control/ControlSetController.cpp
+++ b/OpenSim/Simulation/Control/ControlSetController.cpp
@@ -162,22 +162,19 @@ void ControlSetController::computeControls(const SimTK::State& s, SimTK::Vector&
 {
     SimTK_ASSERT( _controlSet , "ControlSetController::computeControls controlSet is NULL");
 
-    std::string actName = "";
-    int index = -1;
+    std::string actName;
+    for (const Actuator& a : getActuatorSet()) {
+        actName = a.getName();
+        int index = _controlSet->getIndex(actName);
 
-    int na = getActuatorSet().getSize();
-
-    for(int i=0; i< na; ++i){
-        actName = getActuatorSet()[i].getName();
-        index = _controlSet->getIndex(actName);
-        if(index < 0){
+        if (index < 0) {
             actName = actName + ".excitation";
             index = _controlSet->getIndex(actName);
         }
 
-        if(index >= 0){
+        if (index >= 0) {
             SimTK::Vector actControls(1, _controlSet->get(index).getControlValue(s.getTime()));
-            getActuatorSet()[i].addInControls(actControls, controls);
+            a.addInControls(actControls, controls);
         }
     }
 }

--- a/OpenSim/Simulation/Control/Controller.cpp
+++ b/OpenSim/Simulation/Control/Controller.cpp
@@ -176,8 +176,8 @@ void Controller::setActuators(const Set<Actuator>& actuators)
     //Rebuild consistent set of actuator lists
     _actuatorSet.setSize(0);
     updProperty_actuator_list().clear();
-    for (int i = 0; i< actuators.getSize(); i++){
-        addActuator(actuators[i]);
+    for (const Actuator& a : actuators) {
+        addActuator(a);
     }
 }
 

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -167,10 +167,10 @@ void PrescribedController::computeControls(const SimTK::State& s, SimTK::Vector&
     SimTK::Vector actControls(1, 0.0);
     SimTK::Vector time(1, s.getTime());
 
-    for(int i=0; i<getActuatorSet().getSize(); i++){
+    for (int i = 0; i < getActuatorSet().getSize(); i++) {
         actControls[0] = get_ControlFunctions()[i].calcValue(time);
         getActuatorSet()[i].addInControls(actControls, controls);
-    }  
+    }
 }
 
 

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -462,7 +462,7 @@ addAnalysisSetToModel()
 
     int size = _analysisSet.getSize();
     _analysisCopies.setMemoryOwner(false);
-    for(int i=0;i<size;i++) {
+    for (int i = 0; i < size; i++) {
         Analysis *analysis = _analysisSet.get(i).clone();
         _model->addAnalysis(analysis);
         _analysisCopies.adoptAndAppend(analysis);
@@ -488,10 +488,9 @@ addControllerSetToModel()
         throw(Exception(msg,__FILE__,__LINE__));
     }
 
-    int size = _controllerSet.getSize();
     _controllerCopies.setMemoryOwner(false);
-    for(int i=0;i<size;i++) {
-        Controller *controller = _controllerSet.get(i).clone();
+    for (const Controller& src : _controllerSet) {
+        Controller *controller = src.clone();
         _model->addController(controller);
         _controllerCopies.adoptAndAppend(controller);
     }
@@ -740,17 +739,14 @@ void AbstractTool::loadQStorage (const std::string& statesFileName, Storage& rQS
  */
 std::string AbstractTool::getControlsFileName() const
 {
-    int numControllers = _controllerSet.getSize();
-    if (numControllers>=1){ // We have potentially more than one, make sure there's controlset controller
-        for(int i=0; i<numControllers; i++){
-            OpenSim::Controller& controller= _controllerSet.get(i);
-            if (dynamic_cast<OpenSim::ControlSetController *>(&controller)==0)
-                continue;
-            OpenSim::ControlSetController& dController = (OpenSim::ControlSetController&) _controllerSet.get(i);
-            return (dController.getControlSetFileName());
+    for (Controller& c : _controllerSet) {
+        auto* dController = dynamic_cast<OpenSim::ControlSetController*>(&c);
+        if (dController) {
+            return dController->getControlSetFileName();
         }
     }
-    return ("Unassigned");
+
+    return "Unassigned";
 }
 //_____________________________________________________________________________
 /**
@@ -759,17 +755,16 @@ std::string AbstractTool::getControlsFileName() const
  */
 void AbstractTool::setControlsFileName(const std::string& controlsFilename)
 {
-    if (controlsFilename=="" || controlsFilename=="Unassigned") return;
-
-    int numControllers = _controllerSet.getSize();
-
-    for(int i=0; i<numControllers;i++){
-        OpenSim::Controller& controller= _controllerSet.get(i);
-        if (dynamic_cast<OpenSim::ControlSetController *>(&controller)==0)
-            continue;
-        OpenSim::ControlSetController& dController = (OpenSim::ControlSetController&)_controllerSet[i];
-        dController.setControlSetFileName(controlsFilename);
+    if (controlsFilename=="" || controlsFilename=="Unassigned") {
         return;
+    }
+
+    for (Controller& c : _controllerSet) {
+        auto* dController = dynamic_cast<OpenSim::ControlSetController*>(&c);
+        if (dController) {
+            dController->setControlSetFileName(controlsFilename);
+            return;
+        }
     }
     // Create a new controlsetController and add it to the tool
     ControlSetController* csc = new ControlSetController();

--- a/OpenSim/Simulation/Model/AnalysisSet.cpp
+++ b/OpenSim/Simulation/Model/AnalysisSet.cpp
@@ -134,9 +134,8 @@ operator=(const  AnalysisSet &aSet)
 void AnalysisSet::
 setModel(Model& aModel)
 {
-    int i;
     int size = getSize();
-    for(i=0;i<size;i++) {
+    for (int i = 0; i < size; i++) {
         Analysis& analysis = get(i);
         analysis.setModel(aModel);
     }

--- a/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.cpp
+++ b/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.cpp
@@ -129,7 +129,10 @@ void Bhargava2004MuscleMetabolicsProbe::constructProperties()
 void Bhargava2004MuscleMetabolicsProbe::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
-    if (!isEnabled()) return;   // Nothing to connect
+
+    if (!isEnabled()) {
+        return;   // Nothing to connect
+    }
 
     const int nM = 
         get_Bhargava2004MuscleMetabolicsProbe_MetabolicMuscleParameterSet()

--- a/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
+++ b/OpenSim/Simulation/Model/CMCActuatorSubsystem.cpp
@@ -63,7 +63,7 @@ void CMCActuatorSubsystemRep::setCoordinateTrajectories(FunctionSet *aSet) {
         msg += " ERR- NULL function set.\n";
         throw( Exception(msg,__FILE__,__LINE__) );
     }
-    if(aSet->getSize() != _model->getNumCoordinates()) {
+    if (aSet->getSize() != _model->getNumCoordinates()) {
         string msg = "CMCActuatorSubsystemRep.setCoordinateTrajectories:";
         msg += " ERR- incorrect number of trajectories.\n";
         throw( Exception(msg,__FILE__,__LINE__) );
@@ -78,7 +78,7 @@ void CMCActuatorSubsystemRep::setSpeedTrajectories(FunctionSet *aSet) {
         msg += " ERR- NULL function set.\n";
         throw( Exception(msg,__FILE__,__LINE__) );
     }
-    if(aSet->getSize() != _model->getNumSpeeds()) {
+    if (aSet->getSize() != _model->getNumSpeeds()) {
         string msg = "CMCActuatorSubsystemRep.setSpeedTrajectories:";
         msg += " ERR- incorrect number of trajectories.\n";
         throw( Exception(msg,__FILE__,__LINE__) );

--- a/OpenSim/Simulation/Model/ControllerSet.cpp
+++ b/OpenSim/Simulation/Model/ControllerSet.cpp
@@ -108,8 +108,8 @@ void ControllerSet::printInfo() const
           const Set<const Actuator>& actSet = c.getActuatorSet();
           if( actSet.getSize() > 0 ) {
                log_cout("Actuators");
-               for(int j=0;j<get(i).getActuatorSet().getSize(); j++ ) {
-                   log_cout("{}", get(i).getActuatorSet().get(j).getName());
+               for (const Actuator& a : get(i).getActuatorSet()) {
+                   log_cout("{}", a.getName());
                }
            }
       } else { 

--- a/OpenSim/Simulation/Model/ElasticFoundationForce.cpp
+++ b/OpenSim/Simulation/Model/ElasticFoundationForce.cpp
@@ -59,9 +59,8 @@ void ElasticFoundationForce::extendAddToSystem(SimTK::MultibodySystem& system) c
     SimTK::ContactSetIndex set = contacts.createContactSet();
     SimTK::ElasticFoundationForce force(_model->updForceSubsystem(), contacts, set);
     force.setTransitionVelocity(transitionVelocity);
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : contactParametersSet)
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j) {
             // TODO: Dependency of ElasticFoundationForce on ContactGeometry
             // should be handled by Sockets.
@@ -322,12 +321,8 @@ OpenSim::Array<std::string> ElasticFoundationForce::getRecordLabels() const
 {
     OpenSim::Array<std::string> labels("");
 
-    const ContactParametersSet& contactParametersSet = 
-        get_contact_parameters();
-
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : get_contact_parameters())
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j)
         {
             // TODO: Dependency of ElasticFoundationForce on ContactGeometry
@@ -374,9 +369,8 @@ OpenSim::Array<double> ElasticFoundationForce::getRecordValues(const SimTK::Stat
     simtkForce.calcForceContribution(state, bodyForces, particleForces,
                                      mobilityForces);
 
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : contactParametersSet)
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j)
         {
             // TODO: Dependency of ElasticFoundationForce on ContactGeometry

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -221,8 +221,8 @@ void ExternalLoads::transformPointsExpressedInGroundToAppliedBodies(
     const Storage &kinematics, double startTime, double endTime)
 {
     std::vector<ExternalForce*> transformedForces;
-    for(int i=0; i<getSize(); ++i){
-        ExternalForce *transformedExf = transformPointExpressedInGroundToAppliedBody(get(i), kinematics, startTime, endTime);
+    for (const ExternalForce& ef : *this) {
+        ExternalForce *transformedExf = transformPointExpressedInGroundToAppliedBody(ef, kinematics, startTime, endTime);
         transformedForces.push_back(transformedExf);
     }
     // Once we've transformed the forces (done with computation),

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -190,8 +190,9 @@ void ExternalLoads::extendConnectToModel(Model& aModel)
                 _dataFileName + "'.");
         }
 
-        for (int i = 0; i < getSize(); ++i)
-            get(i).setDataSource(*forceData);
+        for (ExternalForce& f : *this) {
+            f.setDataSource(*forceData);
+        }
 
         // add loaded storage into list of storages for later garbage collection
         _storages.push_back(shared_ptr<Storage>(forceData));
@@ -453,8 +454,7 @@ void ExternalLoads::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNum
             // Create Set of Forces from this XML node, which we
             // then reassign to an ExternalForce and add to ExternalLoads
             Set<PrescribedForce> oldForces(getDocument()->getFileName(), true);
-            for(int i=0; i< oldForces.getSize(); i++){
-                PrescribedForce& oldPrescribedForce = oldForces.get(i);
+            for(PrescribedForce& oldPrescribedForce : oldForces) {
                 ExternalForce* newExternalForce = new ExternalForce();
                 newExternalForce->setName(oldPrescribedForce.getName());
                 // In 4.0, PrescribedForce's body_name became a relative path

--- a/OpenSim/Simulation/Model/HuntCrossleyForce.cpp
+++ b/OpenSim/Simulation/Model/HuntCrossleyForce.cpp
@@ -61,9 +61,8 @@ void HuntCrossleyForce::extendAddToSystem(SimTK::MultibodySystem& system) const
     SimTK::ContactSetIndex set = contacts.createContactSet();
     SimTK::HuntCrossleyForce force(_model->updForceSubsystem(), contacts, set);
     force.setTransitionVelocity(transitionVelocity);
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : contactParametersSet)
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j) {
             // TODO: Dependency of HuntCrossleyForce on ContactGeometry
             // should be handled by Sockets.
@@ -326,9 +325,8 @@ OpenSim::Array<std::string> HuntCrossleyForce::getRecordLabels() const
     const ContactParametersSet& contactParametersSet = 
         get_contact_parameters();
 
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : contactParametersSet)
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j)
         {
             // TODO: Dependency of HuntCrossleyForce on ContactGeometry
@@ -377,9 +375,8 @@ getRecordValues(const SimTK::State& state) const
     simtkForce.calcForceContribution(state, bodyForces, particleForces, 
                                      mobilityForces);
 
-    for (int i = 0; i < contactParametersSet.getSize(); ++i)
+    for (ContactParameters& params : contactParametersSet)
     {
-        ContactParameters& params = contactParametersSet.get(i);
         for (int j = 0; j < params.getGeometry().size(); ++j)
         {
             // TODO: Dependency of HuntCrossleyForce on ContactGeometry

--- a/OpenSim/Simulation/Model/MarkerSet.cpp
+++ b/OpenSim/Simulation/Model/MarkerSet.cpp
@@ -37,19 +37,16 @@ using namespace OpenSim;
 void MarkerSet::getMarkerNames(Array<string>& markerNamesArray) const
 {
     markerNamesArray.setSize(0);
-    for (int i = 0; i < getSize(); i++)
+    for (Marker& nextMarker : *this)
     {
-        Marker& nextMarker = get(i);
         markerNamesArray.append(nextMarker.getName());
     }
 }
 
 void MarkerSet::addNamePrefix(const string& prefix)
 {
-    int i;
-
     // Cycle through set and add prefix
-    for (i = 0; i < getSize(); i++)
-        get(i).setName(prefix + get(i).getName());
+    for (Marker& m : *this) {
+        m.setName(prefix + m.getName());
+    }
 }
-

--- a/OpenSim/Simulation/Model/ModelComponent.cpp
+++ b/OpenSim/Simulation/Model/ModelComponent.cpp
@@ -145,9 +145,11 @@ getScaleFactors(const ScaleSet& scaleSet, const Frame& frame) const
 {
     const std::string& baseFrameName = frame.findBaseFrame().getName();
 
-    for (int i = 0; i < scaleSet.getSize(); ++i)
-        if (scaleSet[i].getSegmentName() == baseFrameName)
-            return scaleSet[i].getScaleFactors();
+    for (Scale& s : scaleSet) {
+        if (s.getSegmentName() == baseFrameName) {
+            return s.getScaleFactors();
+        }
+    }
 
     // No scale factors found for the base Body.
     return InvalidScaleFactors;

--- a/OpenSim/Simulation/Model/PhysicalFrame.cpp
+++ b/OpenSim/Simulation/Model/PhysicalFrame.cpp
@@ -107,17 +107,17 @@ void PhysicalFrame::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
 
-    for (int i = 0; i < get_WrapObjectSet().getSize(); i++)
-        get_WrapObjectSet()[i].setFrame(*this);
+    for (WrapObject& wo : get_WrapObjectSet()) {
+        wo.setFrame(*this);
+    }
 }
 
 const WrapObject* PhysicalFrame::getWrapObject(const string& aName) const
 {
-    int i;
-
-    for (i = 0; i < get_WrapObjectSet().getSize(); i++) {
-        if (aName == get_WrapObjectSet()[i].getName())
-            return &get_WrapObjectSet()[i];
+    for (WrapObject& wo : get_WrapObjectSet()) {
+        if (aName == wo.getName()) {
+            return &wo;
+        }
     }
     return nullptr;
 }

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -461,16 +461,17 @@ void Coordinate::setPrescribedFunction(const OpenSim::Function& function)
  */
  bool Coordinate::isDependent(const SimTK::State& s) const
 {
-    if(get_is_free_to_satisfy_constraints())
+    if(get_is_free_to_satisfy_constraints()) {
         return true;
+    }
 
-    for(int i=0; i<_model->getConstraintSet().getSize(); i++){
-        Constraint& constraint = _model->getConstraintSet().get(i);
-        CoordinateCouplerConstraint* couplerp = 
-            dynamic_cast<CoordinateCouplerConstraint*>(&constraint);
+    for (Constraint& constraint : _model->getConstraintSet()) {
+        auto* couplerp =
+                dynamic_cast<CoordinateCouplerConstraint*>(&constraint);
         if(couplerp) {
-            if (couplerp->getDependentCoordinateName() == getName())
+            if (couplerp->getDependentCoordinateName() == getName()) {
                 return couplerp->isEnforced(s);
+            }
         }
     }
     return false;

--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -179,9 +179,11 @@ void SimbodyEngine::getUnlockedCoordinates(const SimTK::State &s, CoordinateSet&
     rUnlockedCoordinates.setSize(0);
     rUnlockedCoordinates.setMemoryOwner(false);
 
-    for (int i = 0; i < _model->getCoordinateSet().getSize(); i++)
-        if (!_model->getCoordinateSet().get(i).getLocked(s))
-            rUnlockedCoordinates.adoptAndAppend(&_model->getCoordinateSet().get(i));
+    for (Coordinate& c : _model->getCoordinateSet()) {
+        if (!c.getLocked(s)) {
+            rUnlockedCoordinates.adoptAndAppend(&c);
+        }
+    }
 }
 
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -1112,7 +1112,7 @@ void testSerializeDeserialize() {
     const auto& newConstraintSet = newModel.getConstraintSet();
 
     ASSERT(oldConstraintSet.getSize() == newConstraintSet.getSize());
-    for(int i = 0; i < oldConstraintSet.getSize(); ++i) {
+    for (int i = 0; i < oldConstraintSet.getSize(); ++i) {
         ASSERT(oldConstraintSet.get(i).get_isEnforced() ==
                newConstraintSet.get(i).get_isEnforced());
 

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1973,8 +1973,8 @@ void testEquivalentBodyForceForGenForces(Model& model)
 
     // Construct the system vector of body forces from a Joint's equivalence to
     // generalized force calculations
-    for(int j=0; j < model.getJointSet().getSize(); ++j){
-        Joint &joint = model.getJointSet()[j];
+    for (Joint& joint : model.getJointSet()){
+
         const PhysicalFrame& B = joint.getChildFrame();
         MobilizedBodyIndex mbx = B.getMobilizedBodyIndex();
         const Frame& Bo = B.findBaseFrame();
@@ -2197,9 +2197,8 @@ void testAutomaticJointReversal()
     }
 
     cout << "Constrained Model Coordinates:" << endl;
-    for (int i = 0; i < modelConstrained.getCoordinateSet().getSize(); ++i) {
-        cout << modelConstrained.getCoordinateSet()[i].getName() << " = ";
-        cout << modelConstrained.getCoordinateSet()[i].getValue(sc) << endl;
+    for (const Coordinate& c : modelConstrained.getCoordinateSet()) {
+        cout << c.getName() << " = " << c.getValue(sc) << endl;
     }
 
     //The two systems should yield equivalent model dynamics

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -113,8 +113,8 @@ void testAssembleModelWithConstraints(string modelFile)
     const CoordinateSet &coords = model.getCoordinateSet();
     
     cout << "*********** Coordinates before initSystem ******************** " << endl;
-    for(int i=0; i< coords.getSize(); i++) {
-        cout << "Coordinate " << coords[i].getName() << " default value = " << coords[i].getDefaultValue() << endl;
+    for (const Coordinate& c : coords) {
+        cout << "Coordinate " << c.getName() << " default value = " << c.getDefaultValue() << endl;
     }
 
     //model.setUseVisualizer(true);
@@ -124,8 +124,8 @@ void testAssembleModelWithConstraints(string modelFile)
     model.equilibrateMuscles(state);
 
     cout << "*********** Coordinates after initSystem ******************** "  << endl;
-    for(int i=0; i< coords.getSize(); i++) {
-        cout << "Coordinate " << coords[i].getName() << " get value = " << coords[i].getValue(state) << endl;
+    for(const Coordinate& c : coords) {
+        cout << "Coordinate " << c.getName() << " get value = " << c.getValue(state) << endl;
     }
 
     // Initial coordinates after initial assembly
@@ -148,8 +148,7 @@ void testAssembleModelWithConstraints(string modelFile)
     if (model.hasVisualizer()){
         SimTK::Visualizer& viz = model.updVisualizer().updSimbodyVisualizer();
         const JointSet& js = model.getJointSet();
-        for (int i = 0; i < js.getSize(); ++i){
-            const Joint& j = js[i];
+        for (const Joint& j : js){
             viz.addDecoration(j.getParentFrame().getMobilizedBodyIndex(),
                 j.getParentFrame().findTransformInBaseFrame(),
                 SimTK::DecorativeFrame(0.05));
@@ -184,7 +183,7 @@ void testAssembleModelWithConstraints(string modelFile)
     Vector mobilityForces(0);
     double totalYforce = 0;
     
-    for(int i=0; i< constraints.getSize(); i++) {
+    for (int i=0; i< constraints.getSize(); i++) {
         constraints[i].calcConstraintForces(state, constraintBodyForces, mobilityForces);
         cout << "Constraint " << i << ":  " << constraints[i].getName();
         cout << " Force = " << constraintBodyForces(1)(1)(1) << endl;
@@ -205,8 +204,8 @@ void testAssembleModelWithConstraints(string modelFile)
 
     //const CoordinateSet &coords = model.getCoordinateSet();
     double q_error = 0;
-    for(int i=0; i< coords.getSize(); i++) {
-        q_error += fabs(coords[i].getValue(state)-coords[i].getDefaultValue());
+    for (const Coordinate& c : coords) {
+        q_error += fabs(c.getValue(state) - c.getDefaultValue());
     }
 
     cout << "Average Change in  Default Configuration:" << q_error/coords.getSize() << endl;
@@ -302,10 +301,10 @@ void testAssemblySatisfiesConstraints(string modelFile)
 
     const CoordinateSet &modelcoords = model.getCoordinateSet();
     cout << "*********** Coordinate defaults (before initSystem) ******************** " << endl;
-    for(int i=0; i< modelcoords.getSize(); i++) {
-        cout << "Coordinate " << modelcoords[i].getName() 
-            << " default value = " << modelcoords[i].getDefaultValue() << endl
-            << " is_free to_satisfy_constraints = " << modelcoords[i].get_is_free_to_satisfy_constraints()
+    for(const Coordinate& c : modelcoords) {
+        cout << "Coordinate " << c.getName()
+            << " default value = " << c.getDefaultValue() << endl
+            << " is_free to_satisfy_constraints = " << c.get_is_free_to_satisfy_constraints()
             << endl;
     }
 
@@ -314,9 +313,9 @@ void testAssemblySatisfiesConstraints(string modelFile)
 
     const CoordinateSet &coords = model.getCoordinateSet();
     cout << "***** Coordinate values (after initSystem including Assembly ********* " << endl;
-    for(int i=0; i< coords.getSize(); i++) {
-        cout << "Coordinate " << coords[i].getName() << " value = " 
-            << coords[i].getValue(state) << endl;
+    for (const Coordinate& c : coords) {
+        cout << "Coordinate " << c.getName() << " value = "
+            << c.getValue(state) << endl;
     }
 
     double cerr = SimTK::Infinity;

--- a/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
+++ b/OpenSim/Simulation/Test/testMuscleMetabolicsProbes.cpp
@@ -627,8 +627,9 @@ Storage simulateModel(Model& model, double t0, double t1)
     cout << "- initializing" << endl;
     SimTK::State& state = model.initSystem();
 
-    for (int i=0; i<model.getMuscles().getSize(); ++i)
-        model.getMuscles().get(i).setIgnoreActivationDynamics(state, true);
+    for (Muscle& m : model.getMuscles()) {
+        m.setIgnoreActivationDynamics(state, true);
+    }
     model.getMultibodySystem().realize(state, SimTK::Stage::Dynamics);
     model.equilibrateMuscles(state);
 

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -153,10 +153,10 @@ void createStateStorageFile() {
     // Uniform distribution between 0.1 and 0.9.
     std::uniform_real_distribution<double> distribution(0.1, 0.8);
 
-    for (int im = 0; im < model.getMuscles().getSize(); ++im) {
-        controller->addActuator(model.getMuscles()[im]);
+    for (const Muscle& m : model.getMuscles()) {
+        controller->addActuator(m);
         controller->prescribeControlForActuator(
-            model.getMuscles()[im].getName(),
+            m.getName(),
             new Constant(distribution(generator))
             );
     }
@@ -197,8 +197,7 @@ void testFromStatesStorageGivesCorrectStates() {
         SimTK_TEST_EQ(currTime, state.getTime());
 
         // Multibody states.
-        for (int ic = 0; ic < model.getCoordinateSet().getSize(); ++ic) {
-            const auto& coord = model.getCoordinateSet().get(ic);
+        for (const Coordinate& coord : model.getCoordinateSet()) {
             // get value and speed state names for this coordinate
             const auto coordStateNames = coord.getStateVariableNames();
 
@@ -212,8 +211,7 @@ void testFromStatesStorageGivesCorrectStates() {
         }
 
         // Muscle states.
-        for (int im = 0; im < model.getMuscles().getSize(); ++im) {
-            const auto& muscle = model.getMuscles().get(im);
+        for (const Muscle& muscle : model.getMuscles()) {
             // get the activation and fiber_length state names of the muscles
             const auto muscleStateNames = muscle.getStateVariableNames();
 
@@ -237,8 +235,7 @@ void testFromStatesStorageGivesCorrectStates() {
         // These calculations require that the state is realized to velocity.
         model.getMultibodySystem().realize(state, SimTK::Stage::Velocity);
 
-        for (int im = 0; im < model.getMuscles().getSize(); ++im) {
-            const auto& muscle = model.getMuscles().get(im);
+        for (const Muscle& muscle : model.getMuscles()) {
             auto muscleName = muscle.getName();
             SimTK_TEST(!SimTK::isNaN(muscle.getFiberForce(state)));
         }
@@ -450,8 +447,7 @@ void testFromStatesStoragePre40CorrectStates() {
         SimTK_TEST_EQ(currTime, state.getTime());
 
         // Multibody states.
-        for (int ic = 0; ic < model.getCoordinateSet().getSize(); ++ic) {
-            const auto& coord = model.getCoordinateSet().get(ic);
+        for (const Coordinate& coord : model.getCoordinateSet()) {
             auto coordName = coord.getName();
 
             // Coordinate.
@@ -464,8 +460,7 @@ void testFromStatesStoragePre40CorrectStates() {
         }
 
         // Muscle states.
-        for (int im = 0; im < model.getMuscles().getSize(); ++im) {
-            const auto& muscle = model.getMuscles().get(im);
+        for (const Muscle& muscle : model.getMuscles()) {
             auto muscleName = muscle.getName();
 
             // Activation.

--- a/OpenSim/Tests/SimpleOptimizationExample/testSimpleOptimizationExample.cpp
+++ b/OpenSim/Tests/SimpleOptimizationExample/testSimpleOptimizationExample.cpp
@@ -58,10 +58,12 @@ class ExampleOptimizationSystem : public OptimizerSystem {
         // Now equilibrate muscles at this configuration
         const Set<Muscle> &muscleSet = osimModel.getMuscles();
         // Make sure other muscle states are initialized the same with 1.0 activation, 0.1 fiberLength followed by equilibrium computation
-        for(int i=0; i< muscleSet.getSize(); i++ ){
-            muscleSet[i].setActivation(s, 1.0);
-            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&muscleSet[i]);
-            if (afl) afl->setFiberLength(s, .1);
+        for (Muscle& m : muscleSet){
+            m.setActivation(s, 1.0);
+            const auto* afl = ActivationFiberLengthMuscle::safeDownCast(&m);
+            if (afl) {
+                afl->setFiberLength(s, .1);
+            }
         }
         // Make sure the muscles states are in equilibrium
         osimModel.equilibrateMuscles(s);
@@ -108,10 +110,9 @@ int main()
         coords.get("r_shoulder_elev").setValue(si, 0.0);
 
         // Set the initial muscle activations 
-        const Set<Muscle> &muscleSet = osimModel.getMuscles();
-        for(int i=0; i< muscleSet.getSize(); i++ ){
-            muscleSet[i].setActivation(si, 1.0);
-            const ActivationFiberLengthMuscle* afl = ActivationFiberLengthMuscle::safeDownCast(&muscleSet[i]);
+        for (Muscle& m : osimModel.getMuscles()){
+            m.setActivation(si, 1.0);
+            const auto* afl = ActivationFiberLengthMuscle::safeDownCast(&m);
             afl->setFiberLength(si, .1);
         }
         OpenSim::Coordinate& elbowFlexCoord = osimModel.updCoordinateSet().get("r_elbow_flex");

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -427,9 +427,8 @@ void simulateModelWithMusclesNoViz(const string &modelFile, double finalTime, do
     // Initialize the system and get the state representing the state system
     SimTK::State& si = osimModel.initSystem();
 
-    const Set<Muscle>& muscles = osimModel.getMuscles();
-    for (int i=0; i<muscles.getSize(); i++){
-        muscles[i].setActivation(si, activation); //setDisabled(si, true);
+    for (Muscle& m : osimModel.getMuscles()) {
+        m.setActivation(si, activation); //setDisabled(si, true);
     }
     osimModel.equilibrateMuscles(si);
 
@@ -451,9 +450,8 @@ void simulateModelWithPassiveMuscles(const string &modelFile, double finalTime)
     // Initialize the system and get the state representing the state system
     SimTK::State& si = osimModel.initSystem();
 
-    const Set<Muscle>& muscles = osimModel.getMuscles();
-    for (int i=0; i<muscles.getSize(); ++i){
-        muscles[i].setActivation(si, 0); //setDisabled(si, true);
+    for (Muscle& m : osimModel.getMuscles()){
+        m.setActivation(si, 0); //setDisabled(si, true);
     }
     osimModel.equilibrateMuscles(si); 
 
@@ -524,17 +522,17 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
     Array<GeometryPath*> paths;
     Array<String> pathNames;
     int numLigaments = 0, numMuscles = 0;
-    for (int i = 0; i < osimModel.getForceSet().getSize(); ++i) {
-        Ligament* lig = dynamic_cast<Ligament*>(&osimModel.getForceSet()[i]);
-        if (lig != 0) {
+    for (OpenSim::Force& f : osimModel.getForceSet()) {
+        Ligament* lig = dynamic_cast<Ligament*>(&f);
+        if (lig) {
             numLigaments++;
             paths.append(&lig->updGeometryPath());
             pathNames.append(lig->getName());
             continue;
         }
 
-        Muscle* mus = dynamic_cast<Muscle*>(&osimModel.getForceSet()[i]);
-        if (mus != 0) {
+        Muscle* mus = dynamic_cast<Muscle*>(&f);
+        if (mus) {
             numMuscles++;
             paths.append(&mus->updGeometryPath());
             pathNames.append(mus->getName());
@@ -580,8 +578,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         }
 
         // add vias to cableInfo
-        for (int j = 1; j < viaSet.getSize()-1; ++j) { // skip first (origin) and last (insertion) points
-            const AbstractPathPoint& pp = viaSet[j];
+        for (const AbstractPathPoint& pp : viaSet) { // skip first (origin) and last (insertion) points
             ObstacleInfo obs;
             obs.bodyName = pp.getParentFrame().getName();
             obs.X_BS.setP(pp.getLocation(si));
@@ -596,8 +593,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
 
         Array<ObstacleInfo*> wrapObs;
         // add surfaces to cableInfo
-        for (int j = 0; j < wrapSet.getSize(); j++) {
-            const PathWrap& wrap = wrapSet[j];
+        for (const PathWrap& wrap : wrapSet) {
             const WrapObject* wrapObj = wrap.getWrapObject();
             ObstacleInfo obs;
             obs.wrapObjectPtr = wrapObj;
@@ -709,9 +705,9 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         cout << "culling wrap objs from " << osimModel.getBodySet()[i].getName() << ", num wraps = " << wraps.getSize() << endl;
 //        mutableWraps->clearAndDestroy();
         mutableWraps->setMemoryOwner(true);
-        for (int j = 0; j < wraps.getSize(); ++j) {
-            if (wrapObjectsInUse.find(wraps[j].getName()) == wrapObjectsInUse.end()) { // does not contain
-                toRemove.append(&wraps[j]);
+        for (WrapObject& wo : wraps) {
+            if (wrapObjectsInUse.find(wo.getName()) == wrapObjectsInUse.end()) { // does not contain
+                toRemove.append(&wo);
             }
         }
 

--- a/OpenSim/Tools/ActuatorForceTarget.cpp
+++ b/OpenSim/Tools/ActuatorForceTarget.cpp
@@ -255,8 +255,8 @@ computePerformanceVectors(SimTK::State& s, const Vector &aF, Vector &rAccelPerfo
     for(int i=0;i<nacc;i++) rAccelPerformanceVector[i] = sqrt(w[i]) * (a[i] - aDes[i]);
 
     // reset the actuator control
-    for(int i=0;i<fSet.getSize();i++) {
-        auto act = dynamic_cast<const ScalarActuator*>(&fSet[i]);
+    for (const Actuator& a : fSet) {
+        auto act = dynamic_cast<const ScalarActuator*>(&a);
         act->overrideActuation(s, false);
     }
 }
@@ -288,8 +288,7 @@ objectiveFunc(const Vector &aF, const bool new_coefficients, Real& rP) const
     rP = (_accelPerformanceMatrix * aF + _accelPerformanceVector).normSqr() + (_forcePerformanceMatrix * aF + _forcePerformanceVector).normSqr();
 #endif
     // If tracking states, add in errors from them squared
-    for(int t=0; t<tset.getSize(); t++){
-        TrackingTask& ttask = tset.get(t);
+    for (TrackingTask& ttask : tset) {
         StateTrackingTask* stateTask=NULL;
         if ((stateTask=dynamic_cast<StateTrackingTask*>(&ttask))!= NULL){
             double err = stateTask->getTaskError(_saveState);

--- a/OpenSim/Tools/CMC.cpp
+++ b/OpenSim/Tools/CMC.cpp
@@ -508,7 +508,7 @@ void CMC::
 computeInitialStates(SimTK::State& s, double &rTI)
 {
     
-    int i,j;
+    int i;
 
     int N = _predictor->getNX();
     SimTK::State initialState = s;

--- a/OpenSim/Tools/CMC.cpp
+++ b/OpenSim/Tools/CMC.cpp
@@ -128,9 +128,9 @@ CMC::CMC(Model *aModel,CMC_TaskSet *aTaskSet) :
     // STORAGE
     Array<string> labels;
     labels.append("time");
-    for(int i=0;i<_taskSet->getSize();i++) {
-        for(int j=0;j<_taskSet->get(i).getNumTaskFunctions();j++) {
-            labels.append(_taskSet->get(i).getName());
+    for (const TrackingTask& ttask : *_taskSet) {
+        for (int j = 0; j < ttask.getNumTaskFunctions(); j++) {
+            labels.append(ttask.getName());
         }
     }
     _pErrStore.reset(new Storage(1000,"PositionErrors"));
@@ -593,8 +593,8 @@ computeInitialStates(SimTK::State& s, double &rTI)
     for(i=0;i<2;i++) {
 
         // CLEAR ANY PREVIOUS CONTROL NODES
-        for(j=0;j<_controlSet.getSize();j++) {
-            ControlLinear& control = (ControlLinear&)_controlSet.get(j);
+        for (Control& c : _controlSet) {
+            ControlLinear& control = static_cast<ControlLinear&>(c);
             control.clearControlNodes();
         }
 
@@ -774,10 +774,7 @@ computeControls(SimTK::State& s, ControlSet &controlSet)
         log_info("Errors at time {}: ", tiReal);
     }
     int e=0;
-    for(i=0;i<_taskSet->getSize();i++) {
-        
-        TrackingTask& task = _taskSet->get(i);
-
+    for (TrackingTask& task : *_taskSet) {
         if(_verbose) {
             for(j=0;j<task.getNumTaskFunctions();j++) {
                 log_warn("Task '{}': pErr = {}, vErr = {}.", task.getName(),

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -600,16 +600,14 @@ bool CMCTool::run()
 
     GCVSplineSet *qAndPosSet=NULL;
     qAndPosSet = new GCVSplineSet();
-    if(desiredPointsFlag) {
-        int nps=posSet->getSize();
-        for(int i=0;i<nps;i++) {
-            qAndPosSet->adoptAndAppend(&posSet->get(i));
+    if (desiredPointsFlag) {
+        for (Function& f : *posSet) {
+            qAndPosSet->adoptAndAppend(&f);
         }
     }
-    if(desiredKinFlag) {
-        int nqs=qSet->getSize();
-        for(int i=0;i<nqs;i++) {
-            qAndPosSet->adoptAndAppend(&qSet->get(i));
+    if (desiredKinFlag) {
+        for (Function& f : *qSet) {
+            qAndPosSet->adoptAndAppend(&f);
         }
     }
     if (taskSet.getDataFileName()!=""){

--- a/OpenSim/Tools/CMC_Point.cpp
+++ b/OpenSim/Tools/CMC_Point.cpp
@@ -135,8 +135,7 @@ updateWorkVariables(const SimTK::State& s)
             SimTK::Vec3 pVec,vVec;
             double Mass = 0.0;
             // double rP[3] = { 0.0, 0.0, 0.0 };
-            for(int i=0;i<bs.getSize();i++) {
-                Body& body = bs.get(i);
+            for (Body& body : bs) {
                 const SimTK::Vec3& com = body.get_mass_center();
                 pVec = body.findStationLocationInGround(s, com);
                 if(pVec[0] != pVec[0]) throw Exception("CMC_Point.computeAccelerations: ERROR- point task '" + getName() 
@@ -435,8 +434,7 @@ computeAccelerations(const SimTK::State& s )
 
         SimTK::Vec3 pVec,vVec,aVec,com;
         double Mass = 0.0;
-        for(int i=0;i<bs.getSize();i++) {
-            Body& body = bs.get(i);
+        for (Body& body : bs) {
             com = body.get_mass_center();
             aVec = body.findStationAccelerationInGround(s, com);
             if(aVec[0] != aVec[0]) throw Exception("CMC_Point.computeAccelerations: ERROR- point task '" + getName() 

--- a/OpenSim/Tools/CMC_TaskSet.cpp
+++ b/OpenSim/Tools/CMC_TaskSet.cpp
@@ -158,10 +158,7 @@ void CMC_TaskSet::
 setModel(Model& aModel)
 {
     _model = &aModel;
-
-    int i;
-    for(i=0;i<getSize();i++) {
-        TrackingTask& task = get(i);
+    for (TrackingTask& task : *this) {
         task.setModel(*_model);
     }
 }
@@ -200,15 +197,10 @@ getModel() const
 void CMC_TaskSet::setFunctions(FunctionSet &aFuncSet)
 {
     // LOOP THROUGH TRACK OBJECTS
-    int i,j,iFunc=0;
-    int nTrk;
+    int iFunc=0;
     string name;
     Function *f[3];
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         if (dynamic_cast<StateTrackingTask*>(&ttask)!=NULL) {
             StateTrackingTask& sTask = dynamic_cast<StateTrackingTask&>(ttask);
             if (aFuncSet.contains(sTask.getName())){
@@ -231,7 +223,7 @@ void CMC_TaskSet::setFunctions(FunctionSet &aFuncSet)
 
         // FIND FUNCTION(S)
         f[0] = f[1] = f[2] = NULL;
-        nTrk = task.getNumTaskFunctions();
+        int nTrk = task.getNumTaskFunctions();
         iFunc = aFuncSet.getIndex(name,iFunc);
         if (iFunc < 0){
             const Coordinate& coord = _model->getCoordinateSet().get(name);
@@ -244,7 +236,7 @@ void CMC_TaskSet::setFunctions(FunctionSet &aFuncSet)
             }
         }
 
-        for(j=0;j<nTrk;j++) {
+        for(int j=0;j<nTrk;j++) {
             try {
                 f[j] = &aFuncSet.get(iFunc);
             } catch(const Exception& x) {
@@ -282,17 +274,13 @@ void CMC_TaskSet::
 setFunctionsForVelocity(FunctionSet &aFuncSet)
 {
     // LOOP THROUGH TRACK OBJECTS
-    int i,j,iFunc=0;
-    int nTrk;
+    int iFunc=0;
     string name;
     Function *f[3];
 
     const CoordinateSet& coords = getModel()->getCoordinateSet(); 
 
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
+    for (TrackingTask& ttask : *this) {
 
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
@@ -308,7 +296,7 @@ setFunctionsForVelocity(FunctionSet &aFuncSet)
 
         // FIND FUNCTION(S)
         f[0] = f[1] = f[2] = NULL;
-        nTrk = task.getNumTaskFunctions();
+        int nTrk = task.getNumTaskFunctions();
         iFunc = aFuncSet.getIndex(coord.getSpeedName(),iFunc);
 
         if (iFunc < 0){
@@ -322,7 +310,7 @@ setFunctionsForVelocity(FunctionSet &aFuncSet)
             }
         }
 
-        for(j=0;j<nTrk;j++) {
+        for(int j=0;j<nTrk;j++) {
             try {
                 f[j] = &aFuncSet.get(iFunc);
             } catch(const Exception& x) {
@@ -345,17 +333,21 @@ int CMC_TaskSet::
 getNumActiveTaskFunctions() const
 {
     int count=0;
-    for(int i=0; i<getSize(); i++) {
-        TrackingTask& ttask = get(i);
 
-        // If CMC_Task process same way as pre 2.0.2
-        if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
+    for (TrackingTask& ttask : *this) {
+        auto* task = dynamic_cast<CMC_Task*>(&ttask);
+
+        if (task == nullptr) {
             continue;
+        }
 
-        CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        for(int j=0; j<task.getNumTaskFunctions(); j++)
-            if(task.getActive(j)) count++;
+        for (int j = 0; j < task->getNumTaskFunctions(); j++) {
+            if (task->getActive(j)) {
+                count++;
+            }
+        }
     }
+
     return count;
 }
 
@@ -380,17 +372,13 @@ void CMC_TaskSet::
 setFunctionsForAcceleration(FunctionSet &aFuncSet)
 {
     // LOOP THROUGH TRACK OBJECTS
-    int i,j,iFunc=0;
-    int nTrk;
+    int iFunc = 0;
     string name;
     Function *f[3];
 
     const CoordinateSet& coords = getModel()->getCoordinateSet(); 
 
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
+    for (TrackingTask& ttask : *this) {
 
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
@@ -405,7 +393,7 @@ setFunctionsForAcceleration(FunctionSet &aFuncSet)
 
         // FIND FUNCTION(S)
         f[0] = f[1] = f[2] = NULL;
-        nTrk = task.getNumTaskFunctions();
+        int nTrk = task.getNumTaskFunctions();
         iFunc = aFuncSet.getIndex(coord.getSpeedName(),iFunc);
 
         if (iFunc < 0){
@@ -419,7 +407,7 @@ setFunctionsForAcceleration(FunctionSet &aFuncSet)
             }
         }
 
-        for(j=0;j<nTrk;j++) {
+        for(int j=0;j<nTrk;j++) {
             try {
                 f[j] = &aFuncSet.get(iFunc);
             } catch(const Exception& x) {
@@ -446,24 +434,20 @@ getTaskPositions(double aT)
 {
     _pTask.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
-            if(!task.getActive(j)) continue;
-            _pTask.append(task.getTaskPosition(j,aT));
+        for (int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
+            if (task.getActive(j)) {
+                _pTask.append(task.getTaskPosition(j,aT));
+            }
         }
     }
 
-    return(_pTask);
+    return _pTask;
 }
 //_____________________________________________________________________________
 /**
@@ -477,24 +461,19 @@ getTaskVelocities(double aT)
 {
     _vTask.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+        for (int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
             if(!task.getActive(j)) continue;
             _vTask.append(task.getTaskVelocity(j,aT));
         }
     }
 
-    return(_vTask);
+    return _vTask;
 }
 //_____________________________________________________________________________
 /**
@@ -508,24 +487,19 @@ getTaskAccelerations(double aT)
 {
     _aTask.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+        for(int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
             if(!task.getActive(j)) continue;
             _aTask.append(task.getTaskAcceleration(j,aT));
         }
     }
 
-    return(_aTask);
+    return _aTask;
 }
 
 //-----------------------------------------------------------------------------
@@ -543,24 +517,19 @@ getPositionGains()
 {
     _kp.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+        for (int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
             if(!task.getActive(j)) continue;
             _kp.append(task.getKP(j));
         }
     }
 
-    return(_kp);
+    return _kp;
 }
 //_____________________________________________________________________________
 /**
@@ -574,24 +543,20 @@ getVelocityGains()
 {
     _kv.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+
+        for (int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
             if(!task.getActive(j)) continue;
             _kv.append(task.getKV(j));
         }
     }
 
-    return(_kv);
+    return _kv;
 }
 //_____________________________________________________________________________
 /**
@@ -605,24 +570,19 @@ getAccelerationGains()
 {
     _ka.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+        for(int j = 0, n = task.getNumTaskFunctions();j<n;j++) {
             if(!task.getActive(j)) continue;
             _ka.append(task.getKA(j));
         }
     }
 
-    return(_ka);
+    return _ka;
 }
 
 //-----------------------------------------------------------------------------
@@ -682,24 +642,19 @@ getWeights()
 {
     _w.setSize(0);
 
-    int i,j,n;
-    int size = getSize();
-    for(i=0;i<size;i++) {
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
 
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
-        n = task.getNumTaskFunctions();
-        for(j=0;j<n;j++) {
+        for (int j = 0, n = task.getNumTaskFunctions(); j < n; j++) {
             if(!task.getActive(j)) continue;
             _w.append(task.getWeight(j));
         }
     }
 
-    return(_w);
+    return _w;
 }
 
 //-----------------------------------------------------------------------------
@@ -748,13 +703,7 @@ recordErrorsAsLastErrors()
     _pErrLast.setSize(0);
     _vErrLast.setSize(0);
 
-    int i,j;
-    double e0,e1,e2;
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
@@ -762,9 +711,9 @@ recordErrorsAsLastErrors()
         CMC_Task& task = dynamic_cast<CMC_Task&>(ttask);
         
         // POSITION ERRORS
-        e0 = task.getPositionError(0);
-        e1 = task.getPositionError(1);
-        e2 = task.getPositionError(2);
+        double e0 = task.getPositionError(0);
+        double e1 = task.getPositionError(1);
+        double e2 = task.getPositionError(2);
         task.setPositionErrorLast(e0,e1,e2);
 
         // VELOCITY ERRORS
@@ -774,7 +723,7 @@ recordErrorsAsLastErrors()
         task.setVelocityErrorLast(e0,e1,e2);
 
         // SET ERRORS
-        for(j=0;j<3;j++) {
+        for (int j = 0; j < 3; j++) {
             if(!task.getActive(j)) continue;
             _pErrLast.append(task.getPositionErrorLast(j));
             _vErrLast.append(task.getVelocityErrorLast(j));
@@ -793,12 +742,7 @@ computeErrors(const SimTK::State& s, double aT)
     _pErr.setSize(0);
     _vErr.setSize(0);
 
-    int i,j;
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
@@ -809,7 +753,7 @@ computeErrors(const SimTK::State& s, double aT)
         task.computeErrors(s, aT);
 
         // SET ERRORS
-        for(j=0;j<3;j++) {
+        for (int j = 0; j < 3; j++) {
             if(!task.getActive(j)) continue;
             _pErr.append(task.getPositionError(j));
             _vErr.append(task.getVelocityError(j));
@@ -829,12 +773,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aT)
     _w.setSize(0);
     _aDes.setSize(0);
 
-    int i,j;
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
@@ -845,7 +784,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aT)
         task.computeDesiredAccelerations(s, aT);
 
         // SET WEIGHTS AND ACCELERATIONS
-        for(j=0;j<3;j++) {
+        for (int j = 0; j < 3; j++) {
             if(!task.getActive(j)) continue;
             _w.append(task.getWeight(j));
             _aDes.append(task.getDesiredAcceleration(j));
@@ -873,12 +812,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aTI,double aTF)
     _w.setSize(0);
     _aDes.setSize(0);
 
-    int i,j;
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
@@ -889,7 +823,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aTI,double aTF)
         task.computeDesiredAccelerations(s, aTI,aTF);
 
         // SET WEIGHTS AND ACCELERATIONS
-        for(j=0;j<3;j++) {
+        for (int j = 0; j < 3; j++) {
             if(!task.getActive(j)) continue;
             _w.append(task.getWeight(j));
             _aDes.append(task.getDesiredAcceleration(j));
@@ -910,12 +844,7 @@ computeAccelerations(const SimTK::State& s)
 {
     _a.setSize(0);
 
-    int i,j;
-    for(i=0;i<getSize();i++) {
-
-        // OBJECT
-        TrackingTask& ttask = get(i);
-
+    for (TrackingTask& ttask : *this) {
         // If CMC_Task process same way as pre 2.0.2
         if (dynamic_cast<CMC_Task*>(&ttask)==NULL) 
             continue;
@@ -926,7 +855,7 @@ computeAccelerations(const SimTK::State& s)
         task.computeAccelerations(s);
 
         // SET WEIGHTS AND ACCELERATIONS
-        for(j=0;j<3;j++) {
+        for (int j = 0; j < 3; j++) {
             if(!task.getActive(j)) continue;
             _a.append(task.getAcceleration(j));
         }

--- a/OpenSim/Tools/CorrectionController.cpp
+++ b/OpenSim/Tools/CorrectionController.cpp
@@ -257,8 +257,7 @@ void CorrectionController::extendConnectToModel(Model& model)
     const CoordinateSet& cs = _model->getCoordinateSet();
     auto actuators = model.updComponentList<CoordinateActuator>();
 
-    for(int i=0; i<cs.getSize(); i++) {
-        const Coordinate& coord = cs[i];
+    for (Coordinate& coord : cs) {
         const std::string name = coord.getName() + "_corrector";
 
         CoordinateActuator* actuator = nullptr;
@@ -273,7 +272,7 @@ void CorrectionController::extendConnectToModel(Model& model)
         if(!actuator) {
             // create the corrector actuator if it doe not already exist
             actuator = new CoordinateActuator();
-            actuator->setCoordinate(&cs.get(i));
+            actuator->setCoordinate(&coord);
             actuator->setName(name);
             // Since CorrectionController is creating these actuators for its
             // own devices, it should take ownership of them, so that when

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -171,22 +171,20 @@ void DynamicsTool::disableModelForces(Model &model, SimTK::State &s, const Array
     for(int i=0; i<forcesByNameOrGroup.getSize(); i++){
         //Check for keywords first starting with ALL
         if(IO::Uppercase(forcesByNameOrGroup[i]) == "ALL"){
-            for(int i=0; i<modelForces.getSize(); i++){
-                modelForces[i].setAppliesForce(s, false);
+            for (Force& f : modelForces){
+                f.setAppliesForce(s, false);
             }
             return;
         }
         if(IO::Uppercase(forcesByNameOrGroup[i]) == "ACTUATORS"){
-            Set<Actuator> &acts = model.updActuators();
-            for(int i=0; i<acts.getSize(); i++){
-                acts[i].setAppliesForce(s, false);
+            for (Actuator& a : model.updActuators()){
+                a.setAppliesForce(s, false);
             }
             continue;
         }
         if(IO::Uppercase(forcesByNameOrGroup[i]) == "MUSCLES"){
-            Set<Muscle> &muscles = model.updMuscles();
-            for(int i=0; i<muscles.getSize(); i++){
-                muscles[i].setAppliesForce(s, false);
+            for (Muscle& m : model.updMuscles()) {
+                m.setAppliesForce(s, false);
             }
             continue;
         }

--- a/OpenSim/Tools/IKTaskSet.h
+++ b/OpenSim/Tools/IKTaskSet.h
@@ -47,11 +47,10 @@ public:
     IKTaskSet(const IKTaskSet &aIKTaskSet) : Set<IKTask>(aIKTaskSet) { }
     IKTaskSet(const std::string &aFileName) : Set<IKTask>(aFileName) { }
     void createMarkerWeightSet(Set<MarkerWeight>& aWeights){
-        for(int i=0; i< getSize(); i++){
-            if(IKMarkerTask *nextTask = dynamic_cast<IKMarkerTask *>(&get(i))){
-                if(nextTask->getApply()){
-                    aWeights.cloneAndAppend(*(new MarkerWeight(nextTask->getName(), nextTask->getWeight())));
-                }
+        for (IKTask& t : *this) {
+            auto* nextTask = dynamic_cast<IKMarkerTask *>(&t);
+            if (nextTask && nextTask->getApply()) {
+                aWeights.cloneAndAppend(*(new MarkerWeight(nextTask->getName(), nextTask->getWeight())));
             }
         }
     };

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -209,8 +209,8 @@ void InverseDynamicsTool::getJointsByName(Model &model, const Array<std::string>
     for(int i=0; i<jointNames.getSize();  ++i){
         //Check for keywords first starting with ALL
         if(IO::Uppercase(jointNames[i]) == "ALL"){
-            for(int j=0; j<modelJoints.getSize(); ++j){
-                joints.adoptAndAppend(&modelJoints[j]);
+            for (Joint& j : modelJoints){
+                joints.adoptAndAppend(&j);
             }
             break;
         } 

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -422,9 +422,9 @@ void InverseKinematicsTool::populateReferences(MarkersReference& markersReferenc
     // Loop through old "IKTaskSet" and assign weights to the coordinate and marker references
     // For coordinates, create the functions for coordinate reference values
     int index = 0;
-    for (int i = 0; i < get_IKTaskSet().getSize(); i++) {
-        if (!get_IKTaskSet()[i].getApply()) continue;
-        if (IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&get_IKTaskSet()[i])) {
+    for (IKTask& t : get_IKTaskSet()) {
+        if (!t.getApply()) continue;
+        if (IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&t)) {
             CoordinateReference *coordRef = NULL;
             if (coordTask->getValueType() == IKCoordinateTask::FromFile) {
                 if (!coordFunctions)
@@ -452,7 +452,7 @@ void InverseKinematicsTool::populateReferences(MarkersReference& markersReferenc
 
             coordinateReferences.push_back(*coordRef);
         }
-        else if (IKMarkerTask *markerTask = dynamic_cast<IKMarkerTask *>(&get_IKTaskSet()[i])) {
+        else if (IKMarkerTask *markerTask = dynamic_cast<IKMarkerTask *>(&t)) {
             if (markerTask->getApply()) {
                 // Only track markers that have a task and it is "applied"
                 markerWeights.adoptAndAppend(

--- a/OpenSim/Tools/MarkerPlacer.cpp
+++ b/OpenSim/Tools/MarkerPlacer.cpp
@@ -315,8 +315,8 @@ bool MarkerPlacer::processModel(Model* aModel,
     }
     
     int index = 0;
-    for(int i=0; i< _ikTaskSet.getSize(); i++){
-        IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&_ikTaskSet[i]);
+    for (IKTask& t : _ikTaskSet){
+        IKCoordinateTask *coordTask = dynamic_cast<IKCoordinateTask *>(&t);
         if (coordTask && coordTask->getApply()){
             std::unique_ptr<CoordinateReference> coordRef{};
             if(coordTask->getValueType() == IKCoordinateTask::FromFile){
@@ -441,11 +441,8 @@ void MarkerPlacer::moveModelMarkersToPose(SimTK::State& s, Model& aModel,
 
     MarkerSet& markerSet = aModel.updMarkerSet();
 
-    int i;
-    for (i = 0; i < markerSet.getSize(); i++)
+    for (Marker& modelMarker : markerSet)
     {
-        Marker& modelMarker = markerSet.get(i);
-
         if (!modelMarker.get_fixed())
         {
             int index = aPose.getMarkerIndex(modelMarker.getName());

--- a/OpenSim/Tools/Measurement.cpp
+++ b/OpenSim/Tools/Measurement.cpp
@@ -166,19 +166,15 @@ Measurement& Measurement::operator=(const Measurement &aMeasurement)
  */
 void Measurement::applyScaleFactor(double aFactor, ScaleSet& aScaleSet)
 {
-    for (int i = 0; i < _bodyScaleSet.getSize(); i++)
-    {
-        const string& bodyName = _bodyScaleSet[i].getName();
-        for (int j = 0; j < aScaleSet.getSize(); j++)
-        {
-            if (aScaleSet[j].getSegmentName() == bodyName)
-            {
-                const Array<std::string>& axisNames = _bodyScaleSet[i].getAxisNames();
+    for (const BodyScale& bs : _bodyScaleSet) {
+        const string& bodyName = bs.getName();
+        for (Scale& s : aScaleSet) {
+            if (s.getSegmentName() == bodyName) {
+                const Array<std::string>& axisNames = bs.getAxisNames();
                 Vec3 factors(1.0);
-                aScaleSet[j].getScaleFactors(factors);
+                s.getScaleFactors(factors);
 
-                for (int k = 0; k < axisNames.getSize(); k++)
-                {
+                for (int k = 0; k < axisNames.getSize(); k++) {
                     if (axisNames[k] == "x" || axisNames[k] == "X")
                         factors[0] = aFactor;
                     else if (axisNames[k] == "y" || axisNames[k] == "Y")
@@ -186,7 +182,7 @@ void Measurement::applyScaleFactor(double aFactor, ScaleSet& aScaleSet)
                     else if (axisNames[k] == "z" || axisNames[k] == "Z")
                         factors[2] = aFactor;
                 }
-                aScaleSet[j].setScaleFactors(factors);
+                s.setScaleFactors(factors);
             }
         }
     }

--- a/OpenSim/Tools/ModelScaler.cpp
+++ b/OpenSim/Tools/ModelScaler.cpp
@@ -267,19 +267,19 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
                 }
 
                 /* Now take and apply the measurements. */
-                for (int j = 0; j < _measurementSet.getSize(); j++)
+                for (Measurement& m : _measurementSet)
                 {
-                    if (_measurementSet.get(j).getApply())
+                    if (m.getApply())
                     {
                         if(!markerData)
                             throw Exception("ModelScaler.processModel: ERROR- "+_markerFileNameProp.getName()+
                                                 " not set but measurements are used",__FILE__,__LINE__);
-                        double scaleFactor = computeMeasurementScaleFactor(s,*aModel, *markerData, _measurementSet.get(j));
+                        double scaleFactor = computeMeasurementScaleFactor(s,*aModel, *markerData, m);
                         if (!SimTK::isNaN(scaleFactor))
-                            _measurementSet.get(j).applyScaleFactor(scaleFactor, theScaleSet);
+                            m.applyScaleFactor(scaleFactor, theScaleSet);
                         else
                             log_warn("'{}' measurement not used to scale {}", 
-                                _measurementSet.get(j).getName(),
+                                m.getName(),
                                 aModel->getName());
                     }
                 }
@@ -289,13 +289,13 @@ bool ModelScaler::processModel(Model* aModel, const string& aPathToSubject,
              */
             else if (_scalingOrder[i] == "manualScale")
             {
-                for (int j = 0; j < _scaleSet.getSize(); j++)
+                for (Scale& s : _scaleSet)
                 {
-                    if (_scaleSet[j].getApply())
+                    if (s.getApply())
                     {
-                        const string& bodyName = _scaleSet[j].getSegmentName();
+                        const string& bodyName = s.getSegmentName();
                         Vec3 factors(1.0);
-                        _scaleSet[j].getScaleFactors(factors);
+                        s.getScaleFactors(factors);
                         for (int k = 0; k < theScaleSet.getSize(); k++)
                         {
                             if (theScaleSet[k].getSegmentName() == bodyName)

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -586,27 +586,28 @@ bool RRATool::run()
     // ANALYSES
     addNecessaryAnalyses();
 
-    GCVSplineSet *qAndPosSet=NULL;
-    qAndPosSet = new GCVSplineSet();
-    if(desiredPointsFlag) {
-        int nps=posSet->getSize();
-        for(int i=0;i<nps;i++) {
-            qAndPosSet->adoptAndAppend(&posSet->get(i));
+    GCVSplineSet* qAndPosSet = new GCVSplineSet();
+
+    if (desiredPointsFlag) {
+        for (Function& f : *posSet) {
+            qAndPosSet->adoptAndAppend(&f);
         }
     }
-    if(desiredKinFlag) {
-        int nqs=qSet->getSize();
-        for(int i=0;i<nqs;i++) {
-            qAndPosSet->adoptAndAppend(&qSet->get(i));
+
+    if (desiredKinFlag) {
+        for (Function& f : *qSet) {
+            qAndPosSet->adoptAndAppend(&f);
         }
     }
-    if (taskSet.getDataFileName()!=""){
+
+    if (taskSet.getDataFileName() != "") {
         // Add functions from data files to track states
         Storage stateStorage(taskSet.getDataFileName());
         GCVSplineSet* stateFuntcions = new GCVSplineSet(3, &stateStorage);
-        for (int i=0; i< stateFuntcions->getSize(); i++)
-            qAndPosSet->cloneAndAppend(stateFuntcions->get(i));
-
+        for (Function& f : *stateFuntcions) {
+            qAndPosSet->cloneAndAppend(f);
+        }
+        // TODO: this leaks, right?
     }
 
     taskSet.setFunctions(*qAndPosSet);

--- a/OpenSim/Tools/Test/testExternalLoads.cpp
+++ b/OpenSim/Tools/Test/testExternalLoads.cpp
@@ -287,8 +287,9 @@ void testExternalLoadDefaultProperties() {
 
     extLoads->print("testExternalLoadDefaultProperties_ExternalLoads.xml");
 
-    for(int i=0; i<extLoads->getSize(); i++)
-        model.addForce(&(*extLoads)[i]);
+    for (ExternalForce& f : *extLoads) {
+        model.addForce(&f);
+    }
     
     // Ensure that, even when force_expressed_in_body is unspecified, no issues
     // occur when initializing ExternalForce.


### PR DESCRIPTION
Missed my usual Friday refactoring window, but I eventually got there :). This PR adds a `.begin()` and `.end()` to `OpenSim::Set`, so that downstream code can write:

```c++
// before
for (int i = 0; i < set.getSize(); ++i) {
    El& el = set.get(i);
    // do stuff
}

// after
for (El& e : set) {
    // do stuff
}
```

The main motivation behind this is to marginally simplify code that uses sets. A longer-term motivation is to gradually port our existing containers (`Set<T>`, `Array<T>`, etc.) to have an identical downstream API to standard library containers (e.g. by adding iterator support (this), a `.size()` alias, a `.empty()` member, etc.) with the hope of making it easier to substitute containers later (e.g. if it turns out that an algorithm only needs a container, not the full-fat API /w serialization that a `Set` is designed for).

This initial PR contains commits that pass tests on my machine. CI will probably find some edge-cases I didn't code for. Perf-wise, despite the iterator being under-optimized (it currently performs two checks), the performance measurements are identical to `master` (I'll try and paste them in here).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2879)
<!-- Reviewable:end -->
