### PR TITLE
Remove final from PhysicalOffsetFrame dtor

### DIFF
--- a/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
+++ b/OpenSim/Simulation/Model/PhysicalOffsetFrame.h
@@ -60,7 +60,7 @@ public:
     using OffsetFrame<PhysicalFrame>::OffsetFrame;
 #endif
 
-    ~PhysicalOffsetFrame() final {}
+    ~PhysicalOffsetFrame() = default;
 
 protected:
     /** Extend Component interface for adding the PhysicalOffsetFrame to the 


### PR DESCRIPTION
It produces many warnings on clang.

If the intention is to make the class `final`, that should be declared at the `class` level

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3231)
<!-- Reviewable:end -->
