### PR TITLE
WIP: Add overload to OpenSim::Function for unary callers

### DIFF
--- a/Applications/Scale/test/testScale.cpp
+++ b/Applications/Scale/test/testScale.cpp
@@ -697,9 +697,9 @@ void scaleJointsAndConstraints()
         transform[3].setFunction(new LinearFunction(1.234, 5.678));
 
         // Evaluate LinearFunction before scaling and compare after scaling.
-        const Vector xA = Vector(1, 0.);
+        const double xA = 0.0;
         const double yA = transform[3].getFunction().calcValue(xA);
-        const Vector xB = Vector(1, 123.456);
+        const double xB = 123.456;
         const double yB = transform[3].getFunction().calcValue(xB);
 
         CustomJoint* custom1 =

--- a/OpenSim/Actuators/RigidTendonMuscle.cpp
+++ b/OpenSim/Actuators/RigidTendonMuscle.cpp
@@ -138,11 +138,10 @@ calcMuscleLengthInfo(const State& s, MuscleLengthInfo& mli) const
     mli.pennationAngle = acos(mli.cosPennationAngle);
     mli.normFiberLength = mli.fiberLength/getOptimalFiberLength();
 
-    const Vector arg(1, mli.normFiberLength);
     mli.fiberActiveForceLengthMultiplier = 
-        get_active_force_length_curve().calcValue(arg);
+        get_active_force_length_curve().calcValue(mli.normFiberLength);
     mli.fiberPassiveForceLengthMultiplier = 
-        SimTK::clamp(0, get_passive_force_length_curve().calcValue(arg), 10);
+        SimTK::clamp(0, get_passive_force_length_curve().calcValue(mli.normFiberLength), 10);
 
     mli.normTendonLength = 1.0;
     mli.tendonStrain = 0.0;
