### PR TITLE
Communicate through swig that PathPointSet::insert takes ownership 

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -31,6 +31,15 @@ using namespace SimTK;
 
 %rename OpenSim::PathPointSet::clone unused_clone;
 
+// replace insert with a variant that takes ownership of passed in AbstractPathPoint
+// in the method 'insert' ends in super class so we can call it internally
+%typemap(javacode) OpenSim::PathPointSet %{
+    public boolean insert(int aIndex, AbstractPathPoint aObject) {
+       aObject.markAdopted();
+       return super.insert(aIndex, aObject);
+   }
+%}
+
 %extend OpenSim::Body {
     void getInertia(Array<double>& rInertia) {
         SimTK::Mat33 inertia= self->getInertia().toMat33();

--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -31,8 +31,9 @@ using namespace SimTK;
 
 %rename OpenSim::PathPointSet::clone unused_clone;
 
-// replace insert with a variant that takes ownership of passed in AbstractPathPoint
-// in the method 'insert' ends in super class so we can call it internally
+// replace insert with a variant that takes ownership of passed in AbstractPathPoint.
+// in java the method 'insert' ends in super class so we can call it internally
+// and that hides the super class method 
 %typemap(javacode) OpenSim::PathPointSet %{
     public boolean insert(int aIndex, AbstractPathPoint aObject) {
        aObject.markAdopted();

--- a/Bindings/Python/swig/python_simulation.i
+++ b/Bindings/Python/swig/python_simulation.i
@@ -92,6 +92,10 @@ MODEL_ADOPT_HELPER(Controller);
     args[1]._markAdopted()
 %}
 
+// PathPointSet takes ownership of passed in object
+%pythonappend OpenSim::PathPointSet::insert %{
+    aObject._markAdopted()
+%}
 // Typemaps
 // ========
 // None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v4.4.1
 ======
 
 - Made `Component::getSocketNames` a `const` member method (previously: non-const)
+- Modifed the swig interface files to make OpenSim::PathPointSet adopt new PathPoints inserted into it. (Issue #3276)
 
 v4.4
 ====


### PR DESCRIPTION
Fixes issue #3274 
### Brief summary of changes
Bindings for Python and Java now mark the passed in object to PathPointSet::insert as owned by the Set so it doesn't get double deleted or garbage collected early from scripting environment

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3276)
<!-- Reviewable:end -->
