### PR TITLE
Bodykinematics header fix

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -81,11 +81,13 @@ int main()
         cout << e.what() << endl;
         failures.push_back("testActuationAnalysisWithDisabledForce");
     }
-    try { testBodyKinematics(); } 
+    try { testBodyKinematics(); }
     catch (const std::exception& e) { 
         cout << e.what() << endl;
         failures.push_back("testBodyKinematics");
-    }    if (!failures.empty()) {
+    }   
+
+    if (!failures.empty()) {
         cout << "Done, with failure(s): " << failures << endl;
         return 1;
     }
@@ -276,7 +278,6 @@ void testBodyKinematics() {
         model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
         body, SimTK::Vec3(0), SimTK::Vec3(0, SimTK::Pi/2, 0));
     model.addJoint(&joint);
-    model.finalizeConnections();
 
     BodyKinematics bodyKinematicsLocal;
     bodyKinematicsLocal.setName("local");

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -30,7 +30,7 @@
 #include <OpenSim/Analyses/OutputReporter.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Auxiliary/auxiliaryTestMuscleFunctions.h>
-#include <OpenSim/Simulation/SimbodyEngine/PlanarJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Analyses/BodyKinematics.h>
 
@@ -272,7 +272,7 @@ void testBodyKinematics() {
 
     // Rotate child frame so that planar rotational joint is about
     // the body's local X axis, and the ground's Z axis
-    PlanarJoint joint("joint",
+    FreeJoint joint("joint",
         model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
         body, SimTK::Vec3(0), SimTK::Vec3(0, SimTK::Pi/2, 0));
     model.addJoint(&joint);
@@ -295,11 +295,11 @@ void testBodyKinematics() {
     double speedRot = 1.0;
     double speedX = 2.0;
     double speedY = 3.0;
-    joint.updCoordinate(PlanarJoint::Coord::RotationZ)
+    joint.updCoordinate(FreeJoint::Coord::Rotation3Z)
             .setSpeedValue(s, speedRot);
-    joint.updCoordinate(PlanarJoint::Coord::TranslationX)
+    joint.updCoordinate(FreeJoint::Coord::TranslationX)
             .setSpeedValue(s, speedX);
-    joint.updCoordinate(PlanarJoint::Coord::TranslationY)
+    joint.updCoordinate(FreeJoint::Coord::TranslationY)
             .setSpeedValue(s, speedY);
 
     Manager manager(model);

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -279,18 +279,18 @@ void testBodyKinematics() {
         body, SimTK::Vec3(0), SimTK::Vec3(0, SimTK::Pi/2, 0));
     model.addJoint(&joint);
 
-    BodyKinematics bodyKinematicsLocal;
-    bodyKinematicsLocal.setName("local");
-    bodyKinematicsLocal.setExpressResultsInLocalFrame(true);
-    bodyKinematicsLocal.setInDegrees(true);
+    BodyKinematics* bodyKinematicsLocal = new BodyKinematics(&model);
+    bodyKinematicsLocal->setName("local");
+    bodyKinematicsLocal->setExpressResultsInLocalFrame(true);
+    bodyKinematicsLocal->setInDegrees(true);
 
-    BodyKinematics bodyKinematicsGround;
-    bodyKinematicsGround.setName("ground");
-    bodyKinematicsGround.setExpressResultsInLocalFrame(false);
-    bodyKinematicsGround.setInDegrees(false);
+    BodyKinematics* bodyKinematicsGround = new BodyKinematics(&model);
+    bodyKinematicsGround->setName("ground");
+    bodyKinematicsGround->setExpressResultsInLocalFrame(false);
+    bodyKinematicsGround->setInDegrees(false);
 
-    model.addAnalysis(&bodyKinematicsLocal);
-    model.addAnalysis(&bodyKinematicsGround);
+    model.addAnalysis(bodyKinematicsLocal);
+    model.addAnalysis(bodyKinematicsGround);
 
     SimTK::State& s = model.initSystem();
     double speedRot = 1.0;
@@ -308,8 +308,8 @@ void testBodyKinematics() {
     manager.initialize(s);
     s = manager.integrate(duration);
 
-    bodyKinematicsLocal.printResults("BodyKinematics");
-    bodyKinematicsGround.printResults("BodyKinematics");
+    bodyKinematicsLocal->printResults("BodyKinematics");
+    bodyKinematicsGround->printResults("BodyKinematics");
 
     Storage localVel("BodyKinematics_local_vel_bodyLocal.sto");
     Storage groundVel("BodyKinematics_ground_vel_global.sto");

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -278,18 +278,18 @@ void testBodyKinematics() {
     model.addJoint(&joint);
     model.finalizeConnections();
 
-    BodyKinematics* bodyKinematicsLocal = new BodyKinematics();
-    bodyKinematicsLocal->setName("local");
-    bodyKinematicsLocal->setExpressResultsInLocalFrame(true);
-    bodyKinematicsLocal->setInDegrees(true);
+    BodyKinematics bodyKinematicsLocal;
+    bodyKinematicsLocal.setName("local");
+    bodyKinematicsLocal.setExpressResultsInLocalFrame(true);
+    bodyKinematicsLocal.setInDegrees(true);
 
-    BodyKinematics* bodyKinematicsGround = new BodyKinematics();
-    bodyKinematicsGround->setName("ground");
-    bodyKinematicsGround->setExpressResultsInLocalFrame(false);
-    bodyKinematicsGround->setInDegrees(false);
+    BodyKinematics bodyKinematicsGround;
+    bodyKinematicsGround.setName("ground");
+    bodyKinematicsGround.setExpressResultsInLocalFrame(false);
+    bodyKinematicsGround.setInDegrees(false);
 
-    model.addAnalysis(bodyKinematicsLocal);
-    model.addAnalysis(bodyKinematicsGround);
+    model.addAnalysis(&bodyKinematicsLocal);
+    model.addAnalysis(&bodyKinematicsGround);
 
     SimTK::State& s = model.initSystem();
     double speedRot = 1.0;
@@ -307,8 +307,8 @@ void testBodyKinematics() {
     manager.initialize(s);
     s = manager.integrate(duration);
 
-    bodyKinematicsLocal->printResults("BodyKinematics");
-    bodyKinematicsGround->printResults("BodyKinematics");
+    bodyKinematicsLocal.printResults("BodyKinematics");
+    bodyKinematicsGround.printResults("BodyKinematics");
 
     Storage localVel("BodyKinematics_local_vel_bodyLocal.sto");
     Storage groundVel("BodyKinematics_ground_vel_global.sto");

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -312,21 +312,22 @@ void testBodyKinematics() {
 
     Storage localVel("BodyKinematics_local_vel_bodyLocal.sto");
     Storage groundVel("BodyKinematics_ground_vel_global.sto");
-    Array<double> localVelOx, localVelOz, globalVelOx, globalVelOz;
+    Array<double> localVelOx, localVelOz, groundVelOx, groundVelOz;
     localVel.getDataColumn("body_Ox", localVelOx);
     localVel.getDataColumn("body_Oz", localVelOz);
-    groundVel.getDataColumn("body_Ox", globalVelOx);
-    groundVel.getDataColumn("body_Oz", globalVelOz);
+    groundVel.getDataColumn("body_Ox", groundVelOx);
+    groundVel.getDataColumn("body_Oz", groundVelOz);
 
-    assert(localVelOx.getLast() == speedRot * SimTK_RADIAN_TO_DEGREE);
-    assert(localVelOz.getLast() == 0);
-    assert(groundVelOx.getLast() == 0);
-    assert(groundVelOz.getLast() == speedrot);
+    double tol = 1e-6;
+    ASSERT_EQUAL<double>(localVelOx.getLast(), speedRot * SimTK_RADIAN_TO_DEGREE, tol);
+    ASSERT_EQUAL<double>(localVelOz.getLast(), 0, tol);
+    ASSERT_EQUAL<double>(groundVelOx.getLast(), 0, tol);
+    ASSERT_EQUAL<double>(groundVelOz.getLast(), speedRot, tol);
 
     Array<double> groundPosX, groundPosY;
     Storage groundPos("BodyKinematics_ground_pos_global.sto");
     groundPos.getDataColumn("body_X", groundPosX);
     groundPos.getDataColumn("body_Y", groundPosY);
-    assert(groundPosX.getLast() == speedX * duration);
-    assert(groundPosY.getLast() == speedY * duration);
+    ASSERT_EQUAL<double>(groundPosX.getLast(), speedX * duration, tol);
+    ASSERT_EQUAL<double>(groundPosY.getLast(), speedY * duration, tol);
 }

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -269,15 +269,15 @@ void testActuationAnalysisWithDisabledForce() {
 void testBodyKinematics() { 
     Model model;
     model.setGravity(SimTK::Vec3(0));
-    Body body("body", 1, SimTK::Vec3(0), SimTK::Inertia(1));
-    model.addBody(&body);
+    Body* body = new Body("body", 1, SimTK::Vec3(0), SimTK::Inertia(1));
+    model.addBody(body);
 
     // Rotate child frame so that planar rotational joint is about
     // the body's local X axis, and the ground's Z axis
-    FreeJoint joint("joint",
+    FreeJoint* joint = new FreeJoint("joint",
         model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
-        body, SimTK::Vec3(0), SimTK::Vec3(0, SimTK::Pi/2, 0));
-    model.addJoint(&joint);
+        *body, SimTK::Vec3(0), SimTK::Vec3(0, SimTK::Pi/2, 0));
+    model.addJoint(joint);
 
     BodyKinematics* bodyKinematicsLocal = new BodyKinematics(&model);
     bodyKinematicsLocal->setName("local");
@@ -296,11 +296,11 @@ void testBodyKinematics() {
     double speedRot = 1.0;
     double speedX = 2.0;
     double speedY = 3.0;
-    joint.updCoordinate(FreeJoint::Coord::Rotation3Z)
+    joint->updCoordinate(FreeJoint::Coord::Rotation3Z)
             .setSpeedValue(s, speedRot);
-    joint.updCoordinate(FreeJoint::Coord::TranslationX)
+    joint->updCoordinate(FreeJoint::Coord::TranslationX)
             .setSpeedValue(s, speedX);
-    joint.updCoordinate(FreeJoint::Coord::TranslationY)
+    joint->updCoordinate(FreeJoint::Coord::TranslationY)
             .setSpeedValue(s, speedY);
 
     Manager manager(model);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v4.3
 - Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
 - Upgrade bindings to use SWIG version 4.0 (allowing doxygen comments to carry over to Java/Python files).
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
+- Fixed incorrect header information in BodyKinematics file output
 
 v4.2
 ====

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -708,7 +708,7 @@ printResults(const string &aBaseName,const string &aDir,double aDT,
     else suffix = "_global";
 
     // Set the file headers just before printing in case the flag
-    // _expressInLocalFrame has changed since construction
+    // _expressInLocalFrame has changed or inDegrees
     constructDescription();
     _aStore->setInDegrees(getInDegrees());
     _vStore->setInDegrees(getInDegrees());

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -710,6 +710,9 @@ printResults(const string &aBaseName,const string &aDir,double aDT,
     // Set the file headers just before printing in case the flag
     // _expressInLocalFrame has changed since construction
     constructDescription();
+    _aStore->setInDegrees(getInDegrees());
+    _vStore->setInDegrees(getInDegrees());
+    _pStore->setInDegrees(getInDegrees());
 
     // ACCELERATIONS
     Storage::printResult(_aStore,aBaseName+"_"+getName()+"_acc"+suffix,aDir,aDT,aExtension);

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -196,11 +196,11 @@ constructDescription()
     strcat(descrip, " body-fixed X-Y-Z Euler angles.\n");
     if (_expressInLocalFrame) {
         strcat(descrip, "\nAngular velocities and accelerations are");
-        strcat(descrip, " expressed in the body-local axes.\n");
+        strcat(descrip, " expressed in the body-local frame.\n");
     } 
     else {
         strcat(descrip, "\nAngular velocities and accelerations are");
-        strcat(descrip, " expressed in the ground frame axes.\n");
+        strcat(descrip, " expressed in the ground frame.\n");
     }
     strcat(descrip, "\nUnits are S.I. units (seconds, meters, Newtons, ...)");
     strcat(descrip, "\nIf the header above contains a line with ");

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -194,8 +194,14 @@ constructDescription()
     strcat(descrip, tmp);
     strcat(descrip, "\nBody segment orientations are described using");
     strcat(descrip, " body-fixed X-Y-Z Euler angles.\n");
-    strcat(descrip, "\nAngular velocities and accelerations are given about");
-    strcat(descrip, " the body-local axes.\n");
+    if (_expressInLocalFrame) {
+        strcat(descrip, "\nAngular velocities and accelerations are");
+        strcat(descrip, " expressed in the body-local axes.\n");
+    } 
+    else {
+        strcat(descrip, "\nAngular velocities and accelerations are");
+        strcat(descrip, " expressed in the ground frame axes.\n");
+    }
     strcat(descrip, "\nUnits are S.I. units (seconds, meters, Newtons, ...)");
     strcat(descrip, "\nIf the header above contains a line with ");
     strcat(descrip, "'inDegrees', this indicates whether rotational values ");
@@ -700,6 +706,10 @@ printResults(const string &aBaseName,const string &aDir,double aDT,
     string suffix;
     if(_expressInLocalFrame) suffix = "_bodyLocal";
     else suffix = "_global";
+
+    // Set the file headers just before printing in case the flag
+    // _expressInLocalFrame has changed since construction
+    constructDescription();
 
     // ACCELERATIONS
     Storage::printResult(_aStore,aBaseName+"_"+getName()+"_acc"+suffix,aDir,aDT,aExtension);


### PR DESCRIPTION
Fixes issue #2842 and other undocumented issues

### Brief summary of changes
- Update header to note whether angular velocities and accelerations are given in local or ground frame
- Update inDegrees to match output
- Add a test that uses BodyKinematics

### Testing I've completed
- Added test
- Inspected output files for correct header output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2991)
<!-- Reviewable:end -->
