### PR TITLE
Allow IMUPlacer to run without model_file specification if model is set

### DIFF
--- a/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
@@ -87,7 +87,7 @@ bool IMUPlacer::run(bool visualizeResults) {
     _calibrated = false;
     // Check there's a model file specified before trying to open it
     if (_model.empty() && get_model_file().size() == 0) {
-        OPENSIM_THROW(Exception, "No model file specified for IMUPlacer.");
+        OPENSIM_THROW(Exception, "No model or model_file was specified for IMUPlacer.");
     }
     if (_model.empty()) { _model.reset(new Model(get_model_file())); }
     TimeSeriesTable_<SimTK::Quaternion> quatTable(

--- a/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
@@ -86,7 +86,7 @@ bool IMUPlacer::run(bool visualizeResults) {
 
     _calibrated = false;
     // Check there's a model file specified before trying to open it
-    if (get_model_file().size() == 0) {
+    if (_model.empty() && get_model_file().size() == 0) {
         OPENSIM_THROW(Exception, "No model file specified for IMUPlacer.");
     }
     if (_model.empty()) { _model.reset(new Model(get_model_file())); }

--- a/OpenSim/Tools/IMUInverseKinematicsTool.cpp
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.cpp
@@ -245,11 +245,12 @@ void IMUInverseKinematicsTool::runInverseKinematicsWithOrientationsFromFile(
                 fullOutputFilename);
         if (get_report_errors()) {
             STOFileAdapter_<double>::write(*modelOrientationErrors,
-                    getName() + "_orientationErrors.sto");
+                    outName + "_orientationErrors.sto");
         }
     } 
     else
-        log_info("IMUInverseKinematicsTool: No output files are written.");
+        log_info("IMUInverseKinematicsTool: No output files were generated, "
+            "set output_motion_file to generate output files.");
     // Results written to file, clear in case we run again
     ikReporter->clearTable();
 }

--- a/OpenSim/Tools/IMUInverseKinematicsTool.cpp
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.cpp
@@ -219,7 +219,7 @@ void IMUInverseKinematicsTool::runInverseKinematicsWithOrientationsFromFile(
         IO::makeDir(resultsDir);
         // directory will be restored on block exit
         // by changing dir all other files are created in resultsDir
-        IO::CwdChanger::changeTo(resultsDir);
+        auto cwd = IO::CwdChanger::changeTo(resultsDir);
         std::string outName = get_output_motion_file();
         outName = IO::GetFileNameFromURI(outName);
         if (outName.empty()) {


### PR DESCRIPTION
Fixes issue #2190 

### Brief summary of changes
Fix issue reported in testing GUI where setModel is not enough to run IMUPlacer if model file is unspecified.

### Testing I've completed
Ran test suite
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2898)
<!-- Reviewable:end -->
