### PR TITLE
install adolc shared libraries on ubuntu

### DIFF
--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -36,13 +36,13 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
             "${script}" @ONLY)
     install(SCRIPT "${script}")
 
-    elseif(TROPTER_COPY_DEPENDENCIES AND UNIX)
+elseif(TROPTER_COPY_DEPENDENCIES AND UNIX)
         get_filename_component(gcc_libdir "${pkgcfg_lib_IPOPT_gfortran}" DIRECTORY)
 
-    	file(GLOB gfortran "${gcc_libdir}/libgfortran*.so")
-    	file(GLOB quadmath "${gcc_libdir}/libquadmath*.so")
+        file(GLOB gfortran "${gcc_libdir}/libgfortran*.so")
+        file(GLOB quadmath "${gcc_libdir}/libquadmath*.so")
 
-    	install(FILES
+        install(FILES
            ${ADOLC_DIR}/lib64/libadolc.so.2.1.0 DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 


### PR DESCRIPTION
Fixes issue #0 
Trying to invoke opensim-cmd from command line on ubuntu fails due to missing adolc shared libraries.

### Brief summary of changes
Copy adolc libraries to install folder on linux

### Testing I've completed
Built on ubuntu, set LD_LIBRARY_PATH and was able to invoke opensim-cmd

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3092)
<!-- Reviewable:end -->
