### PR TITLE
Account for other conda variants by using conda-meta to detect conda

### DIFF
--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,7 +1,7 @@
 import sys
 import os
 if (sys.version_info.major == 3 and sys.version_info.minor >= 8 and sys.platform.startswith('win')):
-   if (os.path.exists(os.path.join(sys.prefix, 'conda'))):
+   if (os.path.exists(os.path.join(sys.prefix, 'conda-meta'))):
       os.add_dll_directory(os.path.dirname(os.path.realpath(__file__)))
    else:
       os.add_dll_directory(DLL_PATH)


### PR DESCRIPTION

Fixes issue #2869

### Brief summary of changes
On windows detecting conda to set dll_path relied on presence of conda folder in path, doesn't seem to always hold but conda-meta folder works per testers.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3250)
<!-- Reviewable:end -->
