### PR TITLE
Only issue warning if value changes upon clamping

### DIFF
--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -174,14 +174,16 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
 
 
     } else { 
-
-        if(get_minimum_activation() > 0.){
+        double min_activation = get_minimum_activation();
+        if (min_activation > 0. && 
+            std::abs(clamp(0, min_activation, 1) -
+                                            min_activation) > SimTK::Eps) {
             log_info("'{}': Parameter update for the damped-model: "
                 "minimum_activation was {} but is now {}",
                    getName(), get_minimum_activation(), 
                    clamp(0, get_minimum_activation(), 1));
 
-            set_minimum_activation(clamp(0, get_minimum_activation(), 1));
+            set_minimum_activation(clamp(0, min_activation, 1));
         }
         if(falCurve.getMinValue() > 0.0){
             log_info("'{}' Parameter update for the damped-model: "

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -174,8 +174,8 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
 
 
     } else { 
-        double min_activation = get_minimum_activation();
-        double min_activation_clamped = clamp(0, min_activation, 1);
+        const double min_activation = get_minimum_activation();
+        const double min_activation_clamped = clamp(0, min_activation, 1);
         if (min_activation > 0. && 
             std::abs(min_activation_clamped -min_activation) > SimTK::Eps) {
             log_info("'{}': Parameter update for the damped-model: "

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -175,15 +175,15 @@ void Millard2012EquilibriumMuscle::extendFinalizeFromProperties()
 
     } else { 
         double min_activation = get_minimum_activation();
+        double min_activation_clamped = clamp(0, min_activation, 1);
         if (min_activation > 0. && 
-            std::abs(clamp(0, min_activation, 1) -
-                                            min_activation) > SimTK::Eps) {
+            std::abs(min_activation_clamped -min_activation) > SimTK::Eps) {
             log_info("'{}': Parameter update for the damped-model: "
                 "minimum_activation was {} but is now {}",
-                   getName(), get_minimum_activation(), 
-                   clamp(0, get_minimum_activation(), 1));
+                    getName(), min_activation, 
+                   min_activation_clamped);
 
-            set_minimum_activation(clamp(0, min_activation, 1));
+            set_minimum_activation(min_activation_clamped);
         }
         if(falCurve.getMinValue() > 0.0){
             log_info("'{}' Parameter update for the damped-model: "


### PR DESCRIPTION
Fixes issue #2937

### Brief summary of changes
Avoid unnecessary warnings if clamping doesn't change values
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2939)
<!-- Reviewable:end -->
