### PR TITLE
Use imus in opensense

### DIFF
--- a/Applications/opensense/test/calibrated_pelvis_rot.osim
+++ b/Applications/opensense/test/calibrated_pelvis_rot.osim
@@ -42,20 +42,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="pelvis_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -438,20 +424,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -766,20 +738,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1118,20 +1076,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1236,20 +1180,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1564,20 +1494,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1916,20 +1832,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -14928,5 +14830,39 @@
 			<objects />
 			<groups />
 		</ContactGeometrySet>
+		<!--Additional components in the model.-->
+		<ComponentSet name="componentset">
+			<objects>
+				<IMU name="pelvis_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/pelvis/pelvis_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_r/tibia_r_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_r/femur_r_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_l/tibia_l_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_l/femur_l_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_l/calcn_l_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_r/calcn_r_imu</socket_frame>
+				</IMU>
+			</objects>
+			<groups />
+		</ComponentSet>
 	</Model>
 </OpenSimDocument>

--- a/Applications/opensense/test/std_calibrated_pelvis_rot.osim
+++ b/Applications/opensense/test/std_calibrated_pelvis_rot.osim
@@ -42,20 +42,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="pelvis_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -438,20 +424,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -766,20 +738,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1118,20 +1076,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1236,20 +1180,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1564,20 +1494,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -1916,20 +1832,6 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
@@ -14928,5 +14830,39 @@
 			<objects />
 			<groups />
 		</ContactGeometrySet>
+		<!--Additional components in the model.-->
+		<ComponentSet name="componentset">
+			<objects>
+				<IMU name="pelvis_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/pelvis/pelvis_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_r/tibia_r_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_r/femur_r_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_l/tibia_l_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_l/femur_l_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_l/calcn_l_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_r/calcn_r_imu</socket_frame>
+				</IMU>
+			</objects>
+			<groups />
+		</ComponentSet>
 	</Model>
 </OpenSimDocument>

--- a/Applications/opensense/test/std_calibrated_subject07.osim
+++ b/Applications/opensense/test/std_calibrated_subject07.osim
@@ -42,26 +42,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="pelvis_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>-0.080635799999999994 0 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>1.9059930165959802 1.2048562226534925 -0.39301779577527757</orientation>
+							<orientation>1.9059930286726432 1.2048562102479718 -0.39301778369861573</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -423,26 +409,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0 -0.16878299999999999 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>-3.0223047706965711 -0.017156837798393651 -1.5929161084814525</orientation>
+							<orientation>-3.0223047471190658 -0.017156836235066239 -1.5929160954362545</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -746,26 +718,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0 -0.20469100000000001 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>3.0983145230251958 -0.12617221868762463 -1.5448328404448608</orientation>
+							<orientation>3.0983145480436671 -0.1261722192559758 -1.5448328272153662</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1078,26 +1036,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_r_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0.090637599999999999 0.029999999999999999 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>1.9510619803276614 -0.22885165756363368 -0.7410304813537324</orientation>
+							<orientation>1.9510620048171152 -0.22885166976186394 -0.74103047634731645</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1186,26 +1130,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="femur_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0 -0.16385 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>-0.10810494345885641 0.21471931772257755 1.6476879346111601</orientation>
+							<orientation>-0.10810491725702659 0.21471931913994774 1.6476879212442614</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1509,26 +1439,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="tibia_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0 -0.202735 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>0.087597279415662879 0.053015899226704286 1.5102581499140815</orientation>
+							<orientation>0.087597303463795559 0.053015898077442017 1.5102581368094063</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1841,26 +1757,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="calcn_l_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>0.089596899999999993 0.029999999999999999 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>1.4738110815268277 -0.44553232623555772 1.8784808096345931</orientation>
+							<orientation>1.4738111042730471 -0.44553233931045538 1.8784808082249196</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1949,26 +1851,12 @@
 								<!--Scale factors in X, Y, Z directions respectively.-->
 								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
 							</FrameGeometry>
-							<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
-							<attached_geometry>
-								<Brick name="torso_imu_geom_1">
-									<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
-									<socket_frame>..</socket_frame>
-									<!--Default appearance attributes for this Geometry-->
-									<Appearance>
-										<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
-										<color>1 0.5 0</color>
-									</Appearance>
-									<!--Half lengths in X, Y, Z respectively.-->
-									<half_lengths>0.02 0.01 0.0050000000000000001</half_lengths>
-								</Brick>
-							</attached_geometry>
 							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
 							<socket_parent>..</socket_parent>
 							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
 							<translation>-0.029999999999999999 0.336366 0</translation>
 							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
-							<orientation>2.632157713598184 1.0903438015317259 -1.0742704735175783</orientation>
+							<orientation>2.6321577149471858 1.0903437951252011 -1.0742704487035837</orientation>
 						</PhysicalOffsetFrame>
 					</components>
 					<!--The geometry used to display the axes of this Frame.-->
