### PR TITLE
Use python 3.8 and numpy 1.20.3 for ci

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Test Python bindings
       run: |
         $env:PATH += ";$env:USERPROFILE/opensim-core-install/bin"
-        $env:PATH
+        $env:PYTHONPATH = "$env:USERPROFILE/opensim-core-install/bin"
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Test opensim-core
       run: |
         chdir $env:GITHUB_WORKSPACE\\build
-        ctest --parallel 4 --output-on-failure --build-config Release
+        ctest --parallel 4 --output-on-failure --build-config Release -E python.*
 
     - name: Install opensim-core
       # TODO: This is where we wish to do the installing, but it's done above for now.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Test Python bindings
       run: |
-        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+        # echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -102,7 +102,7 @@ jobs:
     - name: Test Python bindings
       run: |
         $env:PATH += ";$env:USERPROFILE/opensim-core-install/bin"
-        $env:PYTHONPATH = "$env:USERPROFILE/opensim-core-install/bin"
+        echo "PYTHONPATH=$env:USERPROFILE/opensim-core-install/bin" >> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -102,7 +102,6 @@ jobs:
     - name: Test Python bindings
       run: |
         $env:PATH += ";$env:USERPROFILE/opensim-core-install/bin"
-        echo "PYTHONPATH=$env:USERPROFILE/opensim-core-install/bin" >> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -107,6 +107,7 @@ jobs:
         echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
+        python setup_win_python38.py
         # Run python tests.
         python -m unittest discover --start-directory opensim/tests --verbose
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,7 +40,7 @@ jobs:
       run: python -m pip install numpy==1.20.3
 
     - name: Install SWIG
-      run: choco install swig --version 4.0.0 --yes --limit-output
+      run: choco install swig --version 4.0.2 --yes --limit-output
 
     - name: Cache dependencies
       id: cache-dependencies

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,9 +39,6 @@ jobs:
       #Need numpy to use SWIG numpy typemaps.
       run: python -m pip install numpy==1.20.3
 
-    - name: Install SWIG
-      run: choco install swig --version 4.0.2 --yes --limit-output
-
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@v1

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Test Python bindings
       run: |
-        # echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,11 +33,11 @@ jobs:
     - name: Install Python packages
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
         
     - name: Install numpy
       #Need numpy to use SWIG numpy typemaps.
-      run: python -m pip install numpy==1.19.3
+      run: python -m pip install numpy==1.20.3
 
     - name: Install SWIG
       run: choco install swig --version 4.0.0 --yes --limit-output
@@ -162,9 +162,9 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen python@3.7
+        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen python@3.8
         brew reinstall gcc
-        pip3 install numpy==1.19.3
+        pip3 install numpy==1.20.3
         gfortran -v
         mkdir gfortran_version
         gfortran -v &> gfortran_version/gfortran_version.txt

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,7 +37,7 @@ jobs:
         
     - name: Install numpy
       #Need numpy to use SWIG numpy typemaps.
-      run: python -m pip install numpy==1.20.3
+      run: python -m pip install numpy==1.20.2
 
     - name: Install SWIG
       run: choco install swig --version 4.0.0 --yes --limit-output --allow-downgrade
@@ -163,7 +163,7 @@ jobs:
       run: |
         brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen python@3.8
         brew reinstall gcc
-        pip3 install numpy==1.20.3
+        pip3 install numpy==1.20.2
         gfortran -v
         mkdir gfortran_version
         gfortran -v &> gfortran_version/gfortran_version.txt

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Test Python bindings
       run: |
-        $env:PATH += ";$env:USERPROFILE/opensim-core-install/bin"
+        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
         # Move to the installed location of the python package.
         cd ~/opensim-core-install/sdk/python
         # Run python tests.

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -254,12 +254,9 @@ OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/setup.py" ".")
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" opensim)
 
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/report.py" opensim)
-# for Python 3.8+/Windows we create a file dll_location.txt and use
-# it in setup_win_python38.py to set additional dll directory
+# for Python 3.8+/Windows we use a special script
+# setup_win_python38.py to set additional dll directory in __init__.py on client machine
 if (WIN32)