@@ -165,7 +164,7 @@ void RigidTendonMuscle::calcFiberVelocityInfo(const State& s, FiberVelocityInfo&
     fvi.normFiberVelocity = fvi.fiberVelocity / 
                             (getOptimalFiberLength()*getMaxContractionVelocity());
     fvi.fiberForceVelocityMultiplier = 
-        get_force_velocity_curve().calcValue(Vector(1, fvi.normFiberVelocity));
+        get_force_velocity_curve().calcValue(fvi.normFiberVelocity);
 }
 
 /* calculate muscle's active and passive force-length, force-velocity, 
@@ -219,13 +218,12 @@ double RigidTendonMuscle::computeActuation(const State& s) const
 
 double RigidTendonMuscle::computeIsometricForce(State& s, double activation) const
 {
-    const double &aNormFiberLength = getNormalizedFiberLength(s);
+    const double aNormFiberLength = getNormalizedFiberLength(s);
 
-    const Vector arg(1, aNormFiberLength);
     double activeForceLength = 
-        get_active_force_length_curve().calcValue(arg);
+        get_active_force_length_curve().calcValue(aNormFiberLength);
     double passiveForceLength = 
-        get_passive_force_length_curve().calcValue(arg);
+        get_passive_force_length_curve().calcValue(aNormFiberLength);
 
     // Isometric means velocity is zero, so velocity "factor" is 1
     return (activation*activeForceLength + passiveForceLength)

--- a/OpenSim/Actuators/Schutte1993Muscle_Deprecated.cpp
+++ b/OpenSim/Actuators/Schutte1993Muscle_Deprecated.cpp
@@ -221,7 +221,7 @@ double Schutte1993Muscle_Deprecated::computeActuation(const SimTK::State& s) con
 
     tendonForce = calcTendonForce(s,norm_tendon_length);
     passiveForce =  calcNonzeroPassiveForce(s,normFiberLength, 0.0);
-    activeForce = getActiveForceLengthCurve().calcValue(SimTK::Vector(1, normFiberLength) );
+    activeForce = getActiveForceLengthCurve().calcValue(normFiberLength);
     if (activeForce < 0.0) activeForce = 0.0;
 
    /* If pennation equals 90 degrees, fiber length equals muscle width and fiber
@@ -353,7 +353,7 @@ double Schutte1993Muscle_Deprecated::calcTendonForce(const SimTK::State& s, doub
    if (tendon_strain < 0.0)
       tendon_force = 0.0;
    else
-      tendon_force = getTendonForceLengthCurve().calcValue(SimTK::Vector(1, tendon_strain));
+      tendon_force = getTendonForceLengthCurve().calcValue(tendon_strain);
 
    return tendon_force;
 }
@@ -379,7 +379,7 @@ double Schutte1993Muscle_Deprecated::calcNonzeroPassiveForce(const SimTK::State&
    if (getProperty_passive_force_length_curve().getValueIsDefault())
        flcomponent = exp(8.0*(aNormFiberLength - 1.0)) / exp(4.0);
    else
-       flcomponent = getPassiveForceLengthCurve().calcValue(SimTK::Vector(1, aNormFiberLength) );
+       flcomponent = getPassiveForceLengthCurve().calcValue(aNormFiberLength);
    return flcomponent + get_damping() * aNormFiberVelocity;
 }
 
@@ -477,7 +477,7 @@ double Schutte1993Muscle_Deprecated::computeIsometricForce(SimTK::State& s, doub
       cos_factor = cos(atan(muscle_width / length));
       fiberLength = length / cos_factor;
 
-        activeForce =  getActiveForceLengthCurve().calcValue(SimTK::Vector(1, fiberLength / _optimalFiberLength)) * aActivation * _maxIsometricForce;
+        activeForce =  getActiveForceLengthCurve().calcValue(fiberLength / _optimalFiberLength) * aActivation * _maxIsometricForce;
        if (activeForce < 0.0) activeForce = 0.0;
 
         passiveForce = calcNonzeroPassiveForce(s, fiberLength / _optimalFiberLength, 0.0) * _maxIsometricForce;
@@ -517,7 +517,7 @@ double Schutte1993Muscle_Deprecated::computeIsometricForce(SimTK::State& s, doub
    // ERROR_LIMIT of each other), stop; else change the length guesses based
    // on the error and try again.
    for (i = 0; i < MAX_ITERATIONS; i++) {
-        activeForce = getActiveForceLengthCurve().calcValue(SimTK::Vector(1, fiberLength / _optimalFiberLength)) * aActivation;
+        activeForce = getActiveForceLengthCurve().calcValue(fiberLength / _optimalFiberLength) * aActivation;
       if (activeForce < 0.0) activeForce = 0.0;
 
         passiveForce = calcNonzeroPassiveForce(s, fiberLength / _optimalFiberLength, 0.0);
@@ -529,7 +529,7 @@ double Schutte1993Muscle_Deprecated::computeIsometricForce(SimTK::State& s, doub
       if (tendon_strain < 0.0)
          tendon_force = 0.0;
       else
-         tendon_force = getTendonForceLengthCurve().calcValue(SimTK::Vector(1, tendon_strain)) * _maxIsometricForce;
+         tendon_force = getTendonForceLengthCurve().calcValue(tendon_strain) * _maxIsometricForce;
       setActuation(s, tendon_force);
       setTendonForce(s, tendon_force);
 
@@ -561,7 +561,7 @@ double Schutte1993Muscle_Deprecated::computeIsometricForce(SimTK::State& s, doub
             double tendon_elastic_modulus = 1200.0;
             double tendon_max_stress = 32.0;
 
-         tendon_stiffness = getTendonForceLengthCurve().calcValue(SimTK::Vector(1, tendon_strain)) *
+         tendon_stiffness = getTendonForceLengthCurve().calcValue(tendon_strain) *
                 _maxIsometricForce / _tendonSlackLength;
 
          min_tendon_stiffness = (activeForce + passiveForce) *
@@ -572,7 +572,7 @@ double Schutte1993Muscle_Deprecated::computeIsometricForce(SimTK::State& s, doub
             tendon_stiffness = min_tendon_stiffness;
 
          fiber_stiffness = _maxIsometricForce / _optimalFiberLength *
-             (getActiveForceLengthCurve().calcValue(SimTK::Vector(1, fiberLength / _optimalFiberLength))  +
+             (getActiveForceLengthCurve().calcValue(fiberLength / _optimalFiberLength)  +
             calcNonzeroPassiveForce(s, fiberLength / _optimalFiberLength, 0.0));
 
          // determine how much the fiber and tendon lengths have to
@@ -623,5 +623,5 @@ double Schutte1993Muscle_Deprecated::calcPassiveForce(const SimTK::State& s, dou
 }
 double Schutte1993Muscle_Deprecated::calcActiveForce(const SimTK::State& s, double aNormFiberLength) const
 {
-    return getActiveForceLengthCurve().calcValue(SimTK::Vector(1, aNormFiberLength) );
+    return getActiveForceLengthCurve().calcValue(aNormFiberLength);
 }

--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -117,7 +117,7 @@ SimTK::Vector OpenSim::interpolate(const SimTK::Vector& x,
     for (int i = 0; i < newX.size(); ++i) {
         const auto& newXi = newX[i];
         if (x_no_nans[0] <= newXi && newXi <= x_no_nans[x_no_nans.size() - 1])
-            newY[i] = function.calcValue(SimTK::Vector(1, newXi));
+            newY[i] = function.calcValueUnary(newXi);
     }
     return newY;
 }

--- a/OpenSim/Common/Function.h
+++ b/OpenSim/Common/Function.h
@@ -118,6 +118,24 @@ public:
     }
 
     /**
+     * Calculate the value of this function at a given point.
+     *
+     * This assumes that this function object represents a unary function.
+     *
+     * @param v The input argument
+     * @return The value of the function at `v`
+     */
+    double calcValueUnary(double v) const {
+        // this differently-named overload exists because of "name hiding",
+        // which C++ applies when derived classes override base methods.
+        //
+        // see:
+        // - https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
+        // - https://isocpp.org/wiki/faq/strange-inheritance#overload-derived
+        return calcValue(v);
+    }
+
+    /**
      * Calculate a partial derivative of this function at a particular point.  Which derivative to take is specified
      * by listing the input components with which to take it.  For example, if derivComponents=={0}, that indicates
      * a first derivative with respective to component 0.  If derivComponents=={0, 0, 0}, that indicates a third

--- a/OpenSim/Common/Function.h
+++ b/OpenSim/Common/Function.h
@@ -102,6 +102,21 @@ public:
      *          its size must equal the value returned by getArgumentSize().
      */
     virtual double calcValue(const SimTK::Vector& x) const;
