### PR TITLE
Add CMake flag SKIP_SWIG_DOXYGEN to make processing Doxygen by SWIG optional

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -11,11 +11,11 @@ if(WITH_EZC3D)
 endif()
 #flag to indicate whether to let SWIG process Doxygen comments
 # Will be on for releases but too many warnings/errors for regular dev.
-set(SKIP_SWIG_DOXYGEN OFF CACHE BOOL "Don't carry Doxygen comments to bindings")
-mark_as_advanced(SKIP_SWIG_DOXYGEN)
-set(SWIG_DOXYGEN "")
-if (NOT SKIP_SWIG_DOXYGEN)
-    set(SWIG_DOXYGEN "-doxygen")
+set(SWIG_DOXYGEN ON CACHE BOOL "Carry Doxygen comments to bindings")
+mark_as_advanced(SWIG_DOXYGEN)
+set(SWIG_DOXYGEN_STRING "")
+if (SWIG_DOXYGEN)
+    set(SWIG_DOXYGEN_STRING "-doxygen")
 endif()
 
 if(BUILD_PYTHON_WRAPPING)

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -9,6 +9,13 @@ endif()
 if(WITH_EZC3D)
     set(SWIG_FLAGS "-DWITH_EZC3D")
 endif()
+#flag to indicate whether to let SWIG process Doxygen comments
+# Will be on for releases but too many warnings/errors for regular dev.
+set(BUILD_SWIG_DOXYGEN OFF CACHE BOOL "Carry Doxygen comments to bindings")
+set(SWIG_DOXYGEN "")
+if (BUILD_SWIG_DOXYGEN)
+    set(SWIG_DOXYGEN "-doxygen")
+endif()
 
 if(BUILD_PYTHON_WRAPPING)
     add_subdirectory(Python)

--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -11,9 +11,10 @@ if(WITH_EZC3D)
 endif()
 #flag to indicate whether to let SWIG process Doxygen comments
 # Will be on for releases but too many warnings/errors for regular dev.
-set(BUILD_SWIG_DOXYGEN OFF CACHE BOOL "Carry Doxygen comments to bindings")
+set(SKIP_SWIG_DOXYGEN OFF CACHE BOOL "Don't carry Doxygen comments to bindings")
+mark_as_advanced(SKIP_SWIG_DOXYGEN)
 set(SWIG_DOXYGEN "")
-if (BUILD_SWIG_DOXYGEN)
+if (NOT SKIP_SWIG_DOXYGEN)
     set(SWIG_DOXYGEN "-doxygen")
 endif()
 

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -11,7 +11,7 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 function(OpenSimGenerateJavaWrapper
         NAME INPUT_INTERFACE_FILE OUTPUT_CXX_FILE OUTPUT_H_FILE)
 
-    set(_swig_common_args -c++ -java ${SWIG_DOXYGEN}
+    set(_swig_common_args -c++ -java ${SWIG_DOXYGEN_STRING}
             -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -11,7 +11,7 @@ set_directory_properties(PROPERTIES COMPILE_OPTIONS "")
 function(OpenSimGenerateJavaWrapper
         NAME INPUT_INTERFACE_FILE OUTPUT_CXX_FILE OUTPUT_H_FILE)
 
-    set(_swig_common_args -c++ -java -doxygen
+    set(_swig_common_args -c++ -java ${SWIG_DOXYGEN}
             -package ${OPENSIM_JAVA_WRAPPING_PACKAGE}
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -96,7 +96,7 @@ macro(OpenSimAddPythonModule)
             #-debug-tmused # Which typemaps were used?
             -v # verbose
             -o ${_output_cxx_file}
-            ${SWIG_DOXYGEN}
+            ${SWIG_DOXYGEN_STRING}
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
             ${_swig_common_args}
         DEPENDS ${_${OSIMSWIGPY_MODULE}_dependencies}

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -73,7 +73,7 @@ macro(OpenSimAddPythonModule)
     # We run swig once to get dependencies and then again to actually generate
     # the wrappers. This variable holds the parts of the swig command that
     # are shared between both invocations.
-    set(_swig_common_args -c++ -python -py3 -doxygen
+    set(_swig_common_args -c++ -python -py3
             -I${OpenSim_SOURCE_DIR}
             -I${OpenSim_SOURCE_DIR}/Bindings/
             -I${Simbody_INCLUDE_DIR}
@@ -96,7 +96,7 @@ macro(OpenSimAddPythonModule)
             #-debug-tmused # Which typemaps were used?
             -v # verbose
             -o ${_output_cxx_file}
-            -doxygen
+            ${SWIG_DOXYGEN}
             -outdir "${CMAKE_CURRENT_BINARY_DIR}"
             ${_swig_common_args}
         DEPENDS ${_${OSIMSWIGPY_MODULE}_dependencies}


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Added CMake variable to control whether to process Doxygen comments for scripting purposes. While great for final releases, in dev environments it takes longer and produces massive list of bogus errors/warnings
### Testing I've completed
Built on windows with the flag on and off and got expected behavior
### Looking for feedback on...
Whether this is useful and the cmake variable name has the right connotation
### CHANGELOG.md (choose one)

- no need to update because DOXYGEN inclusion was just introduced in 4.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3054)
<!-- Reviewable:end -->
