### PR TITLE
Fix Bindings for OrientationsReference

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -229,8 +229,12 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %template(SetMarkerWeights) OpenSim::Set<MarkerWeight, OpenSim::Object>;
 %include <OpenSim/Simulation/CoordinateReference.h>
 %include <OpenSim/Simulation/OrientationsReference.h>
+// Since we have both OrientationsReference and shared_ptr<OrientationsReference>
+// Across the interface, DO NOT use %shared_ptr macro here as it treats
+// all pointers and references as std::shared_ptr
+//
 %template (SetOientationWeights) OpenSim::Set<OrientationWeight, OpenSim::Object>;
-%shared_ptr(OpenSim::OrientationsReference);
+%template(SharedOrientationsReference) std::shared_ptr<OpenSim::OrientationsReference>;
 %include <OpenSim/Simulation/BufferedOrientationsReference.h>
 %shared_ptr(OpenSim::BufferedOrientationsReference);
 


### PR DESCRIPTION
This PR is related to [this PR](https://github.com/opensim-org/opensim-core/pull/3089), which fixes [this issue](https://github.com/opensim-org/opensim-core/issues/3087). There was an issue with the bindings related to std::shared_ptr<OpenSim::MarkersReference>, and this PR fixes the analogous bug with std::shared_ptr<OpenSim::OrientationsReference>.

This issue can be reproduced with the following code in python (and probably the analogous code in MATLAB):
```python
import opensim

model = opensim.Model()
markersRef = opensim.MarkersReference()
orientationsRef = opensim.OrientationsReference()
coordRefArray = osim.SimTKArrayCoordinateReference()

iksolver = opensim.InverseKinematicsSolver(model, markersRef, orientationsRef, coordRefArray)
```

### Brief summary of changes
* Modified bindings for std::shared_ptr\<OpenSim::OrientationsReference>
to match the bindings of std::shared_ptr\<OpenSim::MarkersReference>

### Testing I've completed
To ensure the bug is with the bindings and not from some other source, I tested the following C++ code, with no errors.
```C++
#include <OpenSim/OpenSim.h>
using namespace SimTK;
using namespace OpenSim;

int main() {
    Model model;
    MarkersReference markersRef;
    OrientationsReference orientationsRef;
    SimTK::Array_<CoordinateReference> coordRefArray;

    InverseKinematicsSolver ik(model, markersRef, orientationsRef, coordRefArray);
}
```
To test the changes to the bindings, I compiled successfully and tested InverseKinematicsSolver constructor with the optional OrientationsReference argument.

### Looking for feedback on...
* I copied the code comment for the bindings of MarkersReference and modified slightly for OrientationsReference. It is likely better to have just one comment that explains the whole situation. However, since I do not know all of the intricacies of this facet of opensim, I would feedback on how I should comment this.
* It is probably better to swap line 236 and 237, to keep sequential consistency with MarkersReference. However, I was advised that the order of the bindings could affect some things, so I would like feedback on whether it is safe/advisable to swap these lines.

### CHANGELOG.md (choose one)

- no need to update because... not modifying interface or functionality, just a bug fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3193)
<!-- Reviewable:end -->