-    set(DLL_PATH_FILE ${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt)
-    file(WRITE ${DLL_PATH_FILE} "${CMAKE_INSTALL_PREFIX}/bin")
-    OpenSimPutFileInPythonPackage("${DLL_PATH_FILE}" opensim)
     OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/setup_win_python38.py" ".")
 endif()
 

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -255,11 +255,12 @@ OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" opensim)
 
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/report.py" opensim)
 # for Python 3.8+/Windows we create a file dll_location.txt and use
-# it in __init__.py to set additional dll directory
+# it in setup_win_python38.py to set additional dll directory
 if (WIN32)
     set(DLL_PATH_FILE ${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt)
     file(WRITE ${DLL_PATH_FILE} "${CMAKE_INSTALL_PREFIX}/bin")
     OpenSimPutFileInPythonPackage("${DLL_PATH_FILE}" opensim)
+    OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/setup_win_python38.py" ".")
 endif()
 
 # Test files. If you require more test resource files, list them here.

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -254,6 +254,13 @@ OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/setup.py" ".")
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" opensim)
 
 OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/report.py" opensim)
+# for Python 3.8+/Windows we create a file dll_location.txt and use
+# it in __init__.py to set additional dll directory
+if (WIN32)
+    set(DLL_PATH_FILE ${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt)
+    file(WRITE ${DLL_PATH_FILE} "${CMAKE_INSTALL_PREFIX}/bin")
+    OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt" opensim)
+endif()
 
 # Test files. If you require more test resource files, list them here.
 foreach(test_file

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -259,7 +259,7 @@ OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_SOURCE_DIR}/report.py" opensim)
 if (WIN32)
     set(DLL_PATH_FILE ${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt)
     file(WRITE ${DLL_PATH_FILE} "${CMAKE_INSTALL_PREFIX}/bin")
-    OpenSimPutFileInPythonPackage("${CMAKE_CURRENT_BINARY_DIR}/dll_location.txt" opensim)
+    OpenSimPutFileInPythonPackage("${DLL_PATH_FILE}" opensim)
 endif()
 
 # Test files. If you require more test resource files, list them here.

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import os
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-    print('Reading dll_location.txt from '+os.getcwd())
+    print('Reading dll_location.txt from '+os.getcwd()+' platform: '+sys.platform)
     with open('opensim/dll_location.txt', 'r') as reader:
         os.add_dll_directory(reader.read())
 

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,9 +1,7 @@
 import sys
 import os
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-    cwd = os.getcwd()
-    # print(cwd)
-    print('Writing new dll_location.txt conatining '+cwd)
+    print('Reading dll_location.txt from '+os.getcwd())
     with open('opensim/dll_location.txt', 'r') as reader:
         os.add_dll_directory(reader.read())
 

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,3 +1,12 @@
+import sys
+import os
+if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+    cwd = os.getcwd()
+    # print(cwd)
+    print('Writing new dll_location.txt conatining '+cwd)
+    with open('opensim/dll_location.txt', 'r') as reader:
+        os.add_dll_directory(reader.read())
+
 from .simbody import *
 from .common import *
 from .simulation import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,8 +1,7 @@
 import sys
 import os
-from pathlib import Path
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-        if (Path('opensim/dll_location.txt').is_file()):
+        if (os.path.isfile('opensim/dll_location.txt')):
             with open('opensim/dll_location.txt', 'r') as reader:
                 os.add_dll_directory(reader.read())
         else:

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,7 +1,12 @@
 import sys
 import os
+from pathlib import Path
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-        os.add_dll_directory(DLL_PATH)
+        if (Path('opensim/dll_location.txt').is_file()):
+            with open('opensim/dll_location.txt', 'r') as reader:
+                os.add_dll_directory(reader.read())
+        else:
+            os.add_dll_directory(DLL_PATH)
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,11 +1,7 @@
 import sys
 import os
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-        if (os.path.isfile('opensim/dll_location.txt')):
-            with open('opensim/dll_location.txt', 'r') as reader:
-                os.add_dll_directory(reader.read())
-        else:
-            os.add_dll_directory(DLL_PATH)
+   os.add_dll_directory(DLL_PATH)
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,9 +1,7 @@
 import sys
 import os
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-    print('Reading dll_location.txt from '+os.getcwd()+' platform: '+sys.platform)
-    with open('opensim/dll_location.txt', 'r') as reader:
-        os.add_dll_directory(reader.read())
+        os.add_dll_directory(DLL_PATH)
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,6 +1,6 @@
 import sys
 import os
-if (sys.version_info.major == 3 and sys.version_info.minor >= 8):
+if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
     cwd = os.getcwd()
     # print(cwd)
     print('Writing new dll_location.txt conatining '+cwd)

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -3,7 +3,11 @@
 import os
 import sys
 
-from setuptools import setup
+if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
+	install_path=os.path.abspath('../../bin')
+	with open('opensim/dll_location.txt', 'w') as writer:
+		writer.write(install_path)
+		writer.write("\n")
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -7,7 +7,6 @@ if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform
    install_path=os.path.abspath('../../bin')
    with open('opensim/dll_location.txt', 'w') as writer:
       writer.write(install_path)
-      writer.write("\n")
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -2,11 +2,14 @@
 
 import os
 import sys
+import fileinput
 from setuptools import setup
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
    install_path=os.path.abspath('../../bin')
-   with open('opensim/dll_location.txt', 'w') as writer:
-      writer.write(install_path)
+   new_path = install_path.replace(os.sep, '/')
+   with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
+     for line in file:
+          print(line.replace('DLL_PATH', "'"+new_path+"'"), end='')
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -2,15 +2,7 @@
 
 import os
 import sys
-import fileinput
 from setuptools import setup
-if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-   install_path=os.path.abspath('../../bin')
-   new_path = install_path.replace(os.sep, '/')
-   with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
-     for line in file:
-          print(line.replace('DLL_PATH', "'"+new_path+"'"), end='')
-
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:
     execfile('opensim/version.py')

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -2,12 +2,12 @@
 
 import os
 import sys
-
+from setuptools import setup
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-	install_path=os.path.abspath('../../bin')
-	with open('opensim/dll_location.txt', 'w') as writer:
-		writer.write(install_path)
-		writer.write("\n")
+   install_path=os.path.abspath('../../bin')
+   with open('opensim/dll_location.txt', 'w') as writer:
+      writer.write(install_path)
+      writer.write("\n")
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:

--- a/Bindings/Python/setup_win_python38.py
+++ b/Bindings/Python/setup_win_python38.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import sys
+import os
+import fileinput
+if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
+   install_path=os.path.abspath('../../bin')
+   new_path = install_path.replace(os.sep, '/')
+   with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
+     for line in file:
+          print(line.replace('DLL_PATH', "'"+new_path+"'"), end='')

--- a/Bindings/Python/setup_win_python38.py
+++ b/Bindings/Python/setup_win_python38.py
@@ -5,6 +5,7 @@ import fileinput
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
    install_path = os.path.abspath('../../bin')
    new_path = install_path.replace(os.sep, '/')
+   print ('install path found as '+ new_path)
    with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
      for line in file:
           print(line.replace('DLL_PATH', "'" + new_path + "'"), end='')

--- a/Bindings/Python/setup_win_python38.py
+++ b/Bindings/Python/setup_win_python38.py
@@ -3,8 +3,8 @@ import sys
 import os
 import fileinput
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-   install_path=os.path.abspath('../../bin')
+   install_path = os.path.abspath('../../bin')
    new_path = install_path.replace(os.sep, '/')
    with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
      for line in file:
-          print(line.replace('DLL_PATH', "'"+new_path+"'"), end='')
+          print(line.replace('DLL_PATH', "'" + new_path + "'"), end='')

--- a/Bindings/Python/version.py.in
+++ b/Bindings/Python/version.py.in
@@ -1,1 +1,1 @@
-__version__ = "@OPENSIM_QUALIFIED_VERSION@"
+__version__ = "@OPENSIM_RELEASE_VERSION@"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ v4.3
 - Upgrade bindings to use SWIG version 4.0 (allowing doxygen comments to carry over to Java/Python files).
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
 - Fixed incorrect header information in BodyKinematics file output
+- Default build to python 3.8 and numpy 1.20.3
 
 v4.2
 ====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ v4.3
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
 - Fixed incorrect header information in BodyKinematics file output
 - Fixed bug applying non-uniform scaling to inertia matrix of a Body due to using local vaiable of type SysMat33 (Issue #2871).
-- Default build to python 3.8 and numpy 1.20.3
+- Default build to python 3.8 and numpy 1.20
 
 v4.2
 ====


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Force ci to use python 3.8 and numpy 1.20.3 in sync with latest released anaconda

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3013)
<!-- Reviewable:end -->
