### PR TITLE
Add setters to `DataTable.h` to make setting columns scripting friendly

### DIFF
--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -1023,12 +1023,67 @@ public:
         return _depData.updCol(static_cast<int>(index));
     }
 
+    /** Set dependent column at index using a SimTK::VectorView.
+    
+    \throws EmptyTable If the table is empty.
+    \throws ColumnIndexOutOfRange If index is out of range for number of columns
+                                  in the table.
+    \throws InvalidColumn If the input column contains incorrect number of 
+                          rows.                                              */
+    void setDependentColumnAtIndex(size_t index, const VectorView& depCol) {
+        OPENSIM_THROW_IF(depCol.nrow() != (int)getNumRows(), 
+                         IncorrectNumRows,
+                         static_cast<size_t>(getNumRows()),
+                         static_cast<size_t>(depCol.nrow()));
+
+        updDependentColumnAtIndex(index) = depCol;
+    }
+
+    /** Set dependent column at index using a SimTK::Vector.
+
+    \throws EmptyTable If the table is empty.
+    \throws ColumnIndexOutOfRange If index is out of range for number of columns
+                                  in the table.
+    \throws InvalidColumn If the input column contains incorrect number of
+                          rows.                                              */
+    void setDependentColumnAtIndex(size_t index, const Vector& depCol) {
+        setDependentColumnAtIndex(index, depCol.getAsVectorView());
+    }
+
     /** Update dependent Column which has the given column label.
 
     \throws KeyNotFound If columnLabel is not found to be label of any existing
                         column.                                               */
     VectorView updDependentColumn(const std::string& columnLabel) {
         return _depData.updCol(static_cast<int>(getColumnIndex(columnLabel)));
+    }
+
+    /** Set dependent column which has the given column label 
+        using a SimTK::VectorView.
+
+    \throws KeyNotFound If columnLabel is not found to be label of any existing
+                        column.    
+    \throws InvalidColumn If the input column contains incorrect number of
+                          rows.                                              */
+    void setDependentColumn(const std::string& columnLabel, 
+                            const VectorView& depCol) {
+        OPENSIM_THROW_IF(depCol.nrow() != (int)getNumRows(), IncorrectNumRows,
+                static_cast<size_t>(getNumRows()),
+                static_cast<size_t>(depCol.nrow()));
+
+        updDependentColumn(columnLabel) = depCol;
+    }
+
+    /** Set dependent column which has the given column label
+        using a SimTK::Vector.
+
+    \throws KeyNotFound If columnLabel is not found to be label of any existing
+                        column.
+    \throws InvalidColumn If the input column contains incorrect number of
+                          rows.                                              */
+    void setDependentColumn(const std::string& columnLabel, 
+                            const Vector& depCol) {
+        setDependentColumn(columnLabel, depCol.getAsVectorView());
     }
 
     /** %Set value of the independent column at index.

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -225,6 +225,14 @@ TEST_CASE("DataTable") {
                        table.getRowAtIndex(r)[c]);
     }
 
+    std::cout << "Test scripting-friendly column setters." << std::endl;
+    table.setDependentColumn("6", Vector(5, 5.0));
+    table.setDependentColumnAtIndex(6, Vector(5, 5.0));
+    for (unsigned r = 0; r < table.getNumRows(); ++r) {
+        ASSERT(table.getDependentColumn("6")[r] == 5.0);
+        ASSERT(table.getDependentColumnAtIndex(6)[r] == 5.0);
+    }
+
     std::cout << "Test numComponentsPerElement()." << std::endl;
     ASSERT((static_cast<AbstractDataTable&&>
             (DataTable_<double, double    >{})).


### PR DESCRIPTION
### Brief summary of changes
This PR introduces the methods `setDependentColumnAtIndex` and `setDependentColumn` (two signatures each) for setting dependent columns in `DataTable`s. These are more scripting-friendly, whereas the `upd`-based methods fail.

### Testing I've completed
Added tests to `testDataTable.cpp`.

### Looking for feedback on...
These methods are needed because interacting with the `VectorView` object doesn't work in scripting. I could see the argument for fixing this issue directly, but this update is probably more straight-forward and these methods generally useful.

### CHANGELOG.md (choose one)

- updated.