@@ -6129,7 +6017,40 @@
 		</ProbeSet>
 		<!--Additional components in the model.-->
 		<ComponentSet name="componentset">
-			<objects />
+			<objects>
+				<IMU name="torso_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/torso/torso_imu</socket_frame>
+				</IMU>
+				<IMU name="pelvis_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/pelvis/pelvis_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_r/tibia_r_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_r/femur_r_imu</socket_frame>
+				</IMU>
+				<IMU name="tibia_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/tibia_l/tibia_l_imu</socket_frame>
+				</IMU>
+				<IMU name="femur_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/femur_l/femur_l_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_r_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_r/calcn_r_imu</socket_frame>
+				</IMU>
+				<IMU name="calcn_l_imu">
+					<!--Path to a Component that satisfies the Socket 'frame' of type PhysicalFrame (description: The frame to which the IMU is attached.).-->
+					<socket_frame>/bodyset/calcn_l/calcn_l_imu</socket_frame>
+				</IMU>
+			</objects>
 			<groups />
 		</ComponentSet>
 	</Model>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -237,8 +237,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 
 %include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
 
-%shared_ptr(OpenSim::IMU);
-%template(StdVectorIMUs) std::vector< std::shared_ptr<OpenSim::IMU> >;
+%template(StdVectorIMUs) std::vector< OpenSim::IMU* >;
 
 %include <OpenSim/Simulation/StatesTrajectory.h>
 // This enables iterating using the getBetween() method.

