### PR TITLE
Replace individual SUPERBUILD_ flags used for Moco build with two options

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -64,7 +64,7 @@ jobs:
         # /W0 disables warnings.
         # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
         # TODO: CMake provides /W3, which overrides our /W0
-        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON
+        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
         cmake --build . --config Release -- /maxcpucount:4
 
     - name: Configure opensim-core
@@ -204,6 +204,8 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
         DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
         DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=10.10)
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
@@ -331,6 +333,8 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
         cmake "${DEP_CMAKE_ARGS[@]}"
         make --jobs 4

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -214,6 +214,8 @@ AddDependency(NAME    eigen
               DEFAULT ON
               URL     https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip)
 
+mark_as_advanced(SUPERBUILD_eigen)
+
 AddDependency(NAME colpack
               DEFAULT ON
               GIT_URL https://github.com/opensim-org/colpack.git
@@ -222,8 +224,10 @@ AddDependency(NAME colpack
                          -DENABLE_EXAMPLES:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
 
+mark_as_advanced(SUPERBUILD_colpack)
+
 CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
-                       "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+                       "OPENSIM_WITH_TROPTER" ON)
 CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
                        "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
 endif()
@@ -231,6 +235,7 @@ endif()
 if (OPENSIM_WITH_CASADI)
     CMAKE_DEPENDENT_OPTION(SUPERBUILD_casadi "Automatically download, configure, build and install casadi" ON
                            "OPENSIM_WITH_CASADI" OFF)
+    mark_as_advanced(SUPERBUILD_casadi)
 endif()
 
 if (WIN32)
@@ -247,6 +252,8 @@ if (WIN32)
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""
             INSTALL_COMMAND ${ADOLC_INSTALL_CMD})
+
+        mark_as_advanced(SUPERBUILD_adolc)
     endif()
 
 
@@ -281,7 +288,7 @@ if (WIN32)
         # COIN-OR may make binaries available on GitHub (see release 3.13.2),
         # likely using Intel Fortran.
         # https://github.com/coin-or/Ipopt/releases
-
+        mark_as_advanced(SUPERBUILD_ipopt)
     endif()
 else()
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -227,7 +227,7 @@ AddDependency(NAME colpack
 mark_as_advanced(SUPERBUILD_colpack)
 
 CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
-                       "OPENSIM_WITH_TROPTER" ON)
+                       "OPENSIM_WITH_TROPTER" OFF)
 CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
                        "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
 endif()

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 3.2)
 
 include(ExternalProject)
 include(CMakeParseArguments)
+include(CMakeDependentOption)
 
 # Set the default for CMAKE_INSTALL_PREFIX.
 function(SetDefaultCMakeInstallPrefix)
@@ -200,7 +201,15 @@ AddDependency(NAME       spdlog
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
+# Moco settings.
+# --------------
+option(OPENSIM_WITH_CASADI
+        "Build CasADi support for Moco (MocoCasADiSolver)." OFF)
+option(OPENSIM_WITH_TROPTER
+        "Build the tropter optimal control library, for use in MocoTropterSolver." OFF)
 
+
+if(OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI)
 AddDependency(NAME    eigen
               DEFAULT ON
               URL     https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip)
@@ -213,13 +222,16 @@ AddDependency(NAME colpack
                          -DENABLE_EXAMPLES:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
 
-set(SUPERBUILD_adolc ON CACHE BOOL 
-    "Automatically download, configure, build and install adolc")
-set(SUPERBUILD_ipopt ON CACHE BOOL 
-    "Automatically download, configure, build and install ipopt")
+CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
+                       "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
+                       "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+endif()
 
-set(SUPERBUILD_casadi ON CACHE BOOL 
-    "Automatically download, configure, build and install casadi")
+if (OPENSIM_WITH_CASADI)
+    CMAKE_DEPENDENT_OPTION(SUPERBUILD_casadi "Automatically download, configure, build and install casadi" ON
+                           "OPENSIM_WITH_CASADI" OFF)
+endif()
 
 if (WIN32)
 


### PR DESCRIPTION
Use same options OPENSIM_WITH_TROPTER, OPENSIM_WITH_CASADI used in opensim-core build

Fixes issue #3156

### Brief summary of changes
Introduced two flags to control the Superbuild_ flags so the setting is consistent.
### Testing I've completed
Built with both flags on, off, or mixed.
### Looking for feedback on...
1. Should these new options be off by default? I chose this because otherwise the Superbuild_ options will show defeating the purpose.
2. Should the Superbuild_ options be marked as advanced?
3. 
### CHANGELOG.md (choose one)

- no need to update because not sure this is user facing, will look

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3173)
<!-- Reviewable:end -->
