### PR TITLE
fix bug with Actuation analysis leading to extra columns in output

### DIFF
--- a/Applications/Analyze/test/PlotterTool.xml
+++ b/Applications/Analyze/test/PlotterTool.xml
@@ -44,6 +44,18 @@
 					<!--Flag indicating whether moments should be computed.--> 
 					<compute_moments>false</compute_moments>
 				</MuscleAnalysis>
+				<Actuation name="Actuation">
+					<!--Flag (true or false) specifying whether on. True by default.-->
+					<on>true</on>
+					<!--Start time.-->
+					<start_time>-Inf</start_time>
+					<!--End time.-->
+					<end_time>Inf</end_time>
+					<!--Specifies how often to store results during a simulation. More specifically, the interval (a positive integer) specifies how many successful integration steps should be taken before results are recorded again.-->
+					<step_interval>1</step_interval>
+					<!--Flag (true or false) indicating whether the results are in degrees or not.-->
+					<in_degrees>true</in_degrees>
+				</Actuation>
 			</objects>
 			<groups />
 		</AnalysisSet>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ request related to the change, then we may provide the commit.
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 v4.3
 ====
+- Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
 
 v4.2
 ====

--- a/OpenSim/Analyses/Actuation.cpp
+++ b/OpenSim/Analyses/Actuation.cpp
@@ -416,7 +416,7 @@ begin(const SimTK::State& s)
     if (!proceed()) return(0);
 
     // NUMBER OF ACTUATORS
-    int na = _model->getActuators().getSize();
+    int na = getNumEnabledActuators();
     _na = na;
     // WORK ARRAY
     if (_fsp != NULL) delete[] _fsp;


### PR DESCRIPTION
Fixes issue #2977 

### Brief summary of changes
Update Actuator analysis's "begin" function to count the correct number of actuators enabled.

### Testing I've completed
Added a test to an existing Analysis test.

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2980)
<!-- Reviewable:end -->