--- a/OpenSim/Analyses/IMUDataReporter.cpp
+++ b/OpenSim/Analyses/IMUDataReporter.cpp
@@ -164,7 +164,7 @@ int IMUDataReporter::begin(const SimTK::State& s )
     if (_imuComponents.empty()) {
         // Populate _imuComponents based on properties
         _modelLocal.reset(_model->clone());
-        auto& compList = _modelLocal->getComponentList<OpenSim::IMU>();
+        auto compList = _modelLocal->getComponentList<OpenSim::IMU>();
         // To convert the const_ref to a Ptr for use by SimTK::ReferencePtr
         // Using this relatively expensive maneuver
         for (const IMU& imu : compList) { 

--- a/OpenSim/Analyses/IMUDataReporter.cpp
+++ b/OpenSim/Analyses/IMUDataReporter.cpp
@@ -105,9 +105,7 @@ void IMUDataReporter::setNull()
 
     setName("IMUDataReporter");
     _modelLocal = nullptr;
-
-    _orientationsReporter = nullptr;
-    _angularVelocityReporter = _linearAccelerationsReporter = nullptr;
+    // ReferencePtr members are initialized to null by construction
 }
 //_____________________________________________________________________________
 //=============================================================================
@@ -182,9 +180,9 @@ int IMUDataReporter::begin(const SimTK::State& s )
     }
     // If already part of the system, then a rerun and no need to add to _modelLocal
     if (!_orientationsReporter->hasSystem()) {
-        _modelLocal->addComponent(_orientationsReporter);
-        _modelLocal->addComponent(_angularVelocityReporter);
-        _modelLocal->addComponent(_linearAccelerationsReporter);
+        _modelLocal->addComponent(_orientationsReporter.get());
+        _modelLocal->addComponent(_angularVelocityReporter.get());
+        _modelLocal->addComponent(_linearAccelerationsReporter.get());
 
         for (auto& comp : _imuComponents) {
             if (get_report_orientations())

--- a/OpenSim/Analyses/IMUDataReporter.cpp
+++ b/OpenSim/Analyses/IMUDataReporter.cpp
@@ -44,7 +44,6 @@ using namespace std;
  */
 IMUDataReporter::~IMUDataReporter()
 { 
-    _modelLocal.reset();
 }
 //_____________________________________________________________________________
 /**
@@ -146,13 +145,10 @@ int IMUDataReporter::begin(const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
-    _orientationsReporter.clearTable();
-    _angularVelocityReporter.clearTable();
-    _linearAccelerationsReporter.clearTable();
-
     if (_imuComponents.empty()) {
         // Populate _imuComponents based on properties
         _modelLocal.reset(_model->clone());
+        _modelLocal->updAnalysisSet().setSize(0);
         auto compList = _modelLocal->updComponentList<OpenSim::IMU>();
         for (IMU& imu : compList) { 
             SimTK::ReferencePtr<OpenSim::IMU> imuRef(imu);

--- a/OpenSim/Analyses/IMUDataReporter.cpp
+++ b/OpenSim/Analyses/IMUDataReporter.cpp
@@ -145,6 +145,10 @@ int IMUDataReporter::begin(const SimTK::State& s )
 {
     if(!proceed()) return(0);
 
+    _orientationsReporter.clearTable();
+    _angularVelocityReporter.clearTable();
+    _linearAccelerationsReporter.clearTable();
+
     if (_imuComponents.empty()) {
         // Populate _imuComponents based on properties
         _modelLocal.reset(_model->clone());

--- a/OpenSim/Analyses/IMUDataReporter.h
+++ b/OpenSim/Analyses/IMUDataReporter.h
@@ -74,9 +74,9 @@ public:
 private:
     std::vector<std::shared_ptr<OpenSim::IMU> > _imuComponents;
     /** Output tables. */
-    TableReporter_<SimTK::Quaternion> _orientationsReporter;
-    TableReporter_<SimTK::Vec3> _angularVelocityReporter;
-    TableReporter_<SimTK::Vec3> _linearAccelerationsReporter;
+    TableReporter_<SimTK::Quaternion>* _orientationsReporter;
+    TableReporter_<SimTK::Vec3>* _angularVelocityReporter;
+    TableReporter_<SimTK::Vec3>* _linearAccelerationsReporter;
 
     std::unique_ptr<Model> _modelLocal;
 //=============================================================================
@@ -92,15 +92,15 @@ public:
     // In memory access to IMU data as Tables (Orientations)
     const TimeSeriesTable_<SimTK::Quaternion_<double> >&
     getOrientationsTable() const {
-        return _orientationsReporter.getTable();
+        return _orientationsReporter->getTable();
     }
     // In memory access to IMU data as Tables Angular Velocities)
     const TimeSeriesTable_<SimTK::Vec3>& getGyroscopeSignalsTable() const {
-        return _angularVelocityReporter.getTable();
+        return _angularVelocityReporter->getTable();
     }
     // In memory access to IMU data as Tables (Linear Accelerations)
     const TimeSeriesTable_<SimTK::Vec3>& getAccelerometerSignalsTable() const {
-        return _linearAccelerationsReporter.getTable();
+        return _linearAccelerationsReporter->getTable();
     }
 
 public:

--- a/OpenSim/Analyses/IMUDataReporter.h
+++ b/OpenSim/Analyses/IMUDataReporter.h
@@ -74,9 +74,9 @@ public:
 private:
     std::vector<std::shared_ptr<OpenSim::IMU> > _imuComponents;
     /** Output tables. */
-    TableReporter_<SimTK::Quaternion>* _orientationsReporter;
-    TableReporter_<SimTK::Vec3>* _angularVelocityReporter;
-    TableReporter_<SimTK::Vec3>* _linearAccelerationsReporter;
+    SimTK::ReferencePtr<TableReporter_<SimTK::Quaternion>> _orientationsReporter;
+    SimTK::ReferencePtr < TableReporter_<SimTK::Vec3>> _angularVelocityReporter;
+    SimTK::ReferencePtr <TableReporter_<SimTK::Vec3>> _linearAccelerationsReporter;
 
     std::unique_ptr<Model> _modelLocal;
 //=============================================================================

--- a/OpenSim/Analyses/IMUDataReporter.h
+++ b/OpenSim/Analyses/IMUDataReporter.h
@@ -72,14 +72,14 @@ public:
 // DATA
 //=============================================================================
 private:
-    std::vector<std::shared_ptr<OpenSim::IMU> > _imuComponents;
+    std::vector<SimTK::ReferencePtr<const OpenSim::IMU>> _imuComponents;
     /** Output tables. */
     SimTK::ReferencePtr<TableReporter_<SimTK::Quaternion>> _orientationsReporter;
     SimTK::ReferencePtr < TableReporter_<SimTK::Vec3>> _angularVelocityReporter;
     SimTK::ReferencePtr <TableReporter_<SimTK::Vec3>> _linearAccelerationsReporter;
 
-    std::unique_ptr<Model> _modelLocal;
-//=============================================================================
+    std::shared_ptr<Model> _modelLocal;
+    //=============================================================================
 // METHODS
 //=============================================================================
 public:

--- a/OpenSim/Simulation/OpenSense/IMU.h
+++ b/OpenSim/Simulation/OpenSense/IMU.h
@@ -82,10 +82,12 @@ public:
 
         // @TODO default color, size, shape should be obtained from hints
         const OpenSim::PhysicalFrame& physFrame = this->get_frame();
+        SimTK::Transform relativeXform = physFrame.findTransformInBaseFrame();
         appendToThis.push_back(
                 SimTK::DecorativeBrick(SimTK::Vec3(0.02, 0.01, 0.005))
                         .setBodyId(physFrame.getMobilizedBodyIndex())
-                                        .setColor(SimTK::Purple));
+                                        .setColor(SimTK::Orange)
+                        .setTransform(relativeXform));
     }
 
 private:

