### PR TITLE
Use simbody fix to handle latest msvc

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -158,7 +158,7 @@ AddDependency(NAME       BTK
 AddDependency(NAME       simbody
               DEFAULT    ON
               URL        https://github.com/simbody/simbody.git
-              TAG        Simbody-3.7
+              TAG        8cad2aa70b6c30410302c9d096ad3df1d2f73750
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF 
                          -DBUILD_TESTING:BOOL=OFF)
 


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Use commit hash with fix to compilation failure of simbody using latest msvc 16.8.2

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2912)
<!-- Reviewable:end -->
