### PR TITLE
fix rpath issue with casadi dependency on Mac

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -66,6 +66,9 @@ if(APPLE AND OPENSIM_COPY_DEPENDENCIES AND (NOT (DEFINED OPENSIM_WITH_CASADI AND
         ${CMAKE_CURRENT_BINARY_DIR}/OpenSimMocoInstallMacDependencyLibraries.cmake)
     configure_file(OpenSimMocoInstallMacDependencyLibraries.cmake.in
             "${script}" @ONLY)
+    # Variables are not forwarded to the install script, so add a line
+    # to set the OPENSIM_WITH_CASADI variable during the install step.
+    install(CODE "set(OPENSIM_WITH_CASADI \"${OPENSIM_WITH_CASADI}\")")
     install(SCRIPT "${script}")
 
 endif()


### PR DESCRIPTION
Fixes issue #3259 

### Brief summary of changes
When an install script is used in cmake, variables are not forwarded into the install step. This adds a line to set the `OPENSIM_WITH_CASADI` during the install step.

### Testing I've completed
Checked if rpath's were updated in local build. Will test again and update after artifact is made if a Moco example runs in MATLAB.

### CHANGELOG.md (choose one)
Did not update as this is a bug fix due to recent changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3260)
<!-- Reviewable:end -->
