### PR TITLE
missing goal in API

### DIFF
--- a/OpenSim/Moco/RegisterTypes_osimMoco.cpp
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.cpp
@@ -61,6 +61,7 @@ static osimMocoInstantiator instantiator;
 OSIMMOCO_API void RegisterTypes_osimMoco() {
     try {
         Object::registerType(MocoFinalTimeGoal());
+        Object::registerType(MocoAverageSpeedGoal());
         Object::registerType(MocoWeight());
         Object::registerType(MocoWeightSet());
         Object::registerType(MocoStateTrackingGoal());


### PR DESCRIPTION
Fixes [this issue reported on the moco repo ](https://github.com/opensim-org/opensim-moco/issues/662).

### Brief summary of changes

Add `MocoAverageSpeedGoal` as a registerType.

### Testing I've completed

Successfully loaded an .xml file including a `MocoAverageSpeedGoal` through `MocoStudy(<.xml>)`

### CHANGELOG.md (choose one)

- no need to update because very minor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2917)
<!-- Reviewable:end -->
