### PR TITLE
Fix issue where problems with path constraints return a zero time vector

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-03-21: Fixed a bug where failing `MocoProblem`s with path constraints returned
+              a zero time vector.
+
 - 2023-03-08: Added `MocoTrajectory::trimToIndices`.
 
 - 2023-02-25: Added `getSphereForce`, `getHalfSpaceForce`, and associated `Output`s 

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -762,7 +762,7 @@ Solution Transcription::solve(const Iterate& guessOrig) {
         casadi::DMVector constraintsOut;
         constraintFunc.call(finalVarsDMV, constraintsOut);
         printConstraintValues(solution, expandConstraints(constraintsOut[0]));
-    }
+   }
     return solution;
 }
 
@@ -1110,7 +1110,7 @@ void Transcription::printConstraintValues(const Iterate& it,
                     const double L1 = max;
                     const double time_of_max = it.times(argmax).scalar();
 
-                    std::string label = fmt::format("{}_{:02i}", pc.name, ieq);
+                    std::string label = fmt::format("{}_{}", pc.name, ieq);
                     ss << std::setfill('0') << std::setw(2) << ipc << ":"
                            << std::setfill(' ') << std::setw(maxNameLength)
                            << label << spacer << std::setprecision(2)
@@ -1121,6 +1121,7 @@ void Transcription::printConstraintValues(const Iterate& it,
                 ++ipc;
             }
         }
+
         ss << "Path constraint values at each path constraint point:" << std::endl;
         ss << "      time  ";
         for (int ipc = 0; ipc < (int)pathconNames.size(); ++ipc) {
@@ -1140,7 +1141,9 @@ void Transcription::printConstraintValues(const Iterate& it,
         }
     }
     if (stream.rdbuf() == std::cout.rdbuf()) {
-        OpenSim::log_cout(ss.str());
+        // TODO log_cout() does not work for Level::Warn and up.
+        // OpenSim::log_cout(ss.str());
+        std::cout << ss.str() << std::endl;
     } else {
         stream << ss.str() << std::endl;
     }
@@ -1160,7 +1163,9 @@ void Transcription::printObjectiveBreakdown(const Iterate& it,
         }
     }
     if (stream.rdbuf() == std::cout.rdbuf()) {
-        OpenSim::log_cout(ss.str());
+        // TODO log_cout() does not work for Level::Warn and up.
+        // OpenSim::log_cout(ss.str());
+        std::cout << ss.str() << std::endl;
     } else {
         stream << ss.str() << std::endl;
     }

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -1095,7 +1095,7 @@ void Transcription::printConstraintValues(const Iterate& it,
         updateMaxNameLength(pathconNames);
         // To make space for indices.
         maxNameLength += 3;
-        ss << "\n  L2 norm across mesh, max abs value (L1 norm), time of "
+        ss << "  L2 norm across mesh, max abs value (L1 norm), time of "
                   "max abs"
                << std::endl;
         row.resize(1, m_numMeshPoints);
@@ -1121,7 +1121,7 @@ void Transcription::printConstraintValues(const Iterate& it,
                 ++ipc;
             }
         }
-        ss << "Path constraint values at each path constraint point:" << std::endl;
+        ss << "\nPath constraint values at each path constraint point:" << std::endl;
         ss << "      time  ";
         for (int ipc = 0; ipc < (int)pathconNames.size(); ++ipc) {
             ss << std::setw(9) << ipc << "  ";
@@ -1152,7 +1152,7 @@ void Transcription::printObjectiveBreakdown(const Iterate& it,
         const casadi::DM& objectiveTerms,
         std::ostream& stream) const {
     std::stringstream ss;
-    ss << "Breakdown of objective (including weights):";
+    ss << "\nBreakdown of objective (including weights):";
     if (objectiveTerms.numel() == 0) {
         ss << " no terms";
     } else {

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -762,7 +762,7 @@ Solution Transcription::solve(const Iterate& guessOrig) {
         casadi::DMVector constraintsOut;
         constraintFunc.call(finalVarsDMV, constraintsOut);
         printConstraintValues(solution, expandConstraints(constraintsOut[0]));
-   }
+    }
     return solution;
 }
 
@@ -1121,7 +1121,6 @@ void Transcription::printConstraintValues(const Iterate& it,
                 ++ipc;
             }
         }
