### PR TITLE
Fixed being unable to compile on OSX with CASADI disabled

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -46,7 +46,7 @@ install(FILES OpenSimMacros.cmake
 
 install(EXPORT OpenSimTargets DESTINATION "${OPENSIM_INSTALL_CMAKEDIR}")
 
-if(OPENSIM_COPY_DEPENDENCIES AND APPLE)
+if(APPLE AND OPENSIM_COPY_DEPENDENCIES AND (NOT (DEFINED OPENSIM_WITH_CASADI AND NOT ${OPENSIM_WITH_CASADI})))
     # Temporary hack to package dependencies on Macs.
     # TODO if we're building a standalone binary distribution, we should
     # use superbuild to build the dependencies.


### PR DESCRIPTION
This is a minor change to handle compiling OpenSim 4.3 with CASADI disabled on Mac OS.

My use-case is that I'm trying to compile OpenSim on a Mac Monetary (MacOS 12.3) OS.

CASADI+Tropter tend to fail to compile on modern installs of Mac. I believe it's because modern C/C++ compilers have stricter warnings enabled by default and some of the source code in those dependencies is now disallowed.

I don't have time to investigate a 4th-party codebase, so I opted to disable these dependencies altogether by building OpenSim's dependencies with `-DSUPERBUILD_adolc=OFF -DSUPERBUILD_ipopt=OFF -DSUPERBUILD_casadi=OFF` followed by building OpenSim with `-DOPENSIM_WITH_CASADI=NO -DOPENSIM_WITH_TROPTER=NO`. Here is a copy of the in-development buildscript (OpenSim build is line 166):

- https://gist.github.com/adamkewley/af9f0a0c5015e9eab9a0e5c87778bb80

This fails because an unrelated cmake file, which is used by the OpenSim build, makes the assumption that the `casadi` target is always built. The code that's protected by the (patched) `if` block tries to pull properties out of that target and then fails.

The reason why the patch is `AND (NOT (DEFINED OPENSIM_WITH_CASADI AND NOT ${OPENSIM_WITH_CASADI})` rather than `AND NOT ${OPENSIM_WITH_CASADI}` is to ensure that the legacy behavior still works even if the variable has not been set yet. The `if` guard specifically handles when the calling code has explicitly set `OPENSIM_WITH_CASADI` to a negative value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3206)
<!-- Reviewable:end -->
