### PR TITLE
Add synthetic IMU utility to SimulationUtilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 v4.3
 ====
 - Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
+- Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on an existing model trajectory.
 
 v4.2
 ====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 v4.3
 ====
 - Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
-- Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on an existing model trajectory.
+- Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
 
 v4.2
 ====

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -397,7 +397,15 @@ TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(
         const TimeSeriesTable& statesTable, const TimeSeriesTable& controlsTable,
         const std::vector<std::string>& framePaths) {
     std::vector<std::string> outputPaths;
+
+    ComponentPath path
     for (const auto& framePath : framePaths) {
+        OPENSIM_THROW_IF(!path.isLegalPathElement(framePath), Exception,
+            "Provided frame path '{}' contains invalid characters.", framePath);
+        OPENSIM_THROW_IF(
+            !model.hasComponent<PhysicalFrame>(framePath), Exception,
+            "Expected provided frame path '{}' to point to component of "
+            "type PhysicalFrame, but no such component was found.", framePath);
         outputPaths.push_back(framePath + "\\|linear_acceleration");
     }
     TimeSeriesTableVec3 accelTableEffort = analyze<SimTK::Vec3>(

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -402,8 +402,9 @@ TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(Model model,
     TimeSeriesTableVec3 accelTableEffort = analyze<SimTK::Vec3>(
             model, statesTable, controlsTable, outputPaths);
 
-    // Create synthetic IMU signals by extracting the gravity offset from the
-    // solution accelerations and expressing them in the model frames.
+    // Create synthetic IMU signals by extracting the gravitational acceleration
+    // vector from the solution accelerations and expressing them in the model
+    // frames.
     const auto& statesTraj =
             StatesTrajectory::createFromStatesTable(model, statesTable);
     const auto& ground = model.getGround();

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -400,7 +400,7 @@ TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(
 
     ComponentPath path;
     for (const auto& framePath : framePaths) {
-        OPENSIM_THROW_IF(!path.isLegalPathElement(framePath), Exception,
+        OPENSIM_THROW_IF(path.isLegalPathElement(framePath), Exception,
             "Provided frame path '{}' contains invalid characters.", framePath);
         OPENSIM_THROW_IF(
             !model.hasComponent<PhysicalFrame>(framePath), Exception,

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -392,7 +392,8 @@ void OpenSim::checkLabelsMatchModelStates(const Model& model,
     }
 }
 
-TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(Model model,
+TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(
+        const Model& model,
         const TimeSeriesTable& statesTable, const TimeSeriesTable& controlsTable,
         const std::vector<std::string>& framePaths) {
     std::vector<std::string> outputPaths;

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -398,7 +398,7 @@ TimeSeriesTableVec3 OpenSim::createSyntheticIMUAccelerationSignals(
         const std::vector<std::string>& framePaths) {
     std::vector<std::string> outputPaths;
 
-    ComponentPath path
+    ComponentPath path;
     for (const auto& framePath : framePaths) {
         OPENSIM_THROW_IF(!path.isLegalPathElement(framePath), Exception,
             "Provided frame path '{}' contains invalid characters.", framePath);

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -304,6 +304,10 @@ TimeSeriesTable_<T> analyze(Model model, const TimeSeriesTable& statesTable,
 /// arguments must contain the same time points and we assume that the states
 /// obey any kinematic constraints in the Model.
 ///
+/// @note The passed in model must have the correct mass and inertia properties
+/// included, since computing accelerations requires realizing to
+/// SimTK::Stage::Acceleration which depends on SimTK::Stage::Dynamics.
+///
 /// @ingroup simulationutil
 TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(
         const Model& model,

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -305,7 +305,8 @@ TimeSeriesTable_<T> analyze(Model model, const TimeSeriesTable& statesTable,
 /// obey any kinematic constraints in the Model.
 ///
 /// @ingroup simulationutil
-TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(Model model,
+TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(
+        const Model& model,
         const TimeSeriesTable& statesTable, const TimeSeriesTable& controlsTable,
         const std::vector<std::string>& framePaths);
 

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -291,6 +291,24 @@ TimeSeriesTable_<T> analyze(Model model, const TimeSeriesTable& statesTable,
     return reporter->getTable();
 }
 
+/// Calculate "synthetic" acceleration signals equivalent to signals recorded
+/// from inertial measurement units (IMUs). First, this utility computes the
+/// linear acceleration for each frame included in 'framePaths' using Frame's
+/// 'linear_acceleration' Output. Then, to mimic acceleration signals measured
+/// from IMUs, the model's gravitational acceleration vector is subtracted from
+/// the linear accelerations and the resulting accelerations are re-expressed in
+/// the bases of the associated Frame%s.
+///
+/// @note The linear acceleration Output%s are computed using the analyze()
+/// simulation utility, and therefore the 'statesTable' and 'controlsTable'
+/// arguments must contain the same time points and we assume that the states
+/// obey any kinematic constraints in the Model.
+///
+/// @ingroup simulationutil
+TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(Model model,
+        const TimeSeriesTable& statesTable, const TimeSeriesTable& controlsTable,
+        const std::vector<std::string>& framePaths);
+
 } // end of namespace OpenSim
 
 #endif // OPENSIM_SIMULATION_UTILITIES_H_

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -309,7 +309,7 @@ TimeSeriesTable_<T> analyze(Model model, const TimeSeriesTable& statesTable,
 /// SimTK::Stage::Acceleration which depends on SimTK::Stage::Dynamics.
 ///
 /// @ingroup simulationutil
-TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(
+OSIMSIMULATION_API TimeSeriesTableVec3 createSyntheticIMUAccelerationSignals(
         const Model& model,
         const TimeSeriesTable& statesTable, const TimeSeriesTable& controlsTable,
         const std::vector<std::string>& framePaths);


### PR DESCRIPTION
Related issue #2982

### Brief summary of changes
- Added createSyntheticIMUAccelerationSignals() to SimulationUtilities
- Updated testMocoGoals to use new utility

### Testing I've completed
- Re-ran testMocoGoals

### Looking for feedback on...
- Utility name
- Implementation, specifically regarding future compatibility with a "SyntheticIMU" reporter

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2988)
<!-- Reviewable:end -->
