### PR TITLE
Support Swig 4.0

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,7 +35,7 @@ jobs:
       run: python -m pip install numpy
 
     - name: Install SWIG
-      run: choco install swig --version 4.0.2 --yes --limit-output
+      run: choco install swig --version 4.0.0 --yes --limit-output
 
     - name: Cache dependencies
       id: cache-dependencies
@@ -175,7 +175,7 @@ jobs:
       if: steps.cache-swig.outputs.cache-hit != 'true'
       run: |
         mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/rel-4.0.2.tar.gz
+        wget https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
         tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
         make && make -j4 install

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,7 +34,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-      # Need numpy to use SWIG numpy typemaps.
+        
+    - name: Install numpy
+      #Need numpy to use SWIG numpy typemaps.
       run: python -m pip install numpy
 
     - name: Install SWIG

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,7 +35,7 @@ jobs:
       run: python -m pip install numpy
 
     - name: Install SWIG
-      run: choco install swig --version 3.0.12 --yes --limit-output
+      run: choco install swig --version 4.0.2 --yes --limit-output
 
     - name: Cache dependencies
       id: cache-dependencies
@@ -175,8 +175,8 @@ jobs:
       if: steps.cache-swig.outputs.cache-hit != 'true'
       run: |
         mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/rel-3.0.12.tar.gz
-        tar xzf rel-3.0.12.tar.gz && cd swig-rel-3.0.12
+        wget https://github.com/swig/swig/archive/rel-4.0.2.tar.gz
+        tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
         make && make -j4 install
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -342,6 +342,7 @@ jobs:
         OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
         OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
         OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
         # TODO: Update to simbody.github.io/latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -341,7 +341,7 @@ jobs:
         OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
         OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
         # TODO: Update to simbody.github.io/latest

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -300,8 +300,16 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Install packages
-      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools swig
+      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools
 
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
+        tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@v1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,6 +31,9 @@ jobs:
         echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
     - name: Install Python packages
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
       # Need numpy to use SWIG numpy typemaps.
       run: python -m pip install numpy
 
@@ -157,7 +160,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen
+        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen python@3.7
         brew reinstall gcc
         pip3 install numpy
         gfortran -v

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -172,7 +172,7 @@ jobs:
         key: ${{ runner.os }}-swig
 
     - name: Install SWIG
-      if: steps.cache-swig.outputs.cache-hit != 'true'
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
       run: |
         mkdir ~/swig-source && cd ~/swig-source
         wget https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -341,6 +341,7 @@ jobs:
         OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
         OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
         OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
         # TODO: Update to simbody.github.io/latest

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,11 +1,7 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
     # We require 3.0.8 for the reason mentioned here (for Python 3):
     # https://github.com/tensorflow/tensorflow/issues/830
