### PR TITLE
Add support to change endpoint constraint bounds in scripting // fix failing tests when CasADi + Tropter are disabled

### DIFF
--- a/Bindings/Python/tests/test_moco.py
+++ b/Bindings/Python/tests/test_moco.py
@@ -241,8 +241,8 @@ class TestSwigAddtlInterface(unittest.TestCase):
     def test_StdVectorMocoBounds(self):
         bounds = osim.StdVectorMocoBounds()
         bounds.append(osim.MocoBounds(1.23, 4.56))
-        assert(bounds.get(0).getLower() == 1.23)
-        assert(bounds.get(0).getUpper() == 4.56)
+        assert(bounds[0].getLower() == 1.23)
+        assert(bounds[0].getUpper() == 4.56)
 
 class TestWorkflow(unittest.TestCase):
 

--- a/Bindings/Python/tests/test_moco.py
+++ b/Bindings/Python/tests/test_moco.py
@@ -238,6 +238,12 @@ class TestSwigAddtlInterface(unittest.TestCase):
         pr = mp.createRep();
         assert(len(pr.createStateInfoNames()) == 2);
 
+    def test_StdVectorMocoBounds(self):
+        bounds = osim.StdVectorMocoBounds()
+        bounds.append(osim.MocoBounds(1.23, 4.56))
+        assert(bounds.get(0).getLower() == 1.23)
+        assert(bounds.get(0).getUpper() == 4.56)
+
 class TestWorkflow(unittest.TestCase):
 
     def test_default_bounds(self):

