### PR TITLE
Reset _controllerSet storage in the manager to avoid memory leaks

### DIFF
--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -790,10 +790,6 @@ void Manager::initializeStorageAndAnalyses(const SimTK::State& s)
         // STORE STARTING CONTROLS
         if (_model->isControlled()){
             _controllerSet->connectToModel(*_model);
-			// Here we call the constructStorage because it possible that the
-			// Model's control storage has already be appended in a previous
-			// simulation [Dimitar Stanev; see Manager memory leak PR].
-            _controllerSet->constructStorage();
         }
 
         OPENSIM_THROW_IF(!hasStateStorage(), Exception,
@@ -805,7 +801,7 @@ void Manager::initializeStorageAndAnalyses(const SimTK::State& s)
 }
 //_____________________________________________________________________________
 /**
-* set and initialize a SimTK::TimeStepper
+* Set and initialize a SimTK::TimeStepper
 */
 void Manager::initialize(const SimTK::State& s)
 {
@@ -826,11 +822,18 @@ void Manager::initialize(const SimTK::State& s)
         _timeStepper->initialize(s);
         _timeStepper->setReportAllSignificantStates(true);
     }
+
+	// Here we call the constructStorage because it is possible that the Model's
+	// control storage has already be appended in a previous simulation [Dimitar
+	// Stanev; see Manager memory leak PR].
+	if( _writeToStorage )
+        if (_model->isControlled())
+            _controllerSet->constructStorage();
 }
 
 void Manager::record(const SimTK::State& s, const int& step)
 {
-    // ANALYSES 
+    // ANALYSES
     if (_performAnalyses) {
         AnalysisSet& analysisSet = _model->updAnalysisSet();
         if (step == 0)

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -22,7 +22,7 @@
  * -------------------------------------------------------------------------- */
 
 /* Note: This code was originally developed by Realistic Dynamics Inc.
- * Author: Frank C. Anderson 
+ * Author: Frank C. Anderson
  */
 #include <cstdio>
 #include "Manager.h"
@@ -369,7 +369,7 @@ getTimeArray()
 }
 //_____________________________________________________________________________
 /**
- * Get the integration step (index) that occurred prior to or at 
+ * Get the integration step (index) that occurred prior to or at
  * a specified time.
  *
  * @param aTime Time of the integration step.
@@ -823,12 +823,13 @@ void Manager::initialize(const SimTK::State& s)
         _timeStepper->setReportAllSignificantStates(true);
     }
 
-    // Here we call the constructStorage because it is possible that the Model's
-    // control storage has already be appended in a previous simulation [Dimitar
-    // Stanev; see Manager memory leak PR].
-    if( _writeToStorage )
-        if (_model->isControlled())
-            _controllerSet->constructStorage();
+    // Here we call the constructStorage because it is possible that
+    // the Model's control storage has already been appended in a
+    // previous simulation since the Manager mutates the model
+    // (Dimitar Stanev; issue:
+    // https://github.com/opensim-org/opensim-core/issues/2865).
+    if( _writeToStorage && _model->isControlled())
+        _controllerSet->constructStorage();
 }
 
 void Manager::record(const SimTK::State& s, const int& step)

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -823,10 +823,10 @@ void Manager::initialize(const SimTK::State& s)
         _timeStepper->setReportAllSignificantStates(true);
     }
 
-	// Here we call the constructStorage because it is possible that the Model's
-	// control storage has already be appended in a previous simulation [Dimitar
-	// Stanev; see Manager memory leak PR].
-	if( _writeToStorage )
+    // Here we call the constructStorage because it is possible that the Model's
+    // control storage has already be appended in a previous simulation [Dimitar
+    // Stanev; see Manager memory leak PR].
+    if( _writeToStorage )
         if (_model->isControlled())
             _controllerSet->constructStorage();
 }

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -21,7 +21,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/* Note: This code was originally developed by Realistic Dynamics Inc. 
+/* Note: This code was originally developed by Realistic Dynamics Inc.
  * Author: Frank C. Anderson 
  */
 #include <cstdio>
@@ -54,7 +54,7 @@ Manager::Manager(Model& model) : Manager(model, true)
 }
 
 Manager::Manager(Model& model, const SimTK::State& state)
