### PR TITLE
Fix inline assemble in catch.hpp dependency for ARM Macs

### DIFF
--- a/OpenSim/Auxiliary/catch.hpp
+++ b/OpenSim/Auxiliary/catch.hpp
@@ -7910,7 +7910,11 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 

--- a/Vendors/tropter/external/catch/catch.hpp
+++ b/Vendors/tropter/external/catch/catch.hpp
@@ -6011,7 +6011,11 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break


### PR DESCRIPTION
See original change in https://github.com/catchorg/Catch2/issues/1127

### Testing I've completed

OpenSim now builds on my M1 Mac

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3118)
<!-- Reviewable:end -->
