### PR TITLE
[Moco] Disallow joints where qdot != u

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,11 @@ Moco Change Log
 
 0.5.0
 -----
+- 2021-01-11: An Exception is now thrown if the model includes joints whose
+              generalized speeds do not match the derivative of the generalized
+              coordinates (i.e., BallJoint, FreeJoint, EllipsoidJoint, and
+              ScapulothoracicJoint).
+  
 - 2020-12-10: Fixed bugs where ModOpReplaceMusclesWithDeGrooteFregly2016 didn't 
               include the muscle PathWrapSet and muscle wrapping wasn't 
               thread-safe (preventing parallelization with MocoCasADiSolver).

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -28,6 +28,10 @@
 #include <unordered_set>
 
 #include <OpenSim/Simulation/SimulationUtilities.h>
+#include <OpenSim/Simulation/SimbodyEngine/ScapulothoracicJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/BallJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 
 using namespace OpenSim;
 
@@ -103,6 +107,39 @@ void MocoProblemRep::initialize() {
         m_position_motion_base->setEnabled(m_state_base, true);
     }
 
+    // Disallow joints where the derivative of the generalized coordinates does
+    // not equal the generalized speeds.
+    for (const auto& joint : m_model_base.getComponentList<Joint>()) {
+        if (const auto* ballJoint =
+                dynamic_cast<const BallJoint*>(&joint)) {
+            OPENSIM_THROW(Exception, "BallJoint with name '{}' detected, but "
+                                     "BallJoints are not yet supported in Moco "
+                                     "(since qdot != u). Consider replacing "
+                                     "with a CustomJoint.",
+                         ballJoint->getName());
+        } else if (const auto* ellipsoidJoint =
+                dynamic_cast<const EllipsoidJoint*>(&joint)) {
+            OPENSIM_THROW(Exception, "EllipsoidJoint with name '{}' detected, "
+                                     "but EllipsoidJoints are not yet supported "
+                                     "in Moco (since qdot != u). Consider "
+                                     "replacing with a CustomJoint.",
+                          ellipsoidJoint->getName());
+        } else if (const auto* freeJoint =
+                dynamic_cast<const FreeJoint*>(&joint)) {
+            OPENSIM_THROW(Exception, "FreeJoint with name '{}' detected, "
+                                     "but FreeJoints are not yet supported "
+                                     "in Moco (since qdot != u). Consider "
+                                     "replacing with a CustomJoint.",
+                          freeJoint->getName());
+        } else if (const auto* scapJoint =
+                dynamic_cast<const ScapulothoracicJoint*>(&joint)) {
+            OPENSIM_THROW(Exception, "ScapulothoracicJoint with name '{}' "
+                                     "detected, but ScapulothoracicJoints are "
+                                     "not yet supported in Moco "
+                                     "(since qdot != u).",
+                          scapJoint->getName());
+        }
+    }
 
     // We would like to eventually compute the model accelerations through
     // realizing to Stage::Acceleration. However, if the model has constraints,

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -28,10 +28,6 @@
 #include <unordered_set>
 
 #include <OpenSim/Simulation/SimulationUtilities.h>
-#include <OpenSim/Simulation/SimbodyEngine/ScapulothoracicJoint.h>
-#include <OpenSim/Simulation/SimbodyEngine/BallJoint.h>
-#include <OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h>
-#include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -31,8 +31,8 @@
 
 using namespace OpenSim;
 
