### PR TITLE
Fixed OpenSim::Controller leaking memory whenever it is copied

### DIFF
--- a/OpenSim/Simulation/Control/Controller.cpp
+++ b/OpenSim/Simulation/Control/Controller.cpp
@@ -49,10 +49,7 @@ Controller::Controller() :
     _numControls{0},
     _actuatorSet{}
 {
-    setAuthors("Ajay Seth, Frank Anderson, Chand John, Samuel Hamner");
-    constructProperty_enabled(true);
-    constructProperty_actuator_list();
-    _actuatorSet.setMemoryOwner(false);
+    constructProperties();
 }
 
 Controller::Controller(Controller const& src) :
@@ -62,11 +59,16 @@ Controller::Controller(Controller const& src) :
     _numControls{src._numControls},
     _actuatorSet{}
 {
+    // care: the reason this custom copy constructor exists is to prevent
+    // a memory leak (#3247)
     _actuatorSet.setMemoryOwner(false);
 }
 
 Controller& Controller::operator=(Controller const& src)
 {
+    // care: the reason this custom copy assignment exists is to prevent
+    // a memory leak (#3247)
+
     if (&src != this)
     {
         static_cast<ModelComponent&>(*this) = static_cast<ModelComponent const&>(src);
@@ -85,6 +87,17 @@ Controller::~Controller() noexcept = default;
 //=============================================================================
 //_____________________________________________________________________________
 //_____________________________________________________________________________
+
+/**
+ * Connect properties to local pointers.
+ */
+void Controller::constructProperties()
+{
+    setAuthors("Ajay Seth, Frank Anderson, Chand John, Samuel Hamner");
+    constructProperty_enabled(true);
+    constructProperty_actuator_list();
+    _actuatorSet.setMemoryOwner(false);
+}
 
 void Controller::updateFromXMLNode(SimTK::Xml::Element& node,
                                    int versionNumber) {

--- a/OpenSim/Simulation/Control/Controller.cpp
+++ b/OpenSim/Simulation/Control/Controller.cpp
@@ -44,29 +44,47 @@ using namespace std;
 /**
  * Default constructor.
  */
-Controller::Controller() 
+Controller::Controller() :
+    ModelComponent{},
+    _numControls{0},
+    _actuatorSet{}
 {
-    constructProperties();
+    setAuthors("Ajay Seth, Frank Anderson, Chand John, Samuel Hamner");
+    constructProperty_enabled(true);
+    constructProperty_actuator_list();
+    _actuatorSet.setMemoryOwner(false);
 }
 
+Controller::Controller(Controller const& src) :
+    ModelComponent{src},
+    PropertyIndex_enabled{src.PropertyIndex_enabled},
+    PropertyIndex_actuator_list{src.PropertyIndex_actuator_list},
+    _numControls{src._numControls},
+    _actuatorSet{}
+{
+    _actuatorSet.setMemoryOwner(false);
+}
+
+Controller& Controller::operator=(Controller const& src)
+{
+    if (&src != this)
+    {
+        static_cast<ModelComponent&>(*this) = static_cast<ModelComponent const&>(src);
+        PropertyIndex_enabled = src.PropertyIndex_enabled;
+        PropertyIndex_actuator_list = src.PropertyIndex_actuator_list;
+        _numControls = src._numControls;
+        _actuatorSet.setSize(0);
+    }
+    return *this;
+}
+
+Controller::~Controller() noexcept = default;
 
 //=============================================================================
 // CONSTRUCTION
 //=============================================================================
 //_____________________________________________________________________________
 //_____________________________________________________________________________
-/**
- * Connect properties to local pointers.
- */
-void Controller::constructProperties()
-{
-    setAuthors("Ajay Seth, Frank Anderson, Chand John, Samuel Hamner");
-    constructProperty_enabled(true);
-    constructProperty_actuator_list();
-
-    // Set is only a reference list, not ownership
-    _actuatorSet.setMemoryOwner(false);
-}
 
 void Controller::updateFromXMLNode(SimTK::Xml::Element& node,
                                    int versionNumber) {
@@ -125,8 +143,8 @@ void Controller::extendConnectToModel(Model& model)
     // if we use a list Socket<Actuator> 
 
     // make sure controller does not take ownership
-    _actuatorSet.setMemoryOwner(false);
     _actuatorSet.setSize(0);
+    _actuatorSet.setMemoryOwner(false);
 
     int nac = getProperty_actuator_list().size();
     if (nac == 0)
@@ -172,9 +190,9 @@ void Controller::setActuators(const Set<Actuator>& actuators)
     //TODO this needs to be setting a Socket list of Actuators
 
     // make sure controller does NOT assume ownership
+    _actuatorSet.setSize(0);
     _actuatorSet.setMemoryOwner(false);
     //Rebuild consistent set of actuator lists
-    _actuatorSet.setSize(0);
     updProperty_actuator_list().clear();
     for (int i = 0; i< actuators.getSize(); i++){
         addActuator(actuators[i]);

--- a/OpenSim/Simulation/Control/Controller.h
+++ b/OpenSim/Simulation/Control/Controller.h
@@ -81,6 +81,9 @@ public:
 
     /** Default constructor. */
     Controller();
+    Controller(Controller const&);
+    Controller& operator=(Controller const&);
+    ~Controller() noexcept override;
 
     // Uses default (compiler-generated) destructor, copy constructor and copy 
     // assignment operator.
@@ -142,12 +145,6 @@ private:
 
     // the (sub)set of Model actuators that this controller controls */ 
     Set<const Actuator> _actuatorSet;
-
-    // construct and initialize properties
-    void constructProperties();
-
-    //friend class ControlSet;
-    friend class ControllerSet;
 
 //=============================================================================
 };  // END of class Controller

--- a/OpenSim/Simulation/Control/Controller.h
+++ b/OpenSim/Simulation/Control/Controller.h
@@ -146,6 +146,9 @@ private:
     // the (sub)set of Model actuators that this controller controls */ 
     Set<const Actuator> _actuatorSet;
 
+    // construct and initialize properties
+    void constructProperties();
+
 //=============================================================================
 };  // END of class Controller
 


### PR DESCRIPTION
This PR tries to fix a memory leak in `OpenSim::Controller`.

The leak occurs when copy-constructing or copy-assigning a `Controller` (or any derived class). It also happens when copying any class that contains a controller (e.g. an `OpenSim::Model`). When the conditions are triggered, `Controller` will leak copies of the `OpenSim::Actuator`s it references. These can have fairly large memory footprints (e.g. because the `Actuator`s are muscles containing paths, functions, etc.). A concrete example of a file that will do this is `ToyLandingModel.osim` ([here](https://github.com/opensim-org/opensim-models/blob/b2a7e32/Models/ToyLanding/ToyLandingModel.osim)), which contains a `ToyReflexController`. Each time `ToyLandingModel.osim` is copied, around ~1-2 MB of memory will leak.

The reason it happens is because of its `_actuatorSet` member. It is an `OpenSim::Set<const Actuator>` that, internally, has `setMemoryOwner` set to `false`.  However, the original code doesn't account for the behavior of `Set` (more specifically, the `OpenSim::ArrayPtrs` it wraps), which is that--regardless of memory ownership--copy constructing (or assigning) a `Set` will unconditionally clone all of its elements, followed by re-setting `setMemoryOwner` to `true`. This causes problems because other parts of the code unconditionally call `setMemoryOwner(false)` later on, causing a leak.

This PR is a *patch* solution to the behavior. It adds user-defined copy constructor and copy assignment functions. These implementations try to implement the necessary copy semantics while avoiding the `_actuatorSet`.

A longer-term solution would be to use the sockets API to fix this. However, that *may* involve breaking the API, because the current controller API assumes that a set of `Actuators` is available via `getActuators`, `setActuators`, addActuator`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3247)
<!-- Reviewable:end -->
