### PR TITLE
Fix generateDecorations of EllipsoidJoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ v4.2
   - Previously, `opensim.log` would always be created - even if nothing was written to it (fixed above)
   - Setting `OPENSIM_DISABLE_LOG_FILE` only disables the automatic creation of `opensim.log`. File logging can still be manually be enabled by calling `Logger::addFileSink()`
   - This flag is `OFF` by default. So standard builds will still observe the existing behavior (`opensim.log` is created).
-- Fix bug with visualization of EllipsoidJoint not attaching to correct frame ([PR #2887] (https://github.com/opensim-org/opensim-core/pull/2887))
+- Fix bug in visualization of EllipsoidJoint that was not attaching to the correct frame ([PR #2887] (https://github.com/opensim-org/opensim-core/pull/2887))
 
 v4.1
 ====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ v4.2
   - Previously, `opensim.log` would always be created - even if nothing was written to it (fixed above)
   - Setting `OPENSIM_DISABLE_LOG_FILE` only disables the automatic creation of `opensim.log`. File logging can still be manually be enabled by calling `Logger::addFileSink()`
   - This flag is `OFF` by default. So standard builds will still observe the existing behavior (`opensim.log` is created).
+- Fix bug with visualization of EllipsoidJoint not attaching to correct frame ([PR #2887] (https://github.com/opensim-org/opensim-core/pull/2887))
 
 v4.1
 ====

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -172,11 +172,13 @@ void EllipsoidJoint::generateDecorations
 {
     // invoke parent class method, this draws 2 Frames
     Super::generateDecorations(fixed,hints,state,geometryArray); 
-
+    // The next line is necessary to avoid ellipsoid below added twice
+    // since this method is called with fixed={true, false}
+    if (!fixed) return; 
     // Construct the visible Ellipsoid
     SimTK::DecorativeEllipsoid ellipsoid(get_radii_x_y_z());
-    ellipsoid.setTransform(getParentFrame().getTransformInGround(state));
+    const OpenSim::PhysicalFrame& frame = getParentFrame();
     ellipsoid.setColor(Vec3(0.0, 1.0, 1.0));
-
+    ellipsoid.setBodyId(frame.getMobilizedBodyIndex());
     geometryArray.push_back(ellipsoid);
 }


### PR DESCRIPTION
Fixes issue gui 1178:
https://github.com/opensim-org/opensim-gui/issues/1178

### Brief summary of changes
Make generateDecorations method handles fixed flag correctly and attaches to correct Body instead of Ground
### Testing I've completed
loaded model in issue and moved coordinate slider and the visualization moved.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2887)
<!-- Reviewable:end -->
