### PR TITLE
Add `MocoTrajectory::trimToIndices()`

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,8 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-03-08: Added `MocoTrajectory::trimToIndices`.
+
 - 2023-02-25: Added `getSphereForce`, `getHalfSpaceForce`, and associated `Output`s 
               `sphere_force` and `half_space_force` to `SmoothSphereHalfSpaceForce`.
 

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -1,9 +1,9 @@
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoTrajectory.cpp                                           *
  * -------------------------------------------------------------------------- *
- * Copyright (c) 2017 Stanford University and the Authors                     *
+ * Copyright (c) 2023 Stanford University and the Authors                     *
  *                                                                            *
- * Author(s): Christopher Dembia                                              *
+ * Author(s): Christopher Dembia, Nicholas Bianco                             *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -513,6 +513,49 @@ void MocoTrajectory::generateAccelerationsFromSpeeds() {
 
     // Assign derivative names.
     m_derivative_names = derivativeNames;
+}
+
+void MocoTrajectory::trimToIndices(int newStartIndex, int newFinalIndex) {
+    OPENSIM_THROW_IF(newFinalIndex < newStartIndex, Exception,
+            fmt::format("Expected newFinalIndex to be greater than "
+                        "newStartIndex, but received {} and {}, respectively.",
+                        newStartIndex, newFinalIndex));
+    OPENSIM_THROW_IF(newStartIndex < 0, Exception,
+            fmt::format("Expected newStartIndex to be greater than or equal to"
+                        "0, but received {}.", newStartIndex));
+    OPENSIM_THROW_IF(newFinalIndex > getNumTimes()-1, Exception,
+            fmt::format("Expected newFinalIndex to be less than or equal to"
+                        "the current final index {}, but received {}.",
+                        getNumTimes()-1, newFinalIndex));
+
+    const int newLength = newFinalIndex - newStartIndex + 1;
+
+    const SimTK::Matrix statesBlock =
+            m_states(newStartIndex, 0, newLength, m_states.ncol());
+    m_states = statesBlock;
+
+    const SimTK::Matrix controlsBlock =
+            m_controls(newStartIndex, 0, newLength, m_controls.ncol());
+    m_controls = controlsBlock;
+
+    const SimTK::Matrix multipliersBlock =
+            m_multipliers(newStartIndex, 0, newLength, m_multipliers.ncol());
+    m_multipliers = multipliersBlock;
+
+    const SimTK::Matrix derivativesBlock =
+            m_derivatives(newStartIndex, 0, newLength, m_derivatives.ncol());
+    m_derivatives = derivativesBlock;
+
+    const SimTK::Matrix slacksBlock =
+            m_slacks(newStartIndex, 0, newLength, m_slacks.ncol());
+    m_slacks = slacksBlock;
+
+    SimTK::Vector newTime(newLength, 0.0);
+    for (int i = 0; i < newLength; ++i) {
+        newTime[i] = m_time[i + newStartIndex];
+    }
+
+    m_time = newTime;
 }
 
 double MocoTrajectory::getInitialTime() const {

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -518,7 +518,8 @@ void MocoTrajectory::generateAccelerationsFromSpeeds() {
 void MocoTrajectory::trimToIndices(int newStartIndex, int newFinalIndex) {
     OPENSIM_THROW_IF(newFinalIndex < newStartIndex, Exception,
             fmt::format("Expected newFinalIndex to be greater than "
-                        "newStartIndex, but received {} and {}, respectively.",
+                        "newStartIndex, but received {} and {} for "
+                        "newStartIndex and newFinalIndex, respectively.",
                         newStartIndex, newFinalIndex));
     OPENSIM_THROW_IF(newStartIndex < 0, Exception,
             fmt::format("Expected newStartIndex to be greater than or equal to"

--- a/OpenSim/Moco/MocoTrajectory.h
+++ b/OpenSim/Moco/MocoTrajectory.h
@@ -3,9 +3,9 @@
 /* -------------------------------------------------------------------------- *
  * OpenSim: MocoTrajectory.h                                                  *
  * -------------------------------------------------------------------------- *
- * Copyright (c) 2017 Stanford University and the Authors                     *
+ * Copyright (c) 2023 Stanford University and the Authors                     *
  *                                                                            *
- * Author(s): Christopher Dembia                                              *
+ * Author(s): Christopher Dembia, Nicholas Bianco                             *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -423,6 +423,9 @@ public:
     /// trajectory.
     /// @note Overrides any existing acceleration values in the trajectory.
     void generateAccelerationsFromSpeeds();
+    /// Trim the trajectory to include the rows starting at newStartIndex and
+    /// and ending at newFinalIndex.
+    void trimToIndices(int newStartIndex, int newFinalIndex);
     /// @}
 
     /// @name Accessors

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -1430,11 +1430,11 @@ TEMPLATE_TEST_CASE("MocoTrajectory", "", MocoCasADiSolver, MocoTropterSolver) {
         std::vector<std::string> snames{"s0"};
         std::vector<std::string> cnames{"c0"};
         SimTK::Matrix states = SimTK::Test::randMatrix(5, 1);
-        states.set(1, 1, 1.23);
-        states.set(3, 1, 4.56);
+        states.set(1, 0, 1.23);
+        states.set(3, 0, 4.56);
         SimTK::Matrix controls = SimTK::Test::randMatrix(5, 1);
-        states.set(1, 1, 7.89);
-        states.set(3, 1, 1.01);
+        controls.set(1, 0, 7.89);
+        controls.set(3, 0, 1.01);
         MocoTrajectory it(time, snames, cnames, {}, {}, states, controls,
                 SimTK::Matrix(), SimTK::RowVector());
 

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -1424,6 +1424,32 @@ TEMPLATE_TEST_CASE("MocoTrajectory", "", MocoCasADiSolver, MocoTropterSolver) {
         }
     }
 
+    // trimToIndices()
+    {
+        SimTK::Vector time = createVectorLinspace(5, -3.1, 8.9);
+        std::vector<std::string> snames{"s0"};
+        std::vector<std::string> cnames{"c0"};
+        SimTK::Matrix states = SimTK::Test::randMatrix(5, 1);
+        states.set(1, 1, 1.23);
+        states.set(3, 1, 4.56);
+        SimTK::Matrix controls = SimTK::Test::randMatrix(5, 1);
+        states.set(1, 1, 7.89);
+        states.set(3, 1, 1.01);
+        MocoTrajectory it(time, snames, cnames, {}, {}, states, controls,
+                SimTK::Matrix(), SimTK::RowVector());
+
+        it.trimToIndices(1, 3);
+        SimTK_TEST_EQ(it.getInitialTime(), time[1]);
+        SimTK_TEST_EQ(it.getFinalTime(), time[3]);
+
+        SimTK::VectorView_<double> s0 = it.getState("s0");
+        SimTK::VectorView_<double> c0 = it.getControl("c0");
+        SimTK_TEST_EQ(s0[0], 1.23);
+        SimTK_TEST_EQ(s0[it.getNumTimes()-1], 4.56);
+        SimTK_TEST_EQ(c0[0], 7.89);
+        SimTK_TEST_EQ(c0[it.getNumTimes()-1], 1.01);
+    }
+
     // compareContinuousVariablesRMS
     auto testCompareContinuousVariablesRMS =
             [](int NT, int NS, int NC, int NM, double duration, double error,


### PR DESCRIPTION
### Brief summary of changes
Added the method `trimToIndices()` to `MocoTrajectory`, which allows the user to trim the trajectory to a new start and final index.

### Testing I've completed
Added testing to `testMocoInterface.cpp`.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3421)
<!-- Reviewable:end -->
