### PR TITLE
Add gfortan to Mac CI build

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
+        brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen gfortran
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version


### PR DESCRIPTION
### Brief summary of changes

Add gfortran to CI for Mac build.

### CHANGELOG.md (choose one)

- no need to update because...CI fix.
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2920)
<!-- Reviewable:end -->
