### PR TITLE
Make `Component::getSocketNames` const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.4.1
 ======
-- 
+
+- Made `Component::getSocketNames` a `const` member method (previously: non-const)
 
 v4.4
 ====

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -876,7 +876,7 @@ public:
      *     const AbstractSocket& socket = getSocket(name);
      * }
      * @endcode */
-    std::vector<std::string> getSocketNames() {
+    std::vector<std::string> getSocketNames() const {
         std::vector<std::string> names;
         for (const auto& it : _socketsTable) {
             names.push_back(it.first);


### PR DESCRIPTION
### Brief summary of changes

- Made `OpenSim::Component::getSocketNames()` const

### Testing I've completed

- None necessary

### Looking for feedback on...

- None

### CHANGELOG.md

- updated.
