### PR TITLE
Fix for Bhargava2004SmoothMuscleMetabolics

### DIFF
--- a/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
+++ b/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
@@ -253,11 +253,10 @@ void Bhargava2004SmoothedMuscleMetabolics::extendRealizeTopology(
         SimTK::State& state) const {
     Super::extendRealizeTopology(state);
     m_muscleIndices.clear();
-    for (int i=0; i < getProperty_muscle_parameters().size(); ++i) {
+    for (int i = 0; i < getProperty_muscle_parameters().size(); ++i) {
         const auto& muscle = get_muscle_parameters(i).getMuscle();
         if (muscle.get_appliesForce()) {
             m_muscleIndices[muscle.getAbsolutePathString()] = i;
-            ++i;
         }
     }
 }


### PR DESCRIPTION
### Brief summary of changes

When registering muscles added to a `Bhargava2004SmoothMuscleMetabolics` component, the iterator in the for-loop iterating over the muscles was getting iterated twice. This PR fixes that.

### CHANGELOG.md (choose one)

- no need to update because...bug fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/2994)
<!-- Reviewable:end -->
