### PR TITLE
included MocoOutputExtremumGoal functionality

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -427,7 +427,7 @@ jobs:
         key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
     - name: Build dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         mkdir $GITHUB_WORKSPACE/../build_deps
         cd $GITHUB_WORKSPACE/../build_deps

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,8 @@ Moco Change Log
 
 1.2.0
 -----
+- 2023-01-19: Added MocoOutputExtremumGoal.
+
 - 2022-09-07: Added MocoContactImpulseTrackingGoal.
 
 - 2022-06-03: Fixed bug that was breaking marker tracking problems when

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -207,14 +207,14 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
     OPENSIM_THROW_IF_FRMOBJ(m_minimizeVectorNorm == 1 &&
                                         m_data_type == Type_Vec3,
             Exception, "The MocoOutputExtremumGoal cannot be used when "
-            "taking the norm of an ouput of SimTK::Vec3 type. Use the "
+            "taking the norm of an output of SimTK::Vec3 type. Use the "
             "MocoOutputGoal instead.");
 
     OPENSIM_THROW_IF_FRMOBJ(
              m_minimizeVectorNorm == 1 && m_data_type == Type_SpatialVec,
              Exception,
              "The MocoOutputExtremumGoal cannot be used when "
-             "taking the norm of an ouput of SimTK::SpatialVec type. Use the "
+             "taking the norm of an output of SimTK::SpatialVec type. Use the "
              "MocoOutputGoal instead.");
     
     if (get_extremum_type() == "minimum") { 
@@ -228,6 +228,11 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
 
 void MocoOutputExtremumGoal::calcIntegrandImpl(
         const IntegrandInput& input, double& integrand) const {
+    OPENSIM_THROW_IF_FRMOBJ(
+            get_smoothing_factor() < 0.2 || get_smoothing_factor() > 1.0,
+            Exception,
+            "The smoothing factor must be on the closed interval "
+            "[0.2,1.0].");
     double integrand_temp =
             (1 / get_smoothing_factor()) *
             (std::log(1 + exp(get_smoothing_factor() * m_beta *

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -229,7 +229,7 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
 void MocoOutputExtremumGoal::calcIntegrandImpl(
         const IntegrandInput& input, double& integrand) const {
     OPENSIM_THROW_IF_FRMOBJ(
-            get_smoothing_factor() < 0.2 || get_smoothing_factor() > 1.0,
+            get_smoothing_factor() <= 0.2 || get_smoothing_factor() >= 1.0,
             Exception,
             "The smoothing factor must be on the closed interval "
             "[0.2,1.0].");

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -205,7 +205,7 @@ The goal is computed as follows:
 
 \f[
 \frac{1}{dm} \int_{t_i}^{t_f} 
-    w_vB((\frac{1}{s} (\ln (1 + \exp (s\betav))))^p) ~dt
+    w_v\beta((\frac{1}{s} (\ln (1 + \exp (s\betav))))^p) ~dt
 \f]
 We use the following notation:
 - \f$ d \f$: displacement of the system, if `divide_by_displacement` is
@@ -214,14 +214,12 @@ We use the following notation:
   true; 1 otherwise.
 - \f$ v \f$: the output variable of choice.
 - \f$ w_v \f$: the weight for output variable \f$ v \f$.
-- \f$ B \f$: the approximate extremum to be taken (B = -1 for minimum;
-  B = 1 for maximum).
+- \f$ \beta \f$: the approximate extremum to be taken (\beta == -1 for
+  minimum; \beta == 1 for maximum).
 - \f$ s \f$: the smoothing factor for approximating the extremum. With
-  \f$ s \f$ set to >= 1 the approximation is closer to the true extremum
-  to be taken, whilst if it is set to < 1 the approximation is further 
-  from the true extremum (more smoothing). For \f$ v \f$ with magnitudes
-  between 1-3000 during a simulation it is recommended to set this value
-  as 0.2 to prevent the exponential operator from reaching Inf.
+  \f$ s \f$ == 1 the approximation is closer to the true extremum taken.
+  For \f$ v \f$ with potentially large magnitudes (> 2000) during a simulation
+  it is recommended to set this property as 0.2 to avoid Inf.
 - \f$ p \f$: the `exponent`.
 */
 class OSIMMOCO_API MocoOutputExtremumGoal : public MocoOutputBase {
@@ -255,7 +253,10 @@ public:
     }
     std::string getExtremumType() const { return get_extremum_type(); }
 
-    /** Set the smoothing factor used for the extremum approximation. */
+    /** Set the smoothing factor (Default = 1) used for the extremum
+    approximation. It is recommended to set this property to 0.2 to prevent
+    the calculation returning Inf in circumstances when the output may reach
+    large magnitudes (> 2000) during a simulation. */
     void setSmoothingFactor(double smoothing_factor) {
         set_smoothing_factor(smoothing_factor);
     }
@@ -282,17 +283,10 @@ private:
             "(Default extremum type = 'minimum').");
     OpenSim_DECLARE_PROPERTY(smoothing_factor, double,
             "The smoothing factor applied in the approximation of the "
-            "extremum function (Default extremum scaler = 1). For outputs "
-            "with magnitudes between 1-3000 during a simulation it is "
-            "recommended to set this property as 0.2 to prevent the "
-            "calculation from reaching Inf."
-            "For example, if the extremum_type is 'maximum', "
-            "smoothing_factor = 1, and the output variable = 30000; it "
-            "returns Inf. Decrease the smoothing_factor = 0.2; it returns "
-            "3000.0 recurring. With output variable = 25 and "
-            "smoothing_factor = 0.2; it returns 25.0335767. With output "
-            "variable = 25 and smoothing_factor = 1; it returns 25.0 "
-            "recurring.");
+            "extremum function (Default = 1). For outputs with "
+            "potentially large magnitudes (> 2000) during a simulation "
+            "it is recommended to set this property to 0.2 to prevent "
+            "the calculation from reaching Inf.");
 
     enum DataType {
         Type_double,

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -253,10 +253,10 @@ public:
     }
     std::string getExtremumType() const { return get_extremum_type(); }
 
-    /** Set the smoothing factor (Default = 1) used for the extremum
-    approximation. It is recommended to set this property to 0.2 to prevent
-    the calculation returning Inf in circumstances when the output may reach
-    large magnitudes (> 2000) during a simulation. */
+    /** Set the smoothing factor used for the extremum approximation
+    (default = 1.0). This property can be set between [0.2, 1.0]. For Outputs
+    that may take on large values (> ~2000) during a simulation, it is
+    recommended to set this property closer to 0.2.*/
     void setSmoothingFactor(double smoothing_factor) {
         set_smoothing_factor(smoothing_factor);
     }
@@ -283,10 +283,10 @@ private:
             "(Default extremum type = 'minimum').");
     OpenSim_DECLARE_PROPERTY(smoothing_factor, double,
             "The smoothing factor applied in the approximation of the "
-            "extremum function (Default = 1). For outputs with "
-            "potentially large magnitudes (> 2000) during a simulation "
-            "it is recommended to set this property to 0.2 to prevent "
-            "the calculation from reaching Inf.");
+            "extremum function (default = 1.0). This property can be set "
+            "between [0.2, 1.0]. For Outputs that may take on large values "
+            "(> ~2000) during a simulation, it is recommended to set this "
+            "property closer to 0.2.");
 
     enum DataType {
         Type_double,


### PR DESCRIPTION
### Brief summary of changes
Within MocoOutputGoal.h/.cpp I, with the help of Reed and Nick, have included a new goal, MocoOutputGoalExtremum, it is very similar to the original MocoOutputGoal. The goal permits the integration of only positive or negative values from a model output.

### Testing I've completed
So far I have tested it locally on the walking_2d.cpp example and it is producing results as anticipated.

### Looking for feedback on...

### CHANGELOG.md (choose one)
I think I need to update the CHANGELOG_MOCO.md to include the 'MocoOutputGoalExtremum'.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3293)
<!-- Reviewable:end -->
