### PR TITLE
Prop remove item

### DIFF
--- a/Bindings/Java/tests/TestEditProperties.java
+++ b/Bindings/Java/tests/TestEditProperties.java
@@ -75,8 +75,10 @@ class TestEditProperties {
         System.out.println(propertyStringList.toString());
         propertyStringList.setValue(0, "Output0");
         System.out.println(propertyStringList.toString());
-        System.out.println("Test finished!");
         assert propertyStringList.getValue(0).equals("Output0");
+        propertyStringList.removeValueAtIndex(0);
+        assert propertyStringList.size()==1;
+        System.out.println("Test finished!");
         System.exit(0);
     }
     catch(IOException ex){

--- a/Bindings/Java/tests/TestEditProperties.java
+++ b/Bindings/Java/tests/TestEditProperties.java
@@ -78,6 +78,7 @@ class TestEditProperties {
         assert propertyStringList.getValue(0).equals("Output0");
         propertyStringList.removeValueAtIndex(0);
         assert propertyStringList.size()==1;
+        assert propertyStringList.getValue(0).equals("Output2");
         System.out.println("Test finished!");
         System.exit(0);
     }

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -598,7 +598,7 @@ protected:
     virtual void setValueVirtual(int index, const T& value) = 0;
     virtual int appendValueVirtual(const T& value) = 0;
     virtual int adoptAndAppendValueVirtual(T* value) = 0;
-    virtual void removeValueAtIndexVirtual(int index) {};
+    virtual void removeValueAtIndexVirtual(int index) = 0;
     /** @endcond **/
 #endif
 };
@@ -989,7 +989,8 @@ private:
     {   values.push_back(*valuep); // make a copy
         delete valuep; // throw out the old one
         return values.size()-1; }
-
+    void removeValueAtIndexVirtual(int index) override final
+    {   values.erase(&values[index]);  }
     // This is the default implementation; specialization is required if
     // the Simbody default behavior is different than OpenSim's; e.g. for
     // Transform serialization.
@@ -1168,7 +1169,7 @@ public:
     }
     // Remove value at specific index
     void removeValueAtIndexVirtual(int index) override {
-        objects.erase(&objects.at(index));
+        objects.erase(&objects[index]);
     }
 private:
     // Base class checks the index.

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -516,7 +516,16 @@ public:
         setValueIsDefault(false);
         return adoptAndAppendValueVirtual(value);
     }
-
+    /** Remove specific entry of the list at index **/
+    void removeValueAtIndex(int index) {
+        if (index > getNumValues() || index < 0)
+            throw OpenSim::Exception("Property<T>::removeValueAtIndex(): Property " + getName()
+                + "invalid index, out of range, ignored.");
+        if (getNumValues() - 1 < this->getMinListSize() || getNumValues() - 1 > this->getMaxListSize())
+            throw OpenSim::Exception("Property<T>::removeValueAtIndex(): Property " + getName()
+                + "resulting list has improper size, ignored.");
+        removeValueAtIndexVirtual(index);
+    }
     /** Search the value list for an element that has the given \a value and
     return its index if found, otherwise -1. This requires only that the 
     template type T supports operator==(). This is a linear search so will 
@@ -589,6 +598,7 @@ protected:
     virtual void setValueVirtual(int index, const T& value) = 0;
     virtual int appendValueVirtual(const T& value) = 0;
     virtual int adoptAndAppendValueVirtual(T* value) = 0;
+    virtual void removeValueAtIndexVirtual(int index) {};
     /** @endcond **/
 #endif
 };
@@ -1155,6 +1165,10 @@ public:
             if (objects[i]->getName() == name)
                 return i;
         return -1;
+    }
+    // Remove value at specific index
+    void removeValueAtIndexVirtual(int index) override {
+        objects.erase(&objects.at(index));
     }
 private:
     // Base class checks the index.


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
Property<> is backed by a list underneath, the interface for Property allows for appending to the list, clearing the list but not removing an item from the list. For Properties used in a plugin as containers this functionality is needed.
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because not reported by user but needed by BJ Fregly's group

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3403)
<!-- Reviewable:end -->