+
+    /**
+     * Calculate the value of this function at a given point.
+     *
+     * This assumes that this function object represents a unary function.
+     *
+     * @param v The input argument
+     * @return The value of the function at `v`
+     */
+    double calcValue(double v) const {
+        thread_local SimTK::Vector scratch(1);
+        scratch[0] = v;
+        return calcValue(scratch);
+    }
+
     /**
      * Calculate a partial derivative of this function at a particular point.  Which derivative to take is specified
      * by listing the input components with which to take it.  For example, if derivComponents=={0}, that indicates

--- a/OpenSim/Common/FunctionSet.cpp
+++ b/OpenSim/Common/FunctionSet.cpp
@@ -144,7 +144,7 @@ evaluate(Array<double> &rValues,int aDerivOrder,double aX) const
     for(i=0;i<size;i++) {
         Function& func = get(i);
         if (aDerivOrder==0)
-            rValues[i] = func.calcValue(SimTK::Vector(1,aX));
+            rValues[i] = func.calcValue(aX);
         else {
             std::vector<int> derivComponents;
             for(int j=0; j<aDerivOrder; j++)

--- a/OpenSim/Common/PiecewiseConstantFunction.cpp
+++ b/OpenSim/Common/PiecewiseConstantFunction.cpp
@@ -184,7 +184,7 @@ void PiecewiseConstantFunction::init(Function* aFunction)
                   double x[2] = {0.0, 1.0}, y[2];
                   Constant* cons = dynamic_cast<Constant*>(aFunction);
                   if (cons != NULL) {
-                      y[0] = y[1] = cons->calcValue(SimTK::Vector(1, 0.));
+                      y[0] = y[1] = cons->calcValueUnary(0.0);
                   } else {
                       y[0] = y[1] = 1.0;
                   }

--- a/OpenSim/Common/SignalGenerator.cpp
+++ b/OpenSim/Common/SignalGenerator.cpp
@@ -36,5 +36,5 @@ void SignalGenerator::constructProperties() {
 }
 
 double SignalGenerator::getSignal(const SimTK::State& s) const {
-    return get_function().calcValue(SimTK::Vector(1, s.getTime()));
+    return get_function().calcValue(s.getTime());
 }

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -3352,8 +3352,7 @@ double Storage::compareColumnRMS(const Storage& aOtherStorage, const std::string
     double rms = 0.;
 
     for(int i = startIndex; i <= endIndex; i++) {
-        SimTK::Vector inputTime(1, thisTime[i]);
-        double diff = thisData[i] - spline.calcValue(inputTime);
+        double diff = thisData[i] - spline.calcValue(thisTime[i]);
         rms += diff * diff;
     }
 

--- a/OpenSim/Common/TableUtilities.cpp
+++ b/OpenSim/Common/TableUtilities.cpp
@@ -248,15 +248,15 @@ TimeSeriesTable TableUtilities::resample(
 
     std::unique_ptr<FunctionSet> functions =
             createFunctionSet<FunctionType>(in);
-    SimTK::Vector curTime(1);
     SimTK::RowVector row(functions->getSize());
+    double curTime = 0.0;
     for (int itime = 0; itime < (int)newTime.size(); ++itime) {
-        curTime[0] = newTime[itime];
+        curTime = newTime[itime];
         for (int icol = 0; icol < functions->getSize(); ++icol) {
             row(icol) = functions->get(icol).calcValue(curTime);
         }
         // Not efficient!
-        out.appendRow(curTime[0], row);
+        out.appendRow(curTime, row);
     }
     return out;
 }

--- a/OpenSim/Common/XYFunctionInterface.cpp
+++ b/OpenSim/Common/XYFunctionInterface.cpp
@@ -433,18 +433,18 @@ Array<XYPoint>* XYFunctionInterface::renderAsLineSegments(int aIndex)
         int numSegs = 20;
         for (int i=0; i<numSegs-1; i++) {
             double xValue = x[aIndex] + (double)i * (x[aIndex + 1] - x[aIndex]) / ((double)numSegs - 1.0);
-            xyPts->append(XYPoint(xValue, _natCubicSpline->calcValue(SimTK::Vector(1,xValue)) * _scaleFactor));
+            xyPts->append(XYPoint(xValue, _natCubicSpline->calcValueUnary(xValue) * _scaleFactor));
         }
-        xyPts->append(XYPoint(x[aIndex + 1], _natCubicSpline->calcValue(SimTK::Vector(1,x[aIndex+1])) * _scaleFactor));
+        xyPts->append(XYPoint(x[aIndex + 1], _natCubicSpline->calcValueUnary(x[aIndex+1]) * _scaleFactor));
     } else if (_functionType == typeGCVSpline) {
         // X sometimes goes slightly beyond the range due to roundoff error,
         // so do the last point separately.
         int numSegs = 20;
         for (int i=0; i<numSegs-1; i++) {
             double xValue = x[aIndex] + (double)i * (x[aIndex + 1] - x[aIndex]) / ((double)numSegs - 1.0);
-            xyPts->append(XYPoint(xValue, _gcvSpline->calcValue(SimTK::Vector(1,xValue)) * _scaleFactor));
+            xyPts->append(XYPoint(xValue, _gcvSpline->calcValue(xValue) * _scaleFactor));
         }
-        xyPts->append(XYPoint(x[aIndex + 1], _gcvSpline->calcValue(SimTK::Vector(1,x[aIndex + 1])) * _scaleFactor));
+        xyPts->append(XYPoint(x[aIndex + 1], _gcvSpline->calcValue(x[aIndex + 1]) * _scaleFactor));
     } else if (_functionType == typePiecewiseConstantFunction)  {
         xyPts->append(XYPoint(x[aIndex], y[aIndex]));
         xyPts->append(XYPoint(x[aIndex], y[aIndex+1]));

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -165,10 +165,9 @@ void PrescribedController::extendConnectToModel(Model& model)
 void PrescribedController::computeControls(const SimTK::State& s, SimTK::Vector& controls) const
 {
     SimTK::Vector actControls(1, 0.0);
-    SimTK::Vector time(1, s.getTime());
 
     for(int i=0; i<getActuatorSet().getSize(); i++){
-        actControls[0] = get_ControlFunctions()[i].calcValue(time);
+        actControls[0] = get_ControlFunctions()[i].calcValue(s.getTime());
         getActuatorSet()[i].addInControls(actControls, controls);
     }  
 }

--- a/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.cpp
+++ b/OpenSim/Simulation/Model/Bhargava2004MuscleMetabolicsProbe.cpp
@@ -331,8 +331,8 @@ computeProbeInputs(const State& s) const
         // ------------------------------------------
         if (get_forbid_negative_total_power() || get_maintenance_rate_on())
         {
-            Vector tmp(1, fiber_length_normalized);
-            fiber_length_dependence = get_normalized_fiber_length_dependence_on_maintenance_rate().calcValue(tmp);
+            fiber_length_dependence =
+                get_normalized_fiber_length_dependence_on_maintenance_rate().calcValueUnary(fiber_length_normalized);
             
             Mdot = mm.getMuscleMass() * fiber_length_dependence * 
                 ( (mm.get_maintenance_constant_slow_twitch() * slow_twitch_excitation) + (mm.get_maintenance_constant_fast_twitch() * fast_twitch_excitation) );

--- a/OpenSim/Simulation/Model/ExternalForce.cpp
+++ b/OpenSim/Simulation/Model/ExternalForce.cpp
@@ -359,47 +359,59 @@ void ExternalForce::computeForce(const SimTK::State& state,
  */
 Vec3 ExternalForce::getForceAtTime(double aTime) const  
 {
-    SimTK::Vector timeAsVector(1, aTime);
-    const Function* forceX=NULL;
-    const Function* forceY=NULL;
-    const Function* forceZ=NULL;
-    if (_forceFunctions.size()==3){
-        forceX=_forceFunctions[0];  forceY=_forceFunctions[1];  forceZ=_forceFunctions[2];
+    const Function* forceX = nullptr;
+    const Function* forceY = nullptr;
+    const Function* forceZ = nullptr;
+
+    if (_forceFunctions.size() == 3) {
+        forceX = _forceFunctions[0];
+        forceY = _forceFunctions[1];
+        forceZ = _forceFunctions[2];
     }
-    Vec3 force(forceX?forceX->calcValue(timeAsVector):0.0, 
-        forceY?forceY->calcValue(timeAsVector):0.0, 
-        forceZ?forceZ->calcValue(timeAsVector):0.0);
-    return force;
+
+    return Vec3{
+        forceX ? forceX->calcValue(aTime) : 0.0,
+        forceY ? forceY->calcValue(aTime) : 0.0,
+        forceZ ? forceZ->calcValue(aTime) : 0.0,
+    };
 }
 
 Vec3 ExternalForce::getPointAtTime(double aTime) const
 {
-    SimTK::Vector timeAsVector(1, aTime);
-    const Function* pointX=NULL;
-    const Function* pointY=NULL;
-    const Function* pointZ=NULL;
-    if (_pointFunctions.size()==3){
-        pointX=_pointFunctions[0];  pointY=_pointFunctions[1];  pointZ=_pointFunctions[2];
+    const Function* pointX = nullptr;
+    const Function* pointY = nullptr;
+    const Function* pointZ = nullptr;
+
+    if (_pointFunctions.size() == 3) {
+        pointX = _pointFunctions[0];
+        pointY = _pointFunctions[1];
+        pointZ = _pointFunctions[2];
     }
-    Vec3 point(pointX?pointX->calcValue(timeAsVector):0.0, 
-        pointY?pointY->calcValue(timeAsVector):0.0, 
-        pointZ?pointZ->calcValue(timeAsVector):0.0);
-    return point;
+
+    return Vec3{
+        pointX ? pointX->calcValue(aTime) : 0.0,
+        pointY ? pointY->calcValue(aTime) : 0.0,
+        pointZ ? pointZ->calcValue(aTime) : 0.0,
+    };
 }
 
 Vec3 ExternalForce::getTorqueAtTime(double aTime) const
 {
-    SimTK::Vector timeAsVector(1, aTime);
-    const Function* torqueX=NULL;
-    const Function* torqueY=NULL;
-    const Function* torqueZ=NULL;
-    if (_torqueFunctions.size()==3){
-        torqueX=_torqueFunctions[0];    torqueY=_torqueFunctions[1];    torqueZ=_torqueFunctions[2];
+    const Function* torqueX = nullptr;
+    const Function* torqueY = nullptr;
+    const Function* torqueZ = nullptr;
+
+    if (_torqueFunctions.size()==3) {
+        torqueX = _torqueFunctions[0];
+        torqueY = _torqueFunctions[1];
+        torqueZ = _torqueFunctions[2];
     }
-    Vec3 torque(torqueX?torqueX->calcValue(timeAsVector):0.0, 
-        torqueY?torqueY->calcValue(timeAsVector):0.0, 
-        torqueZ?torqueZ->calcValue(timeAsVector):0.0);
-    return torque;
+
+    return Vec3(
+        torqueX ? torqueX->calcValue(aTime) : 0.0,
+        torqueY ? torqueY->calcValue(aTime) : 0.0,
+        torqueZ ? torqueZ->calcValue(aTime) : 0.0
+    );
 }
 
 

--- a/OpenSim/Simulation/Model/FunctionThresholdCondition.cpp
+++ b/OpenSim/Simulation/Model/FunctionThresholdCondition.cpp
@@ -154,7 +154,7 @@ FunctionThresholdCondition& FunctionThresholdCondition::operator=(const Function
 //-----------------------------------------------------------------------------
 bool FunctionThresholdCondition::calcCondition(const SimTK::State& s) const
 {
-    return (_function->calcValue(SimTK::Vector(1, s.getTime())) > _threshold);
+    return _function->calcValue(s.getTime()) > _threshold;
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/Ligament.cpp
+++ b/OpenSim/Simulation/Model/Ligament.cpp
@@ -239,8 +239,8 @@ void Ligament::computeForce(const SimTK::State& s,
     }
     
     // evaluate normalized tendon force length curve
-    force = getForceLengthCurve().calcValue(
-        SimTK::Vector(1, path.getLength(s)/restingLength))* pcsaForce;
+    force = getForceLengthCurve()
+        .calcValue(path.getLength(s)/restingLength) * pcsaForce;
     setCacheVariableValue(s, _tensionCV, force);
 
     OpenSim::Array<PointForceDirection*> PFDs;

--- a/OpenSim/Simulation/Model/MovingPathPoint.cpp
+++ b/OpenSim/Simulation/Model/MovingPathPoint.cpp
@@ -220,28 +220,28 @@ SimTK::Vec3 MovingPathPoint::getLocation(const SimTK::State& s) const
         const double xval = SimTK::clamp(_xCoordinate->getRangeMin(),
             _xCoordinate->getValue(s),
             _xCoordinate->getRangeMax());
-        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, xval));
+        pInF[0] = get_x_location().calcValue(xval);
     }
     else // assume a Constant
-        pInF[0] = get_x_location().calcValue(SimTK::Vector(1, 0.0));
+        pInF[0] = get_x_location().calcValue(0.0);
 
     if (!_yCoordinate.empty()) {
         const double yval = SimTK::clamp(_yCoordinate->getRangeMin(),
             _yCoordinate->getValue(s),
             _yCoordinate->getRangeMax());
-        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, yval));
+        pInF[1] = get_y_location().calcValue(yval);
     }
     else // type == Constant
