### PR TITLE
[WIP] Fix path wrap model-level data mutates+aliases during a simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ v4.4
 - Fixed an issue with SWIG with `OpenSim::Body::getRotationInGround()` where it would return an object without the correct `SimTK::Rotation` methods.
 - Fixed OpenSim::Arrow start_point property being ignored
 - Fixed objects being set as not up to date with their properties by finalizeFromProperties
+- `OpenSim::GeometryPath::getCurrentPath` now returns `const Array<const AbstractPathPoint*>&` (previously: `const Array<AbstractPathPoint*>&`)
+- `OpenSim::PathWrapPoint` now stores its `WrapPath`, `length`, and `location` in cache variables:
+  - This prevents a bug, where computing paths was mutating (the wrapping parts of) the model
+  - The following methods on `PathWrapPoint` now require a `const SimTK::State&`:
+    - `getPathWrap`
+    - `setPathWrap`
+    - `clearPathWrap`
+    - `getWrapLength`
+    - `setWrapLength`
+    - `getLocation`
+    - `setLocation`
+    - `getdPointdQ`
+  - `PathWrapPoint` now inherits from `AbstractPathPoint` (previously: `PathPoint`)
+  - See PR #3159
+
 
 v4.3
 ====

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -35,290 +35,440 @@
 //=============================================================================
 // STATICS
 //=============================================================================
-using namespace std;
 using namespace OpenSim;
 using namespace SimTK;
 using SimTK::Vec3;
 
-//=============================================================================
-// CONSTRUCTOR(S) AND DESTRUCTOR
-//=============================================================================
-//_____________________________________________________________________________
-/*
- * Default constructor.
- */
-GeometryPath::GeometryPath() :
-    ModelComponent(),
-    _preScaleLength(0.0)
+GeometryPath::GeometryPath() : ModelComponent(), _preScaleLength(0.0)
 {
     setAuthors("Peter Loan");
     constructProperties();
- }
+}
+GeometryPath::GeometryPath(const GeometryPath&) = default;
+GeometryPath::GeometryPath(GeometryPath&&) noexcept = default;
+GeometryPath& GeometryPath::operator=(const GeometryPath&) = default;
+GeometryPath& GeometryPath::operator=(GeometryPath&&) noexcept = default;
+GeometryPath::~GeometryPath() noexcept = default;
 
-//_____________________________________________________________________________
-/*
-* Perform set up functions after model has been deserialized or copied.
-*
-*/
-void GeometryPath::extendFinalizeFromProperties()
+const PathPointSet& GeometryPath::getPathPointSet() const
 {
-    Super::extendFinalizeFromProperties();
+    return get_PathPointSet();
+}
 