-const std::vector<std::string> MocoProblemRep::m_disallowedJoints =
-        {"FreeJoint", "BallJoint", "EllipsoidJoint", "ScapulothoracicJoint"};
+const std::vector<std::string> MocoProblemRep::m_disallowedJoints(
+        {"FreeJoint", "BallJoint", "EllipsoidJoint", "ScapulothoracicJoint"});
 
 MocoProblemRep::MocoProblemRep(const MocoProblem& problem)
         : m_problem(&problem) {

--- a/OpenSim/Moco/MocoProblemRep.h
+++ b/OpenSim/Moco/MocoProblemRep.h
@@ -413,7 +413,7 @@ private:
     std::vector<std::pair<std::string, SimTK::ReferencePtr<const Component>>>
             m_implicit_component_refs;
 
-    const static std::vector<std::string> m_disallowedJoints;
+    static const std::vector<std::string> m_disallowedJoints;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Moco/MocoProblemRep.h
+++ b/OpenSim/Moco/MocoProblemRep.h
@@ -412,6 +412,8 @@ private:
             m_implicit_residual_refs;
     std::vector<std::pair<std::string, SimTK::ReferencePtr<const Component>>>
             m_implicit_component_refs;
+
+    const static std::vector<std::string> m_disallowedJoints;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -1001,11 +1001,11 @@ TEMPLATE_TEST_CASE(
     auto* body = new Body("b", 0.7, SimTK::Vec3(0), SimTK::Inertia(1));
     model.addBody(body);
 
-    auto* joint = new FreeJoint("j", model.getGround(), *body);
+    auto* joint = new PlanarJoint("j", model.getGround(), *body);
     model.addJoint(joint);
 
-    auto* constraint = new WeldConstraint("weld", model.getGround(),
-            SimTK::Transform(), *body, SimTK::Transform());
+    auto* constraint = new PointConstraint(model.getGround(), SimTK::Vec3(0),
+                                           *body, SimTK::Vec3(0));
     model.addConstraint(constraint);
     model.finalizeConnections();
 
@@ -1327,11 +1327,11 @@ TEST_CASE("Multipliers are correct", "[casadi]") {
         auto* body = new Body("body", mass, SimTK::Vec3(0), SimTK::Inertia(1));
         model.addBody(body);
 
-        auto* joint = new FreeJoint("joint", model.getGround(), *body);
+        auto* joint = new PlanarJoint("joint", model.getGround(), *body);
         model.addJoint(joint);
 
-        auto* constr = new WeldConstraint("constraint", model.getGround(),
-                SimTK::Transform(), *body, SimTK::Transform());
+        auto* constr = new PointConstraint(model.getGround(), Vec3(0),
+                                           *body, Vec3(0));
         model.addConstraint(constr);
         model.finalizeConnections();
 
@@ -1349,21 +1349,15 @@ TEST_CASE("Multipliers are correct", "[casadi]") {
 
         MocoSolution solution = study.solve();
 
-        // Constraints 0 through 5 are the locks for the 6 DOFs.
-        const auto MX = solution.getMultiplier("lambda_cid6_p0");
-        SimTK::Vector zero(MX);
+        // Constraints 0 through 2 are the locks for the 3 translational DOFs.
+        const auto FX = solution.getMultiplier("lambda_cid3_p0");
+        SimTK::Vector zero(FX);
         zero.setToZero();
-        OpenSim_CHECK_MATRIX_TOL(MX, zero, 1e-5);
-        const auto MY = solution.getMultiplier("lambda_cid6_p1");
-        OpenSim_CHECK_MATRIX_TOL(MY, zero, 1e-5);
-        const auto MZ = solution.getMultiplier("lambda_cid6_p2");
-        OpenSim_CHECK_MATRIX_TOL(MZ, zero, 1e-5);
-        const auto FX = solution.getMultiplier("lambda_cid6_p3");
         OpenSim_CHECK_MATRIX_TOL(FX, zero, 1e-5);
-        const auto FY = solution.getMultiplier("lambda_cid6_p4");
+        const auto FY = solution.getMultiplier("lambda_cid3_p1");
         SimTK::Vector g(zero.size(), model.get_gravity()[1]);
         OpenSim_CHECK_MATRIX_TOL(FY, mass * g, 1e-5);
-        const auto FZ = solution.getMultiplier("lambda_cid6_p5");
+        const auto FZ = solution.getMultiplier("lambda_cid3_p2");
         OpenSim_CHECK_MATRIX_TOL(FZ, zero, 1e-5);
     }
 

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -631,11 +631,11 @@ TEMPLATE_TEST_CASE(
     auto* body = new Body("body", mass, SimTK::Vec3(0), SimTK::Inertia(1));
     model.addBody(body);
 
-    auto* joint = new FreeJoint("joint", model.getGround(), *body);
+    auto* joint = new PlanarJoint("joint", model.getGround(), *body);
     model.addJoint(joint);
 
-    auto* constr = new WeldConstraint("constraint", model.getGround(),
-            SimTK::Transform(), *body, SimTK::Transform());
+    auto* constr = new PointConstraint(model.getGround(), SimTK::Vec3(0),
+                                       *body, SimTK::Vec3(0));
     model.addConstraint(constr);
     model.finalizeConnections();
 

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -35,7 +35,7 @@ void testPropertiesDump(const OpenSim::Object& aObject);
 int testUnrecognizedTypes() {
     try {
         Object* newObject = Object::newInstanceOfType("Unreccognized");
-    } catch (Exception& ex) { 
+    } catch (Exception&) {
         return 0;
     }
     return 1;


### PR DESCRIPTION
Fixes issue #2926

### Brief summary of changes
- Added a check in MocoProblemRep that throws an Exception if there are present any joints where the derivative of the generalized coordinates **does not** equal the generalized speeds (i.e., BallJoints, FreeJoints, EllipsoidJoints, and ScapulothoracicJoints). 

### Testing I've completed
- Updated `testMocoInterface.cpp` to ensure that disallowed joints indeed cause an exception to be thrown.
- Disabled tests that check for extra quaternion slots since all joints that have extra slots also have generalized speeds that do not match the derivative of the generalized coordinates.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2929)
<!-- Reviewable:end -->