-        pInF[1] = get_y_location().calcValue(SimTK::Vector(1, 0.0));
+        pInF[1] = get_y_location().calcValue(0.0);
 
     if (!_zCoordinate.empty()) {
         const double zval = SimTK::clamp(_zCoordinate->getRangeMin(),
             _zCoordinate->getValue(s),
             _zCoordinate->getRangeMax());
-        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, zval));
+        pInF[2] = get_z_location().calcValue(zval);
     }
     else // type == Constant
-        pInF[2] = get_z_location().calcValue(SimTK::Vector(1, 0.0));
+        pInF[2] = get_z_location().calcValue(0.0);
 
     return pInF;
 }

--- a/OpenSim/Simulation/Model/PrescribedForce.cpp
+++ b/OpenSim/Simulation/Model/PrescribedForce.cpp
@@ -251,7 +251,6 @@ void PrescribedForce::computeForce(const SimTK::State& state,
     const FunctionSet& torqueFunctions = getTorqueFunctions();
 
     double time = state.getTime();
-    SimTK::Vector  timeAsVector(1, time);
 
     const bool hasForceFunctions  = forceFunctions.getSize()==3;
     const bool hasPointFunctions  = pointFunctions.getSize()==3;
@@ -261,18 +260,18 @@ void PrescribedForce::computeForce(const SimTK::State& state,
         getSocket<PhysicalFrame>("frame").getConnectee();
     const Ground& gnd = getModel().getGround();
     if (hasForceFunctions) {
-        Vec3 force(forceFunctions[0].calcValue(timeAsVector), 
-                   forceFunctions[1].calcValue(timeAsVector), 
-                   forceFunctions[2].calcValue(timeAsVector));
+        Vec3 force(forceFunctions[0].calcValue(time),
+                   forceFunctions[1].calcValue(time),
+                   forceFunctions[2].calcValue(time));
         if (!forceIsGlobal)
             force = frame.expressVectorInAnotherFrame(state, force, gnd);
 
         Vec3 point(0); // Default is body origin.
         if (hasPointFunctions) {
             // Apply force to a specified point on the body.
-            point = Vec3(pointFunctions[0].calcValue(timeAsVector), 
-                         pointFunctions[1].calcValue(timeAsVector), 
-                         pointFunctions[2].calcValue(timeAsVector));
+            point = Vec3(pointFunctions[0].calcValue(time),
+                         pointFunctions[1].calcValue(time),
+                         pointFunctions[2].calcValue(time));
             if (pointIsGlobal)
                 point = gnd.findStationLocationInAnotherFrame(state, point, frame);
 
@@ -280,9 +279,9 @@ void PrescribedForce::computeForce(const SimTK::State& state,
         applyForceToPoint(state, frame, point, force, bodyForces);
     }
     if (hasTorqueFunctions){
-        Vec3 torque(torqueFunctions[0].calcValue(timeAsVector), 
-                    torqueFunctions[1].calcValue(timeAsVector), 
-                    torqueFunctions[2].calcValue(timeAsVector));
+        Vec3 torque(torqueFunctions[0].calcValue(time),
+                    torqueFunctions[1].calcValue(time),
+                    torqueFunctions[2].calcValue(time));
         if (!forceIsGlobal)
             torque = frame.expressVectorInAnotherFrame(state, torque, gnd);
 
@@ -300,10 +299,9 @@ Vec3 PrescribedForce::getForceAtTime(double aTime) const
     if (forceFunctions.getSize() != 3)
         return Vec3(0);
 
-    const SimTK::Vector timeAsVector(1, aTime);
-    const Vec3 force(forceFunctions[0].calcValue(timeAsVector), 
-                     forceFunctions[1].calcValue(timeAsVector), 
-                     forceFunctions[2].calcValue(timeAsVector));
+    const Vec3 force(forceFunctions[0].calcValue(aTime),
+                     forceFunctions[1].calcValue(aTime),
+                     forceFunctions[2].calcValue(aTime));
     return force;
 }
 
@@ -314,10 +312,9 @@ Vec3 PrescribedForce::getPointAtTime(double aTime) const
     if (pointFunctions.getSize() != 3)
         return Vec3(0);
 
-    const SimTK::Vector timeAsVector(1, aTime);
-    const Vec3 point(pointFunctions[0].calcValue(timeAsVector), 
-                     pointFunctions[1].calcValue(timeAsVector), 
-                     pointFunctions[2].calcValue(timeAsVector));
+    const Vec3 point(pointFunctions[0].calcValue(aTime),
+                     pointFunctions[1].calcValue(aTime),
+                     pointFunctions[2].calcValue(aTime));
     return point;
 }
 
@@ -328,10 +325,9 @@ Vec3 PrescribedForce::getTorqueAtTime(double aTime) const
     if (torqueFunctions.getSize() != 3)
         return Vec3(0);
 
-    const SimTK::Vector timeAsVector(1, aTime);
-    const Vec3 torque(torqueFunctions[0].calcValue(timeAsVector), 
-                      torqueFunctions[1].calcValue(timeAsVector), 
-                      torqueFunctions[2].calcValue(timeAsVector));
+    const Vec3 torque(torqueFunctions[0].calcValue(aTime),
+                      torqueFunctions[1].calcValue(aTime),
+                      torqueFunctions[2].calcValue(aTime));
     return torque;
 }
 

--- a/OpenSim/Tools/CMC_Joint.cpp
+++ b/OpenSim/Tools/CMC_Joint.cpp
@@ -254,13 +254,13 @@ computeErrors(const SimTK::State& s, double aT)
     //std::cout<<_coordinateName<<std::endl;
     //std::cout<<"_pTrk[0]->calcValue(aT) = "<< _pTrk[0]->calcValue(SimTK::Vector(1, aT)) <<std::endl;
     //std::cout<<"_q->getValue(s) = "<<_q->getValue(s)<<std::endl;
-    _pErr[0] = _pTrk[0]->calcValue(SimTK::Vector(1,aT)) - _q->getValue(s);
+    _pErr[0] = _pTrk[0]->calcValue(aT) - _q->getValue(s);
     if(_vTrk[0]==NULL) {
         std::vector<int> derivComponents(1);
         derivComponents[0]=0;
         _vErr[0] = _pTrk[0]->calcDerivative(derivComponents,SimTK::Vector(1,aT)) - _q->getSpeedValue(s);
     } else {
-        _vErr[0] = _vTrk[0]->calcValue(SimTK::Vector(1,aT)) - _q->getSpeedValue(s);
+        _vErr[0] = _vTrk[0]->calcValue(aT) - _q->getSpeedValue(s);
     }
 }
 //_____________________________________________________________________________
@@ -295,7 +295,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aT)
         derivComponents[1]=0;
         a = (_ka)[0]*_pTrk[0]->calcDerivative(derivComponents,SimTK::Vector(1,aT));
     } else {
-        a = (_ka)[0]*_aTrk[0]->calcValue(SimTK::Vector(1,aT));
+        a = (_ka)[0]*_aTrk[0]->calcValue(aT);
     }
     _aDes[0] = a + v + p;
 
