### PR TITLE
generateDecorations Apply possible transform between Joint and Body frames

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -180,5 +180,6 @@ void EllipsoidJoint::generateDecorations
     const OpenSim::PhysicalFrame& frame = getParentFrame();
     ellipsoid.setColor(Vec3(0.0, 1.0, 1.0));
     ellipsoid.setBodyId(frame.getMobilizedBodyIndex());
+    ellipsoid.setTransform(frame.findTransformInBaseFrame());
     geometryArray.push_back(ellipsoid);
 }


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-gui/issues/1178

### Brief summary of changes
For a Joint that uses an offset frame, account for the transform between the offset frame and the underlying mobilized body
### Testing I've completed
Visualized the model in https://github.com/opensim-org/opensim-gui/issues/1178
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because corner case of a previous fix already included in changelog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2892)
<!-- Reviewable:end -->