--- a/Bindings/moco.i
+++ b/Bindings/moco.i
@@ -44,8 +44,6 @@ namespace OpenSim {
 %template(StdVectorMocoBounds) std::vector<OpenSim::MocoBounds>;
 
 %ignore OpenSim::MocoMultibodyConstraint::getKinematicLevels;
-//%ignore OpenSim::MocoConstraintInfo::getBounds;
-//%ignore OpenSim::MocoConstraintInfo::setBounds;
 %ignore OpenSim::MocoProblemRep::getMultiplierInfos;
 
 %include <OpenSim/Moco/MocoConstraint.h>

--- a/Bindings/moco.i
+++ b/Bindings/moco.i
@@ -39,10 +39,13 @@ namespace OpenSim {
 %include <OpenSim/Moco/MocoGoal/MocoInitialVelocityEquilibriumDGFGoal.h>
 %include <OpenSim/Moco/MocoGoal/MocoStepTimeAsymmetryGoal.h>
 %include <OpenSim/Moco/MocoGoal/MocoStepLengthAsymmetryGoal.h>
+%include <OpenSim/Moco/MocoConstraintInfo.h>
+
+%template(StdVectorMocoBounds) std::vector<OpenSim::MocoBounds>;
 
 %ignore OpenSim::MocoMultibodyConstraint::getKinematicLevels;
-%ignore OpenSim::MocoConstraintInfo::getBounds;
-%ignore OpenSim::MocoConstraintInfo::setBounds;
+//%ignore OpenSim::MocoConstraintInfo::getBounds;
+//%ignore OpenSim::MocoConstraintInfo::setBounds;
 %ignore OpenSim::MocoProblemRep::getMultiplierInfos;
 
 %include <OpenSim/Moco/MocoConstraint.h>

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -4,7 +4,7 @@ Moco Change Log
 1.2.1
 -----
 - 2023-01-24: Added convenience methods `MocoGoal::setEndpointConstraintBounds` and
-              `MocoGoal::getEndpointConstraintBounds`.        
+              `MocoGoal::getEndpointConstraintBounds`.
 
 - 2023-01-03: Add center of pressure calculations to 
               `MocoUtilities::createExternalLoadsTableForGait`.

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-01-24: Added convenience methods `MocoGoal::setEndpointConstraintBounds` and
+              `MocoGoal::getEndpointConstraintBounds`.        
+
 - 2023-01-03: Add center of pressure calculations to 
               `MocoUtilities::createExternalLoadsTableForGait`.
 

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -139,6 +139,21 @@ public:
     }
     MocoConstraintInfo& updConstraintInfo() { return upd_MocoConstraintInfo(); }
 
+    /// Set the vector of endpoint constraint bounds for this MocoGoal. This
+    /// vector must have length equal to the number of outputs for this goal,
+    /// otherwise an exception is thrown.
+    /// This info is ignored if getSupportsEndpointConstraint() is false.
+    void setEndpointConstraintBounds(const std::vector<MocoBounds>& bounds) {
+        updConstraintInfo().setBounds(bounds);
+    }
+    /// Get the vector of the endpoint constraint bounds for this MocoGoal.
+    /// @details Note: the return value is constructed fresh on every call from
+    /// the internal property. Avoid repeated calls to this function.
+    std::vector<MocoBounds> getEndpointConstraintBounds() const {
+        std::vector<MocoBounds> bounds(getConstraintInfo().getBounds());
+        return bounds;
+    }
+
     /// Get the length of the return value of calcGoal().
     int getNumOutputs() const {
         OPENSIM_THROW_IF_FRMOBJ(!m_model, Exception,

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -911,7 +911,8 @@ TEMPLATE_TEST_CASE("MocoOutputGoal", "", MocoCasADiSolver,
     }
 }
 
-TEST_CASE("MocoOutputPeriodicityGoal and MocoOutputTrackingGoal") {
+TEMPLATE_TEST_CASE("MocoOutputPeriodicityGoal and MocoOutputTrackingGoal", "",
+        MocoCasADiSolver) {
 
         // Output periodicity problem.
         // ---------------------------
@@ -922,7 +923,7 @@ TEST_CASE("MocoOutputPeriodicityGoal and MocoOutputTrackingGoal") {
         goal->setName("periodic_speed");
         goal->setOutputPath("/body|linear_velocity");
         goal->setMode("endpoint_constraint");
-        auto &solver = study.initSolver<MocoCasADiSolver>();
+        auto &solver = study.initSolver<TestType>();
         solver.set_num_mesh_intervals(10);
         MocoSolution solution = study.solve();
         double initialSpeed = solution.getState("/slider/position/speed")[0];
@@ -951,7 +952,7 @@ TEST_CASE("MocoOutputPeriodicityGoal and MocoOutputTrackingGoal") {
         goalTracking->setExponent(2);
         goalTracking->setOutputIndex(0);
         goalTracking->setTrackingFunction(*speedSpline);
-        auto& solverTracking = studyTracking.initSolver<MocoCasADiSolver>();
+        auto& solverTracking = studyTracking.initSolver<TestType>();
         solverTracking.set_num_mesh_intervals(10);
         MocoSolution solutionTracking = studyTracking.solve();
         auto solutionSpeed =

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -400,11 +400,11 @@ TEMPLATE_TEST_CASE("Test tracking goals", "", MocoCasADiSolver,
     }
 }
 
-TEST_CASE("Test MocoScaleFactor", "") {
+TEMPLATE_TEST_CASE("Test MocoScaleFactor", "", MocoCasADiSolver) {
     // Start with double pendulum problem to minimize control effort to create
     // a trajectory to track.
     MocoStudy study =
-            setupMocoStudyDoublePendulumMinimizeEffort<MocoCasADiSolver>();
+            setupMocoStudyDoublePendulumMinimizeEffort<TestType>();
     auto solutionEffort = study.solve();
 
     // Change the strength of the CoordinateActuators in the Model so that we
@@ -436,7 +436,7 @@ TEST_CASE("Test MocoScaleFactor", "") {
 
     // Update the solver with the new problem and disable initSystem() calls for
     // the MocoParameters.
-    auto& solver = study.updSolver<MocoCasADiSolver>();
+    auto& solver = study.updSolver<TestType>();
     solver.set_parameters_require_initsystem(false);
     solver.resetProblem(problem);
     // Construct a guess for the problem. We double the actuator strengths so
@@ -667,6 +667,14 @@ TEMPLATE_TEST_CASE("Endpoint constraints", "[casadi]", MocoCasADiSolver) {
         // the pendulum to end with some downward velocity.
         CHECK(solution.getState("/jointset/j0/q0/speed").getElt(N - 1, 0) ==
                 Approx(-0.05).margin(1e-10));
+    }
+
+    SECTION("Set bounds with scripting-friendly method.") {
+        periodic->setEndpointConstraintBounds(
+                std::vector<MocoBounds>(2, {-1.0, 1.0}));
+        const auto& conInfo = periodic->getConstraintInfo();
+        CHECK(conInfo.getBounds()[0] == MocoBounds(-1.0, 1.0));
+        CHECK(conInfo.getBounds()[1] == MocoBounds(-1.0, 1.0));
     }
 
     SECTION("Goal works in cost mode.") {

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -82,8 +82,7 @@ MocoStudy createSlidingMassMocoStudy() {
     return study;
 }
 
-TEMPLATE_TEST_CASE("Non-uniform mesh", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Non-uniform mesh", "", MocoCasADiSolver, MocoTropterSolver) {
     auto transcriptionScheme =
             GENERATE(as<std::string>{}, "trapezoidal", "hermite-simpson");
     MocoStudy study;
@@ -207,8 +206,7 @@ std::unique_ptr<Model> createPendulumModel() {
     return model;
 }
 
-TEMPLATE_TEST_CASE("Solver options", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Solver options", "", MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
     MocoSolution solDefault = study.solve();
@@ -258,7 +256,7 @@ TEMPLATE_TEST_CASE("Solver options", "", MocoCasADiSolver,
     }
 }
 
-TEMPLATE_TEST_CASE("Ordering of calls", "", MocoCasADiSolver, 
+TEMPLATE_TEST_CASE("Ordering of calls", "", MocoCasADiSolver,
         MocoTropterSolver) {
 
     // Solve a problem, edit the problem, re-solve.
@@ -303,10 +301,10 @@ TEMPLATE_TEST_CASE("Ordering of calls", "", MocoCasADiSolver,
 
 /// Test that we can read in a Moco setup file, solve, edit the setup,
 /// re-solve.
-TEST_CASE("Serializing a MocoStudy", "") {
+TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver) {
     std::string fname = "testMocoInterface_testOMOCOSerialization.omoco";
     
-    MocoStudy study = createSlidingMassMocoStudy<MocoCasADiSolver>();
+    MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution sol0 = study.solve();
     study.print(fname);
     
@@ -417,8 +415,7 @@ TEST_CASE("Building a problem", "") {
     }
 }
 
-TEMPLATE_TEST_CASE(
-        "Workflow", "", MocoCasADiSolver, MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Workflow", "", MocoCasADiSolver, MocoTropterSolver) {
 
     // Default bounds.
     SECTION("Default bounds") {
@@ -919,8 +916,7 @@ TEMPLATE_TEST_CASE("State tracking", "", MocoCasADiSolver,
     // TODO error if data does not cover time window.
 }
 
-TEMPLATE_TEST_CASE(
-        "Guess", "", MocoCasADiSolver, MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Guess", "", MocoCasADiSolver, MocoTropterSolver) {
 
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     auto& ms = study.initSolver<TestType>();
@@ -1315,8 +1311,7 @@ TEMPLATE_TEST_CASE("Guess time-stepping", "[tropter]",
     }
 }
 
-TEMPLATE_TEST_CASE("MocoTrajectory", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+TEMPLATE_TEST_CASE("MocoTrajectory", "", MocoCasADiSolver, MocoTropterSolver) {
     // Reading and writing.
     {
         const std::string fname = "testMocoInterface_testMocoTrajectory.sto";
@@ -1713,8 +1708,7 @@ TEST_CASE("Interpolate", "") {
     SimTK_TEST(SimTK::isNaN(newY[3]));
 }
 
-TEMPLATE_TEST_CASE("Sliding mass", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+TEMPLATE_TEST_CASE("Sliding mass", "", MocoCasADiSolver, MocoTropterSolver) {
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
     MocoSolution solution = study.solve();
     int numTimes = 20;

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -314,7 +314,7 @@ TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver,
 
     // TODO tropter solutions are very slightly different between successive
     // solves.
-    SimTK_TEST(sol0.isNumericallyEqual(sol1, 1e-10));
+    SimTK_TEST(sol0.isNumericallyEqual(sol1, 1e-8));
 }
 
 // TODO does not pass consistently on Mac

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -301,7 +301,8 @@ TEMPLATE_TEST_CASE("Ordering of calls", "", MocoCasADiSolver,
 
 /// Test that we can read in a Moco setup file, solve, edit the setup,
 /// re-solve.
-TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver) {
+TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver,
+        MocoTropterSolver) {
     std::string fname = "testMocoInterface_testOMOCOSerialization.omoco";
     
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
@@ -310,8 +311,10 @@ TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver) {
     
     MocoStudy mocoDeserialized(fname);
     MocoSolution sol1 = mocoDeserialized.solve();
-    
-    SimTK_TEST(sol0.isNumericallyEqual(sol1));
+
+    // TODO tropter solutions are very slightly different between successive
+    // solves.
+    SimTK_TEST(sol0.isNumericallyEqual(sol1, 1e-10));
 }
 
 // TODO does not pass consistently on Mac

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -301,8 +301,8 @@ TEMPLATE_TEST_CASE("Ordering of calls", "", MocoCasADiSolver,
 
 /// Test that we can read in a Moco setup file, solve, edit the setup,
 /// re-solve.
-TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver,
-        MocoTropterSolver) {
+// TODO tropter solutions are very slightly different between successive solves.
+TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver) {
     std::string fname = "testMocoInterface_testOMOCOSerialization.omoco";
     
     MocoStudy study = createSlidingMassMocoStudy<TestType>();
@@ -312,9 +312,7 @@ TEMPLATE_TEST_CASE("Serializing a MocoStudy", "", MocoCasADiSolver,
     MocoStudy mocoDeserialized(fname);
     MocoSolution sol1 = mocoDeserialized.solve();
 
-    // TODO tropter solutions are very slightly different between successive
-    // solves.
-    SimTK_TEST(sol0.isNumericallyEqual(sol1, 1e-8));
+    SimTK_TEST(sol0.isNumericallyEqual(sol1));
 }
 
 // TODO does not pass consistently on Mac


### PR DESCRIPTION
Fixes issues #3322, #3281

### Brief summary of changes
- Added convenience methods `MocoGoal::setEndpointConstraintBounds()` and `MocoGoal::getEndpointConstraintBounds()`.
- Updated bindings to support `MocoConstraintInfo`.
- Converted tests in `testMocoGoals` and `testMocoInterface` to use `TEMPLATE_TEST_CASE` so that they do not fail when both CasADi and Tropter are disabled.
- Minor formatting clean-up in `testMocoInterface`.

### Testing I've completed
- Added tests to `testMocoGoals`.
- Ran tests for #3281 fix locally.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3371)
<!-- Reviewable:end -->