@@ -337,7 +337,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aTI,double aTF)
         derivComponents[1]=0;
         a = (_ka)[0]*_pTrk[0]->calcDerivative(derivComponents,SimTK::Vector(1,aTF));
     } else {
-        a = (_ka)[0]*_aTrk[0]->calcValue(SimTK::Vector(1,aTF));
+        a = (_ka)[0]*_aTrk[0]->calcValue(aTF);
     }
     _aDes[0] = a + v + p;
 

--- a/OpenSim/Tools/CMC_Point.cpp
+++ b/OpenSim/Tools/CMC_Point.cpp
@@ -272,13 +272,13 @@ computeErrors(const SimTK::State& s, double aT)
     if(_expressBodyName == "ground") {
 
         for(int i=0;i<3;i++) {
-            _inertialPTrk[i] = _pTrk[i]->calcValue(SimTK::Vector(1,aT));
+            _inertialPTrk[i] = _pTrk[i]->calcValue(aT);
             if(_vTrk[i]==NULL) {
                 std::vector<int> derivComponents(1);
                 derivComponents[0]=0;
                 _inertialVTrk[i] = _pTrk[i]->calcDerivative(derivComponents,SimTK::Vector(1,aT));
             } else {
-                _inertialVTrk[i] = _vTrk[i]->calcValue(SimTK::Vector(1,aT));
+                _inertialVTrk[i] = _vTrk[i]->calcValue(aT);
             }
         }
 
@@ -289,14 +289,14 @@ computeErrors(const SimTK::State& s, double aT)
         SimTK::Vec3 pVec,vVec,origin;
 
         for(int i=0;i<3;i++) {
-            pVec(i) = _pTrk[i]->calcValue(SimTK::Vector(1,aT));
+            pVec(i) = _pTrk[i]->calcValue(aT);
         }
         _inertialPTrk = _expressBody->findStationLocationInGround(s, pVec);
         if(_vTrk[0]==NULL) {
             _inertialVTrk = _expressBody->findStationVelocityInGround(s, pVec);
         } else {
             for(int i=0;i<3;i++) {
-                vVec(i) = _vTrk[i]->calcValue(SimTK::Vector(1,aT));
+                vVec(i) = _vTrk[i]->calcValue(aT);
             }
             _inertialVTrk = _expressBody->findStationVelocityInGround(s, origin); // get velocity of _expressBody origin in inertial frame
             _inertialVTrk += vVec; // _vTrk is velocity in _expressBody, so it is simply added to velocity of _expressBody origin in inertial frame
@@ -353,7 +353,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aT)
             derivComponents[1]=0;
             a = (_ka)[0]*_pTrk[i]->calcDerivative(derivComponents,SimTK::Vector(1,aT));
         } else {
-            a = (_ka)[0]*_aTrk[i]->calcValue(SimTK::Vector(1,aT));
+            a = (_ka)[0]*_aTrk[i]->calcValue(aT);
         }
         _aDes[i] = a + v + p;
     }
