### PR TITLE
Realize to Dynamics in `createExternalLoadsForGait` +  report `IMU` gyroscope in IMU frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.5
 ======
+- IMU::calcGyroscopeSignal() now reports angular velocities in the IMU frame.
 - Update `report.py` to set specific colors for plotted trajectories
 - Made `Component::getSocketNames` a `const` member method (previously: non-const)
 - Added `ModOpReplaceMusclesWithPathActuators` to the list of available model operators in `ModelOperators.h`

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -282,7 +282,7 @@ TimeSeriesTable OpenSim::createExternalLoadsTableForGait(Model model,
     TimeSeriesTableVec3 externalForcesTable;
     int count = 0;
     for (const auto& state : trajectory) {
-        model.realizeVelocity(state);
+        model.realizeDynamics(state);
         SimTK::Vec3 sphereForcesRight(0);
         SimTK::Vec3 sphereTorquesRight(0);
         SimTK::Vec3 halfSpaceForcesRight(0);

--- a/OpenSim/Simulation/OpenSense/IMU.h
+++ b/OpenSim/Simulation/OpenSense/IMU.h
@@ -67,15 +67,18 @@ public:
             calcAccelerometerSignal, SimTK::Stage::Acceleration);
     // Outputs
     /// Report the Transform of this IMU in the Ground frame.
+    /// @note Requires realizing the State to SimTK::Stage::Position.
     SimTK::Transform calcTransformInGround(const SimTK::State& s) const {
         return get_frame().getTransformInGround(s);
     }
     /// Report the orientation of this IMU in ground frame expressed as a
     /// Quaternion.
+    /// @note Requires realizing the State to SimTK::Stage::Position.
     SimTK::Quaternion calcOrientationAsQuaternion(const SimTK::State& s) const {
         return SimTK::Quaternion(calcTransformInGround(s).R());
     }
     /// Report the angular velocity of this IMU in the frame it is attached to.
+    /// @note Requires realizing the State to SimTK::Stage::Velocity.
     SimTK::Vec3 calcGyroscopeSignal(const SimTK::State& s) const {
         const auto& model = getModel();
         const auto& ground = model.getGround();
@@ -85,6 +88,7 @@ public:
     /// Report the linear acceleration of the frame to which this IMU is
     /// attached in the Ground grame. Gravity is subtracted and result expressed
     /// in the frame to which the IMU is attached.
+    /// @note Requires realizing the State to SimTK::Stage::Acceleration.
     SimTK::Vec3 calcAccelerometerSignal(
             const SimTK::State& s) const {
         const auto& model = getModel();


### PR DESCRIPTION
Fixes issue #3367, #3385

### Brief summary of changes
- `MocoUtilities::createExternalLoadsForGait` now realizes to `SimTK::Stage::Dynamics` to support all contact models.
- `IMU::calcGyroscopeSignal()` now reports angular velocities in the `IMU` frame.
- Added documentation to `IMU`.

### Testing I've completed
Working on a local test for the `IMU` changes.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3402)
<!-- Reviewable:end -->
