### PR TITLE
[WIP] fix issues with dependencies build with Macs with arm64

### DIFF
--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -6,11 +6,11 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
     file(GLOB quadmath "${gcc_libdir}/libquadmath*.dylib")
 
     # Check for arm64 architecture
-        execute_process(
-            COMMAND uname -m
-            OUTPUT_VARIABLE MACHINE_ARCH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
+    execute_process(
+        COMMAND uname -m
+        OUTPUT_VARIABLE MACHINE_ARCH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
 
     # For ARM-based Macs, install a different set of libraries (without mumps 
     # and metis) because of the different way dependencies are built.
@@ -51,6 +51,7 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
                 ${gcc_libdir}/libgcc_s.1.dylib
 
                 DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif()
 
     # This command must be invoked from the cmake subdirectory so that the
     # editing of libtropter's link libraries is done after libtropter.dylib

--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -5,26 +5,52 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
     file(GLOB gfortran "${gcc_libdir}/libgfortran*.dylib")
     file(GLOB quadmath "${gcc_libdir}/libquadmath*.dylib")
 
-    install(FILES
-            ${ADOLC_DIR}/lib64/libadolc.2.dylib
-            ${ADOLC_DIR}/lib64/libadolc.dylib
-            # /usr/local/opt/boost/lib/libboost_system.dylib
-            ${ColPack_ROOT_DIR}/lib/libColPack.0.dylib
-            ${IPOPT_LIBDIR}/libipopt.1.10.8.dylib
-            ${IPOPT_LIBDIR}/libipopt.1.dylib
-            ${IPOPT_LIBDIR}/libipopt.dylib
-            #${IPOPT_LIBDIR}/libcoinmumps.1.6.0.dylib
-            #${IPOPT_LIBDIR}/libcoinmumps.1.dylib
-            #${IPOPT_LIBDIR}/libcoinmumps.dylib
-            #${IPOPT_LIBDIR}/libcoinmetis.1.3.5.dylib
-            #${IPOPT_LIBDIR}/libcoinmetis.1.dylib
-            #${IPOPT_LIBDIR}/libcoinmetis.dylib
+    # Check for arm64 architecture
+        execute_process(
+            COMMAND uname -m
+            OUTPUT_VARIABLE MACHINE_ARCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
 
-            ${gfortran}
-            ${quadmath}
-            ${gcc_libdir}/libgcc_s.1.dylib
+    # For ARM-based Macs, install a different set of libraries (without mumps 
+    # and metis) because of the different way dependencies are built.
+    if(MACHINE_ARCH STREQUAL "arm64")
+        install(FILES
+                ${ADOLC_DIR}/lib64/libadolc.2.dylib
+                ${ADOLC_DIR}/lib64/libadolc.dylib
+                ${ColPack_ROOT_DIR}/lib/libColPack.0.dylib
+                ${IPOPT_LIBDIR}/libipopt.1.10.8.dylib
+                ${IPOPT_LIBDIR}/libipopt.1.dylib
+                ${IPOPT_LIBDIR}/libipopt.dylib
 
-            DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                ${gfortran}
+                ${quadmath}
+                ${gcc_libdir}/libgcc_s.1.dylib
+
+                DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+    # For x64 Macs, make sure to also include mumps and metis libraries.
+    else()
+        install(FILES
+                ${ADOLC_DIR}/lib64/libadolc.2.dylib
+                ${ADOLC_DIR}/lib64/libadolc.dylib
+                # /usr/local/opt/boost/lib/libboost_system.dylib
+                ${ColPack_ROOT_DIR}/lib/libColPack.0.dylib
+                ${IPOPT_LIBDIR}/libipopt.1.10.8.dylib
+                ${IPOPT_LIBDIR}/libipopt.1.dylib
+                ${IPOPT_LIBDIR}/libipopt.dylib
+                ${IPOPT_LIBDIR}/libcoinmumps.1.6.0.dylib
+                ${IPOPT_LIBDIR}/libcoinmumps.1.dylib
+                ${IPOPT_LIBDIR}/libcoinmumps.dylib
+                ${IPOPT_LIBDIR}/libcoinmetis.1.3.5.dylib
+                ${IPOPT_LIBDIR}/libcoinmetis.1.dylib
+                ${IPOPT_LIBDIR}/libcoinmetis.dylib
+
+                ${gfortran}
+                ${quadmath}
+                ${gcc_libdir}/libgcc_s.1.dylib
+
+                DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     # This command must be invoked from the cmake subdirectory so that the
     # editing of libtropter's link libraries is done after libtropter.dylib

--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -13,12 +13,12 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
             ${IPOPT_LIBDIR}/libipopt.1.10.8.dylib
             ${IPOPT_LIBDIR}/libipopt.1.dylib
             ${IPOPT_LIBDIR}/libipopt.dylib
-            ${IPOPT_LIBDIR}/libcoinmumps.1.6.0.dylib
-            ${IPOPT_LIBDIR}/libcoinmumps.1.dylib
-            ${IPOPT_LIBDIR}/libcoinmumps.dylib
-            ${IPOPT_LIBDIR}/libcoinmetis.1.3.5.dylib
-            ${IPOPT_LIBDIR}/libcoinmetis.1.dylib
-            ${IPOPT_LIBDIR}/libcoinmetis.dylib
+            #${IPOPT_LIBDIR}/libcoinmumps.1.6.0.dylib
+            #${IPOPT_LIBDIR}/libcoinmumps.1.dylib
+            #${IPOPT_LIBDIR}/libcoinmumps.dylib
+            #${IPOPT_LIBDIR}/libcoinmetis.1.3.5.dylib
+            #${IPOPT_LIBDIR}/libcoinmetis.1.dylib
+            #${IPOPT_LIBDIR}/libcoinmetis.dylib
 
             ${gfortran}
             ${quadmath}

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -210,26 +210,33 @@ option(OPENSIM_WITH_TROPTER
 
 
 if(OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI)
-AddDependency(NAME    eigen
-              DEFAULT ON
-              URL     https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip)
+    AddDependency(NAME    eigen
+                  DEFAULT ON
+                  URL     https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip)
 
-mark_as_advanced(SUPERBUILD_eigen)
+    mark_as_advanced(SUPERBUILD_eigen)
 
-AddDependency(NAME colpack
-              DEFAULT ON
-              GIT_URL https://github.com/opensim-org/colpack.git
-              GIT_TAG 72f691e91d59e8eb2123f258e67a4ddc72d105ee
-              CMAKE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=_d
-                         -DENABLE_EXAMPLES:BOOL=OFF
-                         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
+    AddDependency(NAME colpack
+                  DEFAULT ON
+                  GIT_URL https://github.com/opensim-org/colpack.git
+                  GIT_TAG 72f691e91d59e8eb2123f258e67a4ddc72d105ee
+                  CMAKE_ARGS -DCMAKE_DEBUG_POSTFIX:STRING=_d
+                             -DENABLE_EXAMPLES:BOOL=OFF
+                             -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON)
 
-mark_as_advanced(SUPERBUILD_colpack)
+    mark_as_advanced(SUPERBUILD_colpack)
 
-CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
-                       "OPENSIM_WITH_TROPTER" OFF)
-CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
-                       "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+    CMAKE_DEPENDENT_OPTION(SUPERBUILD_adolc "Automatically download, configure, build and install adolc" ON
+                        "OPENSIM_WITH_TROPTER" OFF)
+    CMAKE_DEPENDENT_OPTION(SUPERBUILD_ipopt "Automatically download, configure, build and install ipopt" ON
+                        "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+    CMAKE_DEPENDENT_OPTION(USE_IPOPT_INSTALL "Use an ipopt install folder instead of using the superbuild option." OFF
+                        "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
+    set(IPOPT_INSTALL_DIR "" CACHE STRING "Path to the ipopt install folder when USE_IPOPT_INSTALL is ON")
+endif()
+
+if (SUPERBUILD_ipopt AND USE_IPOPT_INSTALL)
+    message(FATAL_ERROR "SUPERBUILD_ipopt and USE_IPOPT_INSTALL cannot both be ON")
 endif()
 
 if (OPENSIM_WITH_CASADI)
@@ -319,32 +326,97 @@ else()
                                                --with-colpack=${CMAKE_INSTALL_PREFIX}/colpack
                                                --with-boost=no
             BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install)
+            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+            )
     endif()
 
     if(SUPERBUILD_ipopt)
-        # TODO --enable-debug if building in Debug.
-        # TODO must have gfortran for MUMPS (brew install gcc).
-        # TODO CMake documentation says "Whether the current working directory
-        # is preserved between commands is not defined. Behavior of shell
-        # operators like && is not defined."
-        # Patch the scripts that download Metis and MUMPS to use our
-        # Sourceforge mirror. The original links are not reliable.
-        ExternalProject_Add(ipopt
-            URL https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.8.zip
-            INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/ipopt"
-            PATCH_COMMAND cd <SOURCE_DIR>/ThirdParty/Metis && patch < ${CMAKE_SOURCE_DIR}/get.Metis.patch
-                  COMMAND cd <SOURCE_DIR>/ThirdParty/Metis && ./get.Metis
-                  COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && patch < ${CMAKE_SOURCE_DIR}/get.Mumps.patch
-                  COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && ./get.Mumps
-            # GCC 10 generates a warning when compling MUMPS that we must suppress using
-            # -fallow-argument-mismatch.
-            # Suppress warnings treated as errors in Clang/LLVM with -Wno-error=implicit-function-declaration
-            CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch ADD_CFLAGS=-Wno-error=implicit-function-declaration
-            BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
-            INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install)
+
+        # Check for arm64 architecture
+        execute_process(
+            COMMAND uname -m
+            OUTPUT_VARIABLE MACHINE_ARCH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+
+        # For ARM-based Macs, use different version of METIS and MUMPS than
+        # those automatically pulled from IPOPT's ThirdParty submodules.
+        if(APPLE AND MACHINE_ARCH STREQUAL "arm64")
+            
+            # Homebrew dir is /opt/homebrew for arm64 (/usr/local for x86_64).
+            # Use METIS from Homebrew, which is currently 5.1.0 (IPOPT 3.12.8
+            # automatically pulls 4.10.0, which had some segfault issues)
+            set(HOMEBREW_DIR "/opt/homebrew")
+            set(METIS_INSTALL_DIR "${HOMEBREW_DIR}/opt/metis")
+
+            # For MUMPS, use a tag from stable/2.1 branch instead of what
+            # IPOPT 3.12.8 automatically pulls (stable/1.6). Both branches
+            # use MUMPS 4.10.0. This avoid some linker issues with Homebrew METIS.
+            set(MUMPS_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/mumps")
+            ExternalProject_Add(mumps
+                GIT_REPOSITORY    https://github.com/coin-or-tools/ThirdParty-Mumps.git
+                GIT_TAG           f4ad789112161f73b2a3daf1c586f7de85cd7043 #from stable/2.1 branch
+                INSTALL_DIR       ${MUMPS_INSTALL_DIR}
+                PATCH_COMMAND     cd <SOURCE_DIR> && ./get.Mumps
+                CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch ADD_CFLAGS=-Wno-error=implicit-function-declaration
+                                                            --with-metis-cflags=-I${METIS_INSTALL_DIR}/include
+                                                            "--with-metis-lflags=-L${METIS_INSTALL_DIR}/lib -lmetis"
+                BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
+                INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+                )
+
+            # Can still use IPOPT 3.12.8, with a small patch.
+            set(IPOPT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/ipopt")
+            ExternalProject_Add(ipopt
+                DEPENDS           mumps
+                URL               https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.8.zip
+                INSTALL_DIR       ${IPOPT_INSTALL_DIR}
+                # For Ipopt 3.12, patch a file so that it can find the proper MUMPS flags/variables.
+                PATCH_COMMAND     cd <SOURCE_DIR> && patch -p0 < ${CMAKE_SOURCE_DIR}/ipopt.patch
+                CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+                                                            --with-mumps-incdir=${MUMPS_INSTALL_DIR}/include/coin-or/mumps
+                                                            "--with-mumps-lib=-L${MUMPS_INSTALL_DIR}/lib -lcoinmumps"
+                BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
+                INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
+                )
+
+        else()
+            # TODO --enable-debug if building in Debug.
+            # TODO must have gfortran for MUMPS (brew install gcc).
+            # TODO CMake documentation says "Whether the current working directory
+            # is preserved between commands is not defined. Behavior of shell
+            # operators like && is not defined."
+            # Patch the scripts that download Metis and MUMPS to use our
+            # Sourceforge mirror. The original links are not reliable.
+            ExternalProject_Add(ipopt
+                URL https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.8.zip
+                INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/ipopt"
+                PATCH_COMMAND cd <SOURCE_DIR>/ThirdParty/Metis && patch < ${CMAKE_SOURCE_DIR}/get.Metis.patch
+                    COMMAND cd <SOURCE_DIR>/ThirdParty/Metis && ./get.Metis
+                    COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && patch < ${CMAKE_SOURCE_DIR}/get.Mumps.patch
+                    COMMAND cd <SOURCE_DIR>/ThirdParty/Mumps && ./get.Mumps
+                # GCC 10 generates a warning when compling MUMPS that we must suppress using
+                # -fallow-argument-mismatch.
+                # Suppress warnings treated as errors in Clang/LLVM with -Wno-error=implicit-function-declaration
+                CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch ADD_CFLAGS=-Wno-error=implicit-function-declaration
+                BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
+                INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install)
+        endif()
     endif()
 
+endif()
+
+# Use a pre-built IPOPT installation folder instead of using the superbuild.
+if (USE_IPOPT_INSTALL)
+    set(IPOPT_INSTALL_CMD "${CMAKE_COMMAND}" -E copy_directory
+        "${IPOPT_INSTALL_DIR}"
+        "${CMAKE_INSTALL_PREFIX}/ipopt")
+    ExternalProject_Add(ipopt
+        DOWNLOAD_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ${IPOPT_INSTALL_CMD}
+        )
 endif()
 
 if(SUPERBUILD_casadi)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -233,6 +233,9 @@ if(OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI)
     CMAKE_DEPENDENT_OPTION(USE_IPOPT_INSTALL "Use an ipopt install folder instead of using the superbuild option." OFF
                         "OPENSIM_WITH_TROPTER OR OPENSIM_WITH_CASADI" OFF)
     set(IPOPT_INSTALL_DIR "" CACHE STRING "Path to the ipopt install folder when USE_IPOPT_INSTALL is ON")
+
+    mark_as_advanced(USE_IPOPT_INSTALL)
+    mark_as_advanced(IPOPT_INSTALL_DIR)
 endif()
 
 if (SUPERBUILD_ipopt AND USE_IPOPT_INSTALL)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -362,8 +362,8 @@ else()
                 INSTALL_DIR       ${MUMPS_INSTALL_DIR}
                 PATCH_COMMAND     cd <SOURCE_DIR> && ./get.Mumps
                 CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> ADD_FFLAGS=-fallow-argument-mismatch ADD_CFLAGS=-Wno-error=implicit-function-declaration
-                                                            --with-metis-cflags=-I${METIS_INSTALL_DIR}/include
-                                                            "--with-metis-lflags=-L${METIS_INSTALL_DIR}/lib -lmetis"
+                                                         --with-metis-cflags=-I${METIS_INSTALL_DIR}/include
+                                                         "--with-metis-lflags=-L${METIS_INSTALL_DIR}/lib -lmetis"
                 BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
                 INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
                 )
@@ -377,8 +377,10 @@ else()
                 # For Ipopt 3.12, patch a file so that it can find the proper MUMPS flags/variables.
                 PATCH_COMMAND     cd <SOURCE_DIR> && patch -p0 < ${CMAKE_SOURCE_DIR}/ipopt.patch
                 CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
-                                                            --with-mumps-incdir=${MUMPS_INSTALL_DIR}/include/coin-or/mumps
-                                                            "--with-mumps-lib=-L${MUMPS_INSTALL_DIR}/lib -lcoinmumps"
+                                                         --with-mumps-incdir=${MUMPS_INSTALL_DIR}/include/coin-or/mumps
+                                                         "--with-mumps-lib=-L${MUMPS_INSTALL_DIR}/lib -lcoinmumps"
+                                                         --without-hsl --without-hsl-lib --without-hsl-incdir
+                                                         --without-asl --without-asl-lib --without-asl-incdir
                 BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} ${BUILD_FLAGS}
                 INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
                 )

--- a/dependencies/ipopt.patch
+++ b/dependencies/ipopt.patch
@@ -1,0 +1,10 @@
+--- Ipopt/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp	2022-04-13 11:59:52.000000000 -0700
++++ Ipopt/src/Algorithm/LinearSolvers/IpMumpsSolverInterface.cpp	2022-04-13 11:59:37.000000000 -0700
+@@ -16,6 +16,7 @@
+ // The first header to include is the one for MPI.  
+ // In newer ThirdParty/Mumps, mpi.h is renamed to mumps_mpi.h.
+ // We get informed about this by having COIN_USE_MUMPS_MPI_H defined.
++#include "mumps_compat.h"
+ #ifdef COIN_USE_MUMPS_MPI_H
+ #include "mumps_mpi.h"
+ #else


### PR DESCRIPTION
FYI @aymanhab @nickbianco 

Related to #3168 

### Brief summary of changes
- Update superbuild option for a Mac with arm64 architecture
- Add mechanism for using a pre-installed IPOPT

### Testing I've completed
Works locally, though will fail often when using many cores (e.g., `make -j8`) and sporadically with fewer (e.g., `make -j4`). There seems to be a race somewhere for making directories during superbuild. Runners don't seem to be available for GitHub actions yet.

This version passes all OpenSim tests.

### Looking for feedback on...
- Is this more surgical approach OK, or should we switch to this for all Mac builds?
- Is adding the option to use a pre-installed IPOPT overkill? I mainly used it for quicker testing locally when trying to isolate dependencies build issues.
- Not necessarily looking to merge right now (hence [WIP] tag), though this branch will be helpful to make sure I don't break other builds.

### CHANGELOG.md (choose one)
TODO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3192)
<!-- Reviewable:end -->