-    find_package(SWIG 3.0.8 REQUIRED)
-    if(NOT (SWIG_VERSION VERSION_LESS "4.0.0") AND BUILD_JAVA_WRAPPING)
-        message(FATAL_ERROR
-                "SWIG version 4.0.0 and greater not yet supported for Java bindings.")
-    endif()
+    find_package(SWIG 4.0.2 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,6 +1,4 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    # We require 3.0.8 for the reason mentioned here (for Python 3):
-    # https://github.com/tensorflow/tensorflow/issues/830
     find_package(SWIG 4.0.0 REQUIRED)
 endif()
 

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
     # We require 3.0.8 for the reason mentioned here (for Python 3):
     # https://github.com/tensorflow/tensorflow/issues/830
-    find_package(SWIG 4.0.2 REQUIRED)
+    find_package(SWIG 4.0.0 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -11,7 +11,7 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 function(OpenSimGenerateJavaWrapper
         NAME INPUT_INTERFACE_FILE OUTPUT_CXX_FILE OUTPUT_H_FILE)
 
-    set(_swig_common_args -c++ -java
+    set(_swig_common_args -c++ -java -doxygen
             -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -95,6 +95,7 @@ macro(OpenSimAddPythonModule)
             #-debug-tmused # Which typemaps were used?
             -v # verbose
             -o ${_output_cxx_file}
+            -doxygen
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
             ${_swig_common_args}
         DEPENDS ${_${OSIMSWIGPY_MODULE}_dependencies}

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -73,7 +73,7 @@ macro(OpenSimAddPythonModule)
     # We run swig once to get dependencies and then again to actually generate
     # the wrappers. This variable holds the parts of the swig command that
     # are shared between both invocations.
-    set(_swig_common_args -c++ -python
+    set(_swig_common_args -c++ -python -doxygen
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings/
             -I${Simbody_INCLUDE_DIR}

--- a/Bindings/SWIGSimTK/Rotation.h
+++ b/Bindings/SWIGSimTK/Rotation.h
@@ -518,10 +518,10 @@ public:
     /// Theory: calculate qdot=N_P(q)*w_PB using multiplyByBodyXYZ_N_P().
     /// @see multiplyByBodyXYZ_N_P()
     static Vec3 convertAngVelInParentToBodyXYZDot
-       (const Vec2& cosxy,  ///< cos(qx), cos(qy)
-        const Vec2& sinxy,  ///< sin(qx), sin(qy)
-        P        oocosy, ///< 1/cos(qy)
-        const Vec3& w_PB)   ///< angular velocity of B in P, exp. in P
+       (const Vec2& cosxy,  //< cos(qx), cos(qy)
+        const Vec2& sinxy,  //< sin(qx), sin(qy)
+        P        oocosy, //< 1/cos(qy)
+        const Vec3& w_PB)   //< angular velocity of B in P, exp. in P
     {
         return multiplyByBodyXYZ_N_P(cosxy,sinxy,oocosy,w_PB);
     }
@@ -538,11 +538,11 @@ public:
     /// efficiently. The second term is just an acceleration remainder term
     /// quadratic in qdot.
     static Vec3 convertAngAccInParentToBodyXYZDotDot
-       (const Vec2& cosxy,  ///< cos(qx), cos(qy)
-        const Vec2& sinxy,  ///< sin(qx), sin(qy)
-        P        oocosy, ///< 1/cos(qy)
-        const Vec3& qdot,   ///< previously calculated BodyXYZDot
-        const Vec3& b_PB)   ///< angular acceleration, a.k.a. wdot_PB
+       (const Vec2& cosxy,  //< cos(qx), cos(qy)
+        const Vec2& sinxy,  //< sin(qx), sin(qy)
+        P        oocosy, //< 1/cos(qy)
+        const Vec3& qdot,   //< previously calculated BodyXYZDot
+        const Vec3& b_PB)   //< angular acceleration, a.k.a. wdot_PB
     {
         const P s1 = sinxy[1], c1 = cosxy[1];
         const P q0 = qdot[0], q1 = qdot[1], q2 = qdot[2];
@@ -1088,14 +1088,14 @@ public:
 #endif
     Rotation_<P>&        operator~()        { return updInvert(); }
     //@}
-
+#ifndef SWIG
     /// Access individual rows and columns of this InverseRotation; no cost or
     /// copying since suitably-cast references to the actual data are returned.
     /// There are no writable versions of these methods since changing a single
     /// row or column would violate the contract that these are always legitimate
     /// rotation matrices.
     //@{
-#ifndef SWIG
+
     const RowType&  row( int i ) const         { return reinterpret_cast<const RowType&>(asMat33()[i]); }
     const ColType&  col( int j ) const         { return reinterpret_cast<const ColType&>(asMat33()(j)); }
     const ColType&  x() const                  { return col(0); }
@@ -1111,8 +1111,8 @@ public:
     //@{
     const BaseMat&  asMat33() const  { return *static_cast<const BaseMat*>(this); }
     BaseMat         toMat33() const  { return asMat33(); }
-#endif
     //@}
+#endif
 };
 
 #ifndef SWIG

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -364,12 +364,8 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 
 %include <OpenSim/Common/Event.h>
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
-%shared_ptr(std::shared_ptr<OpenSim::TimeSeriesTableVec3>)
-//%template(StdMapStringTimeSeriesTableVec3)
-//        std::map<std::string, std::shared_ptr<OpenSim::TimeSeriesTableVec3> >;
-//%template(StdMapStringTimeSeriesTableVec3Iterator)
-//                 std::map<std::string, 
-//                 std::shared_ptr<OpenSim::TimeSeriesTableVec3> >::Iterator;
+%shared_ptr(OpenSim::TimeSeriesTableVec3)
+
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)
 %shared_ptr(OpenSim::DelimFileAdapter)
@@ -386,9 +382,13 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 %shared_ptr(OpenSim::TRCFileAdapter)
 %shared_ptr(OpenSim::C3DFileAdapter)
 %template(StdMapStringDataAdapter)
-        std::map<std::string, std::shared_ptr<OpenSim::DataAdapter>>;
+        std::map<std::string, std::shared_ptr<OpenSim::DataAdapter> >;
 %template(StdMapStringAbstractDataTable)
-        std::map<std::string, std::shared_ptr<OpenSim::AbstractDataTable>>;
+        std::map<std::string, std::shared_ptr<OpenSim::AbstractDataTable> >;
+//%template(StdMapStringTimeSeriesTableVec3)
+//        std::map<std::string, std::shared_ptr<OpenSim::TimeSeriesTable_<SimTK::Vec3> > >;
+        
+
 %include <OpenSim/Common/DataAdapter.h>
 %include <OpenSim/Common/ExperimentalSensor.h>
 %include <OpenSim/Common/IMUDataReader.h>

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -365,8 +365,8 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 %include <OpenSim/Common/Event.h>
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
 %shared_ptr(std::shared_ptr<OpenSim::TimeSeriesTableVec3>)
-%template(StdMapStringTimeSeriesTableVec3)
-        std::map<std::string,                                        std::shared_ptr<OpenSim::TimeSeriesTableVec3> >;
+//%template(StdMapStringTimeSeriesTableVec3)
+//        std::map<std::string, std::shared_ptr<OpenSim::TimeSeriesTableVec3> >;
 //%template(StdMapStringTimeSeriesTableVec3Iterator)
 //                 std::map<std::string, 
 //                 std::shared_ptr<OpenSim::TimeSeriesTableVec3> >::Iterator;

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -133,19 +133,19 @@ namespace OpenSim {
 %shared_ptr(OpenSim::DataTable_<double, double>);
 %shared_ptr(OpenSim::DataTable_<double, SimTK::Vec3>);
 %shared_ptr(OpenSim::DataTable_<double, SimTK::UnitVec3>);
-%shared_ptr(OpenSim::DataTable_<double, SimTK::Quaternion_<double>>);
+%shared_ptr(OpenSim::DataTable_<double, SimTK::Quaternion_<double> >);
 %shared_ptr(OpenSim::DataTable_<double, SimTK::Vec6>);
 %shared_ptr(OpenSim::DataTable_<double, SimTK::SpatialVec>);
 %shared_ptr(OpenSim::DataTable_<double, SimTK::Mat33>);
-%shared_ptr(OpenSim::DataTable_<double, SimTK::Rotation_<double>>);
+%shared_ptr(OpenSim::DataTable_<double, SimTK::Rotation_<double> >);
 %shared_ptr(OpenSim::TimeSeriesTable_<double>);
 %shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Vec3>);
 %shared_ptr(OpenSim::TimeSeriesTable_<SimTK::UnitVec3>);
-%shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>);
+%shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double> >);
 %shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Vec6>);
 %shared_ptr(OpenSim::TimeSeriesTable_<SimTK::SpatialVec>);
 %shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Mat33>);
-%shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>>);
+%shared_ptr(OpenSim::TimeSeriesTable_<SimTK::Rotation_<double> >);
 %ignore OpenSim::AbstractDataTable::clone;
 %ignore OpenSim::AbstractDataTable::getTableMetaData;
 %ignore OpenSim::AbstractDataTable::updTableMetaData;
