### PR TITLE
Fix failing torque-driven marker tracking example in exampleMocoTrack

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.0
 -----
+- 2022-06-03: Fixed bug that was breaking marker tracking problems when
+              using MocoTrack::setMarkersReferenceFromTRC().
+
 - 2022-04-15: Added MocoInitialOutputGoal, MocoFinalOutputGoal,
               MocoOutputPeriodicityGoal, MocoOutputTrackingGoal, and
               MocoOutputConstraint.

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -168,7 +168,7 @@ void muscleDrivenStateTracking() {
 
 int main() {
 
-    // Solve tq he torque-driven marker tracking problem.
+    // Solve the torque-driven marker tracking problem.
     // This problem takes a few minutes to solve.
     torqueDrivenMarkerTracking();
 

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -56,7 +56,8 @@ void torqueDrivenMarkerTracking() {
     //   track.setModel(ModelProcessor("model.osim") | ModOpAddReserves(250));
 
     // Use this convenience function to set the MocoTrack markers reference
-    // directly from a TRC file.
+    // directly from a TRC file. By default, the marker data is filtered at
+    //  6 Hz
     track.setMarkersReferenceFromTRC("marker_trajectories.trc");
 
     // There is marker data in the 'marker_trajectories.trc' associated with

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -56,8 +56,7 @@ void torqueDrivenMarkerTracking() {
     //   track.setModel(ModelProcessor("model.osim") | ModOpAddReserves(250));
 
     // Use this convenience function to set the MocoTrack markers reference
-    // directly from a TRC file. By default, the markers data is filtered at
-    // 6 Hz and if in millimeters, converted to meters.
+    // directly from a TRC file.
     track.setMarkersReferenceFromTRC("marker_trajectories.trc");
 
     // There is marker data in the 'marker_trajectories.trc' associated with
@@ -169,7 +168,7 @@ void muscleDrivenStateTracking() {
 
 int main() {
 
-    // Solve the torque-driven marker tracking problem.
+    // Solve tq he torque-driven marker tracking problem.
     // This problem takes a few minutes to solve.
     torqueDrivenMarkerTracking();
 

--- a/OpenSim/Moco/MocoTrack.h
+++ b/OpenSim/Moco/MocoTrack.h
@@ -246,12 +246,16 @@ public:
     void setMarkersReference(TableProcessor markers) {
         set_markers_reference(std::move(markers));
     }
-    /// Set the markers reference directly from a TRC file.
+    /// Set the markers reference directly from a TRC file. By default, the
+    /// marker data is low-pass filtered with a 6 Hz cutoff frequency, but you
+    /// may set any frequency using the optional argument.
     /// @note Overrides any existing TableProcessor for 'markers_reference'.
-    void setMarkersReferenceFromTRC(const std::string& filename) {
+    void setMarkersReferenceFromTRC(
+            const std::string& filename, double lowpassFilterFreq = 6.0) {
         TimeSeriesTableVec3 markers(filename);
         TimeSeriesTable markersFlat = markers.flatten();
-        set_markers_reference(TableProcessor(markersFlat));
+        set_markers_reference(TableProcessor(markersFlat) |
+                              TabOpLowPassFilter(lowpassFilterFreq));
     }
 
     MocoStudy initialize();

--- a/OpenSim/Moco/MocoTrack.h
+++ b/OpenSim/Moco/MocoTrack.h
@@ -246,22 +246,12 @@ public:
     void setMarkersReference(TableProcessor markers) {
         set_markers_reference(std::move(markers));
     }
-    /// Set the markers reference directly from a TRC file. By default, the
-    /// marker data is lowpass filtered with a 6 Hz cutoff frequency, but you
-    /// may set any frequency using the optional argument. If the markers data
-    /// is in millimeters (detected via the 'Units' metadata tag), then it is
-    /// converted to meters.
+    /// Set the markers reference directly from a TRC file.
     /// @note Overrides any existing TableProcessor for 'markers_reference'.
-    void setMarkersReferenceFromTRC(
-            const std::string& filename, double lowpassFilterFreq = 6.0) {
+    void setMarkersReferenceFromTRC(const std::string& filename) {
         TimeSeriesTableVec3 markers(filename);
         TimeSeriesTable markersFlat = markers.flatten();
-        if (markersFlat.hasTableMetaDataKey("Units") &&
-                markersFlat.getTableMetaDataAsString("Units") == "mm") {
-            markersFlat.updMatrix() *= 0.001;
-        }
-        set_markers_reference(TableProcessor(markersFlat) |
-                              TabOpLowPassFilter(lowpassFilterFreq));
+        set_markers_reference(TableProcessor(markersFlat));
     }
 
     MocoStudy initialize();


### PR DESCRIPTION
Fixes issue #3094

### Brief summary of changes

~~Remove default option to filter marker trajectory table when using `MocoTrack::setMarkersReferenceFromTRC()`.~~

Per @hwarner's suggestion, the issue was not marker filtering, but rather the marker data scaling step. Marker scaling is unnecessary since the MarkersReference class scales marker data based on the model's units automatically.

### Testing I've completed
Ran exampleMocoTrack locally.

### Looking for feedback on...
~~Is removing the filtering argument entirely the best solution here? Users can also filter using TableOperator utilities, so if we remove it, we can instruct users how to do it that way. We could also provide an additional argument as a flag to turn filtering on/off.~~

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3214)
<!-- Reviewable:end -->