@@ -398,7 +398,7 @@ computeDesiredAccelerations(const SimTK::State& s, double aTI,double aTF)
             derivComponents[1]=0;
             a = (_ka)[0]*_pTrk[i]->calcDerivative(derivComponents,SimTK::Vector(1,aTF));
         } else {
-            a = (_ka)[0]*_aTrk[i]->calcValue(SimTK::Vector(1,aTF));
+            a = (_ka)[0]*_aTrk[i]->calcValue(aTF);
         }
         _aDes[i] = a + v + p;
     }

--- a/OpenSim/Tools/CMC_Task.cpp
+++ b/OpenSim/Tools/CMC_Task.cpp
@@ -679,7 +679,7 @@ getTaskPosition(int aWhich,double aT) const
         string msg = "CMC_Task: ERR- Invalid task.";
         throw( Exception(msg,__FILE__,__LINE__) );
     }
-    double position = _pTrk[aWhich]->calcValue(SimTK::Vector(1,aT));
+    double position = _pTrk[aWhich]->calcValue(aT);
     return(position);
 }
 //_____________________________________________________________________________
@@ -701,7 +701,7 @@ getTaskVelocity(int aWhich,double aT) const
 
     double velocity;
     if(_vTrk[aWhich]!=NULL) {
-        velocity = _vTrk[aWhich]->calcValue(SimTK::Vector(1,aT));
+        velocity = _vTrk[aWhich]->calcValue(aT);
     } else {
         std::vector<int> derivComponents(1);
         derivComponents[0]=0;
@@ -728,7 +728,7 @@ getTaskAcceleration(int aWhich,double aT) const
 
     double acceleration;
     if(_aTrk[aWhich]!=NULL) {
-        acceleration = _aTrk[aWhich]->calcValue(SimTK::Vector(1,aT));
+        acceleration = _aTrk[aWhich]->calcValue(aT);
     } else {
         std::vector<int> derivComponents(2);
         derivComponents[0]=0;

--- a/OpenSim/Tools/SMC_Joint.cpp
+++ b/OpenSim/Tools/SMC_Joint.cpp
@@ -182,7 +182,7 @@ computeDesiredAccelerations( const SimTK::State& state, double aT)
         derivComponents[1]=0;
         a = (_ka)[0]*_pTrk[0]->calcDerivative(derivComponents,SimTK::Vector(1,aT));
     } else {
-        a = (_ka)[0]*_aTrk[0]->calcValue(SimTK::Vector(1,aT));
+        a = (_ka)[0]*_aTrk[0]->calcValue(aT);
     }
 
     // Surface Error

--- a/OpenSim/Tools/StateTrackingTask.h
+++ b/OpenSim/Tools/StateTrackingTask.h
@@ -96,7 +96,7 @@ public:
             val = forceSet.getStateVariableValue(s, getName());
         }
 