@@ -155,7 +155,7 @@ namespace OpenSim {
 %ignore OpenSim::AbstractDataTable::setDependentsMetaData;
 %ignore OpenSim::AbstractDataTable::setColumnLabels(
                                      const std::initializer_list<std::string>&);
-%template(StdVectorMatrix) std::vector<SimTK::Matrix_<double>>;
+%template(StdVectorMatrix) std::vector<SimTK::Matrix_<double> >;
 %extend OpenSim::AbstractDataTable {
     void setColumnLabels(const std::vector<std::string>& columnLabels) {
         $self->setColumnLabels(columnLabels);
@@ -345,28 +345,31 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 %template(DataTable)           OpenSim::DataTable_<double, double>;
 %template(DataTableVec3)       OpenSim::DataTable_<double, SimTK::Vec3>;
 %template(DataTableUnitVec3)   OpenSim::DataTable_<double, SimTK::UnitVec3>;
-%template(DataTableQuaternion) OpenSim::DataTable_<double, SimTK::Quaternion_<double>>;
+%template(DataTableQuaternion) OpenSim::DataTable_<double, SimTK::Quaternion_<double> >;
 %template(DataTableVec6)       OpenSim::DataTable_<double, SimTK::Vec6>;
 %template(DataTableSpatialVec) OpenSim::DataTable_<double, SimTK::SpatialVec>;
 %template(DataTableMat33)      OpenSim::DataTable_<double, SimTK::Mat33>;
-%template(DataTableRotation)   OpenSim::DataTable_<double, SimTK::Rotation_<double>>;
+%template(DataTableRotation)   OpenSim::DataTable_<double, SimTK::Rotation_<double> >;
 
 %template(TimeSeriesTable)         OpenSim::TimeSeriesTable_<double>;
 %template(TimeSeriesTableVec3)     OpenSim::TimeSeriesTable_<SimTK::Vec3>;
 %template(TimeSeriesTableUnitVec3) OpenSim::TimeSeriesTable_<SimTK::UnitVec3>;
 %template(TimeSeriesTableQuaternion)
-                                   OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double>>;
+                                   OpenSim::TimeSeriesTable_<SimTK::Quaternion_<double> >;
 %template(TimeSeriesTableVec6)     OpenSim::TimeSeriesTable_<SimTK::Vec6>;
 %template(TimeSeriesTableSpatialVec)
                                    OpenSim::TimeSeriesTable_<SimTK::SpatialVec>;
 %template(TimeSeriesTableMat33)    OpenSim::TimeSeriesTable_<SimTK::Mat33>;
-%template(TimeSeriesTableRotation) OpenSim::TimeSeriesTable_<SimTK::Rotation_<double>>;
+%template(TimeSeriesTableRotation) OpenSim::TimeSeriesTable_<SimTK::Rotation_<double> >;
 
 %include <OpenSim/Common/Event.h>
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
+%shared_ptr(std::shared_ptr<OpenSim::TimeSeriesTableVec3>)
 %template(StdMapStringTimeSeriesTableVec3)
-        std::map<std::string, 
-                 std::shared_ptr<OpenSim::TimeSeriesTable_<SimTK::Vec3>>>;
+        std::map<std::string,                                        std::shared_ptr<OpenSim::TimeSeriesTableVec3> >;
+//%template(StdMapStringTimeSeriesTableVec3Iterator)
+//                 std::map<std::string, 
+//                 std::shared_ptr<OpenSim::TimeSeriesTableVec3> >::Iterator;
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)
 %shared_ptr(OpenSim::DelimFileAdapter)

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -269,12 +269,42 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %template(ActuatorList) OpenSim::ComponentList<const OpenSim::Actuator>;
 %template(ActuatorIterator) OpenSim::ComponentListIterator<const OpenSim::Actuator>;
 
-%template(getFrameList) OpenSim::Model::getComponentList<OpenSim::Frame>;
-%template(getBodyList) OpenSim::Model::getComponentList<OpenSim::Body>;
-%template(getMuscleList) OpenSim::Model::getComponentList<OpenSim::Muscle>;
-%template(getModelComponentList) OpenSim::Model::getComponentList<OpenSim::ModelComponent>;
-%template(getJointList) OpenSim::Model::getComponentList<OpenSim::Joint>;
-%template(getActuatorList) OpenSim::Model::getComponentList<OpenSim::Actuator>;
+%template(Thelen2003MuscleList)
+    OpenSim::ComponentList<const OpenSim::Thelen2003Muscle>;
+%template(Thelen2003MuscleIterator)
+    OpenSim::ComponentListIterator<const OpenSim::Thelen2003Muscle>;
+
+%template(Millard2012EquilibriumMuscleList)
+    OpenSim::ComponentList<const OpenSim::Millard2012EquilibriumMuscle>;
+%template(Millard2012EquilibriumMuscleIterator)
+    OpenSim::ComponentListIterator<const OpenSim::Millard2012EquilibriumMuscle>;
+
+%extend OpenSim::Model {
+    OpenSim::ComponentList<const OpenSim::Frame> getFrameList(){
+        return $self->getComponentList<OpenSim::Frame>();
+    }
+    OpenSim::ComponentList<const OpenSim::Body> getBodyList(){
+        return $self->getComponentList<OpenSim::Body>();
+    }
+    OpenSim::ComponentList<const OpenSim::Muscle> getMuscleList(){
+        return $self->getComponentList<OpenSim::Muscle>();
+    }
+    OpenSim::ComponentList<const OpenSim::Joint> getJointList(){
+        return $self->getComponentList<OpenSim::Joint>();
+    }
+    OpenSim::ComponentList<const OpenSim::Actuator> getActuatorList(){
+        return $self->getComponentList<OpenSim::Actuator>();
+    }
+    OpenSim::ComponentList<const OpenSim::ModelComponent> getModelComponentList(){
+        return $self->getComponentList<OpenSim::ModelComponent>();
+    }
+    OpenSim::ComponentList<const OpenSim::Thelen2003Muscle> getThelen2003MuscleList(){
+        return $self->getComponentList<OpenSim::Thelen2003Muscle>();
+    }
+    OpenSim::ComponentList<const OpenSim::Millard2012EquilibriumMuscle> getMillard2012EquilibriumMuscleList(){
+        return $self->getComponentList<OpenSim::Millard2012EquilibriumMuscle>();
+    }
+}
 
 %include <OpenSim/Actuators/osimActuatorsDLL.h>
 %include <OpenSim/Actuators/ActiveForceLengthCurve.h>
@@ -289,20 +319,6 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Actuators/Thelen2003Muscle.h>
 %include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 
-%template(Thelen2003MuscleList)
-    OpenSim::ComponentList<const OpenSim::Thelen2003Muscle>;
-%template(Thelen2003MuscleIterator)
-    OpenSim::ComponentListIterator<const OpenSim::Thelen2003Muscle>;
-
-%template(Millard2012EquilibriumMuscleList)
-    OpenSim::ComponentList<const OpenSim::Millard2012EquilibriumMuscle>;
-%template(Millard2012EquilibriumMuscleIterator)
-    OpenSim::ComponentListIterator<const OpenSim::Millard2012EquilibriumMuscle>;
-
-%template(getThelen2003MuscleList)
-  OpenSim::Model::getComponentList<OpenSim::Thelen2003Muscle>;
-%template(getMillard2012EquilibriumMuscleList)
-  OpenSim::Model::getComponentList<OpenSim::Millard2012EquilibriumMuscle>;
 
 // Compensate for insufficient C++11 support in SWIG
 // =================================================

--- a/OpenSim/Actuators/ModelFactory.h
+++ b/OpenSim/Actuators/ModelFactory.h
@@ -19,7 +19,6 @@
  * -------------------------------------------------------------------------- */
 
 #include "osimActuatorsDLL.h"
-
 #include <OpenSim/Simulation/Model/Model.h>
 
 namespace OpenSim {
@@ -91,7 +90,6 @@ public:
             double bound = SimTK::NaN,
             bool skipCoordinatesWithExistingActuators = true);
 
-    /// @}
 };
 
 } // namespace OpenSim

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -81,7 +81,7 @@ C3DFileAdapter::clone() const {
 }
 
 void C3DFileAdapter::write(
-                      const TablesDictionary& tables,
+                      const C3DFileAdapter::Tables& tables,
                       const std::string& fileName) {
     OPENSIM_THROW(Exception, "Writing C3D not supported yet.");
 }

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -80,8 +80,8 @@ C3DFileAdapter::clone() const {
     return new C3DFileAdapter{*this};
 }
 
