### PR TITLE
Fix incorrect indexing of muscle-level metabolics arrays in `Bhargava2004SmoothedMuscleMetabolics`

### DIFF
--- a/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
+++ b/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
@@ -350,11 +350,10 @@ void Bhargava2004SmoothedMuscleMetabolics::calcMetabolicRate(
     activationHeatRate = maintenanceHeatRate = shorteningHeatRate =
         mechanicalWorkRate = 0;
 
-    int i = 0;
     for (const auto& muscleIndex : m_muscleIndices) {
 
-        const auto& muscleParameter =
-            get_muscle_parameters(muscleIndex.second);
+        const auto& index = muscleIndex.second;
+        const auto& muscleParameter = get_muscle_parameters(index);
         const auto& muscle = muscleParameter.getMuscle();
 
         const double maximalIsometricForce = muscle.getMaxIsometricForce();
@@ -526,13 +525,11 @@ void Bhargava2004SmoothedMuscleMetabolics::calcMetabolicRate(
         // --------------------------------
         double Edot = totalHeatRate + mechanicalWorkRate;
 
-        totalRatesForMuscles[i] = Edot;
-        activationRatesForMuscles[i] = activationHeatRate;
-        maintenanceRatesForMuscles[i] = maintenanceHeatRate;
-        shorteningRatesForMuscles[i] = shorteningHeatRate;
-        mechanicalWorkRatesForMuscles[i] = mechanicalWorkRate;
-
-        ++i;
+        totalRatesForMuscles[index] = Edot;
+        activationRatesForMuscles[index] = activationHeatRate;
+        maintenanceRatesForMuscles[index] = maintenanceHeatRate;
+        shorteningRatesForMuscles[index] = shorteningHeatRate;
+        mechanicalWorkRatesForMuscles[index] = mechanicalWorkRate;
     }
 }
 


### PR DESCRIPTION
### Brief summary of changes
In `Bhargava2004SmoothedMuscleMetabolics`, muscle metabolic values were being stored at the wrong indexes in the metabolics arrays. This leads to incorrect metabolic values being reported when calling `getMuscleMetabolicRate()`. This bug should not have any affect on the total metabolic rate (i.e.,  metabolics summed across all muscles) computations.

### Testing I've completed
Will test locally when artifact builds.

### CHANGELOG.md (choose one)

- no need to update because...small bug fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3261)
<!-- Reviewable:end -->
