### PR TITLE
Implemented legacy-compatible support for disabling file logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ v4.2
 - The new Matlab CustomStaticOptimization.m guides the user to build their own custom static optimization code. 
 - Dropped support for separate Kinematics for application of External Loads. ([PR #2770] (https://github.com/opensim-org/opensim-core/pull/2770)). 
 - Refactored InverseKinematicsSolver to allow for adding (live) Orientation data to track, introduced BufferedOrientationsReference to queue data (PR #2855)
+- `opensim.log` will only be created/opened when the first message is logged to it (PR #2880):
+  - Previously, `opensim.log` would always be created, even if nothing was logged
+- Added a CMake option, `OPENSIM_DISABLE_LOG_FILE` (PR #2880):
+  - When set, disables `opensim.log` from being used by the logger by default when the first message is written to the log
+  - Log messages are still written to the standard output/error streams
+  - Previously, `opensim.log` would always be created - even if nothing was written to it (fixed above)
+  - Setting `OPENSIM_DISABLE_LOG_FILE` only disables the automatic creation of `opensim.log`. File logging can still be manually be enabled by calling `Logger::addFileSink()`
+  - This flag is `OFF` by default. So standard builds will still observe the existing behavior (`opensim.log` is created).
 
 v4.1
 ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,24 @@ mark_as_advanced(OPENSIM_PYTHON_STANDALONE) # Mainly for packagers; not users.
 option(BUILD_API_ONLY "Build/install only headers, libraries,
 wrapping, tests; not applications (opensim, ik, rra, etc.)." OFF)
 
+option(OPENSIM_DISABLE_LOG_FILE
+"Disable OpenSim from automatically creating 'opensim.log'.
+
+By default, any application linking to osimCommon will create an
+'opensim.log' file in the current working directory. All log messages
+written by OpenSim (incl. during static initialization) are written to
+both this file and the standard output streams.
+
+Enabling this option disables the automatic creation of
+'opensim.log'. Downstream users can reenable this behavior by calling
+`Logger::addFileSink()`. However, only log messages written after that
+function call will be written. Any log messages written before calling
+that function (e.g. during static initialization) will not be written
+to the log file." OFF)
+
+if(OPENSIM_DISABLE_LOG_FILE)
+    add_definitions(-DOPENSIM_DISABLE_LOG_FILE=1)
+endif()
 
 set(OPENSIM_BUILD_INDIVIDUAL_APPS_DEFAULT OFF)
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,14 +117,7 @@ option(OPENSIM_DISABLE_LOG_FILE
 By default, any application linking to osimCommon will create an
 'opensim.log' file in the current working directory. All log messages
 written by OpenSim (incl. during static initialization) are written to
-both this file and the standard output streams.
-
-Enabling this option disables the automatic creation of
-'opensim.log'. Downstream users can reenable this behavior by calling
-`Logger::addFileSink()`. However, only log messages written after that
-function call will be written. Any log messages written before calling
-that function (e.g. during static initialization) will not be written
-to the log file." OFF)
+both this file and the standard output streams." OFF)
 
 if(OPENSIM_DISABLE_LOG_FILE)
     add_definitions(-DOPENSIM_DISABLE_LOG_FILE=1)

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -30,9 +30,9 @@
 
 using namespace OpenSim;
 
-static void initializeLogger(spdlog::logger& l) {
+static void initializeLogger(spdlog::logger& l, const char* pattern) {
     l.set_level(spdlog::level::info);
-    l.set_pattern("%v");
+    l.set_pattern(pattern);
 }
 
 // cout logger will be initialized during static initialization time
@@ -46,8 +46,8 @@ static std::shared_ptr<spdlog::logger> defaultLogger =
 // this function returns a dummy value so that it can be used in an assignment
 // expression (below) that *must* be executed in-order at static init time
 static bool initializeLogging() {
-    initializeLogger(*coutLogger);
-    initializeLogger(*defaultLogger);
+    initializeLogger(*coutLogger, "%v");
+    initializeLogger(*defaultLogger, "[%l] %v");
     spdlog::flush_on(spdlog::level::info);
     return true;
 }

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -65,7 +65,7 @@ static bool filesink_auto_initialization_disabled = false;
 
 // when filesink initialization *may* happen, ensure it only happens exactly
 // once globally by wrapping it in a function-local static.
-static bool _maybeInitFileLogging() {
+static bool initFileLoggingAsNeeded() {
 #ifdef OPENSIM_DISABLE_LOG_FILE
 // software builders may want to statically ensure that automatic file logging
 // *cannot* happen - even during static initialization. This compiler define
@@ -89,14 +89,14 @@ return true;
 // this function is only called when the caller is about to log something, so
 // it should perform lazy initialization of the file sink
 spdlog::logger& Logger::getCoutLogger() {
-    _maybeInitFileLogging();
+    initFileLoggingAsNeeded();
     return *cout_logger;
 }
 
 // this function is only called when the caller is about to log something, so
 // it should perform lazy initialization of the file sink
 spdlog::logger& Logger::getDefaultLogger() {
-    _maybeInitFileLogging();
+    initFileLoggingAsNeeded();
     return *default_logger;
 }
 

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -37,8 +37,8 @@ class LogSink;
 /// controlling how those messages are presented to the user.
 class OSIMCOMMON_API Logger {
 public:
-    Logger(Logger const&) = delete;
-    Logger& operator=(Logger const&) = delete;
+    ///  This is a static singleton class: there is no way of constructing it
+    Logger() = delete;
 
     /// This enum lists the types of messages that should be logged. These
     /// levels match those of the spdlog logging library that OpenSim uses for
@@ -104,32 +104,44 @@ public:
 
     template <typename... Args>
     static void critical(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->critical(fmt, args...);
+        if (shouldLog(Level::Critical)) {
+            getDefaultLogger().critical(fmt, args...);
+        }
     }
 
     template <typename... Args>
     static void error(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->error(fmt, args...);
+        if (shouldLog(Level::Error)) {
+            getDefaultLogger().error(fmt, args...);
+        }
     }
 
     template <typename... Args>
     static void warn(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->warn(fmt, args...);
+        if (shouldLog(Level::Warn)) {
+            getDefaultLogger().warn(fmt, args...);
+        }
     }
 
     template <typename... Args>
     static void info(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->info(fmt, args...);
+        if (shouldLog(Level::Info)) {
+            getDefaultLogger().info(fmt, args...);
+        }
     }
 
     template <typename... Args>
     static void debug(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->debug(fmt, args...);
+        if (shouldLog(Level::Debug)) {
+            getDefaultLogger().debug(fmt, args...);
+        }
     }
 
     template <typename... Args>
     static void trace(spdlog::string_view_t fmt, const Args&... args) {
-        m_default_logger->trace(fmt, args...);
+        if (shouldLog(Level::Trace)) {
+            getDefaultLogger().trace(fmt, args...);
+        }
     }
 
     /// Use this function to log messages that would normally be sent to
@@ -141,7 +153,7 @@ public:
     /// give users control over what gets logged.
     template <typename... Args>
     static void cout(spdlog::string_view_t fmt, const Args&... args) {
-        m_cout_logger->log(spdlog::level::info, fmt, args...);
+        getCoutLogger().log(spdlog::level::info, fmt, args...);
     }
 
     /// @}
@@ -170,37 +182,9 @@ public:
     /// @note This function is not thread-safe. Do not invoke this function
     /// concurrently, or concurrently with addLogFile() or addSink().
     static void removeSink(const std::shared_ptr<LogSink> sink);
-
-    /// This returns the singleton instance of the Log class, but users never
-    /// need to invoke this function. The member functions in this class are
-    /// static.
-    static const std::shared_ptr<OpenSim::Logger> getInstance() {
-        if (!m_osimLogger) {
-            m_osimLogger =
-                    std::shared_ptr<OpenSim::Logger>(new OpenSim::Logger());
-            addFileSink();
-        }
-        return m_osimLogger;
-    }
 private:
-    /// Initialize spdlog.
-    Logger();
-
-    static void addSinkInternal(std::shared_ptr<spdlog::sinks::sink> sink);
-
-    static void removeSinkInternal(
-            const std::shared_ptr<spdlog::sinks::sink> sink);
-
-    /// This is the logger used in log_cout.
-    static std::shared_ptr<spdlog::logger> m_cout_logger;
-
-    /// This is the singleton OpenSim::Logger
-    static std::shared_ptr<OpenSim::Logger> m_osimLogger;
-
-    static std::shared_ptr<spdlog::logger> m_default_logger;
-
-    /// Keep track of the file sink.
-    static std::shared_ptr<spdlog::sinks::basic_file_sink_mt> m_filesink;
+    static spdlog::logger& getCoutLogger();
+    static spdlog::logger& getDefaultLogger();
 };
 
 /// @name Logging functions


### PR DESCRIPTION
- Added a compiler flag, OPENSIM_DISABLE_LOG_FILE, which prevents
  the logger from automatically creating "opensim.log"

- Reworked Logger implementation to only initialize the log file
  sink (i.e. 'opensim.log') when:

  - The logger is about to write its first log message to the file.
    This means that 'opensim.log' will only be created if logging
    occurs

  - Logger::removeFileSink() has not been called before the first
    log message is written to the log. This enables developers to
    runtime-disable the log by calling Logger::removeFileSink() in
    their application *before* logging anything. Note: if the
    logger writes a message during static initialization, then the
    file will be created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2880)
<!-- Reviewable:end -->