-    for (int i = 0; i < get_PathWrapSet().getSize(); ++i) {
-        if (upd_PathWrapSet()[i].getName().empty()) {
-            std::stringstream label;
-            label << "pathwrap_" << i;
-            upd_PathWrapSet()[i].setName(label.str());
+PathPointSet& GeometryPath::updPathPointSet()
+{
+    return upd_PathPointSet();
+}
+
+AbstractPathPoint* GeometryPath::addPathPoint(
+    const SimTK::State& s,
+    int aIndex,
+    const PhysicalFrame& frame)
+{
+    PathPoint* newPoint = new PathPoint();
+    newPoint->setParentFrame(frame);
+    Vec3 newLocation(0.0);
+    // Note: placeNewPathPoint() returns a location by reference.
+    // It computes a new location according to the index where the new path point
+    // will be inserted along the path(among the other path points).
+    placeNewPathPoint(s, newLocation, aIndex, frame);
+    // Now set computed new location into the newPoint
+    newPoint->setLocation(newLocation);
+    upd_PathPointSet().insert(aIndex, newPoint);
+
+    // Rename the path points starting at this new one.
+    namePathPoints(aIndex);
+
+    // Update start point and end point in the wrap instances so that they
+    // refer to the same path points they did before the new point
+    // was added. These indices are 1-based.
+    aIndex++;
+    for (int i=0; i<get_PathWrapSet().getSize(); i++) {
+
+        int startPoint = get_PathWrapSet().get(i).getStartPoint();
+        int endPoint = get_PathWrapSet().get(i).getEndPoint();
+
+        if (startPoint != -1 && aIndex <= startPoint) {
+            get_PathWrapSet().get(i).setStartPoint(s,startPoint + 1);
+        }
+
+        if (endPoint != -1 && aIndex <= endPoint) {
+            get_PathWrapSet().get(i).setEndPoint(s,endPoint + 1);
         }
     }
+
+    return newPoint;
 }
 
-void GeometryPath::extendConnectToModel(Model& aModel)
+AbstractPathPoint* GeometryPath::appendNewPathPoint(
+    const std::string& proposedName,
+    const PhysicalFrame& frame,
+    const SimTK::Vec3& aPositionOnBody)
 {
-    Super::extendConnectToModel(aModel);
+    PathPoint* newPoint = new PathPoint();
+    newPoint->setParentFrame(frame);
+    newPoint->setName(proposedName);
+    newPoint->setLocation(aPositionOnBody);
+    upd_PathPointSet().adoptAndAppend(newPoint);
 
-    OPENSIM_THROW_IF_FRMOBJ(get_PathPointSet().getSize() < 2,
-        InvalidPropertyValue,
-        getProperty_PathPointSet().getName(),
-        "A valid path must be connected to a model by at least two PathPoints.")
-
-    // Name the path points based on the current path
-    // (i.e., the set of currently active points is numbered
-    // 1, 2, 3, ...).
-    namePathPoints(0);
+    return newPoint;
 }
 
-//_____________________________________________________________________________
-/*
- * Create the SimTK state, discrete and/or cache for this GeometryPath.
- */
- void GeometryPath::extendAddToSystem(SimTK::MultibodySystem& system) const 
+bool GeometryPath::canDeletePathPoint(int aIndex)
 {
-    Super::extendAddToSystem(system);
+    // A path point can be deleted only if there would remain
+    // at least two other fixed points.
 
-    // Allocate cache entries to save the current length and speed(=d/dt length)
-    // of the path in the cache. Length depends only on q's so will be valid
-    // after Position stage, speed requires u's also so valid at Velocity stage.
-    this->_lengthCV = addCacheVariable("length", 0.0, SimTK::Stage::Position);
-    this->_speedCV = addCacheVariable("speed", 0.0, SimTK::Stage::Velocity);
+    int numOtherFixedPoints = 0;
+    for (int i = 0; i < get_PathPointSet().getSize(); i++) {
+        if (i != aIndex) {
+            if (!(  get_PathPointSet().get(i).getConcreteClassName()
+                  ==("ConditionalPathPoint")))
+                numOtherFixedPoints++;
+        }
+    }
 
-    // Cache the set of points currently defining this path.
-    this->_currentPathCV = addCacheVariable("current_path", Array<AbstractPathPoint*>{}, SimTK::Stage::Position);
-
-    // We consider this cache entry valid any time after it has been created
-    // and first marked valid, and we won't ever invalidate it.
-    this->_colorCV = addCacheVariable("color", get_Appearance().get_color(), SimTK::Stage::Topology);
+    return numOtherFixedPoints >= 2;
 }
 
- void GeometryPath::extendInitStateFromProperties(SimTK::State& s) const
+bool GeometryPath::deletePathPoint(const SimTK::State& s, int aIndex)
 {
-    Super::extendInitStateFromProperties(s);
-    markCacheVariableValid(s, _colorCV);  // it is OK at its default value
+    if (canDeletePathPoint(aIndex) == false) {
+        return false;
+    }
+
+    upd_PathPointSet().remove(aIndex);
+
+    // rename the path points starting at the deleted position
+    namePathPoints(aIndex);
+
+    // Update start point and end point in the wrap instances so that they
+    // refer to the same path points they did before the point was
+    // deleted. These indices are 1-based. If the point deleted is start
+    // point or end point, the path wrap range is made smaller by one point.
+    aIndex++;
+    for (int i=0; i<get_PathWrapSet().getSize(); i++) {
+        int startPoint = get_PathWrapSet().get(i).getStartPoint();
+        int endPoint   = get_PathWrapSet().get(i).getEndPoint();
+
+        if (   (startPoint != -1 && aIndex < startPoint)
+            || (startPoint > get_PathPointSet().getSize())) {
+
+            get_PathWrapSet().get(i).setStartPoint(s, startPoint - 1);
+        }
+
+        if (   endPoint > 1
+            && aIndex <= endPoint
+            && (   (endPoint > startPoint)
+                || (endPoint > get_PathPointSet().getSize()))) {
+
+            get_PathWrapSet().get(i).setEndPoint(s, endPoint - 1);
+        }
+    }
+
+    return true;
 }
 
-//------------------------------------------------------------------------------
-//                         GENERATE DECORATIONS
-//------------------------------------------------------------------------------
-// The GeometryPath takes care of drawing itself here, using information it
-// can extract from the supplied state, including position information and
-// color information that may have been calculated as late as Stage::Dynamics.
-// For example, muscles may want the color to reflect activation level and 
-// other path-using components might want to use forces (tension). We will
-// ensure that the state has been realized to Stage::Dynamics before looking
-// at it. (It is only guaranteed to be at Stage::Position here.)
-void GeometryPath::
-generateDecorations(bool fixed, const ModelDisplayHints& hints, 
-                    const SimTK::State& state, 
-                    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
-{        
-    // There is no fixed geometry to generate here.
-    if (fixed) { return; }
+bool GeometryPath::replacePathPoint(
+    const SimTK::State& s,
+    AbstractPathPoint* aOldPathPoint,
+    AbstractPathPoint* aNewPathPoint)
+{
+    if (aOldPathPoint != NULL && aNewPathPoint != NULL) {
+        int count = 0;
+        int index = get_PathPointSet().getIndex(aOldPathPoint);
 
-    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
+        // If you're switching from non-via to via, check to make sure that the
+        // path will be left with at least 2 non-via points.
+        ConditionalPathPoint* oldVia =
+            dynamic_cast<ConditionalPathPoint*>(aOldPathPoint);
+        ConditionalPathPoint* newVia =
+            dynamic_cast<ConditionalPathPoint*>(aNewPathPoint);
 
-    assert(pathPoints.size() > 1);
-
-    const AbstractPathPoint* lastPoint = pathPoints[0];
-    MobilizedBodyIndex mbix(0);
-
-    Vec3 lastPos = lastPoint->getLocationInGround(state);
-    if (hints.get_show_path_points())
-        DefaultGeometry::drawPathPoint(mbix, lastPos, getColor(state), appendToThis);
-
-    Vec3 pos;
-
-    for (int i = 1; i < pathPoints.getSize(); ++i) {
-        AbstractPathPoint* point = pathPoints[i];
-        PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
-
-        if (pwp) {
-            // A PathWrapPoint provides points on the wrapping surface as Vec3s
-            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
-            // The surface points are expressed w.r.t. the wrap surface's body frame.
-            // Transform the surface points into the ground reference frame to draw
-            // the surface point as the wrapping portion of the GeometryPath
-            const Transform& X_BG = pwp->getParentFrame().getTransformInGround(state);
-            // Cycle through each surface point and draw it the Ground frame
-            for (int j = 0; j<surfacePoints.getSize(); ++j) {
-                // transform the surface point into the Ground reference frame
-                pos = X_BG*surfacePoints[j];
-                if (hints.get_show_path_points())
-                    DefaultGeometry::drawPathPoint(mbix, pos, getColor(state),
-                        appendToThis);
-                // Line segments will be in ground frame
-                appendToThis.push_back(DecorativeLine(lastPos, pos)
-                    .setLineThickness(4)
-                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(j));
-                lastPos = pos;
+        if (oldVia == NULL && newVia != NULL) {
+            for (int i=0; i<get_PathPointSet().getSize(); i++) {
+                if (i != index) {
+                    if (dynamic_cast<ConditionalPathPoint*>
+                                        (&get_PathPointSet().get(i)) == NULL)
+                        count++;
+                }
             }
-        } 
-        else { // otherwise a regular PathPoint so just draw its location
-            pos = point->getLocationInGround(state);
-            if (hints.get_show_path_points())
-                DefaultGeometry::drawPathPoint(mbix, pos, getColor(state),
-                    appendToThis);
-            // Line segments will be in ground frame
-            appendToThis.push_back(DecorativeLine(lastPos, pos)
-                .setLineThickness(4)
-                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(i));
-            lastPos = pos;
+        } else {
+            count = 2;
+        }
+        if (count >= 2 && index >= 0) {
+            upd_PathPointSet().set(index, aNewPathPoint, true);
+            return true;
         }
     }
+    return false;
 }
 
-//_____________________________________________________________________________
-/*
- * Connect properties to local pointers.
- */
-void GeometryPath::constructProperties()
+const PathWrapSet& GeometryPath::getWrapSet() const
 {
-    constructProperty_PathPointSet(PathPointSet());
-
-    constructProperty_PathWrapSet(PathWrapSet());
-    
-    Appearance appearance;
-    appearance.set_color(SimTK::Gray);
-    constructProperty_Appearance(appearance);
+    return get_PathWrapSet();
 }
 
-//_____________________________________________________________________________
-/*
- * Name the path points based on their position in the set. To keep the
- * names up to date, this method should be called every time the path changes.
- *
- * @param aStartingIndex The index of the first path point to name.
- */
-void GeometryPath::namePathPoints(int aStartingIndex)
+PathWrapSet& GeometryPath::updWrapSet()
 {
-    char indx[5];
-    for (int i = aStartingIndex; i < get_PathPointSet().getSize(); i++)
-    {
-        sprintf(indx,"%d",i+1);
-        AbstractPathPoint& point = get_PathPointSet().get(i);
-        if (point.getName()=="" && hasOwner()) {
-            point.setName(getOwner().getName() + "-P" + indx);
+    return upd_PathWrapSet();
+}
+
+void GeometryPath::addPathWrap(WrapObject& aWrapObject)
+{
+    PathWrap* newWrap = new PathWrap();
+    newWrap->setWrapObject(aWrapObject);
+    newWrap->setMethod(PathWrap::hybrid);
+    upd_PathWrapSet().adoptAndAppend(newWrap);
+    finalizeFromProperties();
+}
+
+void GeometryPath::moveUpPathWrap(const SimTK::State& s, int aIndex)
+{
+    if (aIndex > 0) {
+        // Make sure wrap object is not deleted by remove().
+        upd_PathWrapSet().setMemoryOwner(false);
+
+        PathWrap& wrap = get_PathWrapSet().get(aIndex);
+        upd_PathWrapSet().remove(aIndex);
+        upd_PathWrapSet().insert(aIndex - 1, &wrap);
+        upd_PathWrapSet().setMemoryOwner(true);
+    }
+}
+
+void GeometryPath::moveDownPathWrap(const SimTK::State& s, int aIndex)
+{
+    if (aIndex < get_PathWrapSet().getSize() - 1) {
+        // Make sure wrap object is not deleted by remove().
+        upd_PathWrapSet().setMemoryOwner(false);
+
+        PathWrap& wrap = get_PathWrapSet().get(aIndex);
+        upd_PathWrapSet().remove(aIndex);
+        upd_PathWrapSet().insert(aIndex + 1, &wrap);
+        upd_PathWrapSet().setMemoryOwner(true);
+    }
+}
+
+void GeometryPath::deletePathWrap(const SimTK::State& s, int aIndex)
+{
+    upd_PathWrapSet().remove(aIndex);
+
+}
+
+const SimTK::Vec3& GeometryPath::getDefaultColor() const
+{
+    return get_Appearance().get_color();
+}
+
+void GeometryPath::setDefaultColor(const SimTK::Vec3& color)
+{
+    updProperty_Appearance().setValueIsDefault(false);
+    upd_Appearance().set_color(color);
+}
+
+Vec3 GeometryPath::getColor(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _colorCV);
+}
+
+void GeometryPath::setColor(const SimTK::State& s, const SimTK::Vec3& color) const
+{
+    setCacheVariableValue(s, _colorCV, color);
+}
+
+
+double GeometryPath::getLength(const SimTK::State& s) const
+{
+    if (isCacheVariableValid(s, _lengthCV)) {
+        return getCacheVariableValue(s, _lengthCV);
+    }
+
+    double& v = updCacheVariableValue(s, _lengthCV);
+    v = calcPathLength(s, getCurrentPath(s));
+    setCacheVariableValue(s, _lengthCV, v);
+
+    return v;
+}
+
+void GeometryPath::setLength(const SimTK::State& s, double length) const
+{
+    setCacheVariableValue(s, _lengthCV, length);
+}
+
+double GeometryPath::getPreScaleLength( const SimTK::State& s) const
+{
+    return _preScaleLength;
+}
+
+void GeometryPath::setPreScaleLength( const SimTK::State& s, double length )
+{
+    _preScaleLength = length;
+}
+
+double GeometryPath::getLengtheningSpeed(const SimTK::State& s) const
+{
+    if (isCacheVariableValid(s, _speedCV)) {
+        return getCacheVariableValue(s, _speedCV);
+    }
+
+    double& v = updCacheVariableValue(s, _speedCV);
+    v = calcLengtheningSpeed(s, getCurrentPath(s));
+    markCacheVariableValid(s, _speedCV);
+    return v;
+}
+
+void GeometryPath::setLengtheningSpeed( const SimTK::State& s, double speed ) const
+{
+    setCacheVariableValue(s, _speedCV, speed);
+}
+
+const OpenSim::Array<const AbstractPathPoint*>& GeometryPath::getCurrentPath(
+    const SimTK::State& s) const
+{
+    if (isCacheVariableValid(s, _currentPathAbspathCV)) {
+        // even though it is valid, re-populate the pointers cache
+        //
+        // this is because although it may be valid *in the state* the
+        // model-level pointers cache may be dirty with lookups from some
+        // other state.
+        const auto& paths = getCacheVariableValue(s, _currentPathAbspathCV);
+        return populatePathPtrsCache(paths);
+    }
+
+    // clear the local pointers cache and populate it with an initial (pre-wrapping)
+    // guess of the path points
+    _currentPathPtrsCache.setSize(0);
+    const PathPointSet& pps = get_PathPointSet();
+    for (int i = 0; i < pps.getSize(); i++) {
+
+        const AbstractPathPoint& p = pps[i];
+
+        if (p.isActive(s)) {
+            _currentPathPtrsCache.append(&p);
         }
     }
-}
 
-//_____________________________________________________________________________
-/*
- * get the current path of the path
- *
- * @return The array of currently active path points.
- * 
- */
-const OpenSim::Array <AbstractPathPoint*> & GeometryPath::
-getCurrentPath(const SimTK::State& s)  const
-{
-    computePath(s);   // compute checks if path needs to be recomputed
-    return getCacheVariableValue< Array<AbstractPathPoint*> >(s, "current_path");
-}
+    // pump the pre-wrapping guess through the wrapping algorithm. This may mutate
+    // the pointers array to contain extra (wrapping) points
+    applyWrapObjects(s, _currentPathPtrsCache);
 
-// get the path as PointForceDirections directions 
-// CAUTION: the return points are heap allocated; you must delete them yourself! 
-// (TODO: that is really lame)
-void GeometryPath::
-getPointForceDirections(const SimTK::State& s, 
-                        OpenSim::Array<PointForceDirection*> *rPFDs) const
-{
-    int i;
-    AbstractPathPoint* start;
-    AbstractPathPoint* end;
-    const OpenSim::PhysicalFrame* startBody;
-    const OpenSim::PhysicalFrame* endBody;
-    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
+    // the pointers array now contains the "correct" (wrapped) path
+    //
+    // because the path is state-dependent (different states may wrap differently), the
+    // path points (abstract) must be stored in a SimTK cache variable.
+    //
+    // However, we can't store raw pointers in a cache variable because that may cause
+    // aliasing issues in downstream code. E.g. the state may later be used with a
+    // copied/moved-from version of the model, rather than the original one, so the
+    // pointers may be stale.
+    std::vector<ComponentPath>& paths = updCacheVariableValue(s, _currentPathAbspathCV);
+    paths.clear();
+    paths.reserve(_currentPathPtrsCache.getSize());
+    for (int i = 0; i < _currentPathPtrsCache.getSize(); ++i) {
+        const AbstractPathPoint* p = _currentPathPtrsCache[i];
+        const Component* owner = &p->getOwner();
 
-    int np = currentPath.getSize();
-    rPFDs->ensureCapacity(np);
-    
-    for (i = 0; i < np; i++) {
-        PointForceDirection *pfd = 
-            new PointForceDirection(currentPath[i]->getLocation(s), 
-                                    currentPath[i]->getParentFrame(), Vec3(0));
-        rPFDs->append(pfd);
-    }
-
-    for (i = 0; i < np-1; i++) {
-        start = currentPath[i];
-        end = currentPath[i+1];
-        startBody = &start->getParentFrame();
-        endBody = &end->getParentFrame();
-
-        if (startBody != endBody)
+        // HACK: manually form a relative path, because OpenSim::getRelativePath is
+        // extremely expensively implemented
+        if (owner == this)
         {
-            Vec3 posStart, posEnd;
-            Vec3 direction(0);
+            paths.emplace_back(p->getName());
+        }
+        else
+        {
+            paths.emplace_back(owner->getName() + "/" + p->getName());
+        }
+    }
+    markCacheVariableValid(s, _currentPathAbspathCV);
 
-            // Find the positions of start and end in the inertial frame.
-            //engine.getPosition(s, start->getParentFrame(), start->getLocation(), posStart);
-            posStart = start->getLocationInGround(s);
-            
-            //engine.getPosition(s, end->getParentFrame(), end->getLocation(), posEnd);
-            posEnd = end->getLocationInGround(s);
+    return _currentPathPtrsCache;
+}
 
+// get the path as PointForceDirections directions
+// CAUTION: the return points are heap allocated; you must delete them yourself!
+// (TODO: that is really lame)
+void GeometryPath::getPointForceDirections(
+    const SimTK::State& s,
+    OpenSim::Array<PointForceDirection*> *rPFDs) const
+{
+    const Array<const AbstractPathPoint*>& currentPath = getCurrentPath(s);
+    int np = currentPath.getSize();
+
+    if (np <= 0) {
+        return;  // no points to add
+    }
+
+    rPFDs->ensureCapacity(np);
+
+    Vec3 nextDirection(0);
+    for (int i = 0; i < np-1; i++) {
+        const AbstractPathPoint* pp1 = currentPath[i];
+        const AbstractPathPoint* pp2 = currentPath[i+1];
+
+        Vec3 direction;
+
+        if (&pp1->getParentFrame() == &pp2->getParentFrame())
+        {
+            direction = nextDirection;
+            nextDirection = Vec3(0);
+        }
+        else
+        {
             // Form a vector from start to end, in the inertial frame.
-            direction = (posEnd - posStart);
+            Vec3 v = pp2->getLocationInGround(s) - pp1->getLocationInGround(s);
+            double len = v.norm();
 
             // Check that the two points are not coincident.
             // This can happen due to infeasible wrapping of the path,
             // when the origin or insertion enters the wrapping surface.
             // This is a temporary fix, since the wrap algorithm should
             // return NaN for the points and/or throw an Exception- aseth
-            if (direction.norm() < SimTK::SignificantReal){
-                direction = direction*SimTK::NaN;
+            if (len < SimTK::SignificantReal) {
+                v = Vec3{SimTK::NaN};
             }
-            else{
-                direction = direction.normalize();
+            else {
+                v /= len;  // normalize
             }
 
-            // Get resultant direction at each point 
-            rPFDs->get(i)->addToDirection(direction);
-            rPFDs->get(i+1)->addToDirection(-direction);
+            direction = nextDirection + v;
+            nextDirection = -direction;  // negate next point
         }
+
+        // add the PFD
+        rPFDs->append(new PointForceDirection(
+            pp1->getLocation(s),
+            pp1->getParentFrame(),
+            direction));
     }
+
+    // add last element
+    assert(np > 0);
+    const AbstractPathPoint* lastPoint = currentPath[np-1];
+    rPFDs->append(new PointForceDirection(
+        lastPoint->getLocation(s),
+        lastPoint->getParentFrame(),
+        nextDirection));
 }
 
-/* add in the equivalent spatial forces on bodies for an applied tension 
-    along the GeometryPath to a set of bodyForces */
-void GeometryPath::addInEquivalentForces(const SimTK::State& s,
-    const double& tension, 
+void GeometryPath::addInEquivalentForces(
+    const SimTK::State& s,
+    const double& tension,
     SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
     SimTK::Vector& mobilityForces) const
 {
-    AbstractPathPoint* start = NULL;
-    AbstractPathPoint* end = NULL;
+    const AbstractPathPoint* start = NULL;
+    const AbstractPathPoint* end = NULL;
     const SimTK::MobilizedBody* bo = NULL;
     const SimTK::MobilizedBody* bf = NULL;
-    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
+    const Array<const AbstractPathPoint*>& currentPath = getCurrentPath(s);
     int np = currentPath.getSize();
 
-    const SimTK::SimbodyMatterSubsystem& matter = 
+    const SimTK::SimbodyMatterSubsystem& matter =
                                         getModel().getMatterSubsystem();
 
     // start point, end point,  direction, and force vectors in ground
     Vec3 po(0), pf(0), dir(0), force(0);
-    // partial velocity of point in body expressed in ground 
+    // partial velocity of point in body expressed in ground
     Vec3 dPodq_G(0), dPfdq_G(0);
 
     // gen force (torque) due to moving point under tension
@@ -354,11 +504,11 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             force = tension*dir;
 
             const MovingPathPoint* mppo =
-                dynamic_cast<MovingPathPoint *>(start);
+                dynamic_cast<const MovingPathPoint*>(start);
 
             // do the same for the end point of this segment of the path
             const MovingPathPoint* mppf =
-                dynamic_cast<MovingPathPoint *>(end);
+                dynamic_cast<const MovingPathPoint*>(end);
 
             // add in the tension point forces to body forces
             if (mppo) {// moving path point location is a function of the state
@@ -390,18 +540,18 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
             // Now account for the work being done by virtue of the moving
             // path point motion relative to the body it is on
             if(mppo){
-                // torque (genforce) contribution due to relative movement 
+                // torque (genforce) contribution due to relative movement
                 // of a via point w.r.t. the body it is connected to.
                 dPodq_G = bo->expressVectorInGroundFrame(s, start->getdPointdQ(s));
-                fo = ~dPodq_G*force;            
+                fo = ~dPodq_G*force;
 
                 // get the mobilized body the coordinate is couple to.
                 const SimTK::MobilizedBody& mpbod =
                     matter.getMobilizedBody(mppo->getXCoordinate().getBodyIndex());
 
                 // apply the generalized (mobility) force to the coordinate's body
-                mpbod.applyOneMobilityForce(s, 
-                    mppo->getXCoordinate().getMobilizerQIndex(), 
+                mpbod.applyOneMobilityForce(s,
+                    mppo->getXCoordinate().getMobilizerQIndex(),
                     fo, mobilityForces);
             }
 
@@ -413,456 +563,232 @@ void GeometryPath::addInEquivalentForces(const SimTK::State& s,
                 const SimTK::MobilizedBody& mpbod =
                     matter.getMobilizedBody(mppf->getXCoordinate().getBodyIndex());
 
-                mpbod.applyOneMobilityForce(s, 
-                    mppf->getXCoordinate().getMobilizerQIndex(), 
+                mpbod.applyOneMobilityForce(s,
+                    mppf->getXCoordinate().getMobilizerQIndex(),
                     ff, mobilityForces);
             }
-        }       
+        }
     }
 }
 
-//_____________________________________________________________________________
-/*
- * Update the geometric representation of the path.
- * The resulting geometry is maintained at the VisibleObject layer.
- * This function should not be made public. It is called internally
- * by compute() only when the path has changed.
- * 
- */
+double GeometryPath::computeMomentArm(
+    const SimTK::State& s,
+    const Coordinate& aCoord) const
+{
+    if (!_maSolver) {
+        const_cast<Self*>(this)->_maSolver.reset(new MomentArmSolver(*_model));
+    }
+
+    return _maSolver->solve(s, aCoord,  *this);
+}
+
 void GeometryPath::updateGeometry(const SimTK::State& s) const
 {
-    // Check if the current path needs to recomputed.
-    computePath(s);
+    getCurrentPath(s); // check if the current path needs to recomputed
 }
 
-//=============================================================================
-// GET
-//=============================================================================
-//-----------------------------------------------------------------------------
-// LENGTH
-//-----------------------------------------------------------------------------
-//_____________________________________________________________________________
-/*
- * Compute the total length of the path.
- *
- * @return Total length of the path.
- */
-double GeometryPath::getLength( const SimTK::State& s) const
-{
-    computePath(s);  // compute checks if path needs to be recomputed
-    return getCacheVariableValue(s, _lengthCV);
-}
-
-void GeometryPath::setLength( const SimTK::State& s, double length ) const
-{
-    setCacheVariableValue(s, _lengthCV, length);
-}
-
-void GeometryPath::setColor(const SimTK::State& s, const SimTK::Vec3& color) const
-{
-    setCacheVariableValue(s, _colorCV, color);
-}
-
-Vec3 GeometryPath::getColor(const SimTK::State& s) const
-{
-    return getCacheVariableValue(s, _colorCV);
-}
-
-//_____________________________________________________________________________
-/*
- * Compute the lengthening speed of the path.
- *
- * @return lengthening speed of the path.
- */
-double GeometryPath::getLengtheningSpeed( const SimTK::State& s) const
-{
-    computeLengtheningSpeed(s);
-    return getCacheVariableValue(s, _speedCV);
-}
-void GeometryPath::setLengtheningSpeed( const SimTK::State& s, double speed ) const
-{
-    setCacheVariableValue(s, _speedCV, speed);
-}
-
-void GeometryPath::setPreScaleLength( const SimTK::State& s, double length ) {
-    _preScaleLength = length;
-}
-double GeometryPath::getPreScaleLength( const SimTK::State& s) const {
-    return _preScaleLength;
-}
-
-//=============================================================================
-// UTILITY
-//=============================================================================
-//_____________________________________________________________________________
-/*
- * Add a new path point, with default location, to the path.
- *
- * @param aIndex The position in the pathPointSet to put the new point in.
- * @param frame The frame to attach the point to.
- * @return Pointer to the newly created path point.
- */
-AbstractPathPoint* GeometryPath::
-addPathPoint(const SimTK::State& s, int aIndex, const PhysicalFrame& frame)
-{
-    PathPoint* newPoint = new PathPoint();
-    newPoint->setParentFrame(frame);
-    Vec3 newLocation(0.0); 
-    // Note: placeNewPathPoint() returns a location by reference.
-    // It computes a new location according to the index where the new path point 
-    // will be inserted along the path(among the other path points).
-    placeNewPathPoint(s, newLocation, aIndex, frame);
-    // Now set computed new location into the newPoint
-    newPoint->setLocation(newLocation);
-    upd_PathPointSet().insert(aIndex, newPoint);
-
-    // Rename the path points starting at this new one.
-    namePathPoints(aIndex);
-
-    // Update start point and end point in the wrap instances so that they
-    // refer to the same path points they did before the new point
-    // was added. These indices are 1-based.
-    aIndex++;
-    for (int i=0; i<get_PathWrapSet().getSize(); i++) {
-        int startPoint = get_PathWrapSet().get(i).getStartPoint();
-        int endPoint = get_PathWrapSet().get(i).getEndPoint();
-        if (startPoint != -1 && aIndex <= startPoint)
-            get_PathWrapSet().get(i).setStartPoint(s,startPoint + 1);
-        if (endPoint != -1 && aIndex <= endPoint)
-            get_PathWrapSet().get(i).setEndPoint(s,endPoint + 1);
-    }
-
-    return newPoint;
-}
-
-AbstractPathPoint* GeometryPath::
-appendNewPathPoint(const std::string& proposedName, 
-                   const PhysicalFrame& frame,
-                   const SimTK::Vec3& aPositionOnBody)
-{
-    PathPoint* newPoint = new PathPoint();
-    newPoint->setParentFrame(frame);
-    newPoint->setName(proposedName);
-    newPoint->setLocation(aPositionOnBody);
-    upd_PathPointSet().adoptAndAppend(newPoint);
-
-    return newPoint;
-}
-
-//_____________________________________________________________________________
-/*
- * Determine an appropriate default XYZ location for a new path point.
- * Note that this method is internal and should not be called directly on a new 
- * point as the point is not really added to the path (done in addPathPoint() 
- * instead)
- * @param aOffset The XYZ location to be determined.
- * @param aIndex The position in the pathPointSet to put the new point in.
- * @param frame The body to attach the point to.
- */
-void GeometryPath::
-placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, int aIndex, 
-                  const PhysicalFrame& frame)
-{
-    // The location of the point is determined by moving a 'distance' from 'base' 
-    // along a vector from 'start' to 'end.' 'base' is the existing path point 
-    // that is in or closest to the index aIndex. 'start' and 'end' are existing
-    // path points--which ones depends on where the new point is being added. 
-    // 'distance' is 0.5 for points added to the middle of a path (so the point
-    // appears halfway between the two adjacent points), and 0.2 for points that
-    // are added to either end of the path. If there is only one point in the 
-    // path, the new point is put 0.01 units away in all three dimensions.
-    if (get_PathPointSet().getSize() > 1) {
-        int start, end, base;
-        double distance;
-        if (aIndex == 0) {
-            start = 1;
-            end = 0;
-            base = end;
-            distance = 0.2;
-        } else if (aIndex >= get_PathPointSet().getSize()) {
-            start = aIndex - 2;
-            end = aIndex - 1;
-            base = end;
-            distance = 0.2;
-        } else {
-            start = aIndex;
-            end = aIndex - 1;
-            base = start;
-            distance = 0.5;
-        }
-
-        const Vec3 startPt = get_PathPointSet()[start].getLocation(s);
-        const Vec3 endPt = get_PathPointSet()[end].getLocation(s);
-        const Vec3 basePt = get_PathPointSet()[base].getLocation(s);
-
-        Vec3 startPt2 = get_PathPointSet()[start].getParentFrame()
-            .findStationLocationInAnotherFrame(s, startPt, frame);
-
-        Vec3 endPt2 = get_PathPointSet()[end].getParentFrame()
-            .findStationLocationInAnotherFrame(s, endPt, frame);
-
-        aOffset = basePt + distance * (endPt2 - startPt2);
-    } else if (get_PathPointSet().getSize() == 1) {
-        aOffset= get_PathPointSet()[0].getLocation(s) + 0.01;
-    }
-    else {  // first point, do nothing?
-    }
-}
-
-//_____________________________________________________________________________
-/*
- * See if a path point can be deleted. All paths must have at least two
- * active path points to define the path.
- *
- * @param aIndex The index of the point to delete.
- * @return Whether or not the point can be deleted.
- */
-bool GeometryPath::canDeletePathPoint( int aIndex)
-{
-    // A path point can be deleted only if there would remain
-    // at least two other fixed points.
-    int numOtherFixedPoints = 0;
-    for (int i = 0; i < get_PathPointSet().getSize(); i++) {
-        if (i != aIndex) {
-            if (!(  get_PathPointSet().get(i).getConcreteClassName()
-                  ==("ConditionalPathPoint")))
-                numOtherFixedPoints++;
-        }
-    }
-
-    if (numOtherFixedPoints >= 2)
-        return true;
-
-    return false;
-}
-
-//_____________________________________________________________________________
-/*
- * Delete a path point.
- *
- * @param aIndex The index of the point to delete.
- * @return Whether or not the point was deleted.
- */
-bool GeometryPath::deletePathPoint(const SimTK::State& s, int aIndex)
-{
-    if (canDeletePathPoint(aIndex) == false)
-        return false;
-
-    upd_PathPointSet().remove(aIndex);
-
-    // rename the path points starting at the deleted position
-    namePathPoints(aIndex);
-
-    // Update start point and end point in the wrap instances so that they
-    // refer to the same path points they did before the point was
-    // deleted. These indices are 1-based. If the point deleted is start
-    // point or end point, the path wrap range is made smaller by one point.
-    aIndex++;
-    for (int i=0; i<get_PathWrapSet().getSize(); i++) {
-        int startPoint = get_PathWrapSet().get(i).getStartPoint();
-        int endPoint   = get_PathWrapSet().get(i).getEndPoint();
-
-        if (   (startPoint != -1 && aIndex < startPoint) 
-            || (startPoint > get_PathPointSet().getSize()))
-            get_PathWrapSet().get(i).setStartPoint(s, startPoint - 1);
-
-        if (   endPoint > 1 
-            && aIndex <= endPoint 
-            && (   (endPoint > startPoint) 
-                || (endPoint > get_PathPointSet().getSize())))
-            get_PathWrapSet().get(i).setEndPoint(s, endPoint - 1);
-    }
-
-    return true;
-}
-
-//_____________________________________________________________________________
-/*
- * Replace a path point in the set with another point. The new one is made a
- * member of all the same groups as the old one, and is inserted in the same
- * place the old one occupied.
- *
- *  @param aOldPathPoint Path point to remove.
- *  @param aNewPathPoint Path point to add.
- */
-bool GeometryPath::
-replacePathPoint(const SimTK::State& s, AbstractPathPoint* aOldPathPoint, 
-                 AbstractPathPoint* aNewPathPoint) 
-{
-    if (aOldPathPoint != NULL && aNewPathPoint != NULL) {
-        int count = 0;
-        int index = get_PathPointSet().getIndex(aOldPathPoint);
-        // If you're switching from non-via to via, check to make sure that the
-        // path will be left with at least 2 non-via points.
-        ConditionalPathPoint* oldVia = 
-            dynamic_cast<ConditionalPathPoint*>(aOldPathPoint);
-        ConditionalPathPoint* newVia = 
-            dynamic_cast<ConditionalPathPoint*>(aNewPathPoint);
-        if (oldVia == NULL && newVia != NULL) {
-            for (int i=0; i<get_PathPointSet().getSize(); i++) {
-                if (i != index) {
-                    if (dynamic_cast<ConditionalPathPoint*>
-                                        (&get_PathPointSet().get(i)) == NULL)
-                        count++;
-                }
-            }
-        } else {
-            count = 2;
-        }
-        if (count >= 2 && index >= 0) {
-            upd_PathPointSet().set(index, aNewPathPoint, true);
-            //computePath(s);
-            return true;
-        }
-    }
-    return false;
-}
-
-//_____________________________________________________________________________
-/*
- * Create a new wrap instance and add it to the set.
- *
- * @param aWrapObject The wrap object to use in the new wrap instance.
- */
-void GeometryPath::addPathWrap(WrapObject& aWrapObject)
-{
-    PathWrap* newWrap = new PathWrap();
-    newWrap->setWrapObject(aWrapObject);
-    newWrap->setMethod(PathWrap::hybrid);
-    upd_PathWrapSet().adoptAndAppend(newWrap);
-    finalizeFromProperties();
-}
-
-//_____________________________________________________________________________
-/*
- * Move a wrap instance up in the list. Changing the order of wrap instances for
- * a path may affect how the path wraps over the wrap objects.
- *
- * @param aIndex The index of the wrap instance to move up.
- */
-void GeometryPath::moveUpPathWrap(const SimTK::State& s, int aIndex)
-{
-    if (aIndex > 0) {
-        // Make sure wrap object is not deleted by remove().
-        upd_PathWrapSet().setMemoryOwner(false); 
-
-        PathWrap& wrap = get_PathWrapSet().get(aIndex);
-        upd_PathWrapSet().remove(aIndex);
-        upd_PathWrapSet().insert(aIndex - 1, &wrap);
-        upd_PathWrapSet().setMemoryOwner(true);
-    }
-}
-
-//_____________________________________________________________________________
-/*
- * Move a wrap instance down in the list. Changing the order of wrap instances
- * for a path may affect how the path wraps over the wrap objects.
- *
- * @param aIndex The index of the wrap instance to move down.
- */
-void GeometryPath::moveDownPathWrap(const SimTK::State& s, int aIndex)
-{
-    if (aIndex < get_PathWrapSet().getSize() - 1) {
-        // Make sure wrap object is not deleted by remove().
-        upd_PathWrapSet().setMemoryOwner(false);
-
-        PathWrap& wrap = get_PathWrapSet().get(aIndex);
-        upd_PathWrapSet().remove(aIndex);
-        upd_PathWrapSet().insert(aIndex + 1, &wrap);
-        upd_PathWrapSet().setMemoryOwner(true);
-    }
-}
-
-//_____________________________________________________________________________
-/*
- * Delete a wrap instance.
- *
- * @param aIndex The index of the wrap instance to delete.
- */
-void GeometryPath::deletePathWrap(const SimTK::State& s, int aIndex)
-{
-    upd_PathWrapSet().remove(aIndex);
-
-}
-
-//==============================================================================
-// SCALING
-//==============================================================================
-void GeometryPath::
-extendPreScale(const SimTK::State& s, const ScaleSet& scaleSet)
+void GeometryPath::extendPreScale(
+    const SimTK::State& s,
+    const ScaleSet& scaleSet)
 {
     Super::extendPreScale(s, scaleSet);
     setPreScaleLength(s, getLength(s));
 }
 
-void GeometryPath::
-extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
+void GeometryPath::extendPostScale(
+    const SimTK::State& s,
+    const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
-    computePath(s);
+    getCurrentPath(s);
 }
 
-//--------------------------------------------------------------------------
-// COMPUTATIONS
-//--------------------------------------------------------------------------
-//=============================================================================
-// PATH, WRAPPING, AND MOMENT ARM
-//=============================================================================
-//_____________________________________________________________________________
-/*
- * Calculate the current path.
- */
-void GeometryPath::computePath(const SimTK::State& s) const
+void GeometryPath::extendFinalizeFromProperties()
 {
-    if (isCacheVariableValid(s, _currentPathCV)) {
+    Super::extendFinalizeFromProperties();
+
+    for (int i = 0; i < get_PathWrapSet().getSize(); ++i) {
+        if (upd_PathWrapSet()[i].getName().empty()) {
+            std::stringstream label;
+            label << "pathwrap_" << i;
+            upd_PathWrapSet()[i].setName(label.str());
+        }
+    }
+}
+
+void GeometryPath::extendConnectToModel(Model& aModel)
+{
+    Super::extendConnectToModel(aModel);
+
+    OPENSIM_THROW_IF_FRMOBJ(get_PathPointSet().getSize() < 2,
+        InvalidPropertyValue,
+        getProperty_PathPointSet().getName(),
+        "A valid path must be connected to a model by at least two PathPoints.")
+
+    // Name the path points based on the current path
+    // (i.e., the set of currently active points is numbered
+    // 1, 2, 3, ...).
+    namePathPoints(0);
+}
+
+void GeometryPath::extendInitStateFromProperties(SimTK::State& s) const
+{
+   Super::extendInitStateFromProperties(s);
+   markCacheVariableValid(s, _colorCV);  // it is OK at its default value
+}
+
+void GeometryPath::extendAddToSystem(SimTK::MultibodySystem& system) const
+{
+    Super::extendAddToSystem(system);
+
+    // allocate cache variables
+    //
+    // - length only depends on `q`s, so it will be valid after Stage::Position
+    // - speed depends on `q`s and `u`s, so it will be valid after Stage::Velocity
+    // - path point positions only depend on the position of points
+    // - color is a decoration cache variable that isn't simulation-related
+
+    this->_lengthCV = addCacheVariable("length", 0.0, SimTK::Stage::Position);
+    this->_speedCV = addCacheVariable("speed", 0.0, SimTK::Stage::Velocity);
+    this->_currentPathAbspathCV = addCacheVariable("current_path", std::vector<ComponentPath>{}, SimTK::Stage::Position);
+    this->_colorCV = addCacheVariable("color", get_Appearance().get_color(), SimTK::Stage::Topology);
+}
+
+void GeometryPath::generateDecorations(
+    bool fixed,
+    const ModelDisplayHints& hints,
+    const SimTK::State& state,
+    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
+{
+    // The GeometryPath takes care of drawing itself here, using information it
+    // can extract from the supplied state, including position information and
+    // color information that may have been calculated as late as Stage::Dynamics.
+    //
+    // For example, muscles may want the color to reflect activation level and
+    // other path-using components might want to use forces (tension). We will
+    // ensure that the state has been realized to Stage::Dynamics before looking
+    // at it. (It is only guaranteed to be at Stage::Position here.)
+
+    // There is no fixed geometry to generate here.
+    if (fixed) {
         return;
     }
 
-    // Clear the current path.
-    Array<AbstractPathPoint*>& currentPath = updCacheVariableValue(s, _currentPathCV);
-    currentPath.setSize(0);
+    const Array<const AbstractPathPoint*>& pathPoints = getCurrentPath(state);
 
-    // Add the active fixed and moving via points to the path.
-    for (int i = 0; i < get_PathPointSet().getSize(); i++) {
-        if (get_PathPointSet()[i].isActive(s))
-            currentPath.append(&get_PathPointSet()[i]); // <--- !!!!BAD
+    assert(pathPoints.size() > 1);
+
+    const AbstractPathPoint* lastPoint = pathPoints[0];
+    MobilizedBodyIndex mbix(0);
+
+    Vec3 lastPos = lastPoint->getLocationInGround(state);
+    if (hints.get_show_path_points())
+        DefaultGeometry::drawPathPoint(mbix, lastPos, getColor(state), appendToThis);
+
+    Vec3 pos;
+
+    for (int i = 1; i < pathPoints.getSize(); ++i) {
+        const AbstractPathPoint* point = pathPoints[i];
+        const PathWrapPoint* pwp = dynamic_cast<const PathWrapPoint*>(point);
+
+        if (pwp) {
+            // A PathWrapPoint provides points on the wrapping surface as Vec3s
+            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
+            // The surface points are expressed w.r.t. the wrap surface's body frame.
+            // Transform the surface points into the ground reference frame to draw
+            // the surface point as the wrapping portion of the GeometryPath
+            const Transform& X_BG = pwp->getParentFrame().getTransformInGround(state);
+            // Cycle through each surface point and draw it the Ground frame
+            for (int j = 0; j<surfacePoints.getSize(); ++j) {
+                // transform the surface point into the Ground reference frame
+                pos = X_BG*surfacePoints[j];
+                if (hints.get_show_path_points())
+                    DefaultGeometry::drawPathPoint(mbix, pos, getColor(state),
+                        appendToThis);
+                // Line segments will be in ground frame
+                appendToThis.push_back(DecorativeLine(lastPos, pos)
+                    .setLineThickness(4)
+                    .setColor(getColor(state)).setBodyId(0).setIndexOnBody(j));
+                lastPos = pos;
+            }
+        }
+        else { // otherwise a regular PathPoint so just draw its location
+            pos = point->getLocationInGround(state);
+            if (hints.get_show_path_points())
+                DefaultGeometry::drawPathPoint(mbix, pos, getColor(state),
+                    appendToThis);
+            // Line segments will be in ground frame
+            appendToThis.push_back(DecorativeLine(lastPos, pos)
+                .setLineThickness(4)
+                .setColor(getColor(state)).setBodyId(0).setIndexOnBody(i));
+            lastPos = pos;
+        }
     }
-  
-    // Use the current path so far to check for intersection with wrap objects, 
-    // which may add additional points to the path.
-    applyWrapObjects(s, currentPath);
-    calcLengthAfterPathComputation(s, currentPath);
-
-    markCacheVariableValid(s, _currentPathCV);
 }
 
-//_____________________________________________________________________________
-/*
- * Compute lengthening speed of the path.
- */
-void GeometryPath::computeLengtheningSpeed(const SimTK::State& s) const
+void GeometryPath::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
 {
-    if (isCacheVariableValid(s, _speedCV)) {
-        return;
+    if (versionNumber < XMLDocument::getLatestVersion()) {
+        if (versionNumber < 30516) {
+            // Create Appearance node under GeometryPath
+            SimTK::Xml::Element appearanceElement("Appearance");
+            aNode.appendNode(appearanceElement);
+            SimTK::Xml::element_iterator visObjectIter = aNode.element_begin("VisibleObject");
+            if (visObjectIter != aNode.element_end()) {
+                SimTK::Xml::element_iterator oldPrefIter = visObjectIter->element_begin("display_preference");
+                // old display_preference was used only for hide/show other options unsupported
+                if (oldPrefIter != visObjectIter->element_end()) {
+                    int oldPrefAsInt = 4;
+                    oldPrefIter->getValueAs<int>(oldPrefAsInt);
+                    if (oldPrefAsInt == 0) { // Hidden => Appearance/Visible
+                        SimTK::Xml::Element visibleElement("visible");
+                        visibleElement.setValueAs<bool>(false);
+                        appearanceElement.insertNodeAfter(appearanceElement.element_end(), visibleElement);
+                    }
+                }
+            }
+            // If default_color existed, copy it to Appearance/color
+            SimTK::Xml::element_iterator defaultColorIter = aNode.element_begin("default_color");
+            if (defaultColorIter != aNode.element_end()) {
+                // Move default_color to Appearance/color
+                SimTK::Xml::Element colorElement("color");
+                const SimTK::String& colorAsString = defaultColorIter->getValue();
+                colorElement.setValue(colorAsString);
+                appearanceElement.appendNode(colorElement);
+            }
+        }
     }
+    // Call base class now assuming aNode has been corrected for current version
+    Super::updateFromXMLNode(aNode, versionNumber);
+}
 
-    const Array<AbstractPathPoint*>& currentPath = getCurrentPath(s);
+void GeometryPath::constructProperties()
+{
+    constructProperty_PathPointSet(PathPointSet());
 
-    double speed = 0.0;
+    constructProperty_PathWrapSet(PathWrapSet());
     
-    for (int i = 0; i < currentPath.getSize() - 1; i++) {
-        speed += currentPath[i]->calcSpeedBetween(s, *currentPath[i+1]);
-    }
-
-    setLengtheningSpeed(s, speed);
+    Appearance appearance;
+    appearance.set_color(SimTK::Gray);
+    constructProperty_Appearance(appearance);
 }
 
-//_____________________________________________________________________________
+Array<const AbstractPathPoint*>& GeometryPath::populatePathPtrsCache(
+    const std::vector<ComponentPath>& absPaths) const
+{
+    _currentPathPtrsCache.setSize(static_cast<int>(absPaths.size()));
+    for (int i = 0; i < static_cast<int>(absPaths.size()); ++i) {
+        _currentPathPtrsCache[i] = &getComponent<OpenSim::AbstractPathPoint>(absPaths[i]);
+    }
+    return _currentPathPtrsCache;
+}
+
 /*
  * Apply the wrap objects to the current path.
  */
-void GeometryPath::
-applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const 
+void GeometryPath::applyWrapObjects(
+    const SimTK::State& s,
+    Array<const AbstractPathPoint*>& path) const
 {
     int wrapSetSize = get_PathWrapSet().getSize();
     if (wrapSetSize < 1)
@@ -904,27 +830,27 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
             }
 
             if (wo->get_active()) {
-                // startPoint and endPoint in wrapStruct represent the 
-                // user-defined starting and ending points in the array of path 
-                // points that should be considered for wrapping. These indices 
-                // take into account via points, whether or not they are active. 
-                // Thus they are indices into mp_orig[], not mp[] (also, mp[] 
+                // startPoint and endPoint in wrapStruct represent the
+                // user-defined starting and ending points in the array of path
+                // points that should be considered for wrapping. These indices
+                // take into account via points, whether or not they are active.
+                // Thus they are indices into mp_orig[], not mp[] (also, mp[]
                 // may contain wrapping points from previous wrap objects, which
-                // would mess up the starting and ending indices). But the goal 
+                // would mess up the starting and ending indices). But the goal
                 // is to find starting and ending indices in mp[] to consider
                 // for wrapping over this wrap object. Here is how that is done:
 
-                // 1. startPoint and endPoint are 1-based, so subtract 1 from 
+                // 1. startPoint and endPoint are 1-based, so subtract 1 from
                 // them to get indices into get_PathPointSet(). -1 (or any value
                 // less than 1) means use the first (or last) point.
                 const int wrapStart = (ws.getStartPoint() < 1
-                                            ? 0 
+                                            ? 0
                                             : ws.getStartPoint() - 1);
                 const int wrapEnd   = (ws.getEndPoint() < 1
-                                            ? get_PathPointSet().getSize() - 1 
+                                            ? get_PathPointSet().getSize() - 1
                                             : ws.getEndPoint() - 1);
 
-                // 2. Scan forward from wrapStart in get_PathPointSet() to find 
+                // 2. Scan forward from wrapStart in get_PathPointSet() to find
                 // the first point that is active. Store a pointer to it (smp).
                 int jfwd = wrapStart;
                 for (; jfwd <= wrapEnd; jfwd++)
@@ -934,7 +860,7 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                     return;
                 const AbstractPathPoint* const smp = &get_PathPointSet().get(jfwd);
 
-                // 3. Scan backwards from wrapEnd in get_PathPointSet() to find 
+                // 3. Scan backwards from wrapEnd in get_PathPointSet() to find
                 // the last point that is active. Store a pointer to it (emp).
                 int jrev = wrapEnd;
                 for (; jrev >= wrapStart; jrev--)
@@ -955,11 +881,11 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                 if (start == -1 || end == -1) // this should never happen
                     return;
 
-                // You now have indices into _currentPath (which is a list of 
-                // all currently active points, including wrap points) that 
-                // represent the used-defined range of points to consider for 
-                // wrapping over this wrap object. Check each path segment in 
-                // this range, choosing the best wrap as the one that changes 
+                // You now have indices into _currentPath (which is a list of
+                // all currently active points, including wrap points) that
+                // represent the used-defined range of points to consider for
+                // wrapping over this wrap object. Check each path segment in
+                // this range, choosing the best wrap as the one that changes
                 // the path segment length the least:
                 for (int pt1 = start; pt1 < end; pt1++)
                 {
@@ -967,47 +893,50 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
 
                     // As long as the two points are not auto wrap points on the
                     // same wrap object, check them for wrapping.
-                    if (   path.get(pt1)->getWrapObject() == NULL 
-                        || path.get(pt2)->getWrapObject() == NULL 
-                        || (   path.get(pt1)->getWrapObject() 
+                    if (   path.get(pt1)->getWrapObject() == NULL
+                        || path.get(pt2)->getWrapObject() == NULL
+                        || (   path.get(pt1)->getWrapObject()
                             != path.get(pt2)->getWrapObject()))
                     {
                         WrapResult wr;
                         wr.startPoint = pt1;
                         wr.endPoint   = pt2;
                         wr.singleWrap = (wrapSetSize==1);
-                        result[i] = wo->wrapPathSegment(s, *path.get(pt1), 
-                                                        *path.get(pt2), ws, wr);
+                        result[i] = wo->wrapPathSegment(s,
+                                                        const_cast<AbstractPathPoint&>(*path.get(pt1)),
+                                                        const_cast<AbstractPathPoint&>(*path.get(pt2)),
+                                                        ws,
+                                                        wr);
                         if (result[i] == WrapObject::mandatoryWrap) {
-                            // "mandatoryWrap" means the path actually 
-                            // intersected the wrap object. In this case, you 
+                            // "mandatoryWrap" means the path actually
+                            // intersected the wrap object. In this case, you
                             // *must* choose this segment as the "best" one for
-                            // wrapping. If the path has more than one segment 
+                            // wrapping. If the path has more than one segment
                             // that intersects the object, the first one is
-                            // taken as the mandatory wrap (this is considered 
+                            // taken as the mandatory wrap (this is considered
                             // an ill-conditioned case).
                             best_wrap = wr;
-                            // Store the best wrap in the pathWrap for possible 
+                            // Store the best wrap in the pathWrap for possible
                             // use next time.
                             ws.setPreviousWrap(wr);
                             break;
                         }  else if (result[i] == WrapObject::wrapped) {
                             // "wrapped" means the path segment was wrapped over
-                            // the object, but you should consider the other 
+                            // the object, but you should consider the other
                             // segments as well to see if one
                             // wraps with a smaller length change.
-                            double path_length_change = 
+                            double path_length_change =
                                 calcPathLengthChange(s, *wo, wr, path);
                             if (path_length_change < min_length_change)
                             {
                                 best_wrap = wr;
-                                // Store the best wrap in the pathWrap for 
+                                // Store the best wrap in the pathWrap for
                                 // possible use next time
                                 ws.setPreviousWrap(wr);
                                 min_length_change = path_length_change;
                             } else {
-                                // The wrap was not shorter than the current 
-                                // minimum, so just free the wrap points that 
+                                // The wrap was not shorter than the current
+                                // minimum, so just free the wrap points that
                                 // were allocated.
                                 wr.wrap_pts.setSize(0);
                             }
@@ -1029,13 +958,13 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
 
                     ws.updWrapPoint2().setWrapPath(s, best_wrap.wrap_pts);
 
-                    // In OpenSim, all conversion to/from the wrap object's 
-                    // reference frame will be performed inside 
+                    // In OpenSim, all conversion to/from the wrap object's
+                    // reference frame will be performed inside
                     // wrapPathSegment(). Thus, all points in this function will
                     // be in their respective body reference frames.
                     // for (j = 0; j < wrapPath.getSize(); j++){
                     //    convert_from_wrap_object_frame(wo, wrapPath.get(j));
-                    //    convert(ms->modelnum, wrapPath.get(j), wo->segment, 
+                    //    convert(ms->modelnum, wrapPath.get(j), wo->segment,
                     //            ms->ground_segment);
                     // }
 
@@ -1052,7 +981,7 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
             }
         }
 
-        const double length = calcLengthAfterPathComputation(s, path); 
+        const double length = calcPathLength(s, path);
         if (std::abs(length - last_length) < 0.0005) {
             break;
         } else {
@@ -1063,7 +992,7 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
             // If the first wrap was a no wrap, and the second was a no wrap
             // because a point was inside the object, switch the order of
             // the first two objects and try again.
-            if (   result[0] == WrapObject::noWrap 
+            if (   result[0] == WrapObject::noWrap
                 && result[1] == WrapObject::insideRadius)
             {
                 order[0] = 1;
@@ -1083,15 +1012,32 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
     }
 }
 
-//_____________________________________________________________________________
+/*
+ * Compute lengthening speed of the path.
+ */
+double GeometryPath::calcLengtheningSpeed(
+    const SimTK::State& s,
+    const Array<const AbstractPathPoint*>& path) const
+{
+    double speed = 0.0;
+
+    for (int i = 0; i < path.getSize() - 1; i++) {
+        speed += path[i]->calcSpeedBetween(s, *path[i+1]);
+    }
+
+    return speed;
+}
+
 /*
  * _calc_path_length_change - given the output of a successful path wrap
  * over a wrap object, determine the percent change in length of the
  * path segment incurred by wrapping.
  */
-double GeometryPath::
-calcPathLengthChange(const SimTK::State& s, const WrapObject& wo, 
-                     const WrapResult& wr, const Array<AbstractPathPoint*>& path)  const
+double GeometryPath::calcPathLengthChange(
+    const SimTK::State& s,
+    const WrapObject& wo,
+    const WrapResult& wr,
+    const Array<const AbstractPathPoint*>& path)  const
 {
     const AbstractPathPoint* pt1 = path.get(wr.startPoint);
     const AbstractPathPoint* pt2 = path.get(wr.endPoint);
@@ -1105,28 +1051,33 @@ calcPathLengthChange(const SimTK::State& s, const WrapObject& wo,
     return wrap_length - straight_length; // return absolute diff, not relative
 }
 
-//_____________________________________________________________________________
 /*
  * Compute the total length of the path. This function
  * assumes that the path has already been updated.
  */
-double GeometryPath::
-calcLengthAfterPathComputation(const SimTK::State& s, 
-                               const Array<AbstractPathPoint*>& currentPath) const
+double GeometryPath::calcPathLength(
+    const SimTK::State& s,
+    const Array<const AbstractPathPoint*>& path) const
 {
+    if (path.getSize() == 0) {
+        return 0.0;
+    }
+
     double length = 0.0;
-    const AbstractPathPoint* p1 = currentPath[0];
+    const AbstractPathPoint* p1 = path[0];
     Vec3 p1InGround = p1->getLocationInGround(s);
+
     // Transform all points to ground once rather than once per-segment
-    for (int i = 1; i < currentPath.getSize() ; i++) {
-        const AbstractPathPoint* p2 = currentPath[i];
+    for (int i = 1; i < path.getSize() ; i++) {
+        const AbstractPathPoint* p2 = path[i];
         Vec3 p2InGround = p2->getLocationInGround(s);
+
         // If both points are wrap points on the same wrap object, then this
-        // path segment wraps over the surface of a wrap object, so just add in 
+        // path segment wraps over the surface of a wrap object, so just add in
         // the pre-calculated length.
-        if (   p1->getWrapObject() 
-            && p2->getWrapObject() 
-            && p1->getWrapObject() == p2->getWrapObject()) 
+        if (   p1->getWrapObject()
+            && p2->getWrapObject()
+            && p1->getWrapObject() == p2->getWrapObject())
         {
             const PathWrapPoint* smwp = dynamic_cast<const PathWrapPoint*>(p2);
             if (smwp)
@@ -1134,64 +1085,95 @@ calcLengthAfterPathComputation(const SimTK::State& s,
         } else {
             length += (p1InGround - p2InGround).norm();
         }
+
         p1 = p2;
         p1InGround = p2InGround;
     }
 
-    setLength(s,length);
-    return( length );
+    return length;
 }
 
-//_____________________________________________________________________________
-/*
- * Compute the path's moment arms for  specified coordinate.
+/**
+ * Name the path points based on their position in the set. To keep the names up to date,
+ * this method should be called every time the path changes.
  *
- * @param aCoord, the coordinate
- */   
-double GeometryPath::
-computeMomentArm(const SimTK::State& s, const Coordinate& aCoord) const
+ * @param aStartingIndex The index of the first path point to name.
+ */
+void GeometryPath::namePathPoints(int aStartingIndex)
 {
-    if (!_maSolver)
-        const_cast<Self*>(this)->_maSolver.reset(new MomentArmSolver(*_model));
-
-    return _maSolver->solve(s, aCoord,  *this);
-}
-
-//_____________________________________________________________________________
-// Override default implementation by object to intercept and fix the XML node
-// underneath the model to match current version.
-void GeometryPath::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
-{
-    if (versionNumber < XMLDocument::getLatestVersion()) {
-        if (versionNumber < 30516) {
-            // Create Appearance node under GeometryPath
-            SimTK::Xml::Element appearanceElement("Appearance");
-            aNode.appendNode(appearanceElement);
-            SimTK::Xml::element_iterator visObjectIter = aNode.element_begin("VisibleObject");
-            if (visObjectIter != aNode.element_end()) {
-                SimTK::Xml::element_iterator oldPrefIter = visObjectIter->element_begin("display_preference");
-                // old display_preference was used only for hide/show other options unsupported
-                if (oldPrefIter != visObjectIter->element_end()) {
-                    int oldPrefAsInt = 4;
-                    oldPrefIter->getValueAs<int>(oldPrefAsInt);
-                    if (oldPrefAsInt == 0) { // Hidden => Appearance/Visible
-                        SimTK::Xml::Element visibleElement("visible");
-                        visibleElement.setValueAs<bool>(false);
-                        appearanceElement.insertNodeAfter(appearanceElement.element_end(), visibleElement);
-                    }
-                }
-            }
-            // If default_color existed, copy it to Appearance/color
-            SimTK::Xml::element_iterator defaultColorIter = aNode.element_begin("default_color");
-            if (defaultColorIter != aNode.element_end()) {
-                // Move default_color to Appearance/color
-                SimTK::Xml::Element colorElement("color");
-                const SimTK::String& colorAsString = defaultColorIter->getValue();
-                colorElement.setValue(colorAsString);
-                appearanceElement.appendNode(colorElement);
-            }
+    char indx[5];
+    for (int i = aStartingIndex; i < get_PathPointSet().getSize(); i++)
+    {
+        sprintf(indx,"%d",i+1);
+        AbstractPathPoint& point = get_PathPointSet().get(i);
+        if (point.getName()=="" && hasOwner()) {
+            point.setName(getOwner().getName() + "-P" + indx);
         }
     }
-    // Call base class now assuming aNode has been corrected for current version
-    Super::updateFromXMLNode(aNode, versionNumber);
+}
+
+/*
+ * Determine an appropriate default XYZ location for a new path point.
+ * Note that this method is internal and should not be called directly on a new 
+ * point as the point is not really added to the path (done in addPathPoint() 
+ * instead)
+ * @param aOffset The XYZ location to be determined.
+ * @param aIndex The position in the pathPointSet to put the new point in.
+ * @param frame The body to attach the point to.
+ */
+void GeometryPath::placeNewPathPoint(
+    const SimTK::State& s,
+    SimTK::Vec3& aOffset,
+    int aIndex,
+    const PhysicalFrame& frame)
+{
+    // The location of the point is determined by moving a 'distance' from 'base'
+    // along a vector from 'start' to 'end.' 'base' is the existing path point
+    // that is in or closest to the index aIndex. 'start' and 'end' are existing
+    // path points--which ones depends on where the new point is being added.
+    // 'distance' is 0.5 for points added to the middle of a path (so the point
+    // appears halfway between the two adjacent points), and 0.2 for points that
+    // are added to either end of the path. If there is only one point in the
+    // path, the new point is put 0.01 units away in all three dimensions.
+
+    if (get_PathPointSet().getSize() > 1) {
+
+        int start, end, base;
+        double distance;
+
+        if (aIndex == 0) {
+            start = 1;
+            end = 0;
+            base = end;
+            distance = 0.2;
+        } else if (aIndex >= get_PathPointSet().getSize()) {
+            start = aIndex - 2;
+            end = aIndex - 1;
+            base = end;
+            distance = 0.2;
+        } else {
+            start = aIndex;
+            end = aIndex - 1;
+            base = start;
+            distance = 0.5;
+        }
+
+        const Vec3 startPt = get_PathPointSet()[start].getLocation(s);
+        const Vec3 endPt = get_PathPointSet()[end].getLocation(s);
+        const Vec3 basePt = get_PathPointSet()[base].getLocation(s);
+
+        Vec3 startPt2 = get_PathPointSet()[start].getParentFrame()
+            .findStationLocationInAnotherFrame(s, startPt, frame);
+
+        Vec3 endPt2 = get_PathPointSet()[end].getParentFrame()
+            .findStationLocationInAnotherFrame(s, endPt, frame);
+
+        aOffset = basePt + distance * (endPt2 - startPt2);
+    }
+    else if (get_PathPointSet().getSize() == 1) {
+        aOffset= get_PathPointSet()[0].getLocation(s) + 0.01;
+    }
+    else {
+        // first point, do nothing?
+    }
 }

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -81,9 +81,9 @@ OpenSim::GeometryPath::GeometryPath() : ModelComponent(), _preScaleLength(0.0)
     constructProperties();
 }
 OpenSim::GeometryPath::GeometryPath(const GeometryPath&) = default;
-OpenSim::GeometryPath::GeometryPath(GeometryPath&&) noexcept = default;
+OpenSim::GeometryPath::GeometryPath(GeometryPath&&) = default;
 OpenSim::GeometryPath& OpenSim::GeometryPath::operator=(const GeometryPath&) = default;
-OpenSim::GeometryPath& OpenSim::GeometryPath::operator=(GeometryPath&&) noexcept = default;
+OpenSim::GeometryPath& OpenSim::GeometryPath::operator=(GeometryPath&&) = default;
 OpenSim::GeometryPath::~GeometryPath() noexcept = default;
 
 const OpenSim::PathPointSet& OpenSim::GeometryPath::getPathPointSet() const

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -29,6 +29,7 @@
 #include "MovingPathPoint.h"
 #include "PointForceDirection.h"
 #include <OpenSim/Simulation/Wrap/PathWrap.h>
+#include <OpenSim/Simulation/Wrap/PathWrapPoint.h>
 #include "Model.h"
 
 //=============================================================================
@@ -152,7 +153,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 
         if (pwp) {
             // A PathWrapPoint provides points on the wrapping surface as Vec3s
-            Array<Vec3>& surfacePoints = pwp->getWrapPath();
+            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
             // The surface points are expressed w.r.t. the wrap surface's body frame.
             // Transform the surface points into the ground reference frame to draw
             // the surface point as the wrapping portion of the GeometryPath
@@ -1017,17 +1018,16 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                 }
 
                 // Deallocate previous wrapping points if necessary.
-                ws.updWrapPoint2().getWrapPath().setSize(0);
+                ws.updWrapPoint2().clearWrapPath(s);
 
                 if (best_wrap.wrap_pts.getSize() == 0) {
                     ws.resetPreviousWrap();
-                    ws.updWrapPoint2().getWrapPath().setSize(0);
+                    ws.updWrapPoint2().clearWrapPath(s);
                 } else {
                     // If wrapping did occur, copy wrap info into the PathStruct.
-                    ws.updWrapPoint1().getWrapPath().setSize(0);
+                    ws.updWrapPoint1().clearWrapPath(s);
 
-                    Array<SimTK::Vec3>& wrapPath = ws.updWrapPoint2().getWrapPath();
-                    wrapPath = best_wrap.wrap_pts;
+                    ws.updWrapPoint2().setWrapPath(s, best_wrap.wrap_pts);
 
                     // In OpenSim, all conversion to/from the wrap object's 
                     // reference frame will be performed inside 
@@ -1039,11 +1039,11 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                     //            ms->ground_segment);
                     // }
 
-                    ws.updWrapPoint1().setWrapLength(0.0);
-                    ws.updWrapPoint2().setWrapLength(best_wrap.wrap_path_length);
+                    ws.updWrapPoint1().setWrapLength(s, 0.0);
+                    ws.updWrapPoint2().setWrapLength(s, best_wrap.wrap_path_length);
 
-                    ws.updWrapPoint1().setLocation(best_wrap.r1);
-                    ws.updWrapPoint2().setLocation(best_wrap.r2);
+                    ws.updWrapPoint1().setLocation(s, best_wrap.r1);
+                    ws.updWrapPoint2().setLocation(s, best_wrap.r2);
 
                     // Now insert the two new wrapping points into mp[] array.
                     path.insert(best_wrap.endPoint, &ws.updWrapPoint1());
@@ -1130,7 +1130,7 @@ calcLengthAfterPathComputation(const SimTK::State& s,
         {
             const PathWrapPoint* smwp = dynamic_cast<const PathWrapPoint*>(p2);
             if (smwp)
-                length += smwp->getWrapLength();
+                length += smwp->getWrapLength(s);
         } else {
             length += (p1InGround - p2InGround).norm();
         }

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -23,14 +23,11 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-
-// INCLUDE
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include "OpenSim/Simulation/Model/ModelComponent.h"
-#include "PathPointSet.h"
+#include <OpenSim/Simulation/Model/ModelComponent.h>
+#include <OpenSim/Simulation/Model/PathPointSet.h>
 #include <OpenSim/Simulation/Wrap/PathWrapSet.h>
 #include <OpenSim/Simulation/MomentArmSolver.h>
-
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -47,202 +44,348 @@ class ScaleSet;
 class WrapResult;
 class WrapObject;
 
-//=============================================================================
-//=============================================================================
 /**
- * A base class representing a path (muscle, ligament, etc.).
+ * A class that represents a sequence ("path") of points in 3D space.
+ *
+ * This path class can be used to represent path-like concepts such as
+ * muscles and ligaments.
  *
  * @author Peter Loan
- * @version 1.0
  */
 class OSIMSIMULATION_API GeometryPath : public ModelComponent {
 OpenSim_DECLARE_CONCRETE_OBJECT(GeometryPath, ModelComponent);
+
+public:
+
     //=============================================================================
     // OUTPUTS
     //=============================================================================
-    OpenSim_DECLARE_OUTPUT(length, double, getLength, SimTK::Stage::Position);
-    // 
-    OpenSim_DECLARE_OUTPUT(lengthening_speed, double, getLengtheningSpeed,
+    OpenSim_DECLARE_OUTPUT(
+        length,
+        double,
+        getLength,
+        SimTK::Stage::Position);
+
+    OpenSim_DECLARE_OUTPUT(
+        lengthening_speed,
+        double,
+        getLengtheningSpeed,
         SimTK::Stage::Velocity);
 
-//=============================================================================
-// DATA
-//=============================================================================
-public:
-    OpenSim_DECLARE_UNNAMED_PROPERTY(Appearance,
+    //=============================================================================
+    // PROPERTIES
+    //=============================================================================
+
+    OpenSim_DECLARE_UNNAMED_PROPERTY(
+        Appearance,
         "Default appearance attributes for this GeometryPath");
 
 private:
-    OpenSim_DECLARE_UNNAMED_PROPERTY(PathPointSet,
+    OpenSim_DECLARE_UNNAMED_PROPERTY(
+        PathPointSet,
         "The set of points defining the path");
 
-    OpenSim_DECLARE_UNNAMED_PROPERTY(PathWrapSet,
+    OpenSim_DECLARE_UNNAMED_PROPERTY(
+        PathWrapSet,
         "The wrap objects that are associated with this path");
+
+public:
+    //=============================================================================
+    // METHODS
+    //=============================================================================
+
+    GeometryPath();
+    GeometryPath(const GeometryPath&);
+    GeometryPath(GeometryPath&&) noexcept;
+    GeometryPath& operator=(const GeometryPath&);
+    GeometryPath& operator=(GeometryPath&&) noexcept;
+    ~GeometryPath() noexcept;
+
+    const PathPointSet& getPathPointSet() const;
+    PathPointSet& updPathPointSet();
+
+    /**
+     * Add a new path point, with default location, to the path point set.
+     *
+     * @param aIndex The position in the pathPointSet to put the new point in.
+     * @param frame The frame to attach the point to.
+     * @return Pointer to the newly created path point.
+     */
+    AbstractPathPoint* addPathPoint(
+        const SimTK::State&,
+        int index,
+        const PhysicalFrame&);
+
+    AbstractPathPoint* appendNewPathPoint(
+        const std::string& proposedName,
+        const PhysicalFrame&,
+        const SimTK::Vec3& locationOnFrame);
+
+    /**
+     * See if a path point can be deleted. All paths must have at least two
+     * active path points to define the path.
+     *
+     * @param aIndex The index of the point to delete.
+     * @return Whether or not the point can be deleted.
+     */
+    bool canDeletePathPoint(int index);
+
+    /**
+     * Delete a path point.
+     *
+     * @param aIndex The index of the point to delete.
+     * @return Whether or not the point was deleted.
+     */
+    bool deletePathPoint(const SimTK::State&, int index);
+
+    /**
+     * Replace a path point in the set with another point. The new one is made a
+     * member of all the same groups as the old one, and is inserted in the same
+     * place the old one occupied.
+     *
+     *  @param aOldPathPoint Path point to remove.
+     *  @param aNewPathPoint Path point to add.
+     */
+    bool replacePathPoint(
+        const SimTK::State&,
+        AbstractPathPoint* oldPathPoint,
+        AbstractPathPoint* newPathPoint);
+
+    const PathWrapSet& getWrapSet() const;
+    PathWrapSet& updWrapSet();
+
+    /**
+     * Create a new wrap instance and add it to the set.
+     *
+     * @param aWrapObject The wrap object to use in the new wrap instance.
+     */
+    void addPathWrap(WrapObject&);
+
+    /**
+     * Move a wrap instance up in the list. Changing the order of wrap instances for
+     * a path may affect how the path wraps over the wrap objects.
+     *
+     * @param aIndex The index of the wrap instance to move up.
+     */
+    void moveUpPathWrap(const SimTK::State&, int index);
+
+    /**
+     * Move a wrap instance down in the list. Changing the order of wrap instances
+     * for a path may affect how the path wraps over the wrap objects.
+     *
+     * @param aIndex The index of the wrap instance to move down.
+     */
+    void moveDownPathWrap(const SimTK::State&, int index);
+
+    /**
+     * Delete a wrap instance.
+     *
+     * @param aIndex The index of the wrap instance to delete.
+     */
+    void deletePathWrap(const SimTK::State&, int index);
+
+    /**
+     * Returns the color that will be used to initialize the color cache at
+     * the next extendAddToSystem() call. The actual color used to draw the
+     * path will be taken from the cache variable, which may have changed.
+     */
+    const SimTK::Vec3& getDefaultColor() const;
+
+    /**
+     * If you call this prior to extendAddToSystem() it will be used to initialize
+     * the color cache variable. Otherwise %GeometryPath will choose its own
+     * default, which varies depending on owner.
+     */
+    void setDefaultColor(const SimTK::Vec3& color);
+
+    /**
+     * Get the current value of the color cache entry owned by this
+     * %GeometryPath object in the given state. You can access this value any
+     * time after the state is initialized, at which point it will have been
+     * set to the default color value specified in a call to setDefaultColor()
+     * earlier, or it will have the default color value chosen by %GeometryPath.
+     *
+     * @see setDefaultColor()
+     */
+    SimTK::Vec3 getColor(const SimTK::State&) const;
+
+    /**
+     * %Set the value of the color cache variable owned by this %GeometryPath
+     * object, in the cache of the given state. The value of this variable is used
+     * as the color when the path is drawn, which occurs with the state realized
+     * to Stage::Dynamics. So you must call this method during realizeDynamics() or
+     * earlier in order for it to have any effect.
+     */
+    void setColor(const SimTK::State&, const SimTK::Vec3& color) const;
+
+    /**
+     * Compute the total length of the path.
+     *
+     * @return Total length of the path.
+     */
+    double getLength(const SimTK::State&) const;
+    void setLength(const SimTK::State&, double length) const;
+
+    double getPreScaleLength(const SimTK::State&) const;
+    void setPreScaleLength(const SimTK::State&, double preScaleLength);
+
+    /**
+     * Compute the lengthening speed of the path.
+     *
+     * @return lengthening speed of the path.
+     */
+    double getLengtheningSpeed(const SimTK::State&) const;
+    void setLengtheningSpeed(const SimTK::State&, double speed) const;
+
+    /**
+     * Get the current path of the path
+     *
+     * @return The array of currently active path points.
+     */
+    const Array<const AbstractPathPoint*>& getCurrentPath(const SimTK::State&) const;
+
+    /**
+     * Get the path as PointForceDirections directions, which can be used
+     * to apply tension to bodies the points are connected to
+     */
+    void getPointForceDirections(
+        const SimTK::State&,
+        OpenSim::Array<PointForceDirection*>* rPFDs) const;
+
+    /**
+     * Add in the equivalent body and generalized forces to be applied to the
+     * multibody system resulting from a tension along the GeometryPath.
+     *
+     * @param state    state used to evaluate forces
+     * @param[in]  tension      scalar (double) of the applied (+ve) tensile force
+     * @param[in,out] bodyForces   Vector of SpatialVec's (torque, force) on bodies
+     * @param[in,out] mobilityForces  Vector of generalized forces, one per mobility
+     */
+    void addInEquivalentForces(
+        const SimTK::State&,
+        const double& tension,
+        SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
+        SimTK::Vector& mobilityForces) const;
+
+    /**
+     * Compute the path's moment arms for a specified coordinate.
+     */
+    virtual double computeMomentArm(const SimTK::State&, const Coordinate&) const;
+
+    /**
+     * Visualization support: update the geometric representation of the path.
+     *
+     * The resulting geometry is maintained at the VisibleObjejct layer. It shows (e.g.)
+     * location of path points and connecting segments in all global/inertial frames)
+     */
+    virtual void updateGeometry(const SimTK::State&) const;
+
+    //--------------------------------------------------------------------------
+    // API overrides / lifecycle hooks
+    //--------------------------------------------------------------------------
+
+protected:
+    /**
+     * Calculate the path length in the current body position and store it for
+     * use after the Model has been scaled.
+     */
+    void extendPreScale(const SimTK::State&, const ScaleSet&) override;
+
+    /**
+     * Recalculate the path after the Model has been scaled.
+     */
+    void extendPostScale(const SimTK::State&, const ScaleSet&) override;
+
+    void extendFinalizeFromProperties() override;
+    void extendConnectToModel(Model&) override;
+    void extendInitStateFromProperties(SimTK::State&) const override;
+    void extendAddToSystem(SimTK::MultibodySystem&) const override;
+
+    // Visual support GeometryPath drawing in SimTK visualizer.
+    void generateDecorations(
+        bool fixed,
+        const ModelDisplayHints&,
+        const SimTK::State&,
+        SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
+
+private:
+
+    /**
+     * Overrides default XML implementation to intercept and fix the XML node
+     * to account for versioning.
+     */
+    void updateFromXMLNode(SimTK::Xml::Element&, int versionNumber = -1) override;
+
+
+    //--------------------------------------------------------------------------
+    // HELPERS
+    //--------------------------------------------------------------------------
+
+private:
+
+    void constructProperties();
+
+    Array<const AbstractPathPoint*>& populatePathPtrsCache(const std::vector<ComponentPath>&) const;
+
+    void applyWrapObjects(const SimTK::State&, Array<const AbstractPathPoint*>&) const;
+
+    double calcLengtheningSpeed(const SimTK::State&, const Array<const AbstractPathPoint*>&) const;
+
+    double calcPathLengthChange(
+        const SimTK::State&,
+        const WrapObject&,
+        const WrapResult&,
+        const Array<const AbstractPathPoint*>&) const;
+
+    double calcPathLength(
+        const SimTK::State&,
+        const Array<const AbstractPathPoint*>&) const;
+
+    void namePathPoints(int aStartingIndex);
+
+    void placeNewPathPoint(
+        const SimTK::State&,
+        SimTK::Vec3& aOffset,
+        int index,
+        const PhysicalFrame&);
+
+    //=============================================================================
+    // DATA
+    //=============================================================================
 
     // used for scaling tendon and fiber lengths
     double _preScaleLength;
 
-    // Solver used to compute moment-arms. The GeometryPath owns this object,
-    // but we cannot simply use a unique_ptr because we want the pointer to be
-    // cleared on copy.
-    SimTK::ResetOnCopy<std::unique_ptr<MomentArmSolver> > _maSolver;
+    // solver used to compute moment-arms
+    //
+    // the GeometryPath owns this object, but it is cleared whenever the GeometryPath
+    // is copied
+    SimTK::ResetOnCopy<std::unique_ptr<MomentArmSolver>> _maSolver;
 
+    // internal cache of raw pointers to the path's points
+    //
+    // this is here for legacy reasons: the path points are *actually* held in
+    // a cache variable as `OpenSim::ComponentPath`s. However, existing APIs might
+    // want an array of raw pointers.
+    //
+    // reset on copy to prevent aliasing issues.
+    mutable SimTK::ResetOnCopy<Array<const AbstractPathPoint*>> _currentPathPtrsCache;
+
+    // cache variable for the path's length
     mutable CacheVariable<double> _lengthCV;
+
+    // cache variable for the path's lengthening speed
     mutable CacheVariable<double> _speedCV;
-    mutable CacheVariable<Array<AbstractPathPoint*>> _currentPathCV;
+
+    // cache variable for (component paths to) the path's points
+    //
+    // populated by the implementation whenever the path's points are computed. The
+    // actual data for the points are held elsewhere in the model tree and must be
+    // looked up via this (value-type) path.
+    mutable CacheVariable<std::vector<ComponentPath>> _currentPathAbspathCV;
+
+    // cache variable for the color of the path (e.g. red, blue)
     mutable CacheVariable<SimTK::Vec3> _colorCV;
-    
-//=============================================================================
-// METHODS
-//=============================================================================
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
-public:
-    GeometryPath();
-    ~GeometryPath() override = default;
-
-    const PathPointSet& getPathPointSet() const { return get_PathPointSet(); }
-    PathPointSet& updPathPointSet() { return upd_PathPointSet(); }
-    const PathWrapSet& getWrapSet() const { return get_PathWrapSet(); }
-    PathWrapSet& updWrapSet() { return upd_PathWrapSet(); }
-    void addPathWrap(WrapObject& aWrapObject);
-
-    //--------------------------------------------------------------------------
-    // UTILITY
-    //--------------------------------------------------------------------------
-    AbstractPathPoint* addPathPoint(const SimTK::State& s, int index,
-        const PhysicalFrame& frame);
-    AbstractPathPoint* appendNewPathPoint(const std::string& proposedName, 
-        const PhysicalFrame& frame, const SimTK::Vec3& locationOnFrame);
-    bool canDeletePathPoint( int index);
-    bool deletePathPoint(const SimTK::State& s, int index);
-    
-    void moveUpPathWrap(const SimTK::State& s, int index);
-    void moveDownPathWrap(const SimTK::State& s, int index);
-    void deletePathWrap(const SimTK::State& s, int index);
-    bool replacePathPoint(const SimTK::State& s, AbstractPathPoint* oldPathPoint,
-        AbstractPathPoint* newPathPoint); 
-
-    //--------------------------------------------------------------------------
-    // GET
-    //--------------------------------------------------------------------------
-
-    /** If you call this prior to extendAddToSystem() it will be used to initialize
-    the color cache variable. Otherwise %GeometryPath will choose its own
-    default which varies depending on owner. **/
-    void setDefaultColor(const SimTK::Vec3& color) {
-        updProperty_Appearance().setValueIsDefault(false);
-        upd_Appearance().set_color(color); 
-    };
-    /** Returns the color that will be used to initialize the color cache
-    at the next extendAddToSystem() call. The actual color used to draw the path
-    will be taken from the cache variable, so may have changed. **/
-    const SimTK::Vec3& getDefaultColor() const { return get_Appearance().get_color(); }
-
-    /** %Set the value of the color cache variable owned by this %GeometryPath
-    object, in the cache of the given state. The value of this variable is used
-    as the color when the path is drawn, which occurs with the state realized 
-    to Stage::Dynamics. So you must call this method during realizeDynamics() or 
-    earlier in order for it to have any effect. **/
-    void setColor(const SimTK::State& s, const SimTK::Vec3& color) const;
-
-    /** Get the current value of the color cache entry owned by this
-    %GeometryPath object in the given state. You can access this value any time
-    after the state is initialized, at which point it will have been set to
-    the default color value specified in a call to setDefaultColor() earlier,
-    or it will have the default color value chosen by %GeometryPath.
-    @see setDefaultColor() **/
-    SimTK::Vec3 getColor(const SimTK::State& s) const;
-
-    double getLength( const SimTK::State& s) const;
-    void setLength( const SimTK::State& s, double length) const;
-    double getPreScaleLength( const SimTK::State& s) const;
-    void setPreScaleLength( const SimTK::State& s, double preScaleLength);
-    const Array<AbstractPathPoint*>& getCurrentPath( const SimTK::State& s) const;
-
-    double getLengtheningSpeed(const SimTK::State& s) const;
-    void setLengtheningSpeed( const SimTK::State& s, double speed ) const;
-
-    /** get the path as PointForceDirections directions, which can be used
-        to apply tension to bodies the points are connected to.*/
-    void getPointForceDirections(const SimTK::State& s, 
-        OpenSim::Array<PointForceDirection*> *rPFDs) const;
-
-    /** add in the equivalent body and generalized forces to be applied to the 
-        multibody system resulting from a tension along the GeometryPath 
-    @param state    state used to evaluate forces
-    @param[in]  tension      scalar (double) of the applied (+ve) tensile force 
-    @param[in,out] bodyForces   Vector of SpatialVec's (torque, force) on bodies
-    @param[in,out] mobilityForces  Vector of generalized forces, one per mobility   
-    */
-    void addInEquivalentForces(const SimTK::State& state,
-                               const double& tension, 
-                               SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
-                               SimTK::Vector& mobilityForces) const;
-
-
-    //--------------------------------------------------------------------------
-    // COMPUTATIONS
-    //--------------------------------------------------------------------------
-    virtual double computeMomentArm(const SimTK::State& s, const Coordinate& aCoord) const;
-
-    //--------------------------------------------------------------------------
-    // SCALING
-    //--------------------------------------------------------------------------
-
-    /** Calculate the path length in the current body position and store it for
-        use after the Model has been scaled. */
-    void extendPreScale(const SimTK::State& s,
-                        const ScaleSet& scaleSet) override;
-
-    /** Recalculate the path after the Model has been scaled. */
-    void extendPostScale(const SimTK::State& s,
-                         const ScaleSet& scaleSet) override;
-
-    //--------------------------------------------------------------------------
-    // Visualization Support
-    //--------------------------------------------------------------------------
-    // Update the geometry attached to the path (location of path points and
-    // connecting segments all in global/inertial frame)
-    virtual void updateGeometry(const SimTK::State& s) const;
-
-protected:
-    // ModelComponent interface.
-    void extendConnectToModel(Model& aModel) override;
-    void extendInitStateFromProperties(SimTK::State& s) const override;
-    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
-
-    // Visual support GeometryPath drawing in SimTK visualizer.
-    void generateDecorations(
-            bool                                        fixed,
-            const ModelDisplayHints&                    hints,
-            const SimTK::State&                         state,
-            SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
-            override;
-
-    void extendFinalizeFromProperties() override;
-
-private:
-
-    void computePath(const SimTK::State& s ) const;
-    void computeLengtheningSpeed(const SimTK::State& s) const;
-    void applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path ) const;
-    double calcPathLengthChange(const SimTK::State& s, const WrapObject& wo, 
-                                const WrapResult& wr, 
-                                const Array<AbstractPathPoint*>& path) const; 
-    double calcLengthAfterPathComputation
-       (const SimTK::State& s, const Array<AbstractPathPoint*>& currentPath) const;
-
-    void constructProperties();
-    void namePathPoints(int aStartingIndex);
-    void placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset, 
-                           int index, const PhysicalFrame& frame);
-    //--------------------------------------------------------------------------
-    // Implement Object interface.
-    //--------------------------------------------------------------------------
-    /** Override of the default implementation to account for versioning. */
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber = -1) override;
 
 //=============================================================================
 };  // END of class GeometryPath

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -96,9 +96,9 @@ public:
 
     GeometryPath();
     GeometryPath(const GeometryPath&);
-    GeometryPath(GeometryPath&&) noexcept;
+    GeometryPath(GeometryPath&&);
     GeometryPath& operator=(const GeometryPath&);
-    GeometryPath& operator=(GeometryPath&&) noexcept;
+    GeometryPath& operator=(GeometryPath&&);
     ~GeometryPath() noexcept;
 
     const PathPointSet& getPathPointSet() const;

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -325,8 +325,6 @@ private:
 
     void constructProperties();
 
-    Array<const AbstractPathPoint*>& populatePathPtrsCache(const std::vector<ComponentPath>&) const;
-
     void applyWrapObjects(const SimTK::State&, Array<const AbstractPathPoint*>&) const;
 
     double calcLengtheningSpeed(const SimTK::State&, const Array<const AbstractPathPoint*>&) const;
@@ -377,12 +375,16 @@ private:
     // cache variable for the path's lengthening speed
     mutable CacheVariable<double> _speedCV;
 
-    // cache variable for (component paths to) the path's points
+    // cache variable for the (order of) the path's points
     //
     // populated by the implementation whenever the path's points are computed. The
-    // actual data for the points are held elsewhere in the model tree and must be
-    // looked up via this (value-type) path.
-    mutable CacheVariable<std::vector<ComponentPath>> _currentPathAbspathCV;
+    // actual data for the points are either held directly (i.e. in PathPointSet) or
+    // as sub elements of directly-held PathWrap objects
+    struct PathElement {
+        int index;
+        enum class Type { InPathPointSet, PathWrapPt1, PathWrapPt2 } type;
+    };
+    mutable CacheVariable<std::vector<PathElement>> _currentPathElsCV;
 
     // cache variable for the color of the path (e.g. red, blue)
     mutable CacheVariable<SimTK::Vec3> _colorCV;

--- a/OpenSim/Simulation/Wrap/PathWrap.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrap.cpp
@@ -25,7 +25,9 @@
 // INCLUDES
 //=============================================================================
 #include "PathWrap.h"
+
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Wrap/PathWrapPoint.h>
 
 //=============================================================================
 // STATICS
@@ -40,7 +42,14 @@ using namespace OpenSim;
 /**
  * Default constructor.
  */
-PathWrap::PathWrap() : ModelComponent()
+PathWrap::PathWrap() :
+    ModelComponent(),
+    _method{},
+    _wrapObject{nullptr},
+    _path{nullptr},
+    _previousWrap{},
+    _wrapPoint1Ix{constructSubcomponent<PathWrapPoint>("pwpt1")},
+    _wrapPoint2Ix{constructSubcomponent<PathWrapPoint>("pwpt2")}
 {
     setNull();
     constructProperties();
@@ -161,6 +170,26 @@ void PathWrap::setWrapObject(WrapObject& aWrapObject)
 {
     _wrapObject = &aWrapObject;
     upd_wrap_object() = aWrapObject.getName();
+}
+
+const PathWrapPoint& PathWrap::getWrapPoint1() const
+{
+    return getMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
+}
+
+PathWrapPoint& PathWrap::updWrapPoint1()
+{
+    return updMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
+}
+
+const PathWrapPoint& PathWrap::getWrapPoint2() const
+{
+    return getMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
+}
+
+PathWrapPoint& PathWrap::updWrapPoint2()
+{
+    return updMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
 }
 
 void PathWrap::setMethod(WrapMethod aMethod)

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -97,7 +97,7 @@ public:
     int getEndPoint() const { return get_range(1); }
 
     const std::string& getWrapObjectName() const { return get_wrap_object(); }
-    const WrapObject* getWrapObject() const { return _wrapObject; }
+    const WrapObject* getWrapObject() const { return _wrapObject.get(); }
     void setWrapObject(WrapObject& aWrapObject);
 
     const PathWrapPoint& getWrapPoint1() const;
@@ -122,8 +122,8 @@ private:
 private:
     WrapMethod _method;
 
-    const WrapObject* _wrapObject;
-    const GeometryPath* _path;
+    SimTK::ReferencePtr<const WrapObject> _wrapObject;
+    SimTK::ReferencePtr<const GeometryPath> _path;
 
     WrapResult _previousWrap;  // results from previous wrapping
 

--- a/OpenSim/Simulation/Wrap/PathWrap.h
+++ b/OpenSim/Simulation/Wrap/PathWrap.h
@@ -23,9 +23,12 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
-#include "PathWrapPoint.h"
-#include "WrapResult.h"
+#include <OpenSim/Common/Component.h>
+#include <OpenSim/Simulation/Model/ModelComponent.h>
+#include <OpenSim/Simulation/Wrap/WrapResult.h>
+#include <SimTKcommon.h>
+
+#include <string>
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -39,6 +42,7 @@ namespace OpenSim {
 class Model;
 class WrapObject;
 class GeometryPath;
+class PathWrapPoint;
 
 /** @cond **/ // hide from Doxygen
 
@@ -91,22 +95,16 @@ public:
 #endif
     int getStartPoint() const { return get_range(0); }
     int getEndPoint() const { return get_range(1); }
+
     const std::string& getWrapObjectName() const { return get_wrap_object(); }
     const WrapObject* getWrapObject() const { return _wrapObject; }
     void setWrapObject(WrapObject& aWrapObject);
 
-    const PathWrapPoint& getWrapPoint1() const {
-        return getMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
-    }
-    const PathWrapPoint& getWrapPoint2() const {
-        return getMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
-    }
-    PathWrapPoint& updWrapPoint1() { 
-        return updMemberSubcomponent<PathWrapPoint>(_wrapPoint1Ix);
-    }
-    PathWrapPoint& updWrapPoint2() {
-        return updMemberSubcomponent<PathWrapPoint>(_wrapPoint2Ix);
-    }
+    const PathWrapPoint& getWrapPoint1() const;
+    PathWrapPoint& updWrapPoint1();
+
+    const PathWrapPoint& getWrapPoint2() const;
+    PathWrapPoint& updWrapPoint2();
 
     WrapMethod getMethod() const { return _method; }
     void setMethod(WrapMethod aMethod);
@@ -129,10 +127,8 @@ private:
 
     WrapResult _previousWrap;  // results from previous wrapping
 
-    MemberSubcomponentIndex _wrapPoint1Ix{
-        constructSubcomponent<PathWrapPoint>("pwpt1") };
-    MemberSubcomponentIndex _wrapPoint2Ix{
-        constructSubcomponent<PathWrapPoint>("pwpt2") };
+    MemberSubcomponentIndex _wrapPoint1Ix;
+    MemberSubcomponentIndex _wrapPoint2Ix;
 //=============================================================================
 };  // END of class PathWrap
 //=============================================================================

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
@@ -1,0 +1,124 @@
+/* -------------------------------------------------------------------------- *
+ *                           OpenSim:  PathWrapPoint.cpp                      *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Peter Loan                                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "PathWrapPoint.h"
+
+OpenSim::PathWrapPoint::PathWrapPoint() = default;
+
+void OpenSim::PathWrapPoint::extendAddToSystem(SimTK::MultibodySystem& system) const
+{
+    Super::extendAddToSystem(system);
+
+    _wrapPath = addCacheVariable("wrap_path", Array<SimTK::Vec3>{}, SimTK::Stage::Position);
+    _wrapPathLength = addCacheVariable("wrap_path_length", 0.0, SimTK::Stage::Position);
+    _location = addCacheVariable("wrap_location", SimTK::Vec3{}, SimTK::Stage::Position);
+}
+
+const OpenSim::Array<SimTK::Vec3>& OpenSim::PathWrapPoint::getWrapPath(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _wrapPath);
+}
+
+void OpenSim::PathWrapPoint::setWrapPath(const SimTK::State& s, const Array<SimTK::Vec3>& src) const
+{
+    updCacheVariableValue(s, _wrapPath) = src;
+    markCacheVariableValid(s, _wrapPath);
+}
+
+void OpenSim::PathWrapPoint::clearWrapPath(const SimTK::State& s) const
+{
+    updCacheVariableValue(s, _wrapPath).setSize(0);
+    markCacheVariableValid(s, _wrapPath);
+}
+
+double OpenSim::PathWrapPoint::getWrapLength(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _wrapPathLength);
+}
+
+void OpenSim::PathWrapPoint::setWrapLength(const SimTK::State& s, double aLength) const
+{
+    updCacheVariableValue(s, _wrapPathLength) = aLength;
+    markCacheVariableValid(s, _wrapPathLength);
+}
+
+const OpenSim::WrapObject* OpenSim::PathWrapPoint::getWrapObject() const
+{
+    return _wrapObject.get();
+}
+
+void OpenSim::PathWrapPoint::setWrapObject(const WrapObject* wrapObject)
+{
+    _wrapObject.reset(wrapObject);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::getLocation(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _location);
+}
+
+void OpenSim::PathWrapPoint::setLocation(const SimTK::State& s, const SimTK::Vec3& loc) const
+{
+    updCacheVariableValue(s, _location) = loc;
+    markCacheVariableValid(s, _location);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::getdPointdQ(const SimTK::State& s) const
+{
+    return SimTK::Vec3(0);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcLocationInGround(const SimTK::State& state) const
+{
+    return getParentFrame().getTransformInGround(state)*getLocation(state);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcVelocityInGround(const SimTK::State& state) const
+{
+    // compute the local position vector of the station in its reference frame
+    // expressed in ground
+    SimTK::Vec3 r = getParentFrame().getTransformInGround(state).R()*getLocation(state);
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(state);
+
+    // The velocity of the station in ground is a function of its frame's
+    // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
+    // velocity of the station: v = vF + omegaF x r
+    return V_GF[1] + V_GF[0] % r;
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcAccelerationInGround(const SimTK::State& state) const
+{
+    // The spatial velocity of the reference frame expressed in ground
+    const SimTK::SpatialVec& V_GF = getParentFrame().getVelocityInGround(state);
+    // The spatial acceleration of the reference frame expressed in ground
+    const SimTK::SpatialVec& A_GF = getParentFrame().getAccelerationInGround(state);
+    // compute the local position vector of the point in its reference frame
+    // expressed in ground
+    SimTK::Vec3 r = getParentFrame().getTransformInGround(state).R()*getLocation(state);
+
+    // The acceleration of the station in ground is a function of its frame's
+    // linear (aF = A_GF[1]) and angular (alpha = A_GF[0]) accelerations and
+    // Coriolis acceleration due to the angular velocity (omega = V_GF[0]) of
+    // its frame, such that: a = aF + alphaF x r + omegaF x (omegaF x r)
+    return A_GF[1] + A_GF[0]%r +  V_GF[0] % (V_GF[0] % r) ;
+}

--- a/OpenSim/Simulation/Wrap/WrapEllipsoid.cpp
+++ b/OpenSim/Simulation/Wrap/WrapEllipsoid.cpp
@@ -31,6 +31,7 @@
 #include <OpenSim/Common/SimmMacros.h>
 #include <OpenSim/Common/ModelDisplayHints.h>
 #include <OpenSim/Common/ScaleSet.h>
+#include <OpenSim/Simulation/Model/PhysicalFrame.h>
 
 //=============================================================================
 // STATICS

--- a/OpenSim/Simulation/Wrap/WrapSphere.cpp
+++ b/OpenSim/Simulation/Wrap/WrapSphere.cpp
@@ -31,6 +31,7 @@
 #include <OpenSim/Common/SimmMacros.h>
 #include <OpenSim/Common/ModelDisplayHints.h>
 #include <OpenSim/Common/ScaleSet.h>
+#include <OpenSim/Simulation/Model/PhysicalFrame.h>
 
 //=============================================================================
 // STATICS

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -554,7 +554,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         GeometryPath* geomPath = paths[i];
         const PathWrapSet& wrapSet = geomPath->getWrapSet();
         const PathPointSet& viaSet = geomPath->getPathPointSet();
-        Array<AbstractPathPoint*> activePathPoints = geomPath->getCurrentPath(si);
+        Array<const AbstractPathPoint*> activePathPoints = geomPath->getCurrentPath(si);
 
         AbstractPathPoint* orgPoint = &viaSet[0];
         AbstractPathPoint* insPoint = &viaSet[viaSet.getSize()-1];
@@ -566,7 +566,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
 
         int numVias = 0, numSurfs = 0;
         for (int j = 0; j < activePathPoints.getSize(); ++j) {
-            AbstractPathPoint* pp = activePathPoints[j];
+            const AbstractPathPoint* pp = activePathPoints[j];
             cout << "pp" << j << " = " << pp->getName() << " @ "
                  << pp->getParentFrame().getName() << ", loc = "
                  << pp->getLocation(si) << endl;
@@ -618,7 +618,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
         int obsIdx = 0;
         int viaPtIdx = 1; // skip first (origin) point
         for (int j = 1; j < activePathPoints.getSize()-1; ++j) { // skip first (origin) and last (insertion)
-            AbstractPathPoint* pp = activePathPoints[j];
+            const AbstractPathPoint* pp = activePathPoints[j];
             if (*pp == viaSet[viaPtIdx]) {
                 viaPtIdx++;
                 obsIdx++;
@@ -632,7 +632,7 @@ void simulateModelWithCables(const string &modelFile, double finalTime)
                         obs->isActive = true;
                         // pp and next pp are wrap points
                         Transform X_SB = obs->X_BS.invert();
-                        AbstractPathPoint* pp_next = activePathPoints[++i]; // increment to next pp
+                        const AbstractPathPoint* pp_next = activePathPoints[++i]; // increment to next pp
                         obs->P_S = X_SB*pp->getLocation(si);
                         obs->Q_S = X_SB*pp_next->getLocation(si);
                         cableInfo.obstacles.insert(obsIdx++, *obs);


### PR DESCRIPTION
Related to: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/123

Effectively, I'm trying to fix a number of issues in the path wrapping code. Notably:

- The current implementation's `GeometryPath` stores pointers to components within the model graph inside a state cache variable.
  - This causes a potential aliasing issue when the state is (e.g.) passed between threads with non-copy semantics. E.g. passing a `unique_ptr<SimTK::State>` between threads causes one thread to have aliased access into the other thread's (potentially destroyed) model components

- The current implementation stores path wrap points as model-/component-level data, rather than as state/cache variables within the state.
  - This means that state-dependent data (e.g. current wrapping path) is stored at the model level
  - It causes bizzare bugs. E.g. realizing a state against a model causes the model to contain a different version of the path wrapping. Subsequently generating decorations against the same model, but with a different state (e.g. because I'm rendering *state sequences* against *one* model) then causes the rendering to glitch because the path wrap data held within the model is mismatched with the state

### Brief summary of changes

- `GeometryPath`'s header was rearranged to match the style of:
  - class
  - properties
  - ctor
  - members (getters, updaters, setters in-order)
  - private members
  - data
- `GeometryPath`'s implementation functions were all moved into the cpp file:
  - Perf measurements indicated that this doesn't have a measurable impact
  - It makes working on `GeometryPath` easier because only one compilation unit is impacted (apart from with data changes)
- `GeometryPath`'s methods were refactored, usually to reduce the number of calls to property getters or the number of passes over datastructures
  - This will need another pass to ensure the algorithm rearrangements didn't cause different behavior. Ancecdotal testing with existing models indicates that nothing obvious has changed

### Testing I've completed

WIP

### Looking for feedback on...

WIP

### CHANGELOG.md (choose one)

WIP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3159)
<!-- Reviewable:end -->
