### PR TITLE
Fix ik memleak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ v4.4
 - Throw exception if body masses are either NaN or -ve (Issue #3130)
 - Fixed issue #3176 where McKibbenActuator is not registered and can't be serialized to XML files
 - Fixed issue #3191 where CustomJoint coordinates ordering in model files affects coordinate definitions.
+- Fixed issue #3220 Memory leak running InverseKinematicsTool repeatedly and using Kinematics analysis.
 
 
 v4.3

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -46,8 +46,9 @@ using namespace std;
 /**
  * Destructor.
  */
-Kinematics::~Kinematics()
-{
+Kinematics::~Kinematics() 
+{ 
+    deleteStorage(); 
 }
 //_____________________________________________________________________________
 /**
@@ -108,7 +109,7 @@ setNull()
     _pStore=_vStore=_aStore=NULL;
 
     // Let the list own the storages so we don't have to manually delete them
-    _storageList.setMemoryOwner(true);
+    _storageList.setMemoryOwner(false);
 
     _recordAccelerations = true;
 }

--- a/OpenSim/Analyses/Kinematics.cpp
+++ b/OpenSim/Analyses/Kinematics.cpp
@@ -108,7 +108,7 @@ setNull()
     setName("Kinematics");
     _pStore=_vStore=_aStore=NULL;
 
-    // Let the list own the storages so we don't have to manually delete them
+    // Make sure storages are owned/managed by the Analysis
     _storageList.setMemoryOwner(false);
 
     _recordAccelerations = true;

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -303,8 +303,10 @@ bool InverseKinematicsTool::run()
             "please see messages window for details..."));
     }
 
-    if (modelFromFile) 
+    if (modelFromFile) { 
+        delete _model.get();
         _model.reset();
+    }
 
     return success;
 }

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -104,7 +104,7 @@ bool InverseKinematicsTool::run()
 {
     bool success = false;
     bool modelFromFile=true;
-    Kinematics* kinematicsReporter = nullptr;
+    std::unique_ptr<Kinematics> kinematicsReporter(new Kinematics());
     try{
         //Load and create the indicated model
         if (_model.empty()) { 
@@ -125,10 +125,9 @@ bool InverseKinematicsTool::run()
         auto cwd = IO::CwdChanger::changeToParentOf(getDocumentFileName());
 
         // Define reporter for output
-        kinematicsReporter = new Kinematics();
         kinematicsReporter->setRecordAccelerations(false);
         kinematicsReporter->setInDegrees(true);
-        _model->addAnalysis(kinematicsReporter);
+        _model->addAnalysis(kinematicsReporter.get());
 
         log_info("Running tool {}.", getName());
 
@@ -248,7 +247,7 @@ bool InverseKinematicsTool::run()
                     get_output_motion_file());
         }
         // Remove the analysis we added to the model, this also deletes it
-        _model->removeAnalysis(kinematicsReporter);
+        _model->removeAnalysis(kinematicsReporter.get());
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);
@@ -298,7 +297,7 @@ bool InverseKinematicsTool::run()
         log_error("InverseKinematicsTool Failed: {}", ex.what());
         // If failure happened after kinematicsReporter was added, make sure to cleanup
         if (kinematicsReporter!= nullptr)
-            _model->removeAnalysis(kinematicsReporter);
+            _model->removeAnalysis(kinematicsReporter.get());
         throw (Exception("InverseKinematicsTool Failed, "
             "please see messages window for details..."));
     }


### PR DESCRIPTION
Fixes issue #3220

### Brief summary of changes
Delete model if owned by tool and allow Kinematics analysis to release the memory/storages it allocated on destruction 
### Testing I've completed
Valgrind doesn't show leaks in ik

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3217)
<!-- Reviewable:end -->
