### PR TITLE
Refactored Geometry to reduce number of steps/copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v4.4
 - Updated ezc3d to version 1.4.6 which better manage the events defined in a c3d file.
 - Fixed an issue that could happen sometimes with ScaleTool where loading the model file or marker set file could fail if the file was given as an absolute path (Issue #3109, PR #3110)
 - Fixed an issue with SWIG with `OpenSim::Body::getRotationInGround()` where it would return an object without the correct `SimTK::Rotation` methods.
+- Reduced the overhead of Geometry::generateDecorations by removing unnecessary allocations and copies from the internal implementation
 
 v4.3
 ====

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -151,6 +151,7 @@ void Geometry::generateDecorations(bool fixed,
     int firstEl = static_cast<int>(appendToThis.size()) - nAdded;
     for (int i = 0; i < nAdded; ++i) {
         SimTK::DecorativeGeometry& dg = appendToThis[firstEl + i];
+        dg.setScaleFactors(get_scale_factors());
         dg.setBodyId(mbidx);
         dg.setTransform(transformInBaseFrame);
         dg.setIndexOnBody(i);
@@ -163,33 +164,31 @@ void Geometry::generateDecorations(bool fixed,
 void Sphere::implementCreateDecorativeGeometry(
     SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeSphere>(decoGeoms, get_radius());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeSphere>(decoGeoms, get_radius());
 }
 
 void Cylinder::implementCreateDecorativeGeometry(
     SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeCylinder>(decoGeoms, get_radius(), get_half_height());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeCylinder>(decoGeoms, get_radius(), get_half_height());
 }
 
 void Cone::implementCreateDecorativeGeometry(
         SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeCone>(decoGeoms,
-                                                 get_origin(),
-                                                 SimTK::UnitVec3(get_direction()),
-                                                 get_height(),
-                                                 get_base_radius());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeCone>(decoGeoms,
+                                    get_origin(),
+                                    SimTK::UnitVec3(get_direction()),
+                                    get_height(),
+                                    get_base_radius());
 }
 
 void LineGeometry::implementCreateDecorativeGeometry(
         SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeLine>(decoGeoms, get_start_point(), get_end_point());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeLine>(decoGeoms,
+                                    get_start_point(),
+                                    get_end_point());
 }
 
 void Arrow::implementCreateDecorativeGeometry(
@@ -200,21 +199,18 @@ void Arrow::implementCreateDecorativeGeometry(
 
     auto& deco = EmplaceGeometry<DecorativeArrow>(decoGeoms, start, end);
     deco.setLineThickness(0.05);
-    deco.setScaleFactors(get_scale_factors());
 }
 
 void Ellipsoid::implementCreateDecorativeGeometry(
         SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeEllipsoid>(decoGeoms, get_radii());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeEllipsoid>(decoGeoms, get_radii());
 }
 
 void Brick::implementCreateDecorativeGeometry(
         SimTK::Array_<SimTK::DecorativeGeometry>& decoGeoms) const
 {
-    auto& deco = EmplaceGeometry<DecorativeBrick>(decoGeoms, get_half_lengths());
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeBrick>(decoGeoms, get_half_lengths());
 }
 
 void FrameGeometry::implementCreateDecorativeGeometry(
@@ -222,7 +218,6 @@ void FrameGeometry::implementCreateDecorativeGeometry(
 {
     auto& deco = EmplaceGeometry<DecorativeFrame>(decoGeoms, 1.0);
     deco.setLineThickness(get_display_radius());
-    deco.setScaleFactors(get_scale_factors());
 }
 
 void Mesh::extendFinalizeFromProperties() {
@@ -334,6 +329,5 @@ void Mesh::implementCreateDecorativeGeometry(
         return;
     }
 
-    auto& deco = EmplaceGeometry<DecorativeMeshFile>(decoGeoms, *cachedMesh);
-    deco.setScaleFactors(get_scale_factors());
+    EmplaceGeometry<DecorativeMeshFile>(decoGeoms, *cachedMesh);
 }

--- a/OpenSim/Simulation/Model/Geometry.h
+++ b/OpenSim/Simulation/Model/Geometry.h
@@ -156,26 +156,6 @@ protected:
     void extendFinalizeConnections(Component& root) override;
 
 private:
-    // Compute Transform of this geometry relative to its base frame, utilizing 
-    // passed in state. Both transform and body_id are set in the passed-in 
-    // decorations as a side effect.
-    void setDecorativeGeometryTransform(
-        SimTK::Array_<SimTK::DecorativeGeometry>& decorations,
-        const SimTK::State& state) const;
-
-    // Manage Appearance (how the Geometry is rendered) by applying Appearance 
-    // from Geometry to DecorativeGeometry.
-    void setDecorativeGeometryAppearance(
-        SimTK::DecorativeGeometry& decoration) const {
-        decoration.setColor(get_Appearance().get_color());
-        decoration.setOpacity(get_Appearance().get_opacity());
-        if (get_Appearance().get_visible())
-            decoration.setRepresentation(
-                (VisualRepresentation)
-                get_Appearance().get_representation());
-        else
-            decoration.setRepresentation(SimTK::DecorativeGeometry::Hide);
-    };
 
     /// Specify the default values for properties of Geometry
     void constructProperties() {


### PR DESCRIPTION
Fixes issue (not an issue)

### Brief summary of changes

- Removes intermediate `SimTK::Array_` from `generateDecorations`
  - The implementation now immediately appends the decorations to the end of the supplied array
  - The added elements are then mutated in-place
- Refactors all geometry implementations to generate the element in-place and then mutate it, rather than copying it
  - This uses a helper method, `EmplaceGeometry<T>`, to place the geometry at the end of the array and return a reference to the added geometry
  - This removes a copy from the existing implementation, where the geometry was locally added *and then* copied to the end of the (temporary) array. It now places it directly on the end of the final array (due to this, and the above, change)
- Refactors private helper methods in `OpenSim::Geometry` directly into `generateDecorations` so that any post-addition fixups (e.g. setting body index, scale factors, etc.) all happen in a single pass over the data
- Moves setting the scale factor to a shared operation in `generateDecorations`, rather than it being in each implementation (**this should be ok? Might require a quick check**)

### Testing I've completed

- I looked at it in the OpenSim Creator UI and it didn't seem to make anything explode

### Looking for feedback on...

- Whether it does make something explode
- Perf measurements

### CHANGELOG.md (choose one)

- Updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3147)
<!-- Reviewable:end -->
