### PR TITLE
Fixed memory leak in OpenSim::CoordinateReference

### DIFF
--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -154,7 +154,7 @@ void AssemblySolver::updateCoordinateReference(const std::string &coordName, dou
     for(p = _coordinateReferencesp.begin(); 
         p != _coordinateReferencesp.end(); p++) {
         if(p->getName() == coordName){
-            p->setValueFunction(*new Constant(value));
+            p->setValueFunction(Constant(value));
             p->setWeight(weight);
             return;
         }

--- a/OpenSim/Simulation/CoordinateReference.cpp
+++ b/OpenSim/Simulation/CoordinateReference.cpp
@@ -142,4 +142,11 @@ void CoordinateReference::setWeight(double weight)
     _defaultWeight = weight;
 }
 
+
+void CoordinateReference::setValueFunction(const OpenSim::Function& function)
+{
+    delete _coordinateValueFunction;
+    _coordinateValueFunction = function.clone();
+}
+
 } // end of namespace OpenSim

--- a/OpenSim/Simulation/CoordinateReference.h
+++ b/OpenSim/Simulation/CoordinateReference.h
@@ -76,7 +76,7 @@ public:
     * @param ReferenceFunction that specifies the value of the coordinate
     *        to be matched at a given time
     */
-    CoordinateReference(const std::string name, 
+    CoordinateReference(const std::string name,
                         const Function &ReferenceFunction);
 
     CoordinateReference(const CoordinateReference& source);
@@ -112,10 +112,7 @@ public:
     void setWeight(double weight);
 
     /** %Set the coordinate value as a function of time. */
-    void setValueFunction(const OpenSim::Function& function)
-    {
-        _coordinateValueFunction = function.clone();
-    }
+    void setValueFunction(const OpenSim::Function& function);
 private:
     void copyData(const CoordinateReference& source);
 


### PR DESCRIPTION
This fixes a memory leak in `OpenSim::CoordinateReference`

The leak is two-fold. The `AssemblySolver` uses `new` to heap-allocate a `CoordinateReference` that ultimately leaks and the `CoordinateReference` itself does not delete any existing functions when `setValueFunction` is called. This results in OpenSim leaking memory whenever the model is assembled (e.g. on a coordinate edit)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3234)
<!-- Reviewable:end -->
