### PR TITLE
Fix coordinate order xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v4.4
 - Fixed objects being set as not up to date with their properties by finalizeFromProperties
 - Throw exception if body masses are either NaN or -ve (Issue #3130)
 - Fixed issue #3176 where McKibbenActuator is not registered and can't be serialized to XML files
+- Fixed issue #3191 where CustomJoint coordinates ordering in model files affects coordinate definitions.
 
 
 v4.3

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -157,10 +157,11 @@ void CustomJoint::constructCoordinates()
         if (coordIndex < 0) {
             coordIndex =
                     constructCoordinate(Coordinate::MotionType::Undefined, i);
-        } else {
-            int sizeAsInt = static_cast<int>(coordIndices.size());
+        } else { 
+            // Coordinate was defined in XML, make sure the order in spatialTransform
+            // matches the order in the XML file/property
             coordinatesInTransformOrder = coordinatesInTransformOrder && 
-                    coordIndex == sizeAsInt;
+                    coordIndex == i;
             coordIndices.push_back(coordIndex);
         }
         Coordinate& coord = upd_coordinates(coordIndex);

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -158,8 +158,9 @@ void CustomJoint::constructCoordinates()
             coordIndex =
                     constructCoordinate(Coordinate::MotionType::Undefined, i);
         } else {
+            int sizeAsInt = static_cast<int>(coordIndices.size());
             coordinatesInTransformOrder = coordinatesInTransformOrder && 
-                    coordIndex == coordIndices.size();
+                    coordIndex == sizeAsInt;
             coordIndices.push_back(coordIndex);
         }
         Coordinate& coord = upd_coordinates(coordIndex);

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -148,7 +148,7 @@ void CustomJoint::constructCoordinates()
     int ncoords = coordinateNames.getSize();
 
     for (int i = 0; i < ncoords; ++i){
-        std::string coordName = spatialTransform.getCoordinateNames()[i];
+        std::string coordName = coordinateNames[i];
         // Locate the coordinate in the set if it has already been defined (e.g. in XML) 
         int coordIndex = getProperty_coordinates().findIndexForName(coordName);
         if (coordIndex < 0) {

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -230,8 +230,10 @@ void CustomJoint::constructCoordinates()
                     newCoord.get_prescribed());
             updProperty_coordinates()[ix].set_is_free_to_satisfy_constraints(
                     newCoord.get_is_free_to_satisfy_constraints());
-            updProperty_coordinates()[ix].set_prescribed_function(
-                    newCoord.get_prescribed_function());
+            if (!newCoord.getProperty_prescribed_function()
+                     .empty())
+                updProperty_coordinates()[ix].set_prescribed_function(
+                        *(newCoord.get_prescribed_function().clone()));
             
         }
     }

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -762,6 +762,7 @@ int Joint::assignSystemIndicesToBodyAndCoordinates(
         if (j < nc){ // assign
             mutableSelf.upd_coordinates(j)._mobilizerQIndex =
                 SimTK::MobilizerQIndex(iq);
+            //<=== This assumes coordinates are in order of mobilities
             mutableSelf.upd_coordinates(j)._bodyIndex =
                 mobod.getMobilizedBodyIndex();
             j++;

--- a/OpenSim/Simulation/SimbodyEngine/Joint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.cpp
@@ -758,11 +758,12 @@ int Joint::assignSystemIndicesToBodyAndCoordinates(
     Self& mutableSelf = const_cast<Self&>(*this);
 
     int j = startingCoordinateIndex;
+
     for (int iq = 0; iq < numMobilities; ++iq){
         if (j < nc){ // assign
+            //<=== This assumes coordinates as PROPERTY are in same order of mobilities
             mutableSelf.upd_coordinates(j)._mobilizerQIndex =
                 SimTK::MobilizerQIndex(iq);
-            //<=== This assumes coordinates are in order of mobilities
             mutableSelf.upd_coordinates(j)._bodyIndex =
                 mobod.getMobilizedBodyIndex();
             j++;


### PR DESCRIPTION
Fixes issue #3191

### Brief summary of changes
Changing the order of Coordinates in XML changes that actual mobilities/motions that the coordinates are attached to for a CustomJoint. This PR reorders the Coordinates to match the expectation/contract of downstream code.
### Testing I've completed
Created various combination of model files with different coordinate orderings
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3196)
<!-- Reviewable:end -->
