### PR TITLE
Continuing inverse kinematics after IpOpt fails to achieve desired accuracy

### DIFF
--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -141,13 +141,19 @@ int main(int argc,char **argv)
     log_info("Constructing tool from setup file {}.", setupFileName);
     InverseKinematicsTool ik(setupFileName);
 
-    // testprint
+    // Adaptive accuracy announcement
     if (ik.get_adaptiveAccuracy())
         log_info("Adaptive accuracy enabled with step {} and threshold {}.",
                 std::to_string(ik.get_adaptiveAccuracyStep()),
                 std::to_string(ik.get_adaptiveAccuracyThreshold()));
     else
         log_info("Adaptive accuracy not enabled.");
+
+    // Ignoring convergence errors announcement
+    if (ik.get_ignoreConvergenceErrors())
+        log_info("Ignoring convergence errors.");
+    else
+        log_info("Ignoring convergence not enabled.");
 
     // start timing
     std::clock_t startTime = std::clock();

--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -141,6 +141,14 @@ int main(int argc,char **argv)
     log_info("Constructing tool from setup file {}.", setupFileName);
     InverseKinematicsTool ik(setupFileName);
 
+    // testprint
+    if (ik.get_adaptiveAccuracy())
+        log_info("Adaptive accuracy enabled with step {} and threshold {}.",
+                std::to_string(ik.get_adaptiveAccuracyStep()),
+                std::to_string(ik.get_adaptiveAccuracyThreshold()));
+    else
+        log_info("Adaptive accuracy not enabled.");
+
     // start timing
     std::clock_t startTime = std::clock();
 

--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -282,7 +282,7 @@ void AssemblySolver::track(SimTK::State &s)
     catch (const std::exception& ex)
     {
         log_info( "AssemblySolver::track() attempt Failed: {}", ex.what());
-        throw Exception("AssemblySolver::track() attempt failed.");
+        throw Exception(fmt::format("AssemblySolver::track() attempt failed because:\n{}", ex.what()));
     }
 }
 

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -219,7 +219,7 @@ bool InverseKinematicsTool::run()
                     // if the accuracy was changed, reassemble
                     if (runAssemble) {
                         if (get_report_errors())
-                            log_info("Adaptive accuracy. Starting asseble at "
+                            log_info("Adaptive accuracy. Starting assemble at "
                                      "time {}",
                                     times[i]);
                         ikSolver.assemble(s);

--- a/OpenSim/Tools/InverseKinematicsToolBase.h
+++ b/OpenSim/Tools/InverseKinematicsToolBase.h
@@ -68,7 +68,25 @@ public:
 
     OpenSim_DECLARE_PROPERTY(accuracy, double,
             "The accuracy of the solution in absolute terms, i.e. the number of "
-            "significant digits to which the solution can be trusted. Default 1e-5.");
+            "significant digits to which the solution can be trusted. Default "
+            "1e-5.");
+
+    OpenSim_DECLARE_PROPERTY(adaptiveAccuracy, bool,
+            "If true, Whenever a timepoint cannot be resolved with the desired "
+            "threshold, a lower accuracy will be used for that point instead "
+            "of throwing exception. Default false.");
+
+    OpenSim_DECLARE_PROPERTY(adaptiveAccuracyStep, double,
+            "A parameter of adaptive accuracy behavior. Increase the threshold "
+            "by this value every time the IK solver fails to reach the desired "
+            "accuracy threshold and throws an exception. For the next step, "
+            "accuracy threshold is reset to this->get_accuracy(). Has to be > 1."
+            "Default 10.");
+
+    OpenSim_DECLARE_PROPERTY(adaptiveAccuracyThreshold, double,
+            "A parameter of adaptive accuracy behavior. The program will stop "
+            "raising the threshold when the threshold will be greater than "
+            "this value and throw the error. Default: 1e-3.");
 
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(
             time_range, double, 2, "The time range for the study.");
@@ -115,6 +133,9 @@ private:
         constructProperty_model_file("");
         constructProperty_constraint_weight(SimTK::Infinity);
         constructProperty_accuracy(1e-5);
+        constructProperty_adaptiveAccuracy(false);
+        constructProperty_adaptiveAccuracyStep(10);
+        constructProperty_adaptiveAccuracyThreshold(1e-3);
         Array<double> range{SimTK::Infinity, 2};
         // Make range -Infinity to Infinity unless limited by data
         range[0] = -SimTK::Infinity; 

--- a/OpenSim/Tools/InverseKinematicsToolBase.h
+++ b/OpenSim/Tools/InverseKinematicsToolBase.h
@@ -72,7 +72,7 @@ public:
             "1e-5.");
 
     OpenSim_DECLARE_PROPERTY(adaptiveAccuracy, bool,
-            "If true, Whenever a timepoint cannot be resolved with the desired "
+            "If true, whenever a timepoint cannot be resolved with the desired "
             "threshold, a lower accuracy will be used for that point instead "
             "of throwing exception. Default false.");
 
@@ -87,6 +87,11 @@ public:
             "A parameter of adaptive accuracy behavior. The program will stop "
             "raising the threshold when the threshold will be greater than "
             "this value and throw the error. Default: 1e-3.");
+
+    OpenSim_DECLARE_PROPERTY(ignoreConvergenceErrors, bool,
+            "Make the inverse kinematics proceed to the next frame instead of "
+            "breaking whenever the optimizer cannot converge on a frame. "
+            "Default false.");
 
     OpenSim_DECLARE_LIST_PROPERTY_SIZE(
             time_range, double, 2, "The time range for the study.");
@@ -136,6 +141,7 @@ private:
         constructProperty_adaptiveAccuracy(false);
         constructProperty_adaptiveAccuracyStep(10);
         constructProperty_adaptiveAccuracyThreshold(1e-3);
+        constructProperty_ignoreConvergenceErrors(false);
         Array<double> range{SimTK::Infinity, 2};
         // Make range -Infinity to Infinity unless limited by data
         range[0] = -SimTK::Infinity; 


### PR DESCRIPTION
Fixes issue #3119

### Brief summary of changes
Added a flag (`adaptiveAccuracy`) and two parameters to InverseKinematicsToolBase that allow rerunning track on a frame with lower accuracy if the optimizer failed to converge.
Added another flag (`ignoreConvergenceErrors`) to InverseKinematicsToolBase that allows ignoring a convergence error during track() of a frame.
`void AssemblySolver::track(SimTK::State &s)` now throws a more comprehensive exception that can be traced, similar to `void AssemblySolver::assemble(SimTK::State &state)`.

### Testing I've completed
Running with flags turned off produces the same results as the default version. Ran tests with enabling each or both of the flags, behavior is similar (mean DOF angle difference ~ 1 degree).

### Looking for feedback on the validity of this approach.

### CHANGELOG.md (choose one)

Please tell me where to append a note of change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3120)
<!-- Reviewable:end -->
