### PR TITLE
Check for NaN or -ve mass specification and follow as invalid inertia

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -64,7 +64,7 @@ jobs:
         # /W0 disables warnings.
         # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
         # TODO: CMake provides /W3, which overrides our /W0
-        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON
+        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
         cmake --build . --config Release -- /maxcpucount:4
 
     - name: Configure opensim-core
@@ -204,6 +204,8 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
         DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
         DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=10.10)
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
@@ -331,6 +333,8 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
         cmake "${DEP_CMAKE_ARGS[@]}"
         make --jobs 4

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -358,9 +358,8 @@ SimTK::MassProperties Body::getMassProperties() const
     const double& m = get_mass();
     const Vec3& com = get_mass_center();
     try {
-        auto validMass = !SimTK::isNaN(m) && m >= 0;
-        string msg ="Body "+getName()+" has unspecified or -ve mass value.";
-        SimTK_ERRCHK_ALWAYS(validMass, "Body::getMassProperties", msg.c_str());
+        OPENSIM_THROW_IF_FRMOBJ(!(m >= 0.0), Exception,
+                "Body " + getName() + " has unspecified or negative mass.");
 
         const SimTK::Inertia& Icom = getInertia();
 

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -357,8 +357,11 @@ SimTK::MassProperties Body::getMassProperties() const
 {
     const double& m = get_mass();
     const Vec3& com = get_mass_center();
+    try {
+        auto validMass = !SimTK::isNaN(m) && m >= 0;
+        string msg ="Body "+getName()+" has unspecified or -ve mass value.";
+        SimTK_ERRCHK_ALWAYS(validMass, "Body::getMassProperties", msg.c_str());
 
-    try{
         const SimTK::Inertia& Icom = getInertia();
 
         SimTK::Inertia Ib = Icom;

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -123,7 +123,7 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
     const Ground& ground = osimModel->getGround();
     OpenSim::Body ball;
     ball.setName("ball");
-
+    ball.setMass(0);
     // Add joints
     FreeJoint free("free", ground, Vec3(0), Vec3(0), ball, Vec3(0), Vec3(0));
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 3.2)
 
 include(ExternalProject)
 include(CMakeParseArguments)
+include(CMakeDependentOption)
 
 # Set the default for CMAKE_INSTALL_PREFIX.
 function(SetDefaultCMakeInstallPrefix)
@@ -200,10 +201,20 @@ AddDependency(NAME       spdlog
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
+# Moco settings.
+# --------------
+option(OPENSIM_WITH_CASADI
+        "Build CasADi support for Moco (MocoCasADiSolver)." OFF)
+option(OPENSIM_WITH_TROPTER
+        "Build the tropter optimal control library, for use in MocoTropterSolver." OFF)
 
+
+if(OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI)
 AddDependency(NAME    eigen
               DEFAULT ON
               URL     https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip)
+
+mark_as_advanced(SUPERBUILD_eigen)
 
 AddDependency(NAME colpack
               DEFAULT ON
@@ -213,13 +224,19 @@ AddDependency(NAME colpack
                          -DENABLE_EXAMPLES:BOOL=OFF
                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
 
-set(SUPERBUILD_adolc ON CACHE BOOL 
-    "Automatically download, configure, build and install adolc")
-set(SUPERBUILD_ipopt ON CACHE BOOL 
-    "Automatically download, configure, build and install ipopt")
+mark_as_advanced(SUPERBUILD_colpack)
 
-set(SUPERBUILD_casadi ON CACHE BOOL 
-    "Automatically download, configure, build and install casadi")
+CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
+                       "OPENSIM_WITH_TROPTER" OFF)
+CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
+                       "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+endif()
+
+if (OPENSIM_WITH_CASADI)
+    CMAKE_DEPENDENT_OPTION(SUPERBUILD_casadi "Automatically download, configure, build and install casadi" ON
+                           "OPENSIM_WITH_CASADI" OFF)
+    mark_as_advanced(SUPERBUILD_casadi)
+endif()
 
 if (WIN32)
 
@@ -235,6 +252,8 @@ if (WIN32)
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""
             INSTALL_COMMAND ${ADOLC_INSTALL_CMD})
+
+        mark_as_advanced(SUPERBUILD_adolc)
     endif()
 
 
@@ -269,7 +288,7 @@ if (WIN32)
         # COIN-OR may make binaries available on GitHub (see release 3.13.2),
         # likely using Intel Fortran.
         # https://github.com/coin-or/Ipopt/releases
-
+        mark_as_advanced(SUPERBUILD_ipopt)
     endif()
 else()
 


### PR DESCRIPTION
Fixes issue #3130 

### Brief summary of changes
Expanded try-block that used to throw if bad inertia is specified to include check for NaN or -ve mass specification.

### Testing I've completed
None other than stepping through the code with bad model.

### Looking for feedback on...
Should we throw for consistency of handling of inertia as opposed to allowing loading models and catch downstream which would be wider spread and unsustainable AFAICT.

### CHANGELOG.md (choose one)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3182)
<!-- Reviewable:end -->
