### PR TITLE
Ipopt options file

### DIFF
--- a/Bindings/Java/Matlab/examples/Moco/example2DWalking/example2DWalking.m
+++ b/Bindings/Java/Matlab/examples/Moco/example2DWalking/example2DWalking.m
@@ -52,6 +52,9 @@ clear;
 % Load the Moco libraries
 import org.opensim.modeling.*;
 
+% Flag to enable or disable the custom ipopt options files.
+USE_CUSTOM_OPTIONS = true;
+
 % ---------------------------------------------------------------------------
 % Set up a coordinate tracking problem where the goal is to minimize the
 % difference between provided and simulated coordinate values and speeds (and
@@ -183,6 +186,16 @@ problem.setStateInfo('/jointset/ankle_l/ankle_angle_l/value', [-15*pi/180, 25*pi
 problem.setStateInfo('/jointset/ankle_r/ankle_angle_r/value', [-15*pi/180, 25*pi/180]);
 problem.setStateInfo('/jointset/lumbar/lumbar/value', [0, 20*pi/180]);
 
+solver = MocoDirectCollocationSolver.safeDownCast(study.updSolver());
+solver.set_verbosity(2);
+solver.set_optim_solver('ipopt');
+solver.set_optim_convergence_tolerance(1e-4);
+solver.set_optim_constraint_tolerance(1e-4);
+solver.set_optim_max_iterations(1000);
+if (USE_CUSTOM_OPTIONS)
+    % This is a file which contains more custom solver options for ipopt.
+    solver.set_optim_ipopt_opt_filename("track_opt.opt");
+end
 
 % Solve the problem
 % =================
@@ -326,6 +339,10 @@ solver.set_optim_constraint_tolerance(1e-4);
 solver.set_optim_max_iterations(1000);
 solver.setGuess(gaitTrackingSolution); % Use tracking solution as initial guess
 
+if (USE_CUSTOM_OPTIONS)
+    % This is a file which contains more custom solver options for ipopt.
+    solver.set_optim_ipopt_opt_filename("predi_opt.opt");
+end
 
 % Solve problem
 % =============

--- a/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
+++ b/OpenSim/Examples/Moco/example2DWalking/CMakeLists.txt
@@ -2,7 +2,9 @@ set(EXAMPLE_2D_WALKING_FILES
         2D_gait.osim
         referenceCoordinates.sto
         referenceGRF.sto
-        referenceGRF.xml)
+        referenceGRF.xml
+        predi_opt.opt
+        track_opt.opt)
 
 OpenSimAddExampleCXX(NAME example2DWalking SUBDIR Moco
     EXECUTABLES example2DWalking example2DWalkingMetabolics

--- a/OpenSim/Examples/Moco/example2DWalking/example2DWalking.cpp
+++ b/OpenSim/Examples/Moco/example2DWalking/example2DWalking.cpp
@@ -47,6 +47,8 @@
 
 using namespace OpenSim;
 
+bool USE_CUSTOM_OPTIONS = false;
+
 /// Set a coordinate tracking problem where the goal is to minimize the
 /// difference between provided and simulated coordinate values and speeds
 /// (and ground reaction forces) as well as to minimize an effort cost (squared
@@ -185,6 +187,11 @@ MocoSolution gaitTracking(double controlEffortWeight = 10,
     solver.set_optim_constraint_tolerance(1e-4);
     solver.set_optim_max_iterations(1000);
 
+    if (USE_CUSTOM_OPTIONS) {
+        // This is a file which contains more custom solver options for ipopt.
+        solver.set_optim_ipopt_opt_filename("track_opt.opt");
+    }
+
     // Solve problem.
     // ==============
     MocoSolution solution = study.solve();
@@ -317,6 +324,11 @@ void gaitPrediction(const MocoSolution& gaitTrackingSolution) {
     solver.set_optim_max_iterations(1000);
     // Use the solution from the tracking simulation as initial guess.
     solver.setGuess(gaitTrackingSolution);
+
+    if (USE_CUSTOM_OPTIONS) {
+        // This is a file which contains more custom solver options for ipopt.
+        solver.set_optim_ipopt_opt_filename("predi_opt.opt");
+    }
 
     // Solve problem.
     // ==============

--- a/OpenSim/Examples/Moco/example2DWalking/predi_opt.opt
+++ b/OpenSim/Examples/Moco/example2DWalking/predi_opt.opt
@@ -1,0 +1,2 @@
+# Warm start since the problem is probably somewhat converged from the first problem.
+warm_start_init_point yes

--- a/OpenSim/Examples/Moco/example2DWalking/track_opt.opt
+++ b/OpenSim/Examples/Moco/example2DWalking/track_opt.opt
@@ -1,0 +1,3 @@
+# Example of an option that can be specified when we use an external options file.
+
+least_square_init_duals yes

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -239,6 +239,8 @@ std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
     checkPropertyValueIsInSet(getProperty_verbosity(), {0, 1, 2});
     if (get_optim_solver() == "ipopt") {
         solverOptions["print_user_options"] = "yes";
+        // Set the optional options file name.
+        solverOptions["option_file_name"] = get_optim_ipopt_opt_filename();
         if (get_verbosity() < 2) {
             solverOptions["print_level"] = 0;
         } else if (get_optim_ipopt_print_level() != -1) {

--- a/OpenSim/Moco/MocoDirectCollocationSolver.cpp
+++ b/OpenSim/Moco/MocoDirectCollocationSolver.cpp
@@ -40,6 +40,7 @@ void MocoDirectCollocationSolver::constructProperties() {
     constructProperty_implicit_auxiliary_derivative_bounds({-1000, 1000});
     constructProperty_minimize_lagrange_multipliers(false);
     constructProperty_lagrange_multiplier_weight(1.0);
+    constructProperty_optim_ipopt_opt_filename("ipopt.opt");
 }
 
 void MocoDirectCollocationSolver::setMesh(const std::vector<double>& mesh) {

--- a/OpenSim/Moco/MocoDirectCollocationSolver.h
+++ b/OpenSim/Moco/MocoDirectCollocationSolver.h
@@ -124,6 +124,10 @@ public:
             "Newton.");
     OpenSim_DECLARE_PROPERTY(optim_ipopt_print_level, int,
             "IPOPT's verbosity (see IPOPT documentation).");
+    OpenSim_DECLARE_PROPERTY(optim_ipopt_opt_filename, std::string,
+            "When using IPOPT, 'ipopt.opt' (default)."
+            "IPOPT looks for this file before it starts and uses it "
+            "to set optimizer options. See: https://coin-or.github.io/Ipopt/OPTIONS.html.");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(enforce_constraint_derivatives, bool,
             "'true' (default) or 'false', whether or not derivatives of "
             "kinematic constraints are enforced as path constraints in the "

--- a/OpenSim/Moco/MocoTropterSolver.cpp
+++ b/OpenSim/Moco/MocoTropterSolver.cpp
@@ -188,6 +188,9 @@ MocoTropterSolver::createTropterSolver(
         // Check that IPOPT print level is valid.
         checkPropertyValueIsInRangeOrSet(
                 getProperty_optim_ipopt_print_level(), 0, 12, {-1});
+        // Set the optional options file name.
+        optsolver.set_advanced_option_string(
+                "option_file_name", get_optim_ipopt_opt_filename());
         if (get_verbosity() < 2) {
             optsolver.set_advanced_option_int("print_level", 0);
         } else {


### PR DESCRIPTION
Addresses issue #3018

### Brief summary of changes
- Add ipopt option to the CasADi solver and tropter solvers in Moco that passes the ipopt options file name to look for.
- Add example of the use of these external files to 2D walking examples.
- Ipopt will look for the external options file each time it runs and use it to set advanced solver parameters. See: [Ipopt options docs](https://coin-or.github.io/Ipopt/OPTIONS.html)
- Note: The way things are setup now, using the external options file, one cannot overwrite any settings that are set and compiled in the source code or otherwise set in the source code or script. Ipopt will simply issue a warning:
```
WARNING: Tried to set option "<option_name>" to a value of "<option_value_in_file>",
         but the previous value is set to disallow clobbering.
         The setting will remain as: "<value_set_in_source_or_script>"
```

### Testing I've completed
- I have tested it with both solvers in the 2D walking examples.

### Looking for feedback on...
- First PR, so anything about contributing that I have missed.
- E.g. I don't know how we handle version numbers.

### CHANGELOG.md
- no need to update because this seems like a minor update that is transparent to the user?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3025)
<!-- Reviewable:end -->
