### PR TITLE
Hotfixed body inertia not updating from property changes (#3395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ v4.4.1
 - Fix CSV file adapter hanging on csv files that are missing end-header (issue #2432).
 - Improve documentation for MotionType to serve scripting users (Issue #3324).
 - Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
+- Hotfixed body inertia not being updated after changing the 'inertia' property of a body (Issue #3395).
 
 v4.4
 ====

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -78,10 +78,10 @@ void Body::constructProperties()
 void Body::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
+    _inertia = SimTK::Inertia{};  // forces `getInertia` to re-update from the property (#3395)
     const SimTK::MassProperties& massProps = getMassProperties();
     _internalRigidBody = SimTK::Body::Rigid(massProps);
     _slaves.clear();
-    _inertia = SimTK::Inertia{};  // forces `getInertia` to re-update from the property (#3395)
 }
 
 //_____________________________________________________________________________
@@ -216,8 +216,8 @@ void Body::scaleInertialProperties(const SimTK::Vec3& scaleFactors, bool scaleMa
     if (scaleMass)
         upd_mass() *= massScaleFactor;
     // Fix issue #2871 by fmatari
-    SimTK::Mat33 inertia = _inertia.toMat33();
-    //SimTK::SymMat33 inertia = _inertia.asSymMat33();
+    SimTK::Mat33 inertia = getInertia().toMat33();
+    //SimTK::SymMat33 inertia = getInertia().asSymMat33();
 
     // If the mass is zero, then make the inertia tensor zero as well.
     // If the X, Y, Z scale factors are equal, then you can scale the
@@ -347,8 +347,7 @@ void Body::scaleInertialProperties(const ScaleSet& scaleSet, bool scaleMass)
 void Body::scaleMass(double aScaleFactor)
 {
     upd_mass() *= aScaleFactor;
-    _inertia *= aScaleFactor;
-    upd_inertia() *= aScaleFactor;
+    setInertia(aScaleFactor * getInertia());
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -81,6 +81,7 @@ void Body::extendFinalizeFromProperties()
     const SimTK::MassProperties& massProps = getMassProperties();
     _internalRigidBody = SimTK::Body::Rigid(massProps);
     _slaves.clear();
+    _inertia = SimTK::Inertia{};  // forces `getInertia` to re-update from the property (#3395)
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Fixes issue #3395 

Related issue: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/597

### Brief summary of changes

Hotfixes body inertia not being updated after changing the associated property and re-finalizing the model.

### Testing I've completed

Reading the code

### Looking for feedback on...

Whether I suit light t-shirts more than dark ones.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3396)
<!-- Reviewable:end -->