--- a/OpenSim/Simulation/OpenSense/IMU.h
+++ b/OpenSim/Simulation/OpenSense/IMU.h
@@ -43,6 +43,13 @@ class OSIMSIMULATION_API IMU : public ModelComponent {
 
 public:
     IMU() {  }
+    virtual ~IMU() { 
+    };
+    IMU(const IMU&) = default;
+    IMU(IMU&&) = default;
+    IMU& operator=(const IMU&) = default;
+    IMU& operator=(IMU&&) = default;
+
     // Attachment frame for placement/visualization
     OpenSim_DECLARE_SOCKET(
             frame, PhysicalFrame, "The frame to which the IMU is attached.");

--- a/OpenSim/Simulation/OpenSense/IMU.h
+++ b/OpenSim/Simulation/OpenSense/IMU.h
@@ -42,9 +42,8 @@ class OSIMSIMULATION_API IMU : public ModelComponent {
     OpenSim_DECLARE_CONCRETE_OBJECT(IMU, ModelComponent);
 
 public:
-    IMU() {  }
-    virtual ~IMU() { 
-    };
+    IMU() = default;
+    virtual ~IMU() = default;
     IMU(const IMU&) = default;
     IMU(IMU&&) = default;
     IMU& operator=(const IMU&) = default;

--- a/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
@@ -218,10 +218,12 @@ bool IMUPlacer::run(bool visualizeResults) {
 
                 imuOffset = new PhysicalOffsetFrame(
                         imuName, *bodies[imuix], SimTK::Transform(R_FB, p_FB));
-                auto* brick = new Brick(Vec3(0.02, 0.01, 0.005));
-                brick->setColor(SimTK::Orange);
-                imuOffset->attachGeometry(brick);
                 bodies[imuix]->addComponent(imuOffset);
+                // Create an IMU Object in the model, connect it to imuOffset
+                IMU* modelImu = new IMU();
+                modelImu->setName(imuName);
+                modelImu->connectSocket_frame(*imuOffset);
+                _model->addModelComponent(modelImu);
                 log_info("Added offset frame for {}.", imuName);
             }
             log_info("{} offset computed from {} data from file.",

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -279,7 +279,7 @@ std::vector<std::shared_ptr<OpenSim::IMU> > OpenSenseUtilities::addModelIMUs(
         const Component& comp = model.getComponent(path);
         next_imu->setName(comp.getName() + "_imu");
         next_imu->connectSocket_frame(comp);
-        model.addComponent(next_imu);
+        model.addModelComponent(next_imu);
         // make sure it's a Frame
         selectedIMUs.push_back(std::shared_ptr<IMU>(next_imu)); 
     }

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.cpp
@@ -270,10 +270,10 @@ SimTK::Vec3 OpenSenseUtilities::computeHeadingCorrection(
     return rotations;
 }
 
-std::vector<std::shared_ptr<OpenSim::IMU> > OpenSenseUtilities::addModelIMUs(
+std::vector<OpenSim::IMU* > OpenSenseUtilities::addModelIMUs(
     Model& model, std::vector<std::string>& paths) {
 
-    std::vector< std::shared_ptr<OpenSim::IMU> > selectedIMUs;
+    std::vector<OpenSim::IMU*> selectedIMUs;
     for (auto path : paths) {
         IMU* next_imu = new IMU();
         const Component& comp = model.getComponent(path);
@@ -281,7 +281,7 @@ std::vector<std::shared_ptr<OpenSim::IMU> > OpenSenseUtilities::addModelIMUs(
         next_imu->connectSocket_frame(comp);
         model.addModelComponent(next_imu);
         // make sure it's a Frame
-        selectedIMUs.push_back(std::shared_ptr<IMU>(next_imu)); 
+        selectedIMUs.push_back(next_imu); 
     }
     model.finalizeConnections();
     return selectedIMUs;

--- a/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
+++ b/OpenSim/Simulation/OpenSense/OpenSenseUtilities.h
@@ -80,7 +80,7 @@ public:
     /// based on paths specification. 
     /// - If "paths" refer to user specified list of frames, then one new 
     ///     "{Frame}_imu" is added to the model and returned in result.
-    static std::vector< std::shared_ptr<OpenSim::IMU> > addModelIMUs(
+    static std::vector< OpenSim::IMU* > addModelIMUs(
             Model& model, std::vector<std::string>& paths);
 }; // end of class OpenSenseUtilities
 }


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
When using IMUPlacer, create and add IMUs to the calibrated model. Make sure IMUs are added in the ModelComponent Set so that they're accessible to GUI.

### Testing I've completed
Built GUI against this branch, ran IMU placer, calibrated model matched 4.2 and IMUs are accessible.

### Looking for feedback on...
Whether this needs to be documented since it should be transparent to users

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3002)
<!-- Reviewable:end -->