-        : Manager(model) 
+        : Manager(model)
 {
     initialize(state);
 }
@@ -563,7 +563,7 @@ getIntegrator() const
 }
 
 /**
-  * Set the Integrator's accuracy. 
+  * Set the Integrator's accuracy.
   */
 void Manager::setIntegratorAccuracy(double accuracy)
 {
@@ -618,7 +618,7 @@ setStateStorage(Storage& aStorage)
  * Get the storage buffer for the integration states.
  */
 Storage& Manager::
-getStateStorage() const 
+getStateStorage() const
 {
     if(!_stateStore)
         throw Exception("Manager::getStateStorage(): Storage is not set");
@@ -765,31 +765,35 @@ const SimTK::State& Manager::getState() const
 /**
  * return the step size when the integrator is taking fixed
  * step sizes
- * 
+ *
  * @param tArrayStep Step number
  */
 double Manager::getFixedStepSize(int tArrayStep) const {
-    if( _constantDT ) 
+    if( _constantDT )
         return( _dt );
-    else { 
-        if( tArrayStep >= _dtArray.getSize() ) 
+    else {
+        if( tArrayStep >= _dtArray.getSize() )
              return( _dtArray[ _dtArray.getSize()-1 ] );
-        else 
+        else
             return(_dtArray[tArrayStep]);
     }
 }
 //_____________________________________________________________________________
 /**
- * initialize storages and analyses 
- * 
+ * initialize storages and analyses
+ *
  * @param s system state before integration
  */
 void Manager::initializeStorageAndAnalyses(const SimTK::State& s)
 {
-    if( _writeToStorage && _performAnalyses ) { 
+    if( _writeToStorage ) {
         // STORE STARTING CONTROLS
         if (_model->isControlled()){
             _controllerSet->connectToModel(*_model);
+			// Here we call the constructStorage because it possible that the
+			// Model's control storage has already be appended in a previous
+			// simulation [Dimitar Stanev; see Manager memory leak PR].
+            _controllerSet->constructStorage();
         }
 
         OPENSIM_THROW_IF(!hasStateStorage(), Exception,
@@ -842,7 +846,7 @@ void Manager::record(const SimTK::State& s, const int& step)
         vec.setStates(s.getTime(), stateValues);
         getStateStorage().append(vec);
         if (_model->isControlled())
-            _controllerSet->storeControls(s, 
+            _controllerSet->storeControls(s,
                 (step < 0) ? getStateStorage().getSize() : step);
     }
 }
@@ -881,6 +885,3 @@ bool Manager::checkHalt()
 {
     return _halt;
 }
-
-
-

--- a/OpenSim/Simulation/Manager/Manager.h
+++ b/OpenSim/Simulation/Manager/Manager.h
@@ -116,7 +116,7 @@ private:
     bool _writeToStorage;
 
     /** controllerSet used for the integration */
-    ControllerSet* _controllerSet;
+    SimTK::ReferencePtr<ControllerSet> _controllerSet;
 
 
 //=============================================================================


### PR DESCRIPTION
Fixes issue #2865

### Brief summary of changes

Make sure to reset `_controllerSet` internal storage with `constructStorage` each time the Manager is initialized.

### Testing I've completed

Manually observed the memory allocation size to ensure that if the manager is destroyed or re-intialized the memory does not grow.

### Looking for feedback on...

Please let me know if this can cause any undesirable behavior outside the Manager class. 

Also, I was thinking of how to fix the initialize method so that we can re-initialize the manager without having to delete it. I think the following part could be removed:

https://github.com/opensim-org/opensim-core/blob/82ec3d1c74af1ff1893d9c5453ef6c52fe2e2fc9/OpenSim/Simulation/Manager/Manager.cpp#L813

What do you think?

### CHANGELOG.md (choose one)

- no need to update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2885)
<!-- Reviewable:end -->
