### PR TITLE
Use osimTableToStruct instead of osimMocoTableToStruct

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimMocoTrajectoryReport.m
+++ b/Bindings/Java/Matlab/Utilities/osimMocoTrajectoryReport.m
@@ -464,9 +464,9 @@ classdef osimMocoTrajectoryReport < handle
                         if ~isvarname(colLabel)
                             % Find any non-alphanumeric characters and replace with '_'
                             colLabel(~(isstrprop(colLabel, 'alphanum'))) = '_';
-                            % Check if first character is a letter, and append 'unlabeled' if not
-                            if ~(isletter(colLabel(1)))
-                                colLabel = colLabel(2:end);
+                            % Check if first character is a letter, and prepend 'a_' if not.
+                            if ~(isletter(col_label(1)))
+                                col_label = ['a_' col_label(2:end)];
                             end
                         end
                         if ~isempty(find(strcmp(fieldnames(ref), colLabel), 1))

--- a/Bindings/Java/Matlab/Utilities/osimMocoTrajectoryReport.m
+++ b/Bindings/Java/Matlab/Utilities/osimMocoTrajectoryReport.m
@@ -131,7 +131,7 @@ classdef osimMocoTrajectoryReport < handle
                         simEngine.convertDegreesToRadians(refTable);
                     end
                 end
-                ref = osimMocoTableToStruct(refTable);
+                ref = osimTableToStruct(refTable);
                 self.refs = [self.refs, {ref}];
             end
             
@@ -460,7 +460,7 @@ classdef osimMocoTrajectoryReport < handle
                     for ir = 1:length(self.refs)
                         ref = self.refs{ir};
                         colLabel = path;
-                        % Copied from osimMocoTableToStruct.
+                        % Copied from osimTableToStruct.
                         if ~isvarname(colLabel)
                             % Find any non-alphanumeric characters and replace with '_'
                             colLabel(~(isstrprop(colLabel, 'alphanum'))) = '_';


### PR DESCRIPTION
Fixes issue reported by @antoinefalisse at the OpenSim 4.2 testing session.

### Brief summary of changes

We created a utility in Moco called `osimMocoTableToStruct` that was a slightly modified version of `osimTableToStruct`. The issues with `osimTableToStruct` have now been fixed (i.e., handling illegal column labels), and `osimMocoTableToStruct` was removed in the Moco merge. I also made this fix `osimMocoTrajectoryReport` here.

### CHANGELOG.md (choose one)

- no need to update because...small bug fix.
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2948)
<!-- Reviewable:end -->
