### PR TITLE
Remove _computeMoments variable and use Property directly everywhere

### DIFF
--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -34,6 +34,7 @@
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
 #include <OpenSim/Analyses/BodyKinematics.h>
+#include <OpenSim/Analyses/MuscleAnalysis.h>
 #include <OpenSim/Analyses/IMUDataReporter.h>
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Simulation/Control/PrescribedController.h>
@@ -54,6 +55,8 @@ void testTugOfWar(const string& dataFileName, const double& defaultAct);
 void testBodyKinematics();
 
 void testIMUDataReporter();
+
+void testMuscleAnalysisSerialization();
 
 int main()
 {
@@ -100,6 +103,12 @@ int main()
     } catch (const std::exception& e) {
         cout << e.what() << endl;
         failures.push_back("testIMUDataReporter");
+    }   
+    try {
+        testMuscleAnalysisSerialization();
+    } catch (const std::exception& e) {
+        cout << e.what() << endl;
+        failures.push_back("testMuscleAnalysisSerialization");
     }   
 
     if (!failures.empty()) {
@@ -587,4 +596,17 @@ void testIMUDataReporter() {
                     sumSquaredError(1, numTimes - 2).sum());
         SimTK_TEST_EQ_TOL(integratedSumSquaredError, 0.0, 1e-5);
     }
+}
+void testMuscleAnalysisSerialization()
+{ 
+    MuscleAnalysis m;
+    m.setComputeMoments(true);
+    m.print("manalysis.xml");
+    MuscleAnalysis roundTrip("manalysis.xml");
+    ASSERT(roundTrip.getComputeMoments());
+    m.setComputeMoments(false);
+    m.print("manalysis.xml");
+    // Check deserialization and copying
+    roundTrip = MuscleAnalysis("manalysis.xml");
+    ASSERT(!roundTrip.getComputeMoments());
 }

--- a/OpenSim/Analyses/MuscleAnalysis.cpp
+++ b/OpenSim/Analyses/MuscleAnalysis.cpp
@@ -141,7 +141,7 @@ void MuscleAnalysis::setNull()
     _muscleListProp.getValueStrArray().updElt(0) = "all";
     _coordinateListProp.getValueStrArray().setSize(1);
     _coordinateListProp.getValueStrArray().updElt(0) = "all";
-    _computeMoments = true;
+    setComputeMoments(true);
 }
 //_____________________________________________________________________________
 /**
@@ -205,7 +205,7 @@ void MuscleAnalysis::allocateStorageObjects()
     _muscleArray.setSize(0);
 
     // FOR MOMENT ARMS AND MOMENTS
-    if(_computeMoments) {
+    if(getComputeMoments()) {
         const CoordinateSet& qSet = _model->getCoordinateSet();
         _coordinateList = _coordinateListProp.getValueStrArray();
 
@@ -409,7 +409,6 @@ MuscleAnalysis& MuscleAnalysis::operator=(const MuscleAnalysis &aAnalysis)
     _muscleListProp = aAnalysis._muscleListProp;
     _coordinateListProp = aAnalysis._coordinateListProp;
     _computeMomentsProp = aAnalysis._computeMomentsProp;
-    _computeMoments = _computeMomentsProp.getValueBool();
     allocateStorageObjects();
 
     return (*this);
@@ -639,7 +638,7 @@ int MuscleAnalysis::record(const SimTK::State& s)
     _tendonPowerStore->append(tReal,tendonPower.getSize(),&tendonPower[0]);
     _musclePowerStore->append(tReal,muscPower.getSize(),&muscPower[0]);
 
-    if (_computeMoments){
+    if (getComputeMoments()){
         // LOOP OVER ACTIVE MOMENT ARM STORAGE OBJECTS
         Coordinate *q = NULL;
         Storage *maStore=NULL, *mStore=NULL;
@@ -699,7 +698,7 @@ int MuscleAnalysis::begin(const SimTK::State&s )
     // RECORD
     int status = 0;
     // Make sure coordinates are not locked
-    if (_computeMoments){
+    if (getComputeMoments()){
     // LOOP OVER ACTIVE MOMENT ARM STORAGE OBJECTS
         Coordinate *q = NULL;
         int nq = _momentArmStorageArray.getSize();

--- a/OpenSim/Analyses/MuscleAnalysis.h
+++ b/OpenSim/Analyses/MuscleAnalysis.h
@@ -133,7 +133,6 @@ private:
     /** Work array for holding the list of coordinates. */
     Array<std::string> _coordinateList;
 
-    bool _computeMoments;
 #ifndef SWIG
     /** Array of active storage and coordinate pairs. */
     ArrayPtrs<StorageCoordinatePair> _momentArmStorageArray;
@@ -213,10 +212,10 @@ public:
     void setCoordinates(Array<std::string>& aCoordinates);
 
     void setComputeMoments(bool aTrueFalse) {
-        _computeMoments = aTrueFalse;
+        _computeMomentsProp.setValue(aTrueFalse);
     }
-    bool getComputeMoments() const {
-        return _computeMoments;
+    bool getComputeMoments() const { 
+        return _computeMomentsProp.getValueBool();
     }
 #ifndef SWIG
     const ArrayPtrs<StorageCoordinatePair>& getMomentArmStorageArray() const { return _momentArmStorageArray; }


### PR DESCRIPTION
Fixes issue #3151 

### Brief summary of changes
Muscle analysis uses old Properties which were designed to have a Property and a variable to reference the bool value inside the property, this issue is due to these variable getting out of sync with the property, so the variable was removed and Property is maintained.
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3157)
<!-- Reviewable:end -->
