### PR TITLE
Add center of pressure calculations to `MocoUtilities::createExternalLoadsTableForGait()`

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-01-03: Add center of pressure calculations to 
+              `MocoUtilities::createExternalLoadsTableForGait`.
+
 - 2022-07-25: Added property `normalize_tracking_error` to `MocoContactTrackingGoal` 
               to normalize the 3D contact tracking error based on the contact 
               tracking data.

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -321,6 +321,7 @@ TimeSeriesTable OpenSim::createExternalLoadsTableForGait(Model model,
         // Compute centers of pressure for both feet. We need to use the force
         // and torque information from the half space to compute the correct
         // locations.
+        // TODO: Support contact plane normals in any direction.
         SimTK::Vec3 copRight(0);
         copRight(0) = halfSpaceTorquesRight(2) / halfSpaceForcesRight(1);
         copRight(2) = -halfSpaceTorquesRight(0) / halfSpaceForcesRight(1);

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -283,36 +283,60 @@ TimeSeriesTable OpenSim::createExternalLoadsTableForGait(Model model,
     int count = 0;
     for (const auto& state : trajectory) {
         model.realizeVelocity(state);
-        SimTK::Vec3 forcesRight(0);
-        SimTK::Vec3 torquesRight(0);
+        SimTK::Vec3 sphereForcesRight(0);
+        SimTK::Vec3 sphereTorquesRight(0);
+        SimTK::Vec3 halfSpaceForcesRight(0);
+        SimTK::Vec3 halfSpaceTorquesRight(0);
         // Loop through all Forces of the right side.
         for (const auto& smoothForce : forcePathsRightFoot) {
             Array<double> forceValues =
                     model.getComponent<Force>(smoothForce).getRecordValues(state);
-            forcesRight += SimTK::Vec3(forceValues[0], forceValues[1],
+            sphereForcesRight += SimTK::Vec3(forceValues[0], forceValues[1],
                     forceValues[2]);
-            torquesRight += SimTK::Vec3(forceValues[3], forceValues[4],
+            sphereTorquesRight += SimTK::Vec3(forceValues[3], forceValues[4],
                     forceValues[5]);
+            halfSpaceForcesRight += SimTK::Vec3(forceValues[6], forceValues[7],
+                    forceValues[8]);
+            halfSpaceTorquesRight += SimTK::Vec3(forceValues[9], forceValues[10],
+                    forceValues[11]);
         }
-        SimTK::Vec3 forcesLeft(0);
-        SimTK::Vec3 torquesLeft(0);
+        SimTK::Vec3 sphereForcesLeft(0);
+        SimTK::Vec3 sphereTorquesLeft(0);
+        SimTK::Vec3 halfSpaceForcesLeft(0);
+        SimTK::Vec3 halfSpaceTorquesLeft(0);
         // Loop through all Forces of the left side.
         for (const auto& smoothForce : forcePathsLeftFoot) {
             Array<double> forceValues =
                     model.getComponent<Force>(smoothForce).getRecordValues(state);
-            forcesLeft += SimTK::Vec3(forceValues[0], forceValues[1],
+            sphereForcesLeft += SimTK::Vec3(forceValues[0], forceValues[1],
                     forceValues[2]);
-            torquesLeft += SimTK::Vec3(forceValues[3], forceValues[4],
+            sphereTorquesLeft += SimTK::Vec3(forceValues[3], forceValues[4],
                     forceValues[5]);
+            halfSpaceForcesLeft += SimTK::Vec3(forceValues[6], forceValues[7],
+                    forceValues[8]);
+            halfSpaceTorquesLeft += SimTK::Vec3(forceValues[9], forceValues[10],
+                    forceValues[11]);
         }
+
+        // Compute centers of pressure for both feet. We need to use the force
+        // and torque information from the half space to compute the correct
+        // locations.
+        SimTK::Vec3 copRight(0);
+        copRight(0) = halfSpaceTorquesRight(2) / halfSpaceForcesRight(1);
+        copRight(2) = -halfSpaceTorquesRight(0) / halfSpaceForcesRight(1);
+
+        SimTK::Vec3 copLeft(0);
+        copLeft(0) = halfSpaceTorquesLeft(2) / halfSpaceForcesLeft(1);
+        copLeft(2) = -halfSpaceTorquesLeft(0) / halfSpaceForcesLeft(1);
+
         // Append row to table.
         SimTK::RowVector_<SimTK::Vec3> row(6);
-        row(0) = forcesRight;
-        row(1) = SimTK::Vec3(0);
-        row(2) = forcesLeft;
-        row(3) = SimTK::Vec3(0);
-        row(4) = torquesRight;
-        row(5) = torquesLeft;
+        row(0) = sphereForcesRight;
+        row(1) = copRight;
+        row(2) = sphereForcesLeft;
+        row(3) = copLeft;
+        row(4) = sphereTorquesRight;
+        row(5) = sphereTorquesLeft;
         externalForcesTable.appendRow(state.getTime(), row);
         ++count;
     }

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -224,20 +224,41 @@ private:
 /// Obtain the ground reaction forces, centers of pressure, and torques
 /// resulting from Force elements (e.g., SmoothSphereHalfSpaceForce), using a
 /// model and states trajectory. Forces and torques are expressed in the ground
-/// frame with respect to the ground origin. Hence, the centers of pressure are
-/// at the origin. Paths to Force elements should be provided separately for
-/// elements of the right and left feet. The output is a table formatted for use
-/// with OpenSim tools; the labels of the columns distinguish between right
-/// ("<>_r") and left ("<>_l") forces, centers of pressure, and torques. The
-/// forces and torques used are taken from the first six outputs of
-/// getRecordValues(); this order is of use for, for example, the
-/// SmoothSphereHalfSpaceForce contact model but might have a different meaning
-/// for different contact models. Centers of pressure are computed assuming the
-/// that the vertical ground contact force is in the y-direction, which is the
-/// OpenSim convention. In addition, the centers of pressure are computed using
-/// the force and torque values applied to the half space, which should be the
-/// second six outputs from getRecordValues() (this order also corresponds to
-/// the SmoothSphereHalfSpaceForces values).
+/// frame with respect to the ground origin. Paths to Force elements should be
+/// provided separately for elements of the right and left feet. The output is a
+/// table formatted for use with OpenSim tools; the labels of the columns
+/// distinguish between right ("<>_r") and left ("<>_l") forces, centers of
+/// pressure, and torques. Centers of pressure are computed assuming the
+/// that the contact plane's normal is in the y-direction, which is the OpenSim
+/// convention.
+///
+/// The forces and torques are computed from the first six outputs of
+/// getRecordValues(), while the centers of pressure are computed from the second
+/// six outputs. The first six outputs should correspond to the contact force
+/// components applied to the foot bodies (e.g., the "sphere" forces in
+/// SmoothSphereHalfSpaceForce), and the second six outputs should correspond to
+/// the contact force components applied to the contact place (e.g., the
+/// "half-space" forces in SmoothSphereHalfSpaceForce). The contact plane is
+/// often attached to ground for foot-ground contact models, but it need not be,
+/// as long as the contact plane normal is in the y-direction.
+///
+/// In general, this utility needs getRecordValues() to report the
+/// following force and torque information at the specified indices:
+///
+/// index - component (body)
+/// ------------------------
+///     0 - force-x (foot)
+///     1 - force-y (foot)
+///     2 - force-z (foot)
+///     3 - torque-x (foot)
+///     4 - torque-y (foot)
+///     5 - torque-z (foot)
+///     6 - force-x (contact plane)
+///     7 - force-y (contact plane)
+///     8 - force-z (contact plane)
+///     9 - torque-x (contact plane)
+///    10 - torque-y (contact plane)
+///    11 - torque-z (contact plane)
 ///
 /// @ingroup mocoutil
 OSIMMOCO_API

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -232,7 +232,13 @@ private:
 /// forces and torques used are taken from the first six outputs of
 /// getRecordValues(); this order is of use for, for example, the
 /// SmoothSphereHalfSpaceForce contact model but might have a different meaning
-/// for different contact models.
+/// for different contact models. Centers of pressure are computed assuming the
+/// that the vertical ground contact force is in the y-direction, which is the
+/// OpenSim convention. In addition, the centers of pressure are computed using
+/// the force and torque values applied to the half space, which should be the
+/// second six outputs from getRecordValues() (this order also corresponds to
+/// the SmoothSphereHalfSpaceForces values).
+///
 /// @ingroup mocoutil
 OSIMMOCO_API
 TimeSeriesTable createExternalLoadsTableForGait(Model model,


### PR DESCRIPTION
### Brief summary of changes
We currently only return net forces and torques from contact spheres when using `MocoUtilities::createExternalLoadsTableForGait()`.  This PR adds center of pressure calculations to complete the information in the returned external loads tables.

[Here is a useful reference](http://www.kwon3d.com/theory/grf/cop.html) for computing center of pressure locations.

### Testing I've completed
Local testing only, but can add unit/regression tests as requested. 

### Looking for feedback on...
- Center of pressure values are currently calculated based on the OpenSim convention that the vertical ground contact forces is pointing the y-direction. If someone uses this function with results using a different convention, the center of pressure values will be incorrect (the forces and torques shouldn't be affected though). Should we support different conventions for the orientation of ground contact forces?

- In order to compute the correct center of pressure values, the forces and torques applied to the ground (e.g., the half space, if using `SmoothSphereHalfSpaceForce`) must be used. The current implementation, including renamed variables, is based on `SmoothSphereHalfSpaceForce`, where the half space force and torque values are returned by the second group of six values returned `getRecordValues()`  (the first group of six values are the sphere force and torque values). Should we take into consideration other contact force elements that might use different conventions to return foot and ground force information? We should definitely consider how to handle @fcanderson's new contact model (#3310), if that is to be used extensively with Moco.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3351)
<!-- Reviewable:end -->
