### PR TITLE
Changed Java and JNI minimum version to 1.8 in cmake.

### DIFF
--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -75,7 +75,7 @@ add_subdirectory(OpenSimJNI)
 
 # Compile java sources.
 # ---------------------
-find_package(Java 1.7 REQUIRED)
+find_package(Java 1.8 REQUIRED)
 
 # To avoid compiling stale .java files, delete any existing files and copy
 # over the new files from the module-specific directories (see
@@ -109,7 +109,7 @@ add_custom_command(
             ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
     COMMAND ${JAVA_COMPILE}
             org/opensim/modeling/*.java 
-            -source 1.7 -target 1.7
+            -source 1.8 -target 1.8
     COMMAND ${JAVA_ARCHIVE} -cvf ${SWIG_JAVA_JAR_NAME}
             org/opensim/modeling/*.class
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src

--- a/Bindings/Java/OpenSimJNI/CMakeLists.txt
+++ b/Bindings/Java/OpenSimJNI/CMakeLists.txt
@@ -2,7 +2,7 @@ set(KIT JavaJNI)
 set(UKIT JAVAJNI)
 
 # For building C++ wrapper.
-find_package(JNI 1.7 REQUIRED)
+find_package(JNI 1.8 REQUIRED)
 
 # Avoid excessive compiler warnings. We set these COMPILE_OPTIONS in the root
 # CMakeLists.txt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ v4.4.1
 - Fixed an issue with IPOPT libraries when building OpenSim with `OPENSIM_WITH_CASADI = ON` but `OPENSIM_WITH_TROPTER = OFF` (Issue #3267).
 - Removed all references to deprecated environment variable `OPENSIM_HOME`.
 - Fix issue where templatized Property classes are not available to Objects defined in plugins.
-
+- Minimum supported version for Java is now 1.8 in the cmake files (Issue #3215).
 
 v4.4
 ====


### PR DESCRIPTION
Fixes issue #3215 

### Brief summary of changes

In the case of CMake not finding Java or JNI, it was showing an error indicating that Java or JNI +1.7 should be installed. However, we currently minimum supported version is 1.8. In order to not confuse users, I changed it.

### Testing I've completed

Building on my machine (Ubuntu 22.04) and CI.

### Looking for feedback on...

N/A.

### CHANGELOG.md (choose one)

- Updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3317)
<!-- Reviewable:end -->
