### PR TITLE
fix for issue #2790 & #2896

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.2
 ====
-- Fixed a bug in Millard2012EquilibriumMuscle::extendFinalizeFromProperties(): the end point slopes on the force velocity curves are constrained to yield a valid curve. This does slightly change the values of the force velocity curve near the extremes (between normalized fiber velocities of 0.9 to 1.0, and -0.9 to -1.0).
+- Fixed a bug in Millard2012EquilibriumMuscle::extendFinalizeFromProperties(): the end point slopes on the inverse force velocity curves are constrained to yield a valid curve. A warning is noted in the log if the slopes are small enough that numerical integration might be slow.
 - Added logging to Millard2012EquilibriumMuscle::extendFinalizeFromProperties(): whenever an internal setting is changed automatically these changes are noted in the log.
 - Introduced new logging system based on spdlog https://github.com/gabime/spdlog.git. The transition should be transparent to end users with default settings except that the name of the log file is now opensim.log. Main features are:
   - The ability to customize error level for reporting (in increasing level of verbosity): Off, Critical, Error, Warn, Info, Debug, Trace 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -217,28 +217,45 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
             "Minimum control cannot be less than minimum activation");
     }
 
-    //The ForceVelocityInverseCurve is used by the classic Hill model: this 
-    //formulation is used when use_fiber_damping is false. When an elastic
-    //tendon is used Eqn. 6 of Millard et al. is used to evaluate the state
-    //derivative of fiber length. As noted in the paper Eqn. 6 has several
-    //singularites one of which is related to the force-velocity-inverse curve:
-    //simply, the force-velocity-inverse curve must be invertible. 
+
+    //The ForceVelocityInverseCurve is used with both the damped and the 
+    // classic Hill model but in different ways:
     //
-    //This is equivalent to saying that the force-velocity-inverse curve must 
-    //have finite endslopes. To avoid this singularity we set the end slopes of 
-    //the force-velocity-inverse curve to be a fraction of the `near' slopes
-    //used by the force-velocity curve. While this may seem confusing don't 
-    //forget: the ForceVelocityInverseCurve takes in the parameters of the 
-    //force-velocity-curve that it inverts. So if you pass in an endslope of 
-    //0 the inverse curve will have an endslope of 1/0 = infinity! Instead we 
-    //make sure that we pass in a finite value for the end slopes so that the 
-    //inverse curve has finite endslopes. 
+    // The damped model uses the fvInvCurve to provide an initial fiber 
+    // velocity prior to numerically solving the root using Eqn. 8 from 
+    // Millard et al.
     //
