### PR TITLE
[Moco] Add option to normalize tracking error in `MocoContactTrackingGoal`

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -1,6 +1,12 @@
 Moco Change Log
 ===============
 
+1.2.1
+-----
+- 2022-07-25: Added property `normalize_tracking_error` to `MocoContactTrackingGoal` 
+              to normalize the 3D contact tracking error based on the contact 
+              tracking data.
+
 1.2.0
 -----
 - 2022-06-03: Fixed bug that was breaking marker tracking problems when

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -204,6 +204,7 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
                 double factor = SimTK::max(
                     data.getDependentColumn(forceID + suffixes[i]).abs());
                 OPENSIM_THROW_IF_FRMOBJ(factor < SimTK::SignificantReal,
+                        Exception,
                         "The property `normalize_tracking_error` was enabled, "
                         "but the peak magnitude of the ground contact force "
                         "data in the {}-direction is close to zero.",

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -59,6 +59,7 @@ void MocoContactTrackingGoal::constructProperties() {
     constructProperty_external_loads_file("");
     constructProperty_projection("none");
     constructProperty_projection_vector();
+    constructProperty_normalize_tracking_error(false);
 }
 
 void MocoContactTrackingGoal::setExternalLoadsFile(

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -198,11 +198,16 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
         }
 
         // Compute normalization factors.
-        std::vector<std::string> suffixes = {"x", "y", "z"};
-        for (int i = 0; i < 3; ++i) {
-            double factor = SimTK::max(
-                data.getDependentColumn(forceID + suffixes[i]).abs());
-            if (factor > SimTK::SignificantReal) {
+        if (get_normalize_tracking_error()) {
+            std::vector<std::string> suffixes = {"x", "y", "z"};
+            for (int i = 0; i < 3; ++i) {
+                double factor = SimTK::max(
+                    data.getDependentColumn(forceID + suffixes[i]).abs());
+                OPENSIM_THROW_IF_FRMOBJ(factor < SimTK::SignificantReal,
+                        "The property `normalize_tracking_error` was enabled, "
+                        "but the peak magnitude of the ground contact force "
+                        "data in the {}-direction is close to zero.",
+                        suffixes[i]);
                 groupInfo.normalizeFactors[i] = factor;
             }
         }

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -286,6 +286,11 @@ private:
             "(optional) If provided, the force error is projected onto the "
             "plane perpendicular to this vector. The vector is expressed in "
             "ground. The vector can have any length.");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(normalize_tracking_error, bool,
+            "Normalize each component of the 3-D tracking error by the peak "
+            "value of each contact force component in the tracking data. "
+            "No normalization is applied when tracking data is close to "
+            "zero.");
 
     void constructProperties();
 
@@ -313,6 +318,7 @@ private:
         std::vector<std::pair<const SmoothSphereHalfSpaceForce*, int>> contacts;
         GCVSplineSet refSplines;
         const PhysicalFrame* refExpressedInFrame = nullptr;
+        SimTK::Vec3 normalizeFactors = SimTK::Vec3(1.0);
     };
     mutable std::vector<GroupInfo> m_groups;
 

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -259,6 +259,14 @@ public:
             const std::string& externalForceName, int index,
             const MocoBounds& bounds);
 
+    /// Normalize each component of the 3-D tracking error by the peak value of 
+    /// each contact force component in the tracking data. No normalization is 
+    /// applied when tracking data is close to zero.
+    void setNormalizeTrackingError(bool tf) {
+        set_normalize_tracking_error(tf);
+    }
+    bool getNormalizeTrackingError() { return get_normalize_tracking_error(); }
+
 protected:
     void initializeOnModelImpl(const Model&) const override;
     void calcIntegrandImpl(

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -261,7 +261,7 @@ public:
 
     /// Normalize each component of the 3-D tracking error by the peak value of 
     /// each contact force component in the tracking data. No normalization is 
-    /// applied when tracking data is close to zero.
+    /// applied when tracking data is close to zero (default: false).
     void setNormalizeTrackingError(bool tf) {
         set_normalize_tracking_error(tf);
     }
@@ -298,7 +298,7 @@ private:
             "Normalize each component of the 3-D tracking error by the peak "
             "value of each contact force component in the tracking data. "
             "No normalization is applied when tracking data is close to "
-            "zero.");
+            "zero (default: false).");
 
     void constructProperties();
 

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.h
@@ -296,9 +296,9 @@ private:
             "ground. The vector can have any length.");
     OpenSim_DECLARE_OPTIONAL_PROPERTY(normalize_tracking_error, bool,
             "Normalize each component of the 3-D tracking error by the peak "
-            "value of each contact force component in the tracking data. "
-            "No normalization is applied when tracking data is close to "
-            "zero (default: false).");
+            "magnitude of each contact force component in the tracking data. "
+            "If the peak magnitude of the ground contact force data is close "
+            "to zero, an exception is thrown (default: false).");
 
     void constructProperties();
 


### PR DESCRIPTION
### Brief summary of changes
Added property `normalize_tracking_error` to `MocoContactTrackingGoal` to allow users to normalize the 3D contact tracking error based on the contact tracking data.

### Testing I've completed
Tested locally.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3270)
<!-- Reviewable:end -->
