### PR TITLE
Fixed Object::makeObjectNamesConsistentWithProperties dirtying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v4.4
 - Updated ezc3d to version 1.4.6 which better manage the events defined in a c3d file.
 - Fixed an issue that could happen sometimes with ScaleTool where loading the model file or marker set file could fail if the file was given as an absolute path (Issue #3109, PR #3110)
 - Fixed an issue with SWIG with `OpenSim::Body::getRotationInGround()` where it would return an object without the correct `SimTK::Rotation` methods.
+- Fixed objects being set as not up to date with their properties by finalizeFromProperties
 
 v4.3
 ====


### PR DESCRIPTION
Fixes a bug (I think?) I noticed, which is that calling `finalizeFromProperties` internally sets `isObjectUpToDateWithProperties` to `false` for a large number of objects in the model tree.

The reason this happens is because `Object::makeObjectNamesConsistentWithProperties` is called during `Model::extendFinalizeFromProperties`. This ends up flagging any objects with object properties as dirty because the routine calls `updPropByIndex` or similar - even if it doesn't actually mutate anything.

### Brief summary of changes

- Added a flag that resets the dirty flag if no modification was actually made

### Testing I've completed

- Brief testing in OpenSim Creator. I noticed the bug because I'm currently micro-benchmarking things like rendering, scene generation, etc. and noticed that `generateDecorations` takes far too long if `finalizeFromProperties` is called on a model. The reason it takes so long is because `OpenSim::Mesh` checks the `isObjectUpToDateWithProperties` flag to decide whether to reload the mesh or not

### Looking for feedback on...

- Anything

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3148)
<!-- Reviewable:end -->
