### PR TITLE
Use Mat33 instead of SymMat33 in Body::scale

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,7 +40,7 @@ jobs:
       run: python -m pip install numpy==1.19.3
 
     - name: Install SWIG
-      run: choco install swig --version 4.0.0 --yes --limit-output
+      run: choco install swig --version 4.0.0 --yes --limit-output --allow-downgrade
 
     - name: Cache dependencies
       id: cache-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ v4.3
 - Upgrade bindings to use SWIG version 4.0 (allowing doxygen comments to carry over to Java/Python files).
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
 - Fixed incorrect header information in BodyKinematics file output
+- Fixed bug applying non-uniform scaling to inertia matrix of a Body due to using local vaiable of type SysMat33 (Issue #2871).
 
 v4.2
 ====

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -214,8 +214,9 @@ void Body::scaleInertialProperties(const SimTK::Vec3& scaleFactors, bool scaleMa
     // Scale the mass.
     if (scaleMass)
         upd_mass() *= massScaleFactor;
-
-    SimTK::SymMat33 inertia = _inertia.asSymMat33();
+    // Fix issue #2871 by fmatari
+    SimTK::Mat33 inertia = _inertia.toMat33();
+    //SimTK::SymMat33 inertia = _inertia.asSymMat33();
 
     // If the mass is zero, then make the inertia tensor zero as well.
     // If the X, Y, Z scale factors are equal, then you can scale the


### PR DESCRIPTION
The code sets values both over/under the diagonal which makes sense for actual Mat33. Fix suggested and tested by fmatari on user forum.

Fixes issue #2871

### Brief summary of changes
Replace type of local variable from SysMat33 to Mat33

### Testing I've completed
Ran regression tests
### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3015)
<!-- Reviewable:end -->
