### PR TITLE
fix scripting issue with getRotationInGround()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v4.4
 ====
 - Updated ezc3d to version 1.4.6 which better manage the events defined in a c3d file.
 - Fixed an issue that could happen sometimes with ScaleTool where loading the model file or marker set file could fail if the file was given as an absolute path (Issue #3109, PR #3110)
+- Fixed an issue with SWIG with `OpenSim::Body::getRotationInGround()` where it would return an object without the correct `SimTK::Rotation` methods.
 
 v4.3
 ====

--- a/OpenSim/Simulation/Model/Frame.h
+++ b/OpenSim/Simulation/Model/Frame.h
@@ -322,7 +322,7 @@ public:
     };
 
     /** Accessor for Rotation matrix of the Frame in Ground. */
-    SimTK::Rotation getRotationInGround(const SimTK::State& state) const {
+    SimTK::Rotation_<double> getRotationInGround(const SimTK::State& state) const {
         return getTransformInGround(state).R();
     };
 


### PR DESCRIPTION
Fixes issue #3134

### Brief summary of changes
Explicitly give template type for the return type of `getRotationInGround()`. Change was cherry picked from @aymanhab's other PR

### Testing I've completed
Tested locally with both MATLAB and Python as described in issue

### CHANGELOG.md (choose one)
- updated.

Pinging @nickbianco for a review since the code was from @aymanhab originally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3135)
<!-- Reviewable:end -->
