### PR TITLE
fix load issue with scale tool 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 v4.4
 ====
 - Updated ezc3d to version 1.4.6 which better manage the events defined in a c3d file.
+- Fixed an issue that could happen sometimes with ScaleTool where loading the model file or marker set file could fail if the file was given as an absolute path (Issue #3109, PR #3110)
 
 v4.3
 ====

--- a/OpenSim/Tools/GenericModelMaker.cpp
+++ b/OpenSim/Tools/GenericModelMaker.cpp
@@ -159,13 +159,17 @@ Model* GenericModelMaker::processModel(const string& aPathToSubject) const
 
     try
     {
-        model = new Model(aPathToSubject + _fileName);
+        std::string modelPath = 
+            SimTK::Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(aPathToSubject, _fileName);
+        model = new Model(modelPath);
         model->initSystem();
 
         if (!_markerSetFileNameProp.getValueIsDefault() && _markerSetFileName !="Unassigned") {
             log_info("Loading marker set from '{}'.", 
                 aPathToSubject + _markerSetFileName);
-            MarkerSet *markerSet = new MarkerSet(aPathToSubject + _markerSetFileName);
+            std::string markerSetPath = 
+                SimTK::Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(aPathToSubject, _markerSetFileName);
+            MarkerSet *markerSet = new MarkerSet(markerSetPath);
             model->updateMarkerSet(*markerSet);
         }
     }

--- a/OpenSim/Tools/ScaleTool.cpp
+++ b/OpenSim/Tools/ScaleTool.cpp
@@ -232,8 +232,11 @@ Model* ScaleTool::createModel() const
         Model *model = getGenericModelMaker().processModel(_pathToSubject);
         if (!model)
         {
-            log_error("Unable to load generic model at path {}.", 
-                _pathToSubject);
+            // processModel() attempts to load both the model and market set
+            // file. _pathToSubject might be misleading of model path was
+            // given as an aboslute path in the setup file, so it was
+            // removed from this error message.
+            log_error("Unable to load the generic model or marker set file.");
             return 0;
         }
         else {


### PR DESCRIPTION
Fixes issue #3109 

### Brief summary of changes
Updated how `GenericModelMaker::processModel()` figures out the path to the model file and marker set file. Also updated an error message in ScaleTool to be less misleading in certain cases.

### Testing I've completed
Ran usual tests locally. Also tested with different setup files that had absolute paths for model and marker set file.

### Looking for feedback on...
Didn't add any test for this, but also couldn't think of a way to reliably add a test with an absolute path in a setup file.

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3110)
<!-- Reviewable:end -->
