### PR TITLE
Fix componentpath formrelativepath

### DIFF
--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -104,6 +104,8 @@ void testComponentPath() {
             // the existing implementation returns this value, so it's kept
             // for backwards-compat
             { "/", "/", "" },
+            { "/a", "/a", "" },
+            { "/a/b", "/a/b", "" },
         };
 
         for (const TestCase& tc : testCases) {

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -119,12 +119,7 @@ void testComponentPath() {
             }
         }
     }
-    ASSERT(CP{"/a/b/c/d"}.formRelativePath(CP{"/a/b/e/f/g/h"}).toString() == "../../../../c/d");
-    ASSERT(CP{"/a/b/e/f/g/h"}.formRelativePath(CP{"/a/b/c/d"}).toString() == "../../e/f/g/h");
-    // Test path that just goes down a tree
-    ASSERT(CP{"/a/b/c/d"}.formRelativePath(CP{"/a/b"}).toString() == "c/d");
-    // Test path that only goes up the tree
-    ASSERT(CP{"/a/b"}.formRelativePath(CP{"/a/b/e/f/g/h"}).toString() == "../../../..");
+
     // Throw exceptions if either or both paths are not absolute
     ASSERT_THROW(Exception, CP{"c/d"}.formRelativePath(CP{"/a/b/e/f/g/h"}));
     ASSERT_THROW(Exception, CP{"/a/b/e/f/g/h"}.formRelativePath(CP{"e/f/g/h"}));

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -100,13 +100,17 @@ void testComponentPath() {
             // other potentially-failing examples, for good measure
             { "/a/b", "/c/d", "../../c/d" },
             { "/a/b/c/", "/e/f/g", "../../../e/f/g" },
+            // logically, the relative path should be "." for this. However,
+            // the existing implementation returns this value, so it's kept
+            // for backwards-compat
+            { "/", "/", "" },
         };
 
         for (const TestCase& tc : testCases) {
             const ComponentPath ans = CP{tc.to}.formRelativePath(CP{tc.from});
             if (ans.toString() != tc.expected) {
                 std::stringstream ss;
-                ss << "ComponentPath::formRelativePath produced invalid output" << std::endl;
+                ss << "ComponentPath::formRelativePath produced an invalid output" << std::endl;
                 ss << "      from = " << tc.from << std::endl;
                 ss << "        to = " << tc.to << std::endl;
                 ss << "  expected = " << tc.expected << std::endl;

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -97,7 +97,16 @@ void testComponentPath() {
         };
 
         for (const TestCase& tc : testCases) {
-            ASSERT(CP{tc.to}.formRelativePath(CP{tc.from}).toString() == tc.expected);
+            const ComponentPath ans = CP{tc.to}.formRelativePath(CP{tc.from});
+            if (ans.toString() != tc.expected) {
+                std::stringstream ss;
+                ss << "ComponentPath::formRelativePath produced invalid output" << std::endl;
+                ss << "      from = " << tc.from << std::endl;
+                ss << "        to = " << tc.to << std::endl;
+                ss << "  expected = " << tc.expected << std::endl;
+                ss << "       got = " << ans.toString();
+                throw std::runtime_error{ss.str()};
+            }
         }
     }
     ASSERT(CP{"/a/b/c/d"}.formRelativePath(CP{"/a/b/e/f/g/h"}).toString() == "../../../../c/d");

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -94,6 +94,12 @@ void testComponentPath() {
             { "/a/b", "/a/b/c/d", "c/d" },
             // Test path that only goes up the tree
             { "/a/b/e/f/g/h", "/a/b", "../../../.." },
+            // An example that failed post-merge
+            //     see https://github.com/opensim-org/opensim-core/pull/2805
+            { "/contact", "/contact_point", "../contact_point" },
+            // other potentially-failing examples, for good measure
+            { "/a/b", "/c/d", "../../c/d" },
+            { "/a/b/c/", "/e/f/g", "../../../e/f/g" },
         };
 
         for (const TestCase& tc : testCases) {

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -80,6 +80,26 @@ void testComponentPath() {
 
     /* Test formRelativePath(). Both paths must be absolute */
     // Test path that go up and back down the tree
+    {
+        struct TestCase {
+            std::string from;
+            std::string to;
+            std::string expected;
+        };
+
+        TestCase testCases[] = {
+            { "/a/b/e/f/g/h", "/a/b/c/d", "../../../../c/d" },
+            { "/a/b/c/d", "/a/b/e/f/g/h", "../../e/f/g/h" },
+            // Test path that just goes down a tree
+            { "/a/b", "/a/b/c/d", "c/d" },
+            // Test path that only goes up the tree
+            { "/a/b/e/f/g/h", "/a/b", "../../../.." },
+        };
+
+        for (const TestCase& tc : testCases) {
+            ASSERT(CP{tc.to}.formRelativePath(CP{tc.from}).toString() == tc.expected);
+        }
+    }
     ASSERT(CP{"/a/b/c/d"}.formRelativePath(CP{"/a/b/e/f/g/h"}).toString() == "../../../../c/d");
     ASSERT(CP{"/a/b/e/f/g/h"}.formRelativePath(CP{"/a/b/c/d"}).toString() == "../../e/f/g/h");
     // Test path that just goes down a tree


### PR DESCRIPTION
This fixes a bug found here:

https://github.com/opensim-org/opensim-core/pull/2805

It's explained in more detail on that PR but, effectively, `ComponentPath::formRelativePath` is broken on the edge-case of a path subcomponent containing a non-separator at the same offset as another path subcomponent containing its NUL terminator (e.g. `/component`, `/component_path`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2890)
<!-- Reviewable:end -->
