### PR TITLE
Fix mac libgcc problem

### DIFF
--- a/Vendors/tropter/cmake/CMakeLists.txt
+++ b/Vendors/tropter/cmake/CMakeLists.txt
@@ -23,6 +23,7 @@ if(TROPTER_COPY_DEPENDENCIES AND APPLE)
             ${gfortran}
             ${quadmath}
             ${gcc_libdir}/libgcc_s.1.dylib
+            ${gcc_libdir}/libgcc_s.1.1.dylib
 
             DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/Vendors/tropter/cmake/tropter_install_mac_dependency_libraries.cmake.in
+++ b/Vendors/tropter/cmake/tropter_install_mac_dependency_libraries.cmake.in
@@ -54,7 +54,7 @@ macro(install_name_tool_delete_rpath lib rpath)
 endmacro()
 
 # Get the directory containing libgcc_s.1.dylib.
-# otool: Get the list of dependencies of gfortran, which includes libgcc_s.
+# otool: Get the list of dependencies of coinmumps, which includes libgcc_s.
 # grep: Isolate the line containing libgcc.
 # perl: Extract only the directory, without the filename.
 #    ^\\s+     matches all spaces at the start of the string.
@@ -62,7 +62,7 @@ endmacro()
 #   \\/libg.*  matches the rest of the line.
 #   \\1        replaces the contents of the entire match with match group #1
 execute_process(COMMAND bash "-c"
-    "otool -L ${libdir}/libgfortran.dylib | grep 'libgcc' | perl -pe 's/^\\s+(.*)\\/libg.*/\\1/gc'"
+    "otool -L ${libdir}/libcoinmumps.dylib | grep 'libgcc' | perl -pe 's/^\\s+(.*)\\/libg.*/\\1/gc'"
     OUTPUT_VARIABLE libgcc_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -93,7 +93,7 @@ install_name_tool_change_quadmath(ipopt.1)
 install_name_tool_id(coinmumps.1)
 install_name_tool_change(coinmumps.1 coinmetis.1 "@IPOPT_LIBDIR@")
 install_name_tool_change_gfortran(coinmumps.1)
-install_name_tool_change(coinmumps.1 gcc_s.1 "${libgcc_dir}")
+install_name_tool_change(coinmumps.1 gcc_s.1.1 "${libgcc_dir}")
 install_name_tool_change_quadmath(coinmumps.1)
 install_name_tool_add_rpath(coinmumps.1)
 
@@ -109,16 +109,16 @@ install_name_tool_add_rpath(coinmetis.1)
 
 # gfortran
 install_name_tool_id(gfortran)
-install_name_tool_change(gfortran gcc_s.1 "${libgcc_dir}")
+install_name_tool_change(gfortran gcc_s.1.1 "${libgcc_dir}")
 install_name_tool_change_quadmath(gfortran)
 install_name_tool_change_quadmath(gfortran.5)
 install_name_tool_add_rpath(gfortran)
 install_name_tool_add_rpath(gfortran.5)
 
 # gcc_s
-install_name_tool_id(gcc_s.1)
+install_name_tool_id(gcc_s.1.1)
 
 # quadmath
 install_name_tool_id(quadmath.0)
-install_name_tool_change(quadmath.0 gcc_s.1 "${libgcc_dir}")
+install_name_tool_change(quadmath.0 gcc_s.1.1 "${libgcc_dir}")
 install_name_tool_add_rpath(quadmath.0)


### PR DESCRIPTION
Fixes issue #3320 and #3295.

### Brief summary of changes

The script was extracting the directory containing `libgcc_s.1.dylib` from `libgfortran.dylib`, however, it was returning `@rpath/libgcc_s.1.1.dylib` instead of the original path `/usr/local/opt/gcc/lib/gcc/current/libgcc_s.1.1.dylib`. Thus, when trying to update it in the rest of libraries, it was not finding `@rpath/libgcc_s.1.1.dylib`, and not updating it.

Now, I am extracting the directory containing `libgcc_s.1.dylib` from `libcoinmumps.dylib` instead, since we are sure that library has the expected value.

Also, I have changed the name of the library from `libgcc_s.1` to `libgcc_s.1.1`, since it is asking for `libgcc_s.1.1` (but it is still compatible with `libgcc_s.1`). The library `libgcc_s.1.1.dylib` is now also copied with the rest of dependencies.

**Note: If the machine has installed gcc with brew, it will work, since the missing library is included with it.**

### Testing I've completed

- Build and execute on MacOS Big Sur 11 (virtual machine), using `otool -L` to make sure the paths are correct.
- Build on CI in my fork and execute on a clean MacOS Big Sur 11 (virtual machine).
- Manually removed the library in the installed files to check if the error appears again (and check that it wasn't working for any other reason, like retrieving the library from the gcc installation).

### Looking for feedback on...

Test on real MacOS machines, and different versions.

### CHANGELOG.md (choose one)

- no need to update because this is a CI/makefiles issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3334)
<!-- Reviewable:end -->
