### PR TITLE
Replace deprecated CMAKE_GENERATOR with CMAKE_GENERATOR_PLATFORM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ v4.4.1
 - Minimum supported version for Java is now 1.8 in the cmake files (Issue #3215).
 - Fix CSV file adapter hanging on csv files that are missing end-header (issue #2432).
 - Improve documentation for MotionType to serve scripting users (Issue #3324).
+- Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
 
 v4.4
 ====

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,7 @@ if(${BUILD_JAVA_WRAPPING})
     # for MATLAB requires version 7.0 (R14).
     find_package(Matlab COMPONENTS MAIN_PROGRAM)
     # Issue warning if Matlab and OpenSim build architectures differ.
-    # That is, one is 64-bit and other is not.
+    # That is, only 64-bit is supported.
     if(Matlab_FOUND)
         if(${Matlab_MEX_EXTENSION} MATCHES ".*64")
             # On Unix, assume host architecture to be same as target 
@@ -515,26 +515,13 @@ if(${BUILD_JAVA_WRAPPING})
                 message(WARNING ${MSG})
             elseif(MSVC AND NOT ${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
                 string(CONCAT MSG 
-                       "Matlab found is 64-bit but C++ compiler chosen is "
-                       "32-bit. Matlab arch and OpenSim binaries arch have"
-                       " to be same.")
+                       "Matlab found is 32-bit which is no longer supported.")
                 message(WARNING ${MSG})
             endif()
-        elseif(${Matlab_MEX_EXTENSION} MATCHES "32")
-            # On Unix, assume host architecture to be same as target 
-            # architecture.
-            if(UNIX AND ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "64")
-                string(CONCAT MSG
-                       "Matlab found is 32-bit but host is 64-bit. Matlab arch"
-                       " and OpenSim binaries arch have to be same.")
-                message(WARNING ${MSG})
-            elseif(MSVC AND ${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
-                string(CONCAT MSG
-                       "Matlab found is 32-bit but C++ compiler chosen is "
-                       "64-bit. Matlab arch and OpenSim binaries arch have"
-                       " to be same.")
-                message(WARNING ${MSG})
-            endif()
+        else()
+            string(CONCAT MSG
+                       "Matlab 64-bit was not found.")
+            message(WARNING ${MSG})
         endif()
     endif()
     # Most users need to copy dependencies if wrapping is on. Warn user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,15 +505,15 @@ if(${BUILD_JAVA_WRAPPING})
     # Issue warning if Matlab and OpenSim build architectures differ.
     # That is, one is 64-bit and other is not.
     if(Matlab_FOUND)
-        if(${Matlab_MEX_EXTENSION} MATCHES "64")
+        if(${Matlab_MEX_EXTENSION} MATCHES ".*64")
             # On Unix, assume host architecture to be same as target 
             # architecture.
-            if(UNIX AND NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "64")
+            if(UNIX AND NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES ".*64")
                 string(CONCAT MSG 
                        "Matlab found is 64-bit but host is 32-bit. Matlab arch"
                        " and OpenSim binaries arch have to be same.")
                 message(WARNING ${MSG})
-            elseif(MSVC AND NOT ${CMAKE_GENERATOR} MATCHES "64")
+            elseif(MSVC AND NOT ${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
                 string(CONCAT MSG 
                        "Matlab found is 64-bit but C++ compiler chosen is "
                        "32-bit. Matlab arch and OpenSim binaries arch have"
@@ -528,7 +528,7 @@ if(${BUILD_JAVA_WRAPPING})
                        "Matlab found is 32-bit but host is 64-bit. Matlab arch"
                        " and OpenSim binaries arch have to be same.")
                 message(WARNING ${MSG})
-            elseif(MSVC AND ${CMAKE_GENERATOR} MATCHES "64")
+            elseif(MSVC AND ${CMAKE_GENERATOR_PLATFORM} MATCHES "64")
                 string(CONCAT MSG
                        "Matlab found is 32-bit but C++ compiler chosen is "
                        "64-bit. Matlab arch and OpenSim binaries arch have"


### PR DESCRIPTION
Fixes issue #3372

### Brief summary of changes
CMakeLists.txt was using a deprecated variable to decide if building 64 bit, updated to supported variable
### Testing I've completed
Build locally produces no warnings regarding matlab. There's possibly another issue regarding locating java but this seems to be the correct fix for the warning regardless.

### Looking for feedback on...
Leaning toward removing all blocks that handles 32 bit, there's no 32 bit Matlabs anymore for the last few years and the requirement page has min requirement of x86-64 processors
### CHANGELOG.md (choose one)

- no need to update because rather internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3373)
<!-- Reviewable:end -->
