### PR TITLE
gfortran CI fix (second try)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -158,7 +158,6 @@ jobs:
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
         brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
-      # brew reinstall gcc
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -158,6 +158,7 @@ jobs:
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
         brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
+        brew reinstall gcc
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -157,7 +157,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen gfortran
+        brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -157,7 +157,8 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
+        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen
+        brew reinstall gcc
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -158,7 +158,7 @@ jobs:
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
         brew install cmake pkgconfig gcc autoconf libtool automake wget pcre doxygen
-        brew reinstall gcc
+      # brew reinstall gcc
         pip3 install numpy
         gfortran -v
         mkdir gfortran_version


### PR DESCRIPTION
### Brief summary of changes

Removing the gfortran install that was added in the recent PR #2920, because gfortran comes with gcc (which we already install) and we don't want a potential conflict. This change forces gcc to be reinstalled (via `brew reinstall gcc`) on each CI build, so that gfortran is found. Not sure why this is necessary, might be a bug with the homebrew gcc formula. Hopefully we can use the cached gcc install going forward. Doesn't seem to slow the CI down much at all though.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...CI fix.
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2923)
<!-- Reviewable:end -->