-
         ss << "Path constraint values at each path constraint point:" << std::endl;
         ss << "      time  ";
         for (int ipc = 0; ipc < (int)pathconNames.size(); ++ipc) {

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -990,6 +990,51 @@ TEMPLATE_TEST_CASE("DoublePendulumEqualControl", "",
     SimTK_TEST(solution.isNumericallyEqual(solutionDeserialized));
 }
 
+/// Solve an optimal control problem where a double pendulum must reach a
+/// specified final configuration while subject to a constraint that its
+/// actuators must produce an equal control trajectory.
+TEMPLATE_TEST_CASE("test failing constraints", "",
+        MocoCasADiSolver, MocoTropterSolver) {
+    OpenSim::Object::registerType(EqualControlConstraint());
+    MocoStudy study;
+    study.setName("double_pendulum_equal_control");
+    MocoProblem& mp = study.updProblem();
+    auto model = createDoublePendulumModel();
+    model->finalizeConnections();
+    mp.setModelAsCopy(*model);
+
+    auto* equalControlConstraint =
+            mp.addPathConstraint<EqualControlConstraint>();
+    MocoConstraintInfo cInfo;
+    cInfo.setBounds(std::vector<MocoBounds>(1, {0, 0}));
+    equalControlConstraint->setConstraintInfo(cInfo);
+
+    mp.setTimeBounds(0, 1);
+    // Coordinate value state boundary conditions are consistent with the
+    // point-on-line constraint and should require the model to "unfold" itself.
+    mp.setStateInfo("/jointset/j0/q0/value", {-10, 10}, 0, SimTK::Pi / 2);
+    mp.setStateInfo("/jointset/j0/q0/speed", {-50, 50});
+    mp.setStateInfo("/jointset/j1/q1/value", {-10, 10}, SimTK::Pi, 0);
+    mp.setStateInfo("/jointset/j1/q1/speed", {-50, 50});
+    mp.setControlInfo("/tau0", {-50, 50});
+    mp.setControlInfo("/tau1", {-50, 50});
+
+    mp.addGoal<MocoControlGoal>();
+
+    auto& ms = study.initSolver<TestType>();
+    ms.set_optim_max_iterations(5);
+    ms.set_num_mesh_intervals(25);
+    ms.set_verbosity(2);
+    ms.set_optim_solver("ipopt");
+    ms.set_optim_convergence_tolerance(1e-3);
+    ms.setGuess("bounds");
+
+    MocoSolution solution = study.solve().unseal();
+    solution.write("testConstraints_testDoublePendulum_test_fail.sto");
+    // moco.visualize(solution);
+
+}
+
 // This problem is a point mass welded to ground, with gravity. We are
 // solving for the mass that allows the point mass to obey the constraint
 // of staying in place. This checks that the parameters are applied to both


### PR DESCRIPTION
Fixes issue #3296 

### Brief summary of changes
In `CasOC::Transcription` we print out a summary of constraint errors if a problem fails. A call to `fmt::format` was somehow  silently corrupting the optimal control solution, which then returned a zero time vector, causing the linked issue to occur. Changing the `fmt::format` call to remove the integer formatting seems to fix the issue. 

I also made some minor formatting changes to the constraint error output.

### Looking for feedback
I noticed another issue while debugging this one: `OpenSim::log_cout()` does not print output to `std::cout` when the `Logger` is set to `Level::Warn` or higher (i.e., `Level::Debug` prints, but `Level::Error` does not). However, I've only tested this issue for the `OpenSim::log_cout()` calls in `CasOC::Transcription`. In the interest of keeping this fix brief, I've temporarily replaced the `log_cout` calls with `std::cout` so users can get the useful information we compile in the meantime while we fix the issue (which I've captured in #3428 for now).

### Testing I've completed
Added test to `testMocoConstraints.cpp`.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3429)
<!-- Reviewable:end -->
