### PR TITLE
Add ability to solve a MocoStudy with opensim-cmd

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
         7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-        echo "::add-path::$env:GITHUB_WORKSPACE\\doxygen"
+        echo "$env:GITHUB_WORKSPACE\\doxygen" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install Python packages
       # Need numpy to use SWIG numpy typemaps.

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -42,7 +42,7 @@ Options:
 Description:
   The argument <tool-or-class> can be the name of a Tool
   
-         scale  ik  id  rra  cmc  forward  analyze  moco (case-insensitive)
+         scale  ik  id  rra  cmc  forward  analyze  moco   (case-insensitive)
 
   or the name of any registered (concrete) OpenSim class (even from a plugin).
   Here are descriptions of the Tools listed above:

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -42,7 +42,7 @@ Options:
 Description:
   The argument <tool-or-class> can be the name of a Tool
   
-         scale  ik  id  rra  cmc  forward  analyze     (case-insensitive)
+         scale  ik  id  rra  cmc  forward  analyze  moco (case-insensitive)
 
   or the name of any registered (concrete) OpenSim class (even from a plugin).
   Here are descriptions of the Tools listed above:
@@ -55,6 +55,7 @@ Description:
          forward  Perform a forward simulation, using any controllers.
          analyze  Obtain muscle-related quantites, joint loads; 
                   perform Static Optimization; etc.
+         moco     Solve a trajectory optimization problem with Moco.
 
   The template file is written to <output-file> if provided. Otherwise, the
   file is written to the current directory with the name
@@ -92,6 +93,7 @@ int print_xml(int argc, const char** argv) {
     else if (toolLowerCase == "cmc")     className = "CMCTool";
     else if (toolLowerCase == "forward") className = "ForwardTool";
     else if (toolLowerCase == "analyze") className = "AnalyzeTool";
+    else if (toolLowerCase == "moco")    className = "MocoStudy";
     else {
         className = toolOrClass;
         isBuiltInTool = false;

--- a/Applications/opensim-cmd/opensim-cmd_run-tool.h
+++ b/Applications/opensim-cmd/opensim-cmd_run-tool.h
@@ -50,6 +50,7 @@ Description:
             Computed Muscle Control      (CMC)
             Forward                      
             Analyze
+            MocoStudy
 
   This command will also recognize tools from plugins.
 
@@ -115,6 +116,12 @@ int run_tool(int argc, const char** argv) {
         const bool success = scale->run();
         if (success) return EXIT_SUCCESS;
         else return EXIT_FAILURE;
+    } else if (auto* study = dynamic_cast<MocoStudy*>(obj.get())) {
+        log_info("Preparing to run {}.", study->getConcreteClassName());
+        const auto solution = study->solve();
+        if (solution.success()) return EXIT_SUCCESS;
+        else return EXIT_FAILURE;
+
     } else {
         throw Exception("The provided file '" + setupFile + "' does not "
                 "define an OpenSim Tool. Did you intend to load a plugin?");

--- a/Applications/opensim-cmd/parse_arguments.h
+++ b/Applications/opensim-cmd/parse_arguments.h
@@ -26,6 +26,7 @@
 #include <docopt.h>
 
 #include <OpenSim/OpenSim.h>
+#include <OpenSim/Moco/osimMoco.h>
 
 namespace OpenSim {
 

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,8 @@ Moco Change Log
 
 0.5.0 (in development)
 ----------------------
+- 2020-11-17: Add support for solving a MocoStudy to opensim-cmd.
+
 - 2020-08-19: DeGrooteFregly2016Muscle now reports the equilibrium residual 
               as a unitless quantity (normalized by maximum isometric force).
 


### PR DESCRIPTION
Discussed in dev meeting on 11-17-2020 (@adamkewley you don't need to create an issue now).

### Brief summary of changes
Added support for solving a MocoStudy using opensim-cmd. 

### Testing I've completed
- Printing a default MocoStudy setup file (XML) and running it behaves as expected.
- Created and ran a setup file from testMocoInverse and it solved without issue.

### CHANGELOG.md (choose one)

- [ ] no need to update because...
- [x] updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2902)
<!-- Reviewable:end -->
