### PR TITLE
Fixed memory leak when CoordinateSet is populated

### DIFF
--- a/OpenSim/Simulation/Model/CoordinateSet.cpp
+++ b/OpenSim/Simulation/Model/CoordinateSet.cpp
@@ -39,8 +39,8 @@ using namespace OpenSim;
 void CoordinateSet::populate(Model& model)
 {
     // Aggregate Coordinates owned by the Joint's into a single CoordinateSet
-    setMemoryOwner(false);
     setSize(0);
+    setMemoryOwner(false);
 
     auto joints = model.updComponentList<Joint>();
 


### PR DESCRIPTION
This leak appears to happen whenever the model is loaded, re-finalized, etc.

As far as I can tell, `setMemoryOwner` should almost always be called after `setSize(0)`, because it may be the case that the collection does own its contents (e.g. upon copy construction or assignment, where the implementation always deep-copies and owns the contents).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3237)
<!-- Reviewable:end -->
