### PR TITLE
Explicit copy constructor for OrientationWeightSet to support GUI

### DIFF
--- a/OpenSim/Tools/IMUInverseKinematicsTool.h
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.h
@@ -56,6 +56,8 @@ public:
     /** Use Super's constructors. */
     using Super::Super;
     // default copy, assignment operator, and destructor
+    OrientationWeightSet() = default;
+    OrientationWeightSet(const OrientationWeightSet&) = default;
     //=============================================================================
 }; 
         //=============================================================================


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Copy constructor for OrientationWeightSet for use by GUI/editing

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2955)
<!-- Reviewable:end -->
