### PR TITLE
Remove references to OPENSIM_HOME env. variable, 

### DIFF
--- a/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
+++ b/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find the OpenSim libraries and header files.
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install.")
 # This command searches for the file OpenSimConfig.cmake
 # in common system directories and in OPENSIM_INSTALL_DIR.
 find_package(OpenSim 4.0 REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Examples/ControllerExample/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET exampleController CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET exampleCustomActuator CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET exampleLuxoMuscle CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleMain/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET exampleMain CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Examples/MuscleExample/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET exampleMuscle CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET optimizationExample CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 file(GLOB SOURCE_FILES *.cpp)
 file(GLOB INCLUDE_FILES *.h)
 
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-    CACHE PATH "Top-level directory of OpenSim install")
-
 set(PLUGIN_NAME "osimPlugin" CACHE STRING "Name of shared library to create")
 
 # OpenSim uses C++11 language features.

--- a/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 file(GLOB SOURCE_FILES *.cpp)
 file(GLOB INCLUDE_FILES *.h)
 
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-    CACHE PATH "Top-level directory of OpenSim install")
-
 set(PLUGIN_NAME "BodyDragForce" CACHE STRING "Name of shared library to create")
 
 # OpenSim uses C++11 language features.

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
@@ -5,9 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 file(GLOB SOURCE_FILES *.cpp)
 file(GLOB INCLUDE_FILES *.h)
 
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-    CACHE PATH "Top-level directory of OpenSim install")
-
 set(PLUGIN_NAME "osimCoupledBushingForcePlugin"
     CACHE STRING "Name of shared library to create")
 

--- a/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET simpleOptimizationExample CACHE TYPE STRING)
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)

--- a/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
+++ b/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
@@ -40,9 +40,6 @@ set(PLUGIN_NAME "osimExpressionReporter")
 
 # Settings.
 # ---------
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
-
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/OpenSim/Examples/checkEnvironment/CMakeLists.txt
+++ b/OpenSim/Examples/checkEnvironment/CMakeLists.txt
@@ -5,8 +5,6 @@ cmake_minimum_required(VERSION 3.2)
 # Settings.
 # ---------
 set(TARGET checkEnvironment CACHE STRING "Name of example to build")
-set(OPENSIM_INSTALL_DIR $ENV{OPENSIM_HOME}
-        CACHE PATH "Top-level directory of OpenSim install")
 
 # OpenSim uses C++11 language features.
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
instead use CMake's  find_package to locate OpenSim installation or force user to point to OPENSIM_INSTALL_DIR. If a user has 3.3 then it will be picked as default by CMake (wrong) and if not it's useless. 

Fixes issue #3078 

### Brief summary of changes
Remove references to Environment Variable OPENSIM_HOME as not supported since 4.0

### Testing I've completed
Built one example plugin using the update CMakeLists.txt 

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it was never supposed to continue to be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3078)
<!-- Reviewable:end -->
