### PR TITLE
Patched segfault from reading invalid osim data (#3409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ v4.5
 - Improve documentation for MotionType to serve scripting users (Issue #3324).
 - Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
 - Hotfixed body inertia not being updated after changing the 'inertia' property of a body (Issue #3395).
+- Fixed segfault that can occur when working with OpenSim::Models that are initialized from invalid XML (osim) data (#3409)
 
 v4.4
 ====


### PR DESCRIPTION
- Adds bounds checks to OpenSim::SimpleProperty<T>, so that out-of-bounds accesses result in an immediate exception rather than undefined behavior

- Changes XML reading routines in OpenSim::SimpleProperty<T> to behave transactionally, such that failing to read the XML resets the property back to its initial values (rather than clearing it)

Fixes issue #3409

### Testing I've completed

- Loaded bug reproduction file in OpenSim Creator after applying this patch and it works fine (prints warning, but does not segfault). Opened all example `osim` files from `opensim-models` with the patched build and did not encounter any change in behavior.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3411)
<!-- Reviewable:end -->
