### PR TITLE
Add extendPostScale() to DeGrooteFregly2016Muscle

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.0
 -----
+- 2021-11-18: Implemented fix for DeGrooteFregly2016Muscle so that optimal fiber 
+              lengths and tendon slack lengths are scaled when using the ScaleTool.
+  
 - 2021-11-17: Added Matlab and Python support for MocoAngularVelocityTrackingGoal.
               Fixed Matlab and Python issues with 
               MocoOrientationTrackingGoal::setRotationReference(); this method 

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -1069,3 +1069,19 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
     model.finalizeFromProperties();
     model.finalizeConnections();
 }
+
+void DeGrooteFregly2016Muscle::extendPostScale(
+        const SimTK::State& s, const ScaleSet& scaleSet) {
+    Super::extendPostScale(s, scaleSet);
+
+    GeometryPath& path = upd_GeometryPath();
+    if (path.getPreScaleLength(s) > 0.0)
+    {
+        double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);
+        upd_optimal_fiber_length() *= scaleFactor;
+        upd_tendon_slack_length() *= scaleFactor;
+
+        // Clear the pre-scale length that was stored in the GeometryPath.
+        path.setPreScaleLength(s, 0.0);
+    }
+}

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -797,6 +797,15 @@ public:
             Model& model, bool allowUnsupportedMuscles = false);
     /// @}
 
+    /// @name Scaling
+    /// @{
+    /// Adjust the properties of the muscle after the model has been scaled. The
+    /// optimal fiber length and tendon slack length are each multiplied by the
+    /// ratio of the current path length and the path length before scaling.
+    void extendPostScale(
+            const SimTK::State& s, const ScaleSet& scaleSet) override;
+    /// @}
+
 private:
     void constructProperties();
 


### PR DESCRIPTION
Fixes issue #2995

### Brief summary of changes
- Implement `extendPostScale()` for `DeGrooteFregly2016Muscle` so that optimal fiber lengths and tendon slack lengths are scaled with model GeometryPath length changes.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3108)
<!-- Reviewable:end -->
