### PR TITLE
Fix IPOPT library install with only OPENSIM_WITH_CASADI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v4.4.1
 ======
 
 - Made `Component::getSocketNames` a `const` member method (previously: non-const)
+- Fixed an issue with IPOPT libraries when building OpenSim with `OPENSIM_WITH_CASADI = ON` but `OPENSIM_WITH_TROPTER = OFF` (Issue #3267).
 
 v4.4
 ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,20 +862,20 @@ if(UNIX)
 endif()
 
 if (OPENSIM_WITH_CASADI OR OPENSIM_WITH_TROPTER)
-	if(UNIX)
-		pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)
-	else()
-		find_package(Ipopt REQUIRED CONFIG)
-		set_package_properties(IPOPT PROPERTIES
-				URL https://projects.coin-or.org/Ipopt
-				TYPE REQUIRED
-				PURPOSE "Nonlinear optimization")
-		# Flags to use when building a shared library.
-		# TODO move these flags to a specific target.
-		# TODO set(CMAKE_SHARED_LINKER_FLAGS
-		# TODO        "${CMAKE_SHARED_LINKER_FLAGS} ${IPOPT_LINK_FLAGS}")
-		OpenSimCopyDependencyDLLsForWin(DEP_NAME IPOPT DEP_BIN_DIR "${Ipopt_ROOT_DIR}/bin")
-	endif()
+    if(UNIX)
+        pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)
+    else()
+        find_package(Ipopt REQUIRED CONFIG)
+        set_package_properties(IPOPT PROPERTIES
+                URL https://projects.coin-or.org/Ipopt
+                TYPE REQUIRED
+                PURPOSE "Nonlinear optimization")
+        # Flags to use when building a shared library.
+        # TODO move these flags to a specific target.
+        # TODO set(CMAKE_SHARED_LINKER_FLAGS
+        # TODO        "${CMAKE_SHARED_LINKER_FLAGS} ${IPOPT_LINK_FLAGS}")
+        OpenSimCopyDependencyDLLsForWin(DEP_NAME IPOPT DEP_BIN_DIR "${Ipopt_ROOT_DIR}/bin")
+    endif()
 endif()
 
 # Installing dependencies into OpenSim's installation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,16 @@ if(OPENSIM_WITH_CASADI)
     endif()
 endif()
 
+# IPOPT
+# -----
+
+# Avoid using pkg-config on Windows as it's not easy to get
+# on Windows. On UNIX, the pkg-config file for Ipopt provides
+# a flag that we must use.
+if(UNIX)
+    find_package(PkgConfig REQUIRED)
+endif()
+
 if (OPENSIM_WITH_CASADI OR OPENSIM_WITH_TROPTER)
 	if(UNIX)
 		pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,6 +851,22 @@ if(OPENSIM_WITH_CASADI)
     endif()
 endif()
 
+if (OPENSIM_WITH_CASADI OR OPENSIM_WITH_TROPTER)
+	if(UNIX)
+		pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)
+	else()
+		find_package(Ipopt REQUIRED CONFIG)
+		set_package_properties(IPOPT PROPERTIES
+				URL https://projects.coin-or.org/Ipopt
+				TYPE REQUIRED
+				PURPOSE "Nonlinear optimization")
+		# Flags to use when building a shared library.
+		# TODO move these flags to a specific target.
+		# TODO set(CMAKE_SHARED_LINKER_FLAGS
+		# TODO        "${CMAKE_SHARED_LINKER_FLAGS} ${IPOPT_LINK_FLAGS}")
+		OpenSimCopyDependencyDLLsForWin(DEP_NAME IPOPT DEP_BIN_DIR "${Ipopt_ROOT_DIR}/bin")
+	endif()
+endif()
 
 # Installing dependencies into OpenSim's installation.
 # ----------------------------------------------------

--- a/Vendors/tropter/CMakeLists.txt
+++ b/Vendors/tropter/CMakeLists.txt
@@ -84,21 +84,6 @@ set_package_properties(ADOLC PROPERTIES
         PURPOSE "Computing derivatives for optimization")
 tropter_copy_dlls(DEP_NAME ADOLC DEP_INSTALL_DIR "${ADOLC_DIR}/bin")
 
-if(UNIX)
-    pkg_check_modules(IPOPT REQUIRED ipopt IMPORTED_TARGET)
-else()
-    find_package(Ipopt REQUIRED CONFIG)
-    set_package_properties(IPOPT PROPERTIES
-            URL https://projects.coin-or.org/Ipopt
-            TYPE REQUIRED
-            PURPOSE "Nonlinear optimization")
-    # Flags to use when building a shared library.
-    # TODO move these flags to a specific target.
-    # TODO set(CMAKE_SHARED_LINKER_FLAGS
-    # TODO        "${CMAKE_SHARED_LINKER_FLAGS} ${IPOPT_LINK_FLAGS}")
-    tropter_copy_dlls(DEP_NAME IPOPT DEP_INSTALL_DIR "${Ipopt_ROOT_DIR}/bin")
-endif()
-
 # OpenMP allows parallelization (of evaluating dynamics and path constraints
 # across tropter points) and is usually a feature of a compiler. It's fine if
 # the compiler does not support OpenMP.

--- a/Vendors/tropter/CMakeLists.txt
+++ b/Vendors/tropter/CMakeLists.txt
@@ -63,13 +63,6 @@ set_package_properties(Eigen3 PROPERTIES
         TYPE REQUIRED
         PURPOSE "Matrix library")
 
-# Avoid using pkg-config on Windows as it's not easy to get
-# on Windows. On UNIX, the pkg-config file for Ipopt provides
-# a flag that we must use.
-if(UNIX)
-    find_package(PkgConfig REQUIRED)
-endif()
-
 # ColPack can now use CMake to be built.
 find_package(ColPack 1.0.10 REQUIRED HINTS "${OPENSIM_DEPENDENCIES_DIR}/colpack")
 set_package_properties(ColPack PROPERTIES

--- a/cmake/FindIPOPT.cmake
+++ b/cmake/FindIPOPT.cmake
@@ -83,7 +83,7 @@
 # Additional support to YCM was received from the FP7 EU project
 # WALK-MAN (http://walk-man.eu/)
 
-
+message("in FindIPOPT.cmake")
 if(NOT WIN32)
   # On non Windows systems we use PkgConfig to find IPOPT
   find_package(PkgConfig QUIET)

--- a/cmake/FindIPOPT.cmake
+++ b/cmake/FindIPOPT.cmake
@@ -83,7 +83,6 @@
 # Additional support to YCM was received from the FP7 EU project
 # WALK-MAN (http://walk-man.eu/)
 
-message("in FindIPOPT.cmake")
 if(NOT WIN32)
   # On non Windows systems we use PkgConfig to find IPOPT
   find_package(PkgConfig QUIET)


### PR DESCRIPTION
Fixes issue #3267 

### Brief summary of changes
Moved the logic for IPOPT libraries out of the Vendors/tropter folder and into the base CMakeLists file

### Testing I've completed
With `OPENSIM_WITH_CASADI = ON` and `OPENSIM_WITH_TROPER = OFF`, ran tests and a few Moco examples through MATLAB successfully

### Looking for feedback on...
Local testing on another platform would be helpful since there are different branches for Windows and not-Windows,

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3278)
<!-- Reviewable:end -->
