### PR TITLE
Fixed segfault when adding a CoordinateCouplerConstraint with no func…

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
@@ -223,7 +223,7 @@ void CoordinateCouplerConstraint::extendAddToSystem(SimTK::MultibodySystem& syst
     }
 
     // Create and set the underlying coupler constraint function;
-    const Function& f = get_coupled_coordinates_function();
+    const Function& f = getFunction();
     SimTK::Function *simtkCouplerFunction = new CompoundFunction(f.createSimTKFunction(), get_scale_factor());
 
 


### PR DESCRIPTION
This fixes a crashing segfault that can happen if a model contains a `CoordinateCouplerConstraint` that hasn't had a function assigned to it yet.

The reason it segfaults is because the property is tagged with `OPTIONAL` so, as far as I understand, the property is permitted to be empty. However, the patched code assumes that the property is non-empty, which results in it trying to read a non-existent memory location (at property index == 0).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3244)
<!-- Reviewable:end -->
