### PR TITLE
Fix iss 2944 forceset leak

### DIFF
--- a/OpenSim/Simulation/Model/ForceSet.cpp
+++ b/OpenSim/Simulation/Model/ForceSet.cpp
@@ -42,6 +42,13 @@ void ForceSet::extendConnectToModel(Model& aModel)
     updateMuscles();
 }
 
+ForceSet::ForceSet() = default;
+ForceSet::ForceSet(const ForceSet&) = default;
+ForceSet::ForceSet(ForceSet&&) = default;
+ForceSet& ForceSet::operator=(ForceSet&&) = default;
+ForceSet& ForceSet::operator=(const ForceSet&) = default;
+ForceSet::~ForceSet() = default;
+
 
 //=============================================================================
 // GET AND SET

--- a/OpenSim/Simulation/Model/ForceSet.cpp
+++ b/OpenSim/Simulation/Model/ForceSet.cpp
@@ -43,10 +43,40 @@ void ForceSet::extendConnectToModel(Model& aModel)
 }
 
 ForceSet::ForceSet() = default;
-ForceSet::ForceSet(const ForceSet&) = default;
+
+// this custom copy constructor is necesssary to prevent a leak that can
+// form when _actuators and _muscles are recursively copy-constructed. The
+// leak happens because `Set<T>::Set(const Set<T>&)` will `.clone()` all
+// elements inside the set - even if they aren't owned. Here, _actuators
+// and _muscles are just lookups into *this and shouldn't be owned.
+//
+// see:
+//     https://github.com/opensim-org/opensim-core/issues/2944
+ForceSet::ForceSet(const ForceSet& other) :
+    Super{other},
+    _actuators{},
+    _muscles{} {
+
+    updateActuators();
+    updateMuscles();
+}
+
 ForceSet::ForceSet(ForceSet&&) = default;
 ForceSet& ForceSet::operator=(ForceSet&&) = default;
-ForceSet& ForceSet::operator=(const ForceSet&) = default;
+
+// see copy ctor for why this is here
+//
+// see:
+//     https://github.com/opensim-org/opensim-core/issues/2944
+ForceSet& ForceSet::operator=(const ForceSet& other) {
+    Super::operator=(other);
+
+    updateActuators();
+    updateMuscles();
+
+    return *this;
+}
+
 ForceSet::~ForceSet() = default;
 
 

--- a/OpenSim/Simulation/Model/ForceSet.h
+++ b/OpenSim/Simulation/Model/ForceSet.h
@@ -69,6 +69,13 @@ public:
     /** Use Super's constructors. @see ModelComponentSet */
     using Super::Super;
 
+    ForceSet();
+    ForceSet(const ForceSet&);
+    ForceSet(ForceSet&&);
+    ForceSet& operator=(ForceSet&&);
+    ForceSet& operator=(const ForceSet&);
+    ~ForceSet() override;
+
 private:
     void updateActuators();
     void updateMuscles();


### PR DESCRIPTION
This is a hotfix for the (large) memory leak found in #2944 .

This does not fix all leaks I've found (of which, 98 % come from `ArrayPtr`s). It does, however, fix a source of *large* (multi-megabyte) leaks.

See issue posting for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2951)
<!-- Reviewable:end -->
