### PR TITLE
Warn when writing result files if path is specified for filename

### DIFF
--- a/Applications/ID/test/testID.cpp
+++ b/Applications/ID/test/testID.cpp
@@ -50,6 +50,17 @@ int main()
             std::vector<double>(23, 1e-2), __FILE__, __LINE__,
             "testArm failed");
         cout << "testArm passed" << endl;
+        // setOutputGenForceFileName including folder name, test 
+        // that folder will be ignored and file is written to Results
+        InverseDynamicsTool id12("arm26_Setup_InverseDynamics.xml");
+        id12.setOutputGenForceFileName(
+                "unused_folder/arm26_InverseDynamics_rerun.sto");
+        id12.run();
+        Storage result12("Results/arm26_InverseDynamics_rerun.sto");
+        CHECK_STORAGE_AGAINST_STANDARD(result1, result12,
+                std::vector<double>(23, 1e-5), __FILE__, __LINE__,
+                "testArm ignore path in output file spec. failed");
+        cout << "testArm output file spec. passed" << endl;
 
         InverseDynamicsTool id2("subject01_Setup_InverseDynamics.xml");
         id2.run();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 v4.3
 ====
 - Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
+- Fix issue where including path in output file name caused output to not be written without warning, now warning is given and file is written (Issue #3042).
 - Fix copy-paste bug in reporting orientation errors (Issue #2893, fixed by Henrik-Norgren). 
 - Upgrade bindings to use SWIG version 4.0 (allowing doxygen comments to carry over to Java/Python files).
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2857,13 +2857,22 @@ print(const string &aFileName,double aDT,const string &aMode) const
     return(nTotal);
 }
 
-void Storage::
-printResult(const Storage *aStorage,const std::string &aName,
-                const std::string &aDir,double aDT,const std::string &aExtension)
-{
-    if(!aStorage) return;
-    std::string path = (aDir=="") ? "." : aDir;
-    std::string name = (aName.rfind(aExtension)==string::npos)? (path + "/" + aName + aExtension) :  (path + "/" + aName);
+void Storage::printResult(const Storage* aStorage, const std::string& aName,
+        const std::string& aDir, double aDT, const std::string& aExtension) {
+    if (!aStorage) return;
+    std::string path = (aDir == "") ? "." : aDir;
+    std::string directory;
+    bool dontApplySearchPath;
+    std::string fileName, extension;
+    SimTK::Pathname::deconstructPathname(
+            aName, dontApplySearchPath, directory, fileName, extension);
+    if (directory != "") {
+        log_warn("Directory {} was specified where only file name {} is expected. It will "
+                 "be ignored. Result files will be written to directory '{}' instead.",
+                directory, fileName, path);
+    }
+    std::string name = (extension == "") ? (path + "/" + fileName + aExtension)
+                                         : (path + "/" + fileName + extension);
     if(aDT<=0.0) aStorage->print(name);
     else aStorage->print(name,aDT);
 }

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -2867,9 +2867,10 @@ void Storage::printResult(const Storage* aStorage, const std::string& aName,
     SimTK::Pathname::deconstructPathname(
             aName, dontApplySearchPath, directory, fileName, extension);
     if (directory != "") {
-        log_warn("Directory {} was specified where only file name {} is expected. It will "
-                 "be ignored. Result files will be written to directory '{}' instead.",
-                directory, fileName, path);
+        log_warn("Directory '{}' was specified where only file name '{}' is "
+                 "expected. The directory will be ignored. Result files will "
+                 "be written to directory '{}' instead.",
+                    directory, fileName, path);
     }
     std::string name = (extension == "") ? (path + "/" + fileName + aExtension)
                                          : (path + "/" + fileName + extension);

--- a/OpenSim/Tools/InverseDynamicsTool.cpp
+++ b/OpenSim/Tools/InverseDynamicsTool.cpp
@@ -137,7 +137,12 @@ void InverseDynamicsTool::setupProperties()
     _lowpassCutoffFrequencyProp.setName("lowpass_cutoff_frequency_for_coordinates");
     _propertySet.append( &_lowpassCutoffFrequencyProp );
 
-    _outputGenForceFileNameProp.setComment("Name of the storage file (.sto) to which the generalized forces are written.");
+    string genForceComment =
+            "Name of the storage file (.sto) to which the generalized forces "
+            "are written. Only a filename should be specified here (not a "
+            "full path); the file will appear in the location provided in the "
+            "results_directory property.";
+    _outputGenForceFileNameProp.setComment(genForceComment);
     _outputGenForceFileNameProp.setName("output_gen_force_file");
     _outputGenForceFileNameProp.setValue("inverse_dynamics.sto");
     _propertySet.append(&_outputGenForceFileNameProp);


### PR DESCRIPTION
Also update property comment for InverseDynamicsTool accordingly

Fixes issue #3042

### Brief summary of changes
When using Storage::printResults that takes a directory name and file name, check and warn if file name (often from XML) contains path specification.

### Testing I've completed
Ran test suite.
### Looking for feedback on...
Message and behavior if specification is wrong (warn vs. throw).

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3045)
<!-- Reviewable:end -->