-        return (_pTrk[0]->calcValue(SimTK::Vector(1,s.getTime()))- val);
+        return (_pTrk[0]->calcValue(s.getTime())- val);
     }
     /**
      * Return the gradient of the tracking error as a vector, whose length 


### PR DESCRIPTION
Not a fundamental change, nor a necessary one, nor a large performance increase (yet ;)). This is just an idea I'm bouncing around.

# Overview 

`OpenSim::Function` provides an API for a function that accepts n `double`s and returns a single `double`:

```c++
    /**
     * Calculate the value of this function at a particular point.
     *
     * @param x the Vector of input arguments.
     *          its size must equal the value returned by getArgumentSize().
     */
    virtual double calcValue(const SimTK::Vector& x) const;
```

Which is conceptually fine, but has a few annoying design issues:

- It accepts a `SimTK::Vector`, rather than (e.g.) a `span`-like object or pointer range. 
  - The caller's *actual* requirements (imho) are that it is provided `n` `doubles` that are contiguous in memory. 
  - A `SimTK::Vector` introduces the concept of dynamic memory allocation + resizable/appendable sequences to an API that ultimately just wants a non-mutating contiguous view of `n` `double`s
  - This means that the arguments *must* be heap-allocated in a `SimTK::Vector`. Arguments can't be provided (e.g.) via the stack.
- It's the caller's responsibility to allocate + populate this memory
  - A caller *must* provide the vector by writing (e.g.) `function.calcValue(SimTK::Vector(1, val))` (or similar)
  - So the caller, rather than the API, is responsible for constructing the argument's representation in memory. This ultimately means that almost all callers in OpenSim end up containing (e.g.) `SimTK::Vector(1, val)` at the call site
  - This design might be useful if a caller is calling a function with the same argument pack over and over (because a caller could then construct the arguments once and recycle them). It's also our legacy behavior, so the existing API should remain
  - However, *most* callers are calling the function in a one-off manner, so the API should *also* provide a way of having standard calling conventions - even if the initial implementation of that API does exactly the same thing that the callers were doing before it (`SimTK::Vector(n, args...)`). It would still be beneficial because it moves a common pattern into one place (`OpenSim::Function`) rather than it spreading to all callsites

So an ideal API would look like this:

```c++
f.calcValue(1.0);
g.calcValue(1.0, 2.0, 3.0);
```

Which is possible, but might need to also provide (e.g.) `calcValueUnary` or `calcValueT` (or similar) because of how overload name hiding works ("legacy" inheritors of `OpenSim::Function` will virtual-implement the "legacy" overload that takes a `SimTK::Vector const&` but don't currently forward the currently-non-existent value-based overload).


# Early implementation steps

Inital commits in this WIP focus on unary functions by adding a unary overload with this signature:

```c++
double calcValue(double a1) const;
```

Which has a (currently, default) implementation that packs the arguments into a `thread_local` `SimTK::Vector` scratch space followed by forwarding the vector to the existing implementation. The existing API is left untouched. Therefore, this API addition is non-breaking, and passes all tests.

Further commits roll this (unary-only) API out to OpenSim to demonstrate how the new API would look from the caller's side. The rollout also passes all tests. Basic perf measurements of the post-rollout version indicate nothing noteworthy - maybe a 2 % perf uplift in something like `ToyDropLanding`, if you squint. The main benefit is that the caller-side code is clearer (see changeset).


# Where I want this to end up

This is currently WIP, but I'm hoping that the final iteration will provide a templatized version of the API that can accept an arbitrary number of arguments, something like:

```c++
template<typename... Args>
double calcValue(Args... args) const {
    thread_local SimTK::Vector scratch(sizeof...(Args));
    scratch = {args...};
    return calcValue(scratch);
}
```

(+ the same for associated calls, such as derivatives)

Having that API would mean that almost all callsites could be cleaned up to just directly provide the arguments. Once that's rolled out, there would be scope for providing performance-oriented overloads to the existing API (e.g. functions accept a pointer range, rather than a `SimTK::Vector`, so the scratch space can be replaced by a stack-allocated array of arguments that are forwarded into the implementation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2916)
<!-- Reviewable:end -->
