### PR TITLE
[WIP] Fix `CoordinateCouplerConstraint` bug preventing multiple independent coordinates

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
@@ -45,9 +45,13 @@ public:
     }
 
     double calcValue(const SimTK::Vector& x) const override {
-        SimTK::Vector xf(1);
-        xf[0] = x[0];
-        return scale*f1->calcValue(xf)-x[1];
+        int n_indep_coords = x.size() - 1;
+        SimTK::Vector xf(n_indep_coords);
+        for (int i = 0; i < n_indep_coords; i++) {
+            xf[i] = x[i];
+        }
+        
+        return scale * f1->calcValue(xf) - x[n_indep_coords];
     }
 
     double calcDerivative(const std::vector<int>& derivComponents, const SimTK::Vector& x) const {
@@ -55,20 +59,23 @@ public:
     }
 
     double calcDerivative(const SimTK::Array_<int>& derivComponents, const SimTK::Vector& x) const override {
+        int n_indep_coords = x.size() - 1;
         if (derivComponents.size() == 1){
-            if (derivComponents[0]==0){
-                SimTK::Vector x1(1);
-                x1[0] = x[0];
+            if (derivComponents[0] != n_indep_coords){
+                SimTK::Vector x1(n_indep_coords);
+                for (int i = 0; i < n_indep_coords; i++) {
+                    x1[i] = x[i];
+                }
                 return scale*f1->calcDerivative(derivComponents, x1);
-            }
-            else if (derivComponents[0]==1)
+            } else {
                 return -1;
+            }                
         }
         else if(derivComponents.size() == 2){
-            if (derivComponents[0]==0 && derivComponents[1] == 0){
-                SimTK::Vector x1(1);
-                x1[0] = x[0];
-                return scale*f1->calcDerivative(derivComponents, x1);
+            if (derivComponents[0] != n_indep_coords && derivComponents[1] != n_indep_coords){
+                SimTK::Vector x1(n_indep_coords);
+                for (int i = 0; i < n_indep_coords; i++) { x1[i] = x[i]; }
+                return scale * f1->calcDerivative(derivComponents, x1);
             }
         }
         return 0;


### PR DESCRIPTION
Fixes issue #3435

### Brief summary of changes
The methods calcValue and calcDerivative in `CoordinateCouplerConstraint` used entry 0 of the input vector x as independent coordinate and entry 1 as dependent coordinate of the coupling. In the case of multiple independent coordinates this led to unexpected behavior since only the first two entries of vector x are considered (e.g., in the case of two independent coordinates, the first independent coordinate given as x[0] was used as independent coordinate, the second independent coordinate given as x[1] was used as dependent coordinate, and the actual dependent coordinate given as x[2] was ignored).

The change now considers the length of the vector x, and uses all entries but the last as independent coordinates, and the last entry as dependent coordinate, and passes them on to the implementation of calcValue and calcDerivative, respectively. Additionally, in calcDerivative, the derivative is only computed if it is with respect to one of the independent coordinates.

### Testing I've completed
No unit testing.
Model coordinates show expected behavior if the constraint is used with a `LinearFunction` with two independent coordinates.

### CHANGELOG.md (choose one)
- updated?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3440)
<!-- Reviewable:end -->
