### PR TITLE
update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ On Windows using Visual Studio
     * [TortoiseGit](https://code.google.com/p/tortoisegit/wiki/Download),
       intermediate; good for TortoiseSVN users;
     * [GitHub for Windows](https://windows.github.com/), easiest.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 4.0.2
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
@@ -806,7 +806,7 @@ ctest -j8
 * **version control** (optional): git.
     * Xcode Command Line Tools gives you git on the command line.
     * [GitHub for Mac](https://mac.github.com), for a simple-to-use GUI.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 4.0.2
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
                 'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
@@ -1010,7 +1010,7 @@ specific Ubuntu versions under 'For the impatient' below.
   [Doxygen](http://www.stack.nl/~dimitri/doxygen/download.html) >= 1.8.6;
   `doxygen`.
 * **version control** (optional): git; `git`.
-* **Bindings** (optional): [SWIG](http://www.swig.org/) 3.0.8; `swig`.
+* **Bindings** (optional): [SWIG](http://www.swig.org/) 4.0.2; `swig`.
     * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7;
       `openjdk-7-jdk`.
         * Note: Older versions of MATLAB may use an older version of JVM. Run

--- a/README.md
+++ b/README.md
@@ -513,9 +513,9 @@ On Windows using Visual Studio
       intermediate; good for TortoiseSVN users;
     * [GitHub for Windows](https://windows.github.com/), easiest.
 * **Bindings** (optional): [SWIG](http://www.swig.org/) 4.0.2
-    * **MATLAB scripting** (optional): [Java development kit][java] >= 1.7.
+    * **MATLAB scripting** (optional): [Java development kit][java] >= 1.8.
         * Note: Older versions of MATLAB may use an older version of JVM. Run
-                'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.7).
+                'ver' in MATLAB to check MATLAB's JVM version (must be >= 1.8).
         * Note: Java development kit >= 9 requires CMake >= 3.10.
     * **Python scripting** (optional): Python 2 >= 2.7 or Python 3 >= 3.5
         * [Anaconda](https://www.anaconda.com/distribution/)
@@ -551,10 +551,9 @@ On Windows using Visual Studio
    which to build dependencies. Let's say this is
    `C:/opensim-core-dependencies-build`.
 4. Click the **Configure** button.
-    1. Visual Studio 2015: Choose the *Visual Studio 14 2015* generator (may appear as *Visual Studio 14*).
-    2. Visual Studio 2017: Choose the *Visual Studio 15 2017* generator.
-    3. To build as 64-bit, select the generator with *Win64* in the name.
-    4. Click **Finish**.
+    1. Visual Studio 2019: Choose the *Visual Studio 16 2019* generator.
+    2. Need to build as 64-bit, select the generator with *Win64* in the name.
+    3. Click **Finish**.
 5. Where do you want to install OpenSim dependencies on your computer? Set this
    by changing the `CMAKE_INSTALL_PREFIX` variable. Let's say this is
    `C:/opensim-core-dependencies-install`.


### PR DESCRIPTION
This PR updates the documentation for building opensim-core from source. On windows, you should use swig 4.0.2.

A couple of remarks:
- It did not work with swig 4.0.1 - I had problems with the moco python bindings. I did not try with 4.0.0.
- I see in the readme that there are some `swig3.0` as part of some commands. Not sure we can safely change that to 4.0.2 and I do not have ubuntu to try.

thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3068)
<!-- Reviewable:end -->
