### PR TITLE
Adding force `Output`s to `SmoothSphereHalfSpaceForce`

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-02-25: Added `getSphereForce`, `getHalfSpaceForce`, and associated `Output`s 
+              `sphere_force` and `half_space_force` to `SmoothSphereHalfSpaceForce`.
+
 - 2023-01-24: Added convenience methods `MocoGoal::setEndpointConstraintBounds` and
               `MocoGoal::getEndpointConstraintBounds`.
 

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -204,6 +204,12 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
             Exception, "The extremum type must be either 'minimum' " 
             " or 'maximum'.");
 
+    OPENSIM_THROW_IF_FRMOBJ(
+            get_smoothing_factor() < 0.2 || get_smoothing_factor() > 1.0,
+            Exception,
+            fmt::format("Expected the smoothing factor must be in the range "
+                    "[0.2, 1.0], but received {}.", get_smoothing_factor()));
+
     OPENSIM_THROW_IF_FRMOBJ(m_minimizeVectorNorm == 1 &&
                                         m_data_type == Type_Vec3,
             Exception, "The MocoOutputExtremumGoal cannot be used when "
@@ -228,11 +234,6 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
 
 void MocoOutputExtremumGoal::calcIntegrandImpl(
         const IntegrandInput& input, double& integrand) const {
-    OPENSIM_THROW_IF_FRMOBJ(
-            get_smoothing_factor() <= 0.2 || get_smoothing_factor() >= 1.0,
-            Exception,
-            "The smoothing factor must be on the closed interval "
-            "[0.2,1.0].");
     double integrand_temp =
             (1 / get_smoothing_factor()) *
             (std::log(1 + exp(get_smoothing_factor() * m_beta *

--- a/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.cpp
+++ b/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.cpp
@@ -188,6 +188,50 @@ OpenSim::Array<double> SmoothSphereHalfSpaceForce::getRecordValues(
     return values;
 }
 
+SimTK::SpatialVec SmoothSphereHalfSpaceForce::getSphereForce(
+        const SimTK::State& state) const {
+    const auto& sphere = getConnectee<ContactSphere>("sphere");
+    const auto sphereIdx = sphere.getFrame().getMobilizedBodyIndex();
+
+    const Model& model = getModel();
+    const auto& forceSubsys = model.getForceSubsystem();
+    const SimTK::Force& abstractForce = forceSubsys.getForce(_index);
+    const auto& simtkForce =
+            static_cast<const SimTK::SmoothSphereHalfSpaceForce&>(
+                    abstractForce);
+
+    SimTK::Vector_<SimTK::SpatialVec> bodyForces(0);
+    SimTK::Vector_<SimTK::Vec3> particleForces(0);
+    SimTK::Vector mobilityForces(0);
+
+    simtkForce.calcForceContribution(
+            state, bodyForces, particleForces, mobilityForces);
+
+    return bodyForces(sphereIdx);
+}
+
+SimTK::SpatialVec SmoothSphereHalfSpaceForce::getHalfSpaceForce(
+        const SimTK::State& state) const {
+    const auto& halfSpace = getConnectee<ContactHalfSpace>("half_space");
+    const auto halfSpaceIdx = halfSpace.getFrame().getMobilizedBodyIndex();
+
+    const Model& model = getModel();
+    const auto& forceSubsys = model.getForceSubsystem();
+    const SimTK::Force& abstractForce = forceSubsys.getForce(_index);
+    const auto& simtkForce =
+            static_cast<const SimTK::SmoothSphereHalfSpaceForce&>(
+                    abstractForce);
+
+    SimTK::Vector_<SimTK::SpatialVec> bodyForces(0);
+    SimTK::Vector_<SimTK::Vec3> particleForces(0);
+    SimTK::Vector mobilityForces(0);
+
+    simtkForce.calcForceContribution(
+            state, bodyForces, particleForces, mobilityForces);
+
+    return bodyForces(halfSpaceIdx);
+}
+
 void SmoothSphereHalfSpaceForce::generateDecorations(bool fixed,
         const ModelDisplayHints& hints, const SimTK::State& state,
         SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const {

--- a/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h
+++ b/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h
@@ -116,6 +116,10 @@ public:
             "The sphere participating in this contact.");
     OpenSim_DECLARE_SOCKET(half_space, ContactHalfSpace,
             "The half-space participating in this contact.");
+
+    //=========================================================================
+    // OUTPUTS
+    //=========================================================================
     OpenSim_DECLARE_OUTPUT(sphere_force, SimTK::SpatialVec, getSphereForce,
             SimTK::Stage::Dynamics);
     OpenSim_DECLARE_OUTPUT(half_space_force, SimTK::SpatialVec,
@@ -144,10 +148,12 @@ public:
     OpenSim::Array<double> getRecordValues(
             const SimTK::State& state) const override;
 
-    /// sphere force
+    /// Get a SimTK::SpatialVec containing the forces and torques applied to
+    /// the contact sphere.
     SimTK::SpatialVec getSphereForce(const SimTK::State& s) const;
 
-    /// half space force
+    /// Get a SimTK::SpatialVec containing the forces and torques applied to
+    /// the contact half space.
     SimTK::SpatialVec getHalfSpaceForce(const SimTK::State& s) const;
 
 protected:
@@ -162,6 +168,9 @@ private:
     // INITIALIZATION
     void constructProperties();
     mutable double m_forceVizScaleFactor;
+
+    void calcBodyForces(const SimTK::State& s,
+                        SimTK::Vector_<SimTK::SpatialVec>& bodyForces) const;
 
 //=============================================================================
 }; // END of class SmoothSphereHalfSpaceForce

--- a/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h
+++ b/OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h
@@ -116,6 +116,10 @@ public:
             "The sphere participating in this contact.");
     OpenSim_DECLARE_SOCKET(half_space, ContactHalfSpace,
             "The half-space participating in this contact.");
+    OpenSim_DECLARE_OUTPUT(sphere_force, SimTK::SpatialVec, getSphereForce,
+            SimTK::Stage::Dynamics);
+    OpenSim_DECLARE_OUTPUT(half_space_force, SimTK::SpatialVec,
+            getHalfSpaceForce, SimTK::Stage::Dynamics);
 
     //=========================================================================
     // PUBLIC METHODS
@@ -139,6 +143,12 @@ public:
     /// values are expressed in the ground frame.
     OpenSim::Array<double> getRecordValues(
             const SimTK::State& state) const override;
+
+    /// sphere force
+    SimTK::SpatialVec getSphereForce(const SimTK::State& s) const;
+
+    /// half space force
+    SimTK::SpatialVec getHalfSpaceForce(const SimTK::State& s) const;
 
 protected:
     /// Create a SimTK::Force which implements this Force.


### PR DESCRIPTION
Fixes issue #3205

### Brief summary of changes
- Added `Output`s `sphere_force` and `half_space_force`, which call the new methods `calcSphereForce` and `calcHalfSpaceForce`.
- Some light refactoring with new convenience method `calcBodyForces`.
- Update error checking for `smoothing_factor` to not exclude the boundary values (0.2 and 1). 

### Testing I've completed
- Tested locally (and also tested by Kayla Pariser). 

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3413)
<!-- Reviewable:end -->