-    //This means that fvInvCurve is not the inverse of fvCurve: the end slopes
-    //differ. This has to be the case because the fvCurve is used by the damped
-    //fiber model. This model has no singularities in its state derivative
-    //(Eqn. 8 of Millard et al.) and so a user is permitted to set the end
-    //slopes of the fvCurve to zero.
+    // The classic Hill formulation uses the fvInvCurve to directly solve for 
+    // fiber velocity using Eqn. 6 from Millard et al.
+    //
+    //While the fvCurve and fvInvCurve are inverses of each other between
+    //concentric-velocity-near-vmax to eccentric-velocity-near-vmax these
+    //curves differ outside of this region. Why? When an elastic-tendon model
+    //is used with the classic Hill formulation Eqn. 6 of Millard et al. is 
+    //used to evaluate the state derivative of fiber length. As noted in the 
+    //paper Eqn. 6 has several singularites one of which is related to the 
+    //force-velocity-inverse curve: simply, the force-velocity-inverse curve 
+    //must be invertible.
+    //
+    //In this case this is equivalent to saying that the force-velocity-inverse 
+    //curve must have finite endslopes. To avoid this singularity we set the 
+    //end slopes of the force-velocity-inverse curve to be a fraction of the 
+    //`near' slopes used by the force-velocity curve: this value is guaranteed
+    //to be finite, and is also guaranteed not to break the monotonicity of the 
+    //curve. Also don't forget: the ForceVelocityInverseCurve constructor takes 
+    //in the parameters of the force-velocity-curve that it inverts. So if you 
+    //pass in an endslope of 0 the inverse curve will have an endslope of 
+    //1/0 = infinity! Instead we make sure that we pass in a finite value for 
+    //the end slopes so that the inverse curve has finite endslopes. 
+    //
+    //The fvCurve is used exclusively by the damped model. As such the fvCurve
+    //does not need to be invertible since the damped model's state derivative
+    //(Eqn. 8 of Millard et al.) has no singularities. This means that the user
+    //can set the endslopes to zero which is particularly useful if simulations
+    //of very rapid contractions are being performed. This also means that the
+    //fvInvCurve is not the inverse of fvCurve for concentric velocities faster 
+    //than concentric-velocity-near-vmax and eccentric velocities faster than 
+    //eccentric-velocity-near-vmax: the end slopes differ.
     //
     //Millard M, Uchida T, Seth A, Delp SL. Flexing computational muscle: 
     //modeling and simulation of musculotendon dynamics. Journal of 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -112,7 +112,8 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
     OPENSIM_THROW_IF_FRMOBJ(eccSlopeNearVmax < SimTK::SqrtEps,
             InvalidPropertyValue, 
             "ForceVelocityCurve:eccentric_slope_near_vmax",
-            "Slope near eccentric vmax cannot be less than SimTK::SqrtEps");
+            "Slope near eccentric vmax cannot be less than SimTK::SqrtEps"
+            "(1.49e-8)");
 
 
     // A few parameters may need to be adjusted to avoid singularities 

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -178,7 +178,8 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
         if(get_minimum_activation() > 0.){
             log_info("'{}': Parameter update for the damped-model: "
                 "minimum_activation was {} but is now {}",
-                   getName(), get_minimum_activation(), 0.);
+                   getName(), get_minimum_activation(), 
+                   clamp(0, get_minimum_activation(), 1));
 
             set_minimum_activation(clamp(0, get_minimum_activation(), 1));
         }


### PR DESCRIPTION
Code updated so that extendFinalizeFromProperties() only updates force-velocity curve properties if needed, logs the changes, and sets the end slopes for the inverse-force-velocity curve to acceptable values.

Fixes issue #2896

### Brief summary of changes

Issue #2790 : Problem: a user could manually set the end slopes of the force-velocity curve to legal values that would cause a problem. Why? Internally one of those values was set to a hard-coded constant: this was done in an effort to make sure the classic Hill model (if used) would not be too stiff to integrate.

Issue #2896 Problem with my original fix to #2790: the code looked like it was missing a call to update the force-velocity curve: upon doing this a new curve resulted. Since this curve differed from the one in the past, tests that compared simulated results to saved solutions failed. Most of this bug is due to ambiguous code.

Fix details

#2790
1. Additional variables are added for the end slopes of the force-velocity inverse curve: conSlopeAtVmaxFvInv and eccSlopeAtVmaxFvInv. These variables have been clearly named with "FvInv" appended to the end so that code is easier to understand. These end slopes are not set to fixed values (to avoid the problem noted in issue #2790 but instead are set to half of what ever the "near" end slopes are. This removes the need to have hard-coded limits and fixes the bug noted in #2790.

2. There is a risk now that the user unwittingly chooses very small values for eccSlopeNearVmax and conSlopeNearVmax: this will have the consequence of making numerical simulation slow, in the worst case impossible. A warning message is printed to the log if the values of the end slopes are legal, but are small enough that integration might be slow. Suggestions for fixing the problem are noted in the message.

#2896
3. My initial fix for issue #2790 looked incomplete because I updated force-velocity parameters, but didn't update the curve. When @carmichaelong added code to update the force velocity curve tests failed: because the new force-velocity curve was different from the one in the past tests that compare simulation data to previous solutions failed. This is a `bug' because of my unnecessary updates to some of the force-velocity parameters, and because of some ambiguous variable names: some of those parameters were only intended to be used with the inverse-force velocity curve.  To fix this, first, I've introduced extra variables that clearly indicate in the name that they are only intended for inverse-force velocity curve. Second, I've updated the code so that parameter values for the force-velocity curve are updated only if absolutely necessary: these updates are noted in the log. Now the force-velocity curve matches the one from the past, updates are made sparingly (and with log notes), and internal variable

### Testing I've completed

Run all tests in release mode. I've also manually stepped through the code just to be sure.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2897)
<!-- Reviewable:end -->
