### PR TITLE
MINSIGSTKSZ has been removed from glibc >= 2.34

### DIFF
--- a/OpenSim/Auxiliary/catch.hpp
+++ b/OpenSim/Auxiliary/catch.hpp
@@ -10795,7 +10795,7 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    static constexpr std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },

--- a/Vendors/tropter/external/catch/catch.hpp
+++ b/Vendors/tropter/external/catch/catch.hpp
@@ -8723,7 +8723,7 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    constexpr static std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    constexpr static std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
This is a workaround for issue #3223. With this workaround you can build opensim-core with glibc >= 2.34, but a better aproach should be proposed.

### Brief summary of changes
Removed the use of MINSIGSTKSZ, which has been redefined in glibc >= 2.34 (It throws error in glib >= 2.34).

### Testing I've completed
Continuous integration workflow tests.

### Looking for feedback on...
How a better approach  could be implemented here.

### CHANGELOG.md (choose one)

- no need to update because a better approach should be implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3225)
<!-- Reviewable:end -->
