### PR TITLE
Fix path for copying ezc3d on linux per latest config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ if(${OPENSIM_C3D_PARSER} STREQUAL "ezc3d")
     set(ezc3d_LIBRARY "ezc3d")
     if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)
         OpenSimInstallDependencyLibraries(ezc3d "${ezc3d_DIR}/../../../bin"
-            "${ezc3d_DIR}" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
+            "${ezc3d_DIR}/../../../lib" "${OPENSIM_INSTALL_PYTHONDIR}/opensim")
     endif()
 elseif(${OPENSIM_C3D_PARSER} STREQUAL "BTK")
     set(WITH_EZC3D false)


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
When building standalone python distribution, locate ezc3d library per latest config

### Testing I've completed
Built with different cmake settings on linux successfully
### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3236)
<!-- Reviewable:end -->
