### PR TITLE
Remove IKMarkerTask defaulted copy ctor

### DIFF
--- a/OpenSim/Tools/IKMarkerTask.h
+++ b/OpenSim/Tools/IKMarkerTask.h
@@ -40,7 +40,6 @@ OpenSim_DECLARE_CONCRETE_OBJECT(IKMarkerTask, IKTask);
 
 public:
     IKMarkerTask() = default;
-    IKMarkerTask(const IKMarkerTask&) = default;
     //=============================================================================
 };  // END of class IKMarkerTask
 //=============================================================================


### PR DESCRIPTION
Produces warnings in clang13 because it's a pattern that is formally deprecated. See:

https://stackoverflow.com/questions/51863588/warning-definition-of-implicit-copy-constructor-is-deprecated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3232)
<!-- Reviewable:end -->
