### PR TITLE
Fix tropter libs linux

### DIFF
--- a/Vendors/tropter/CMakeLists.txt
+++ b/Vendors/tropter/CMakeLists.txt
@@ -6,6 +6,10 @@ project(tropter)
 # Include CMake macros that we wrote to reduce duplication in this project.
 include(cmake/tropter_macros.cmake)
 
+# Needed for add_feature_info and set_package_properties CMake functions on
+# Linux.
+include(FeatureSummary)
+
 # CMake settings.
 # ---------------
 # To allow a folder hierarchy within Visual Studio's Solution Explorer.
@@ -85,6 +89,13 @@ set_package_properties(ADOLC PROPERTIES
 tropter_copy_dlls(DEP_NAME ADOLC DEP_INSTALL_DIR "${ADOLC_DIR}/bin")
 
 if(UNIX)
+    # For this to work properly we have to specify the PKG_CONFIG_PATH to point
+    # to the custom-build version of IPOPT's .pc file before running
+    # cmake. Alternately, we can install ipopt using the package manager. How to
+    # use:
+    #
+    # export PKG_CONFIG_PATH=/path-to-ipopt/lib/pkgconfig:$PKG_CONFIG_PATH
+    # cmake .
     pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)
 else()
     find_package(Ipopt REQUIRED CONFIG)

--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -59,9 +59,9 @@ elseif(TROPTER_COPY_DEPENDENCIES AND UNIX)
             ${IPOPT_LIBDIR}/libcoinmetis.so.1
             ${IPOPT_LIBDIR}/libcoinmetis.so
 
-	    # These are system libraries and are not needed on Linux. The user
-	    # should install them through the package manager.
-	    #
+            # These are system libraries and are not needed on Linux. The user
+            # should install them through the package manager.
+            #
             # ${gfortran}
             # ${quadmath}
             # ${gcc_libdir}/libgcc_s.so.1

--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -59,9 +59,12 @@ elseif(TROPTER_COPY_DEPENDENCIES AND UNIX)
             ${IPOPT_LIBDIR}/libcoinmetis.so.1
             ${IPOPT_LIBDIR}/libcoinmetis.so
 
-            ${gfortran}
-            ${quadmath}
-            ${gcc_libdir}/libgcc_s.so.1
+	    # These are system libraries and are not needed on Linux. The user
+	    # should install them through the package manager.
+	    #
+            # ${gfortran}
+            # ${quadmath}
+            # ${gcc_libdir}/libgcc_s.so.1
 
             DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -69,11 +72,16 @@ elseif(TROPTER_COPY_DEPENDENCIES AND UNIX)
     # editing of libtropter's link libraries is done after libtropter.so
     # is installed (add_subdirectory(cmake) must be after
     # add_subdirectory(tropter)).
-    set(script
-     ${CMAKE_CURRENT_BINARY_DIR}/tropter_install_linux_dependency_libraries.cmake)
-     configure_file(tropter_install_linux_dependency_libraries.cmake.in
-            "${script}" @ONLY)
-    install(SCRIPT "${script}")
+
+    # For now I have commented the following because it is not functional and
+    # needed on Linux. Dependencies (ADOLC, ColPack, IPOPT) are copied in the
+    # install directory properly, while system libraries should be installed
+    # with the package manager.
+    #
+    # set(script
+    # ${CMAKE_CURRENT_BINARY_DIR}/tropter_install_linux_dependency_libraries.cmake)
+    # configure_file(tropter_install_linux_dependency_libraries.cmake.in
+    # "${script}" @ONLY) install(SCRIPT "${script}")
 
 endif()
 

--- a/Vendors/tropter/cmake/tropter_install_linux_dependency_libraries.cmake.in
+++ b/Vendors/tropter/cmake/tropter_install_linux_dependency_libraries.cmake.in
@@ -10,6 +10,14 @@ macro(install_name_tool_change lib dep_name dep_oldpath)
             "${libdir}/lib${lib}.dylib")
 endmacro()
 
+# This should work but it is not tested yet.
+macro(patchelf_change lib dep_name dep_oldpath)
+    execute_process(COMMAND pathchelf
+            -replace-needed ${dep_oldpath}/lib${dep_name}.so
+            @rpath/lib${dep_name}.so
+            "${libdir}/lib${lib}.so")
+endmacro()
+
 macro(install_name_tool_change_gfortran lib)
     execute_process(COMMAND bash "-c"
         "otool -L ${libdir}/lib${lib}.dylib | grep 'libgfortran.*version' | perl -pe 's/^\\s+(.*)\\/libg.*/\\1/gc'"
@@ -47,10 +55,25 @@ macro(install_name_tool_add_rpath lib)
             "${libdir}/lib${lib}.dylib")
 endmacro()
 
+# This should not work because we have to find a substitution for
+# @loader_path. The last is specific on of MacOS.
+macro(patchelf_add_rpath lib)
+    execute_process(COMMAND patchelf
+            --add-needed "@loader_path/"
+            "${libdir}/lib${lib}.so")
+endmacro()
+
 macro(install_name_tool_delete_rpath lib rpath)
     execute_process(COMMAND install_name_tool
             -delete_rpath ${rpath}
             "${libdir}/lib${lib}.dylib")
+endmacro()
+
+# This should work but it is not tested yet.
+macro(patchelf_delete_rpath lib rpath)
+    execute_process(COMMAND patchelf
+            --remove-rpath ${rpath}
+            "${libdir}/lib${lib}.so")
 endmacro()
 
 # Get the directory containing libgcc_s.1.dylib.


### PR DESCRIPTION
@aymanhab and @adamkewley I tried to see if we can translate the CMake script to work on Linux. I think this is not needed.

I am not sure if this will work for your use case but I think it should not cause problems during packaging. We do not have to change the path that is inside the dynamic libraries on Linux, because all project dependencies (ColPack, ADOLC, IPOPT) are properly copied in the install folder. For example, if we remove the install folders of the dependencies, the dynamic libraries will locate the ones that are copied in the same folder. The only dependencies which I think we should not copy are the system libraries located in system's `/lib` folder (gfortran, libc, etc.). These should be installed using the packaging manner before building the project. I verified these using the `ldd` tool on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2984)
<!-- Reviewable:end -->
