### PR TITLE
Mark passed in function to TransformAxis::setFunction as adopted 

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -215,3 +215,12 @@ using namespace SimTK;
 %import "java_common.i"
 opensim_unique_ptr(OpenSim::PositionMotion);
 %include <Bindings/simulation.i>
+
+%javamethodmodifiers OpenSim::TransformAxis::setFunction "private"
+%rename OpenSim::TransformAxis::setFunction private_setFunction;
+%typemap(javacode) OpenSim::TransformAxis %{
+  public void setFunction(Function adoptee) {
+      adoptee.markAdopted();
+      private_setFunction(adoptee);
+  }
+%}

--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -212,15 +212,16 @@ using namespace SimTK;
   }
 %}
 
+%javamethodmodifiers OpenSim::TransformAxis::setFunction "private";
+%rename OpenSim::TransformAxis::setFunction private_setFunction;
+%typemap(javacode) OpenSim::TransformAxis %{
+  public void setFunction(Function func) {
+      func.markAdopted();
+      private_setFunction(func);
+  }
+%}
+
 %import "java_common.i"
 opensim_unique_ptr(OpenSim::PositionMotion);
 %include <Bindings/simulation.i>
 
-%javamethodmodifiers OpenSim::TransformAxis::setFunction "private"
-%rename OpenSim::TransformAxis::setFunction private_setFunction;
-%typemap(javacode) OpenSim::TransformAxis %{
-  public void setFunction(Function adoptee) {
-      adoptee.markAdopted();
-      private_setFunction(adoptee);
-  }
-%}

--- a/Bindings/Java/tests/TestModelBuilding.java
+++ b/Bindings/Java/tests/TestModelBuilding.java
@@ -68,7 +68,15 @@ class TestModelBuilding {
 
         WrapEllipsoid ellipsoid = new WrapEllipsoid();
         arm.getGround().addWrapObject(ellipsoid);
-
+        {
+            // test TrasnformAxis.setFunction issue #3210
+            StepFunction stepFunction = new StepFunction(0.5, 3.0, 0.3, 1.0);
+            TransformAxis transformAxis = new TransformAxis();
+            transformAxis.setFunction(stepFunction);
+            System.gc(); // Request gc could free stepFunction and crash
+            Function f = transformAxis.getFunction();
+            System.out.println(f.dump());
+        }
         System.out.println("Test finished!");
     }
     catch (IOException ex){


### PR DESCRIPTION
Avoid function getting garbage collected prematurely by communicating transfer of memory ownership to scripting environment

Fixes issue #3210 

### Brief summary of changes

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3340)
<!-- Reviewable:end -->
