### PR TITLE
[Moco] Add regularization term to exampleTracking.cpp

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,7 @@ jobs:
   windows:
     name: Windows
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v1

--- a/OpenSim/Examples/Moco/exampleTracking/exampleTracking.cpp
+++ b/OpenSim/Examples/Moco/exampleTracking/exampleTracking.cpp
@@ -120,7 +120,7 @@ int main() {
 
     // Cost.
     // -----
-    auto* tracking = problem.addGoal<MocoStateTrackingGoal>();
+    auto* tracking = problem.addGoal<MocoStateTrackingGoal>("tracking");
     TimeSeriesTable ref;
     ref.addTableMetaData<std::string>("inDegrees", "no");
     ref.setColumnLabels({"/jointset/j0/q0/value", "/jointset/j1/q1/value"});
@@ -135,6 +135,9 @@ int main() {
     }
 
     tracking->setReference(ref);
+
+    // A low-weighted cost term minimizing controls helps with convergence.
+    problem.addGoal<MocoControlGoal>("effort", 0.001);
 
     // Configure the solver.
     // =====================


### PR DESCRIPTION
### Brief summary of changes
Was running `exampleTracking.cpp` while investigating a separate issue, but noticed that the problem was converging. I add a small regularization term via `MocoControlGoal` to resolve the issue.
- EDIT: I had to update the CI build script to use `windows-2019`, as now `windows-latest` points to `windows-2022`, which uses `VS2022`.

### Testing I've completed
Tested locally.

### CHANGELOG.md (choose one)

- no need to update because...small change to ensure expected behavior of the example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3145)
<!-- Reviewable:end -->
