### PR TITLE
Fix double deletion iktool

### DIFF
--- a/Bindings/moco.i
+++ b/Bindings/moco.i
@@ -139,8 +139,8 @@ namespace OpenSim {
 %include <OpenSim/Moco/MocoTrack.h>
 
 %include <OpenSim/Moco/MocoUtilities.h>
-%template(analyzeMocoTrajectory) OpenSim::analyze<double>;
-%template(analyzeMocoTrajectoryVec3) OpenSim::analyze<SimTK::Vec3>;
-%template(analyzeMocoTrajectorySpatialVec) OpenSim::analyze<SimTK::SpatialVec>;
+%template(analyzeMocoTrajectory) OpenSim::analyzeMocoTrajectory<double>;
+%template(analyzeMocoTrajectoryVec3) OpenSim::analyzeMocoTrajectory<SimTK::Vec3>;
+%template(analyzeMocoTrajectorySpatialVec) OpenSim::analyzeMocoTrajectory<SimTK::SpatialVec>;
 
 %include <OpenSim/Moco/ModelOperatorsDGF.h>

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -247,7 +247,7 @@ bool InverseKinematicsTool::run()
                     get_output_motion_file());
         }
         // Remove the analysis we added to the model, do not delete as 
-        // the unique_ptr takes care of that.
+        // the unique_ptr takes care of that automatically
         _model->removeAnalysis(kinematicsReporter.get(), false);
 
         if (modelMarkerErrors) {

--- a/OpenSim/Tools/InverseKinematicsTool.cpp
+++ b/OpenSim/Tools/InverseKinematicsTool.cpp
@@ -246,8 +246,9 @@ bool InverseKinematicsTool::run()
             kinematicsReporter->getPositionStorage()->print(
                     get_output_motion_file());
         }
-        // Remove the analysis we added to the model, this also deletes it
-        _model->removeAnalysis(kinematicsReporter.get());
+        // Remove the analysis we added to the model, do not delete as 
+        // the unique_ptr takes care of that.
+        _model->removeAnalysis(kinematicsReporter.get(), false);
 
         if (modelMarkerErrors) {
             Array<string> labels("", 4);
@@ -303,6 +304,7 @@ bool InverseKinematicsTool::run()
     }
 
     if (modelFromFile) { 
+        log_debug("Deleting Model {} at end of IK.run", _model->getName());
         delete _model.get();
         _model.reset();
     }


### PR DESCRIPTION
Fixes issue GUI #1369 
### Brief summary of changes

Avoid deletion of Kinematics analysis since it gets deleted by unique_ptr destructor.

### Testing I've completed
Ran workflow in https://github.com/opensim-org/opensim-gui/issues/1369 without issue
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3224)
<!-- Reviewable:end -->
