### PR TITLE
Fixed PathWrapPoint to hold its points in a cache variable

### DIFF
--- a/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.cpp
@@ -50,6 +50,7 @@ namespace OpenSim {
 OpenSimContext::OpenSimContext( SimTK::State* s, Model* model ) {
     _configState.reset(s);
     _model.reset(model);
+    realizePosition();
 }
 
 

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -26,8 +26,9 @@
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Common/PropertyTransform.h>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
-#include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/Force.h>
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/PathPoint.h>
 #include <OpenSim/Common/Array.h>
 #include <OpenSim/Tools/InverseKinematicsTool.h>
 #include <Bindings/PropertyHelper.h>

--- a/Bindings/Java/OpenSimJNI/OpenSimContext.h
+++ b/Bindings/Java/OpenSimJNI/OpenSimContext.h
@@ -28,7 +28,6 @@
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <OpenSim/Simulation/Model/Force.h>
 #include <OpenSim/Simulation/Model/Model.h>
-#include <OpenSim/Simulation/Model/PathPoint.h>
 #include <OpenSim/Common/Array.h>
 #include <OpenSim/Tools/InverseKinematicsTool.h>
 #include <Bindings/PropertyHelper.h>

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -72,9 +72,7 @@ int main()
     LoadOpenSimLibrary("osimJavaJNI");
 
     Model *model = new Model("wrist.osim");
-    SimTK::State* workingState = &model->initSystem();
-    model->realizePosition(*workingState);
-    OpenSimContext* context = new OpenSimContext(workingState, model);
+    OpenSimContext* context = new OpenSimContext(&model->initSystem(), model);
     const ForceSet& fs = model->getForceSet();
     int n1 = fs.getNumGroups();
     const ObjectGroup* grp = fs.getGroup("wrist");
@@ -86,9 +84,7 @@ int main()
     delete model;
     delete context;
     model = new Model("arm26_20.osim");
-    workingState = &model->initSystem();
-    model->realizePosition(*workingState);
-    context = new OpenSimContext(workingState, model);
+    context = new OpenSimContext(&model->initSystem(), model);
 
     // Make a copy of state contained in context ad make sure content match
     SimTK::State stateCopy = context->getCurrentStateCopy();

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -85,10 +85,10 @@ int main()
     delete context;
     model = new Model("arm26_20.osim");
     context = new OpenSimContext(&model->initSystem(), model);
-
     // Make a copy of state contained in context ad make sure content match
     SimTK::State stateCopy = context->getCurrentStateCopy();
     assert(context->getCurrentStateRef().toString()==stateCopy.toString());
+
     Array<std::string> stateNames = model->getStateVariableNames();
     OpenSim::Force* dForce=&(model->updForceSet().get("TRIlong"));
     Muscle* dTRIlong = dynamic_cast<Muscle*>(dForce);

--- a/Bindings/Java/OpenSimJNI/Test/testContext.cpp
+++ b/Bindings/Java/OpenSimJNI/Test/testContext.cpp
@@ -72,7 +72,9 @@ int main()
     LoadOpenSimLibrary("osimJavaJNI");
 
     Model *model = new Model("wrist.osim");
-    OpenSimContext* context = new OpenSimContext(&model->initSystem(), model);
+    SimTK::State* workingState = &model->initSystem();
+    model->realizePosition(*workingState);
+    OpenSimContext* context = new OpenSimContext(workingState, model);
     const ForceSet& fs = model->getForceSet();
     int n1 = fs.getNumGroups();
     const ObjectGroup* grp = fs.getGroup("wrist");
@@ -84,11 +86,13 @@ int main()
     delete model;
     delete context;
     model = new Model("arm26_20.osim");
-    context = new OpenSimContext(&model->initSystem(), model);
-    // Make a copy of state contained in context ad make sure content match 
+    workingState = &model->initSystem();
+    model->realizePosition(*workingState);
+    context = new OpenSimContext(workingState, model);
+
+    // Make a copy of state contained in context ad make sure content match
     SimTK::State stateCopy = context->getCurrentStateCopy();
     assert(context->getCurrentStateRef().toString()==stateCopy.toString());
-
     Array<std::string> stateNames = model->getStateVariableNames();
     OpenSim::Force* dForce=&(model->updForceSet().get("TRIlong"));
     Muscle* dTRIlong = dynamic_cast<Muscle*>(dForce);
@@ -161,6 +165,8 @@ int main()
     // Compare to known path 
     cout << "New Muscle Path" << endl;
     cout << path.getSize() << endl;
+    context->recreateSystemKeepStage();
+    model->realizePosition(stateCopy);
     for(int i=0; i< path.getSize(); i++)
         cout << path[i]->getParentFrame().getName() 
              << path[i]->getLocation(stateCopy) << endl;

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -152,7 +152,7 @@ generateDecorations(bool fixed, const ModelDisplayHints& hints,
 
         if (pwp) {
             // A PathWrapPoint provides points on the wrapping surface as Vec3s
-            Array<Vec3>& surfacePoints = pwp->getWrapPath();
+            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
             // The surface points are expressed w.r.t. the wrap surface's body frame.
             // Transform the surface points into the ground reference frame to draw
             // the surface point as the wrapping portion of the GeometryPath
@@ -1017,17 +1017,15 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                 }
 
                 // Deallocate previous wrapping points if necessary.
-                ws.updWrapPoint2().getWrapPath().setSize(0);
+                ws.updWrapPoint2().clearWrapPath(s);
 
                 if (best_wrap.wrap_pts.getSize() == 0) {
                     ws.resetPreviousWrap();
-                    ws.updWrapPoint2().getWrapPath().setSize(0);
+                    ws.updWrapPoint2().clearWrapPath(s);
                 } else {
                     // If wrapping did occur, copy wrap info into the PathStruct.
-                    ws.updWrapPoint1().getWrapPath().setSize(0);
-
-                    Array<SimTK::Vec3>& wrapPath = ws.updWrapPoint2().getWrapPath();
-                    wrapPath = best_wrap.wrap_pts;
+                    ws.updWrapPoint1().clearWrapPath(s);
+                    ws.updWrapPoint2().setWrapPath(s, best_wrap.wrap_pts);
 
                     // In OpenSim, all conversion to/from the wrap object's 
                     // reference frame will be performed inside 
@@ -1039,11 +1037,11 @@ applyWrapObjects(const SimTK::State& s, Array<AbstractPathPoint*>& path) const
                     //            ms->ground_segment);
                     // }
 
-                    ws.updWrapPoint1().setWrapLength(0.0);
-                    ws.updWrapPoint2().setWrapLength(best_wrap.wrap_path_length);
+                    ws.updWrapPoint1().setWrapLength(s, 0.0);
+                    ws.updWrapPoint2().setWrapLength(s, best_wrap.wrap_path_length);
 
-                    ws.updWrapPoint1().setLocation(best_wrap.r1);
-                    ws.updWrapPoint2().setLocation(best_wrap.r2);
+                    ws.updWrapPoint1().setLocation(s, best_wrap.r1);
+                    ws.updWrapPoint2().setLocation(s, best_wrap.r2);
 
                     // Now insert the two new wrapping points into mp[] array.
                     path.insert(best_wrap.endPoint, &ws.updWrapPoint1());
@@ -1130,7 +1128,7 @@ calcLengthAfterPathComputation(const SimTK::State& s,
         {
             const PathWrapPoint* smwp = dynamic_cast<const PathWrapPoint*>(p2);
             if (smwp)
-                length += smwp->getWrapLength();
+                length += smwp->getWrapLength(s);
         } else {
             length += (p1InGround - p2InGround).norm();
         }

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  PathWrapPoint.h                          *
+ *                         OpenSim:  PathWrapPoint.cpp                        *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2022 Stanford University and the Authors                *
  * Author(s): Peter Loan                                                      *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.cpp
@@ -1,0 +1,130 @@
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim:  PathWrapPoint.h                          *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Peter Loan                                                      *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "PathWrapPoint.h"
+
+void OpenSim::PathWrapPoint::extendAddToSystem(SimTK::MultibodySystem& system) const
+{
+    Super::extendAddToSystem(system);
+
+    _wrapPath = addCacheVariable("wrap_path", Array<SimTK::Vec3>{}, SimTK::Stage::Position);
+    _wrapPathLength = addCacheVariable("wrap_path_length", 0.0, SimTK::Stage::Position);
+    _location = addCacheVariable("wrap_location", SimTK::Vec3{}, SimTK::Stage::Position);
+}
+
+const OpenSim::WrapObject* OpenSim::PathWrapPoint::getWrapObject() const
+{
+    return _wrapObject.get();
+}
+
+void OpenSim::PathWrapPoint::setWrapObject(const WrapObject* wrapObject)
+{
+    _wrapObject.reset(wrapObject);
+}
+
+const OpenSim::Array<SimTK::Vec3>& OpenSim::PathWrapPoint::getWrapPath(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _wrapPath);
+}
+
+void OpenSim::PathWrapPoint::setWrapPath(const SimTK::State& s, const Array<SimTK::Vec3>& src) const
+{
+    updCacheVariableValue(s, _wrapPath) = src;
+    markCacheVariableValid(s, _wrapPath);
+}
+
+void OpenSim::PathWrapPoint::clearWrapPath(const SimTK::State& s) const
+{
+    updCacheVariableValue(s, _wrapPath).setSize(0);
+    markCacheVariableValid(s, _wrapPath);
+}
+
+double OpenSim::PathWrapPoint::getWrapLength(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _wrapPathLength);
+}
+
+void OpenSim::PathWrapPoint::setWrapLength(const SimTK::State& s, double aLength) const
+{
+    updCacheVariableValue(s, _wrapPathLength) = aLength;
+    markCacheVariableValid(s, _wrapPathLength);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::getLocation(const SimTK::State& s) const
+{
+    return getCacheVariableValue(s, _location);
+}
+
+void OpenSim::PathWrapPoint::setLocation(const SimTK::State& s, const SimTK::Vec3& loc) const
+{
+    updCacheVariableValue(s, _location) = loc;
+    markCacheVariableValid(s, _location);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::getdPointdQ(const SimTK::State& s) const
+{
+    return SimTK::Vec3(0);
+}
+
+// these methods were initially adapted from `OpenSim::Station`'s implementation
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcLocationInGround(const SimTK::State& state) const
+{
+    return getParentFrame().getTransformInGround(state) * getLocation(state);
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcVelocityInGround(const SimTK::State& state) const
+{
+    const PhysicalFrame& parent = getParentFrame();
+
+    // compute the local position vector of the station in its reference frame
+    // expressed in ground
+    SimTK::Vec3 r = parent.getTransformInGround(state).R() * getLocation(state);
+    const SimTK::SpatialVec& V_GF = parent.getVelocityInGround(state);
+
+    // The velocity of the station in ground is a function of its frame's
+    // linear (vF = V_GF[1]) and angular (omegaF = A_GF[0]) velocity, such that
+    // velocity of the station: v = vF + omegaF x r
+    return V_GF[1] + V_GF[0] % r;
+}
+
+SimTK::Vec3 OpenSim::PathWrapPoint::calcAccelerationInGround(const SimTK::State& state) const
+{
+    const PhysicalFrame& parent = getParentFrame();
+
+    // The spatial velocity of the reference frame expressed in ground
+    const SimTK::SpatialVec& V_GF = parent.getVelocityInGround(state);
+
+    // The spatial acceleration of the reference frame expressed in ground
+    const SimTK::SpatialVec& A_GF = parent.getAccelerationInGround(state);
+
+    // compute the local position vector of the point in its reference frame
+    // expressed in ground
+    SimTK::Vec3 r = parent.getTransformInGround(state).R() * getLocation(state);
+
+    // The acceleration of the station in ground is a function of its frame's
+    // linear (aF = A_GF[1]) and angular (alpha = A_GF[0]) accelerations and
+    // Coriolis acceleration due to the angular velocity (omega = V_GF[0]) of
+    // its frame, such that: a = aF + alphaF x r + omegaF x (omegaF x r)
+    return A_GF[1] + A_GF[0]%r +  V_GF[0] % (V_GF[0] % r);
+}

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.h
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2022 Stanford University and the Authors                *
  * Author(s): Peter Loan                                                      *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -23,15 +23,12 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/AbstractPathPoint.h>
 
 namespace OpenSim {
 
 class WrapObject;
 
-//=============================================================================
-//=============================================================================
 /**
  * A class implementing a path wrapping point, which is a path point that
  * is produced by a PathWrap.
@@ -55,9 +52,19 @@ public:
     double getWrapLength(const SimTK::State&) const;
     void setWrapLength(const SimTK::State&, double newLength) const;
 
+    // careful: Although this class effectively represents a *sequence*
+    //          of many wrapping points, these methods still need to be
+    //          here for legacy compatability with `AbstractPathPoint`,
+    //          which is used extensively by `GeometryPath`.
+    //
+    // The implementation uses the first, or last, tangent point of the path
+    // wrap as a "best guess" of the location. `GeometryPath`, itself, handles
+    // stuffing the relevant data data into this class.
+    //
+    // (later iterations of `GeometryPath` may ideally (e.g.) hold a sequence
+    //  of path *segments*, rather than path *points*)
     SimTK::Vec3 getLocation(const SimTK::State&) const override;
     void setLocation(const SimTK::State&, const SimTK::Vec3&) const;
-
     SimTK::Vec3 getdPointdQ(const SimTK::State&) const override;
 
 private:
@@ -76,12 +83,7 @@ private:
 
     // the wrap object this point is on
     SimTK::ReferencePtr<const WrapObject> _wrapObject; 
-
-//=============================================================================
-};  // END of class PathWrapPoint
-//=============================================================================
-//=============================================================================
-
+};
 
 } // end of namespace OpenSim
 

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.h
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.h
@@ -25,6 +25,9 @@
 
 #include <OpenSim/Simulation/Model/AbstractPathPoint.h>
 
+// legacy: this used to be included (older codebases may transitively depend on it)
+#include <OpenSim/Simulation/Model/PathPoint.h>
+
 namespace OpenSim {
 
 class WrapObject;

--- a/OpenSim/Simulation/Wrap/PathWrapPoint.h
+++ b/OpenSim/Simulation/Wrap/PathWrapPoint.h
@@ -24,7 +24,7 @@
  * -------------------------------------------------------------------------- */
 
 // INCLUDE
-#include <OpenSim/Simulation/Model/PathPoint.h>
+#include <OpenSim/Simulation/Model/AbstractPathPoint.h>
 
 namespace OpenSim {
 
@@ -39,32 +39,40 @@ class WrapObject;
  * @author Peter Loan
  * @version 1.0
  */
-class OSIMSIMULATION_API PathWrapPoint : public PathPoint {
-OpenSim_DECLARE_CONCRETE_OBJECT(PathWrapPoint, PathPoint);
-//=============================================================================
-// METHODS
-//=============================================================================
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
+class OSIMSIMULATION_API PathWrapPoint final : public AbstractPathPoint {
+OpenSim_DECLARE_CONCRETE_OBJECT(PathWrapPoint, AbstractPathPoint);
+
 public:
-    PathWrapPoint() {}
-    virtual ~PathWrapPoint() {}
+    void extendAddToSystem(SimTK::MultibodySystem&) const override;
 
-    Array<SimTK::Vec3>& getWrapPath() { return _wrapPath; }
-    double getWrapLength() const { return _wrapPathLength; }
-    void setWrapLength(double aLength) { _wrapPathLength = aLength; }
-    const WrapObject* getWrapObject() const override { return _wrapObject.get(); }
-    void setWrapObject(const WrapObject* wrapObject) { _wrapObject.reset(wrapObject); }
+    const WrapObject* getWrapObject() const override;
+    void setWrapObject(const WrapObject*);
 
-//=============================================================================
-// DATA
-//=============================================================================
+    const Array<SimTK::Vec3>& getWrapPath(const SimTK::State&) const;
+    void setWrapPath(const SimTK::State&, const Array<SimTK::Vec3>&) const;
+    void clearWrapPath(const SimTK::State&) const;
+
+    double getWrapLength(const SimTK::State&) const;
+    void setWrapLength(const SimTK::State&, double newLength) const;
+
+    SimTK::Vec3 getLocation(const SimTK::State&) const override;
+    void setLocation(const SimTK::State&, const SimTK::Vec3&) const;
+
+    SimTK::Vec3 getdPointdQ(const SimTK::State&) const override;
+
 private:
+    SimTK::Vec3 calcLocationInGround(const SimTK::State&) const override;
+    SimTK::Vec3 calcVelocityInGround(const SimTK::State&) const override;
+    SimTK::Vec3 calcAccelerationInGround(const SimTK::State&) const override;
+
     // points defining muscle path on surface of wrap object
-    Array<SimTK::Vec3> _wrapPath{};
-    // length of _wrapPath TODO this should be a cache variable!
-    double _wrapPathLength{ 0.0 };
+    mutable CacheVariable<Array<SimTK::Vec3>> _wrapPath;
+
+    // length of _wrapPath
+    mutable CacheVariable<double> _wrapPathLength;
+
+    // location of the first tangent point of the path wrap
+    mutable CacheVariable<SimTK::Vec3> _location;
 
     // the wrap object this point is on
     SimTK::ReferencePtr<const WrapObject> _wrapObject; 

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -53,9 +53,13 @@ const std::string modelFilename = "arm26.osim";
 // to recompose existing components, this will need continual updating. For example,
 // Joint's often add PhysicalOffsetFrames to handle what used to be baked in location
 // and orientation offsets.
-// 2018-09-05 updates to accommodate ModelComponentSets: BodySet, JointSet,
-//    ConstraintSet, ForceSet, ProbeSet, WrapObjectSet, ...
-const int expectedNumComponents = 200; 
+// 2018-09-05
+//     Updates to accommodate ModelComponentSets: BodySet, JointSet, ConstraintSet,
+//     ForceSet, ProbeSet, WrapObjectSet, ...
+// 2022-03-16
+//     Subtracted 14 from the count because PathWrapPoint no longer inherits from
+//     PathPoint (which internally creates a Station subcomponent)
+const int expectedNumComponents = 186;
 const int expectedNumJointsWithStateVariables = 2;
 // 2018-08-22 added 2 for JointSet and ForceSet that contain Components with states
 const int expectedNumModelComponentsWithStateVariables = 12;


### PR DESCRIPTION
This is a cut-down version of part of the changes in #3159 , such that this individual change can be reviewed in isolation.

This PR fixes a bug in `PathWrapPoint`. `PathWrapPoint` currently stores the wrap point locations as a (model-level) member variable. That is a bug because the path wrap points are state-dependent: each state may produce different wrapping points.

Storing the points at the model-level can cause bizarre bugs. Here's an example scenario:

- Create/load a model
- Simulate the model with (e.g.) a forward dynamic integration method
- Store states from that simulation at regular intervals. Ensure each state is fully realized to the `Report` level, so that other systems (e.g. a UI, report generator, whatever) can handle them as immutable `const` states
- Perform this realization by calling something like `model.realizeReport(latestSimState)`
- You now have a sequence of `SimTK::State`s, where each state is an immutable value that represents one step of the simulation of a model (the model may, itself, have been copied around the application: see #3160 for a separate issue related to that).

Stage set. Hopefully this all sounds reasonable enough. However, with the current implementation, this (roughly written hypothetical code) may encounter a bug:

```c++
SimTK::Array_<SimTK::DecorativeGeometry> buf;
for (const SimTK::State& state : states) {
    buf.clear();
    model.generateDecorations(false, hints, state, buf);
    model.generateDecorations(true, hints, state, buf);
    RenderVideoFrame(buf);
}
```

The bug is that the rendered `PathWrapPoint`s will show whatever was last realized against the model (because the wrap points are stored on the *model*, not the state). This will cause paths in the output render to look extremely bizzare (i.e. wrong). I encountered this issue in opensim-creator: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/123 and have to hack around it by wiping and re-realizing a state before rendering (e.g.: [here](https://github.com/adamkewley/opensim-creator/blob/0.1.2/src/Screens/SimulatorScreen.cpp#L107))

The solution to this problem is to make `PathWrapPoint` store its data in `SimTK` cache variables on each state, so that they are state dependent. That is what this PR aims to do.

### Brief summary of changes

- Made `PathWrapPoint` store its current path and path length in cache variables (previously: member variables)
- Made `PathWrapPoint` inherit from `AbstractPathPoint` (previously: `PathPoint`)
  - This is necessary because `PathPoint` assumes that the point is fixed with respect to the parent frame and, therefore, doesn't require state-level storage
  - This change necessitated also implementing the necessary overrides (e.g. `calcLocationInGround`)
- Made `PathWrapPoint`'s API reflect the new storage model
  - The getters/setters now require access to a `SimTK::State` (which is where their data is now stored)
- Fixed uses of `PathWrapPoint` (e.g. `GeometryPath`) to use the changed API
- Fixed `testIterators`, which contains a hard-coded component count, to contain the new component count
  - This is necessary because `PathPoint` creates a hidden `Station` subcomponent, whereas `AbstractPathPoint` does not. So models containing `PathWrapPoint`s now contain fewer subcomponents.

### Testing I've completed

- Ensured it passes on the existing test suite

### Looking for feedback on...

- Usual stuff

### CHANGELOG.md (choose one)

- no need to update because it's an internal API?


### Performance Changes

Measured some basic forward-dynamic sims of this branch against the current `master` branch. There does not appear to be a significant change in performance (`passive_dynamic` is shorter, so susceptible to OS/bootup noise):


|                  Test Name | lhs [secs] | σ [secs] | rhs [secs] | σ [secs] | Speedup |
| -------------------------- | ---------- | -------- | ---------- | -------- | ------- |
|             RajagopalModel |       6.17 |     0.01 |       6.17 |     0.00 |    1.00 |
|                      Arm26 |       0.16 |     0.00 |       0.16 |     0.00 |    1.00 |
|             ToyDropLanding |      11.31 |     0.02 |      11.26 |     0.02 |    1.00 |
|                   Gait2354 |       0.19 |     0.00 |       0.19 |     0.00 |    1.00 |
|            passive_dynamic |       2.76 |     0.00 |       2.61 |     0.00 |    1.06 |
| passive_dynamic_noanalysis |       1.75 |     0.00 |       1.73 |     0.00 |    1.01 |
|   ToyDropLanding_nomuscles |       0.27 |     0.00 |       0.27 |     0.00 |    1.01 |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3163)
<!-- Reviewable:end -->
