### PR TITLE
Add build on ubuntu 20.04 without moco

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -609,6 +609,108 @@ jobs:
         # bits. So we zip ourselves, even though this causes a double-zip.
         name: opensim-core-${{ steps.configure.outputs.version }}-linux
         path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
+  ubuntu20-nomoco:
+    name: Ubuntu2004-nomoco
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools
+
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
+        tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/opensim_dependencies_install
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+
+    - name: Build dependencies
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
+
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "::set-output name=version::$VERSION"
+
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
+
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        # TODO: Temporary for python to find Simbody libraries.
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+        # ctest --parallel 4 --output-on-failure
+
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make --jobs 4 install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
+        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+
+    # - name: Test Python bindings
+    #   run: |
+    #     echo "TODO: Skipping Python tests."
+    #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+    #     # Run the python tests, verbosely.
+    #     # python3 -m unittest discover --start-directory opensim/tests --verbose
+
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v2
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ steps.configure.outputs.version }}-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco.zip
 
   style:
     name: Style

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -607,7 +607,7 @@ jobs:
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-linux
+        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-linux
         path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
   ubuntu20-nomoco:
     name: Ubuntu2004-nomoco
@@ -709,8 +709,8 @@ jobs:
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-linux
-        path: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco.zip
+        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
 
   style:
     name: Style


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Add one more build option on ubuntu without moco for potential use by opencap
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3290)
<!-- Reviewable:end -->
