### PR TITLE
Throw exception if xml tag for an object is not recognized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ v4.2
   - This flag is `OFF` by default. So standard builds will still observe the existing behavior (`opensim.log` is created).
 - Fix bug in visualization of EllipsoidJoint that was not attaching to the correct frame ([PR #2887] (https://github.com/opensim-org/opensim-core/pull/2887))
 - Fix bug in error reporting of sensor tracking (PR #2893)
+- Throw an exception rather than log an error message when an unrecognized type is encountered in xml/osim files (PR #2914)
+
 v4.1
 ====
 - Added `OrientationsReference` as the frame orientation analog to the location of experimental markers. Enables experimentally measured orientations from wearable sensors (e.g. from IMUs) to be tracked by reference frames in the model. A correspondence between the experimental (IMU frame) orientation column label and that of the virtual frame on the `Model` is expected. The `InverseKinematicsSolver` was extended to simultaneously track the `OrientationsReference` if provided. (PR #2412)

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -602,7 +602,9 @@ newInstanceOfType(const std::string& objectTypeTag)
     const Object* defaultObj = getDefaultInstanceOfType(objectTypeTag);
     if (defaultObj)
         return defaultObj->clone();
-
+    log_error("Object::newInstanceOfType(): object type '{}' is not a registered "
+            "Object! It will be ignored.",
+            objectTypeTag);
     throw Exception( "Object::newInstanceOfType(): object type '{}' is not a registered Object! It will be ignored.", objectTypeTag);
 
     return NULL;

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -603,8 +603,7 @@ newInstanceOfType(const std::string& objectTypeTag)
     if (defaultObj)
         return defaultObj->clone();
 
-    cerr << "Object::newInstanceOfType(): object type '" << objectTypeTag 
-         << "' is not a registered Object!" << endl;
+    throw Exception( "Object::newInstanceOfType(): object type '{}' is not a registered Object! It will be ignored.", objectTypeTag);
 
     return NULL;
 }
@@ -934,8 +933,9 @@ try {
             SimTK::Xml::element_iterator iter = propElementIter->element_begin();
             while(iter != propElementIter->element_end()){
                 // Create an Object of the element tag's type.
-                object = newInstanceOfType(iter->getElementTag());
-                if (!object) { 
+                try {
+                    object = newInstanceOfType(iter->getElementTag());
+                } catch (const Exception& ) { 
                     std::cerr << "Object type " << iter->getElementTag() << " not recognized" 
                               << std::endl; 
                     iter++; 

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -605,7 +605,9 @@ newInstanceOfType(const std::string& objectTypeTag)
     log_error("Object::newInstanceOfType(): object type '{}' is not a registered "
             "Object! It will be ignored.",
             objectTypeTag);
-    throw Exception( "Object::newInstanceOfType(): object type '{}' is not a registered Object! It will be ignored.", objectTypeTag);
+    throw Exception("Object::newInstanceOfType(): object type '{" +
+                    objectTypeTag
+                    +"}' is not a registered Object! It will be ignored.");
 
     return NULL;
 }
@@ -935,14 +937,7 @@ try {
             SimTK::Xml::element_iterator iter = propElementIter->element_begin();
             while(iter != propElementIter->element_end()){
                 // Create an Object of the element tag's type.
-                try {
-                    object = newInstanceOfType(iter->getElementTag());
-                } catch (const Exception& ) { 
-                    std::cerr << "Object type " << iter->getElementTag() << " not recognized" 
-                              << std::endl; 
-                    iter++; 
-                    continue; 
-                }
+                object = newInstanceOfType(iter->getElementTag());
                 objectsFound++;
 
                 if(type==Property_Deprecated::ObjPtr) {

--- a/OpenSim/Common/Test/obj1Bad.xml
+++ b/OpenSim/Common/Test/obj1Bad.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSimDocument Version="40000">
+	<SerializableObject name="TestObject">
+		<!--Comment on deprecated boolean-->
+		<Test_Bool>true</Test_Bool>
+		<!--Comment on deprecated Int-->
+		<Test_Int>0</Test_Int>
+		<!--Comment on deprecated Double Infinity-->
+		<Test_Infinity>Inf</Test_Infinity>
+		<!--Comment on deprecated Double-->
+		<Test_MinusInfinity>-Inf</Test_MinusInfinity>
+		<!--Comment on deprecated Double-->
+		<Test_Dbl>1.2345600000000001</Test_Dbl>
+		<!--Comment on deprecated Double-->
+		<Test_NaN>NaN</Test_NaN>
+		<!--Comment on deprecated String-->
+		<Test_Str>ABC</Test_Str>
+		<!--Comment on deprecated Object-->
+		<SerializableObject2 name="Test_Obj">
+			<!--All properties of this object have their default values.-->
+		</SerializableObject2>
+		<!--Comment on deprecated int-array-->
+		<Test_IntArray> 0 1 2 3</Test_IntArray>
+		<!--Comment on deprecated Dbl-array-->
+		<Test_DblArray> 0 1 2 3</Test_DblArray>
+		<!--Comment on deprecated str-array-->
+		<Test_StrArray> abc def ghi jkl</Test_StrArray>
+		<!--Comment on deprecated Object Array-->
+		<Test_ObjArray>
+			<SerializableObject2 name="Obj1">
+				<!--All properties of this object have their default values.-->
+			</SerializableObject2>
+			<SerializableObjectBad name="Obj2">
+				<!--All properties of this object have their default values.-->
+			</SerializableObjectBad>
+			<SerializableObject2 name="Obj3">
+				<!--All properties of this object have their default values.-->
+			</SerializableObject2>
+		</Test_ObjArray>
+		<!--Comment on deprecated Transform-->
+		<MyTransformProperty> 2 1 0.5 3 2 1</MyTransformProperty>
+		<!--deprecated Point at 3,5,7-->
+		<Test_DblVec3> 3 5 7</Test_DblVec3>
+		<!--Comment on deprecated nameless Object-->
+		<SerializableObject2>
+			<!--All properties of this object have their default values.-->
+		</SerializableObject2>
+	</SerializableObject>
+</OpenSimDocument>

--- a/OpenSim/Common/Test/obj1Defaults.xml
+++ b/OpenSim/Common/Test/obj1Defaults.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <OpenSimDocument Version="20303">
-	<rdSerializableObject name="TestObject">
+  <SerializableObject name="TestObject">
     <defaults>
-      <rdSerializableObject2 name="default">
+      <SerializableObject2 name="default">
         <Test_DblArray2>7 8 9</Test_DblArray2>
         <Test_Bool2>true</Test_Bool2>
-      </rdSerializableObject2>
+      </SerializableObject2>
     </defaults>
       <!--Comment on a boolean-->
 		<Test_Bool>true</Test_Bool>
@@ -16,10 +16,10 @@
 		<!--Comment on a String-->
 		<Test_Str>ABC</Test_Str>
 		<!--Comment on an Object-->
-		<rdSerializableObject2 name="Test_Obj">
+		<SerializableObject2 name="Test_Obj">
 			<Test_Bool2>false</Test_Bool2>
 			<Test_DblArray2> 0.1 0.1 0.1</Test_DblArray2>
-		</rdSerializableObject2>
+		</SerializableObject2>
 		<!--Comment on an int-array-->
 		<Test_IntArray> 0 1 2 3</Test_IntArray>
 		<!--Comment on a Dbl-array-->
@@ -28,17 +28,17 @@
 		<Test_StrArray> abc def ghi jkl</Test_StrArray>
 		<!--Comment on Object Array-->
 		<Test_ObjArray>
-			<rdSerializableObject2 name="Obj1">
+			<SerializableObject2 name="Obj1">
 				<Test_Bool2>false</Test_Bool2>
 				<Test_DblArray2> 0.1 0.1 0.1</Test_DblArray2>
-			</rdSerializableObject2>
-			<rdSerializableObject2 name="Obj2">
-			</rdSerializableObject2>
-			<rdSerializableObject2 name="Obj3">
+			</SerializableObject2>
+			<SerializableObject2 name="Obj2">
+			</SerializableObject2>
+			<SerializableObject2 name="Obj3">
 				<Test_Bool2>false</Test_Bool2>
 				<Test_DblArray2> 0.1 0.1 0.1</Test_DblArray2>
-			</rdSerializableObject2>
+			</SerializableObject2>
 		</Test_ObjArray>
 		<MyTransformProperty> 2 1 0.5 3 2 1</MyTransformProperty>
-	</rdSerializableObject>
+	</SerializableObject>
 </OpenSimDocument>

--- a/OpenSim/Common/Test/testSerialization.cpp
+++ b/OpenSim/Common/Test/testSerialization.cpp
@@ -379,6 +379,7 @@ int main()
         ASSERT(loc == 1);
         int notFound = objWithListProp.getProperty_list_SerializableObject().findIndexForName("Third");
         ASSERT(notFound == -1);
+        SimTK_TEST_MUST_THROW(SerializableObject bad("obj1Bad.xml"));
     }
     catch(const std::exception& e) {
         cerr << "EXCEPTION: " << e.what() << endl;

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -256,6 +256,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( JointInternalPowerProbe() );
     Object::registerType( SystemEnergyProbe() );
     Object::registerType( ActuatorForceProbe() );
+    Object::registerType( ActuatorPowerProbe() );
     Object::registerType( Umberger2010MuscleMetabolicsProbe() );
     Object::registerType( Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameterSet() );
     Object::registerType( Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameter() );

--- a/OpenSim/Tools/Test/testModelCopy.cpp
+++ b/OpenSim/Tools/Test/testModelCopy.cpp
@@ -37,6 +37,7 @@ void testCopyModel( const string& fileName, const int nbod,
 
 int main()
 {
+    LoadOpenSimLibrary("osimActuators");
     try {
 
         // Test copying a simple property.

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -32,6 +32,15 @@ using namespace std;
 
 void testPropertiesDump(const OpenSim::Object& aObject);
 
+int testUnrecognizedTypes() {
+    try {
+        Object* newObject = Object::newInstanceOfType("Unreccognized");
+    } catch (Exception& ex) { 
+        return 0;
+    }
+    return 1;
+}
+
 static void indent(int nSpaces) {
     for (int i=0; i<nSpaces; ++i) cout << " ";
 }
@@ -122,6 +131,12 @@ int main()
 
     }
     catch (const Exception& e) {
+        e.print(cerr);
+        return 1;
+    }
+    try {
+        ASSERT(testUnrecognizedTypes()==0);
+    } catch (const Exception& e) {
         e.print(cerr);
         return 1;
     }


### PR DESCRIPTION
Fixes issue #2911 

### Brief summary of changes
Throw instead of logging an error when an recognized type is found in osim/xml file

### Testing I've completed
Run the test suite

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2914)
<!-- Reviewable:end -->
