### PR TITLE
Clarify the behavior of exponents in `MocoOutputGoal`

### DIFF
--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -63,7 +63,12 @@ public:
     const std::string& getOutputPath() const { return get_output_path(); }
 
     /** Set the exponent applied to the output value in the integrand. This
-    exponent is applied when minimizing the norm of a vector type output. */
+    exponent is applied when minimizing the norm of a vector type output. The
+    default exponent is set to 1, meaning that the output can take on negative
+    values in the integrand. When the exponent is set to a value greater than
+    1, the absolute value function is applied to the output (before the
+    exponent is applied), meaning that odd numbered exponents (greater than 1)
+    do not take on negative values. */
     void setExponent(int exponent) { set_exponent(exponent); }
     int getExponent() const { return get_exponent(); }
 
@@ -112,8 +117,13 @@ private:
             "The absolute path to the output in the model to use as the "
             "integrand for this goal.");
     OpenSim_DECLARE_PROPERTY(exponent, int,
-            "The exponent applied to the output value in the integrand "
-            "(default: 1).");
+            "The exponent applied to the output value in the integrand. "
+            "The output can take on negative values in the integrand when the "
+            "exponent is set to 1 (the default value). When the exponent is "
+            "set to a value greater than 1, the absolute value function is "
+            "applied to the output (before the exponent is applied), meaning "
+            "that odd numbered exponents (greater than 1) do not take on "
+            "negative values.");
     OpenSim_DECLARE_PROPERTY(output_index, int,
             "The index to the value to be minimized when a vector type "
             "Output is specified. For SpatialVec Outputs, indices 0, 1, "


### PR DESCRIPTION
Fixes issue #3294 

### Brief summary of changes
Add clarification to `MocoOutputGoal::setExponent()` to clarify how different exponent values allow or do not allow negative values.

### CHANGELOG.md (choose one)

- no need to update because...simple documentation update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3363)
<!-- Reviewable:end -->
