### PR TITLE
Practically SWIG 4.0.2 is required on all platforms 

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 4.0.0 REQUIRED)
+    find_package(SWIG 4.0.2 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.


### PR DESCRIPTION
while 4.0.0 fails on some. Making it a formal requirement.

Fixes issue #0

### Brief summary of changes
Change CMakelists.txt to correspond to actual/tested build configurations cross platform.

### Testing I've completed
None, this should be a no-op.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update