-void
-C3DFileAdapter::write(const C3DFileAdapter::Tables& tables,
+void C3DFileAdapter::write(
+                      const TablesDictionary& tables,
                       const std::string& fileName) {
     OPENSIM_THROW(Exception, "Writing C3D not supported yet.");
 }

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -117,9 +117,10 @@ public:
     ForceLocation getLocationForForceExpression() const {
         return _location;
     }
-
+#ifndef SWIG
     static void write(
             const TablesDictionary& markerTable, const std::string& fileName);
+#endif
     /** Retrieve the TimeSeriesTableVec3 of Markers */
     std::shared_ptr<TimeSeriesTableVec3> getMarkersTable(DataAdapter::OutputTables& tables) {
         std::shared_ptr<AbstractDataTable>& adt = tables.at("markers");

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -30,8 +30,6 @@
 
 namespace OpenSim {
 
-typedef std::map<std::string, std::shared_ptr<TimeSeriesTableVec3>> TablesDictionary;
-
 /** C3DFileAdapter reads a C3D file into markers and forces tables of type
 TimeSeriesTableVec3. The markers table has each column labeled by its
 corresponding marker name. For the forces table, the data are grouped
@@ -43,6 +41,7 @@ CenterOfPressure, or the PointOfWrenchApplication. */
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
 public:
     typedef std::vector<Event>                         EventTable; 
+    typedef std::map<std::string, std::shared_ptr<TimeSeriesTableVec3>> Tables;
 
     /** Enumerated list of locations in which read in forces are expressed.
         %Measurement from force plates can be expressed by the C3DFileAdapter
@@ -117,15 +116,18 @@ public:
     ForceLocation getLocationForForceExpression() const {
         return _location;
     }
+
 #ifndef SWIG
-    static void write(
-            const TablesDictionary& markerTable, const std::string& fileName);
+    static
+    void write(const Tables& markerTable, const std::string& fileName);
 #endif
+
     /** Retrieve the TimeSeriesTableVec3 of Markers */
     std::shared_ptr<TimeSeriesTableVec3> getMarkersTable(DataAdapter::OutputTables& tables) {
         std::shared_ptr<AbstractDataTable>& adt = tables.at("markers");
         return std::dynamic_pointer_cast<TimeSeriesTableVec3>(adt);
     }
+
     /** Retrieve the TimeSeriesTableVec3 of Forces */
      std::shared_ptr<TimeSeriesTableVec3> getForcesTable(DataAdapter::OutputTables& tables) {
         std::shared_ptr<AbstractDataTable>& adt = tables.at("forces");

--- a/OpenSim/Common/C3DFileAdapter.h
+++ b/OpenSim/Common/C3DFileAdapter.h
@@ -30,6 +30,8 @@
 
 namespace OpenSim {
 
+typedef std::map<std::string, std::shared_ptr<TimeSeriesTableVec3>> TablesDictionary;
+
 /** C3DFileAdapter reads a C3D file into markers and forces tables of type
 TimeSeriesTableVec3. The markers table has each column labeled by its
 corresponding marker name. For the forces table, the data are grouped
@@ -41,7 +43,6 @@ CenterOfPressure, or the PointOfWrenchApplication. */
 class OSIMCOMMON_API C3DFileAdapter : public FileAdapter {
 public:
     typedef std::vector<Event>                         EventTable; 
-    typedef std::map<std::string, std::shared_ptr<TimeSeriesTableVec3>> Tables;
 
     /** Enumerated list of locations in which read in forces are expressed.
         %Measurement from force plates can be expressed by the C3DFileAdapter
@@ -117,8 +118,8 @@ public:
         return _location;
     }
 
-    static
-    void write(const Tables& markerTable, const std::string& fileName);
+    static void write(
+            const TablesDictionary& markerTable, const std::string& fileName);
     /** Retrieve the TimeSeriesTableVec3 of Markers */
     std::shared_ptr<TimeSeriesTableVec3> getMarkersTable(DataAdapter::OutputTables& tables) {
         std::shared_ptr<AbstractDataTable>& adt = tables.at("markers");

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -577,7 +577,9 @@ protected:
     Property(Property&&) = default;
     Property& operator=(const Property&) = default;
     Property& operator=(Property&&) = default;
-    /** @cond **/ // Hide from Doxygen.
+#ifndef SWIG
+    /** @cond **/ 
+    // Hide from Doxygen.
     // This is the interface that SimpleProperty and ObjectProperty must
     // implement.
     // Base class verifies that 0 <= index < size(), and for append operations
@@ -588,6 +590,7 @@ protected:
     virtual int appendValueVirtual(const T& value) = 0;
     virtual int adoptAndAppendValueVirtual(T* value) = 0;
     /** @endcond **/
+#endif
 };
 
 

--- a/OpenSim/Moco/MocoStudyFactory.h
+++ b/OpenSim/Moco/MocoStudyFactory.h
@@ -32,8 +32,8 @@ public:
     /// LinearTangentFinalSpeed. This function is intended for use in testing.
     /// This problem has an analytical solution, and
     /// is described in Section 2.4 of Bryson and Ho [1]. Bryson, A. E., Ho,
-    /// Y.‐C., Applied Optimal Control, Optimization, Estimation, and Control.
-    /// New York‐London‐Sydney‐Toronto. John Wiley & Sons. 1975.
+    /// Y.C., Applied Optimal Control, Optimization, Estimation, and Control.
+    /// New York London Sydney Toronto. John Wiley & Sons. 1975.
     static MocoStudy createLinearTangentSteeringStudy(
             double acceleration, double finalTime, double finalHeight);
 };

--- a/OpenSim/Simulation/StatesTrajectory.h
+++ b/OpenSim/Simulation/StatesTrajectory.h
@@ -476,7 +476,6 @@ public:
      * default values for `allowMissingColumns` and `allowExtraColumns`. */
     static StatesTrajectory createFromStatesStorage(const Model& model,
             const std::string& filepath);
-    /// @}
 };
 
 } // namespace

--- a/OpenSim/Tools/InverseKinematicsTool.h
+++ b/OpenSim/Tools/InverseKinematicsTool.h
@@ -106,15 +106,17 @@ public:
     // INTERFACE
     //--------------------------------------------------------------------------
     bool run() override SWIG_DECLARE_EXCEPTION;
-
+#ifndef SWIG
     /** @cond **/ // hide from Doxygen
+#endif
     // For testing/debugging it is necessary to know exactly what are the
     // MarkersReference (set of marker trajectories and their weights) and
     // CoordinateReferences that are being used by the InverseKinematicsSolver.
     void populateReferences(MarkersReference& markersReference,
         SimTK::Array_<CoordinateReference>&coordinateReferences) const;
+#ifndef SWIG
     /** @endcond **/
-
+#endif
 private:
     void constructProperties();
 


### PR DESCRIPTION
Fixes issue #2524

### Brief summary of changes
-Upgrade makefiles to require SWIG 4.0
- Include doxygen option to pass docs to python, java 
- Update interface files to 4.0 
- Some ifdef/endif in headers due to issues parsing doxygen comments by SWIG
- Moved methods that traverse componentLists to Model class due to new stricter scoping rules

### Testing I've completed
Standard test suite passes, Java bindings work in GUI and comments available in GUI IDE

### Looking for feedback on...
How this looks in Matlab and in Python, whether comments are available/helpful

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2976)
<!-- Reviewable:end -->
