### PR TITLE
Exit parsing header if line of data is encountered.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ v4.4.1
 - Removed all references to deprecated environment variable `OPENSIM_HOME`.
 - Fix issue where templatized Property classes are not available to Objects defined in plugins.
 - Minimum supported version for Java is now 1.8 in the cmake files (Issue #3215).
+- Fix CSV file adapter hanging on csv files that are missing end-header (issue #2432).
 
 v4.4
 ====

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -340,9 +340,11 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
         if(std::regex_match(line, endheader))
             break;
         // Exit this loop for parsing header if we hit data line
-        // this may blow up downstream but at least we don't hang
+        // this will blow up immediately rather than hang
         if (std::regex_match(line, dataLine))
-            break;
+            OPENSIM_THROW(
+                Exception,
+                "Missing end of header block");
 
         // Detect Key value pairs of the form "key = value" and add them to
         // metadata.

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -325,7 +325,7 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     std::regex keyvalue{R"((.*)=(.*))"};
     std::string header{};
     std::string line{};
-    std::string numberOrDelim = "[0-9."+_delimitersRead+" -]+";
+    std::string numberOrDelim = "[0-9][0-9."+_delimitersRead+" -]+";
     std::regex dataLine{ numberOrDelim };
     ValueArrayDictionary keyValuePairs;
     while(std::getline(in_stream, line)) {

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -325,6 +325,8 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     std::regex keyvalue{R"((.*)=(.*))"};
     std::string header{};
     std::string line{};
+    std::string numberOrDelim = "[0-9."+_delimitersRead+" -]+";
+    std::regex dataLine{ numberOrDelim };
     ValueArrayDictionary keyValuePairs;
     while(std::getline(in_stream, line)) {
         ++line_num;
@@ -336,6 +338,10 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
             line.pop_back();
 
         if(std::regex_match(line, endheader))
+            break;
+        // Exit this loop for parsing header if we hit data line
+        // this may blow up downstream but at least we don't hang
+        if (std::regex_match(line, dataLine))
             break;
 
         // Detect Key value pairs of the form "key = value" and add them to


### PR DESCRIPTION
Fixes issue #2432 

### Brief summary of changes
Check if a line of data (not key=value or other acceptable non-data) is encountered during parsing header.
### Testing I've completed
Tried loading csv file from APDM using CSVFileAdapter failed quickly rather than hung.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- will update once reviewed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3338)
<!-- Reviewable:end -->
