### PR TITLE
Millard muscle curves deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ v4.5
 - Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
 - Hotfixed body inertia not being updated after changing the 'inertia' property of a body (Issue #3395).
 - Fixed segfault that can occur when working with OpenSim::Models that are initialized from invalid XML (osim) data (#3409)
-- Deduplication of `SmoothSegmentedFunction` data for representing the muscle curves (#3442).
+- Deduplicated `SmoothSegmentedFunction` data when constructing the muscle curves (#3442).
 
 v4.4
 ====

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ v4.5
 - Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
 - Hotfixed body inertia not being updated after changing the 'inertia' property of a body (Issue #3395).
 - Fixed segfault that can occur when working with OpenSim::Models that are initialized from invalid XML (osim) data (#3409)
+- Deduplication of `SmoothSegmentedFunction` data for representing the muscle curves (#3442).
 
 v4.4
 ====

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -127,26 +127,26 @@ bool operator==(
 //=============================================================================
 
 template <typename T>
-inline std::size_t HashCombine(std::size_t seed, const T& v)
+inline size_t HashCombine(size_t seed, const T& v)
 {
     std::hash<T> hasher;
     return seed ^ (hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
-template <typename T> inline std::size_t HashOf(const T& v)
+template <typename T> inline size_t HashOf(const T& v)
 {
     return std::hash<T>{}(v);
 }
 
 template <typename T, typename... Others>
-inline std::size_t HashOf(const T& v, const Others&... others)
+inline size_t HashOf(const T& v, const Others&... others)
 {
     return HashCombine(HashOf(v), HashOf(others...));
 }
 
-template <> inline std::size_t HashOf(const SimTK::Matrix& matrix)
+template <> inline size_t HashOf(const SimTK::Matrix& matrix)
 {
-    std::size_t hash = HashOf(matrix.nrow(), matrix.ncol());
+    size_t hash = HashOf(matrix.nrow(), matrix.ncol());
     for (int r = 0; r < matrix.nrow(); ++r) {
         for (int c = 0; c < matrix.ncol(); ++c) {
             hash = HashCombine(hash, matrix.row(r)[c]);

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -77,29 +77,18 @@ struct SmoothSegmentedFunctionParameters
         _computeIntegral(computeIntegral),
         _intx0x1(intx0x1) {}
 
-    // Uninitialized parameters.
-    SmoothSegmentedFunctionParameters() :
-        _mX(SimTK::Matrix()),
-        _mY(SimTK::Matrix()),
-        _x0(SimTK::NaN),
-        _x1(SimTK::NaN),
-        _y0(SimTK::NaN),
-        _y1(SimTK::NaN),
-        _dydx0(SimTK::NaN),
-        _dydx1(SimTK::NaN),
-        _computeIntegral(false),
-        _intx0x1(false) {}
+    SmoothSegmentedFunctionParameters() {}
 
-    SimTK::Matrix _mX;
-    SimTK::Matrix _mY;
-    double _x0;
-    double _x1;
-    double _y0;
-    double _y1;
-    double _dydx0;
-    double _dydx1;
-    bool _computeIntegral;
-    bool _intx0x1;
+    SimTK::Matrix _mX = SimTK::Matrix();
+    SimTK::Matrix _mY = SimTK::Matrix();
+    double _x0 = SimTK::NaN;
+    double _x1 = SimTK::NaN;
+    double _y0 = SimTK::NaN;
+    double _y1 = SimTK::NaN;
+    double _dydx0 = SimTK::NaN;
+    double _dydx1 = SimTK::NaN;
+    bool _computeIntegral = false;
+    bool _intx0x1 = false;
 };
 
 bool operator==(

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <utility>
+#include <math.h>
 
 //=============================================================================
 // STATICS
@@ -76,6 +77,19 @@ struct SmoothSegmentedFunctionParameters
         _computeIntegral(computeIntegral),
         _intx0x1(intx0x1) {}
 
+    // Uninitialized parameters.
+    SmoothSegmentedFunctionParameters():
+    _mX(SimTK::Matrix()),
+    _mY(SimTK::Matrix()),
+    _x0(SimTK::NaN),
+    _x1(SimTK::NaN),
+    _y0(SimTK::NaN),
+    _y1(SimTK::NaN),
+    _dydx0(SimTK::NaN),
+    _dydx1(SimTK::NaN),
+    _computeIntegral(false),
+    _intx0x1(false) {}
+
     SimTK::Matrix _mX;
     SimTK::Matrix _mY;
     double _x0;
@@ -110,16 +124,25 @@ bool operator==(
     const SmoothSegmentedFunctionParameters& rhs)
 {
     return
-    lhs._mX == rhs._mX &&
-    lhs._mY == rhs._mY &&
-    lhs._x0 == rhs._x0 &&
-    lhs._x1 == rhs._x1 &&
-    lhs._y0 == rhs._y0 &&
-    lhs._y1 == rhs._y1 &&
-    lhs._dydx0 == rhs._dydx0 &&
-    lhs._dydx1 == rhs._dydx1 &&
-    lhs._computeIntegral == rhs._computeIntegral &&
-    lhs._intx0x1 == rhs._intx0x1;
+        lhs._mX == rhs._mX &&
+        lhs._mY == rhs._mY &&
+        ((
+            lhs._x0 == rhs._x0 &&
+            lhs._x1 == rhs._x1 &&
+            lhs._y0 == rhs._y0 &&
+            lhs._y1 == rhs._y1 &&
+            lhs._dydx0 == rhs._dydx0 &&
+            lhs._dydx1 == rhs._dydx1
+        ) || (
+            std::isnan(lhs._x0) && std::isnan(rhs._x0) &&
+            std::isnan(lhs._x1) && std::isnan(rhs._x1) &&
+            std::isnan(lhs._y0) && std::isnan(rhs._y0) &&
+            std::isnan(lhs._y1) && std::isnan(rhs._y1) &&
+            std::isnan(lhs._dydx0) && std::isnan(rhs._dydx0) &&
+            std::isnan(lhs._dydx1) && std::isnan(rhs._dydx1)
+        )) &&
+        lhs._computeIntegral == rhs._computeIntegral &&
+        lhs._intx0x1 == rhs._intx0x1;
 }
 
 } // namespace OpenSim
@@ -485,15 +508,13 @@ SmoothSegmentedFunction::SmoothSegmentedFunction(
 {}
 
 SmoothSegmentedFunction::SmoothSegmentedFunction():
-    _x0(SimTK::NaN),
-    _x1(SimTK::NaN),
-    _y0(SimTK::NaN),
-    _y1(SimTK::NaN),
-    _dydx0(SimTK::NaN),
-    _dydx1(SimTK::NaN),
-    _computeIntegral(false),
-    _intx0x1(false),
-    _name("NOT_YET_SET") {}
+    _smoothData(
+        SmoothSegmentedFunctionDataLookup(
+            SmoothSegmentedFunctionParameters(),
+            "NOT_YET_SET")
+        ),
+    _name("NOT_YET_SET")
+{}
 
 /*Detailed Computational Costs
 ________________________________________________________________________

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -65,7 +65,7 @@ struct SmoothSegmentedFunctionParameters
         double dydx0,
         double dydx1,
         bool computeIntegral,
-        bool intx0x1):
+        bool intx0x1) :
         _mX(mX),
         _mY(mY),
         _x0(x0),
@@ -219,7 +219,7 @@ struct SmoothSegmentedFunctionData
 
     SmoothSegmentedFunctionData(
         const SmoothSegmentedFunctionParameters& params,
-        const std::string& name):
+        const std::string& name) :
         SmoothSegmentedFunctionData(
             params._mX,
             params._mY,
@@ -420,7 +420,7 @@ SmoothSegmentedFunctionData::SmoothSegmentedFunctionData(
     double dydx1,
     bool computeIntegral,
     bool intx0x1,
-    const std::string& name):
+    const std::string& name) :
     _x0(x0),
     _x1(x1),
     _y0(y0),
@@ -505,7 +505,7 @@ SmoothSegmentedFunction::SmoothSegmentedFunction(
     double dydx1,
     bool computeIntegral,
     bool intx0x1,
-    const std::string& name):
+    const std::string& name) :
     _smoothData(
         SmoothSegmentedFunctionDataLookup(
             SmoothSegmentedFunctionParameters(
@@ -524,7 +524,7 @@ SmoothSegmentedFunction::SmoothSegmentedFunction(
     _name(name)
 {}
 
-SmoothSegmentedFunction::SmoothSegmentedFunction():
+SmoothSegmentedFunction::SmoothSegmentedFunction() :
     _smoothData(
         SmoothSegmentedFunctionDataLookup(
             SmoothSegmentedFunctionParameters(),

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -122,29 +122,33 @@ bool operator==(
     lhs._intx0x1 == rhs._intx0x1;
 }
 
+} // namespace OpenSim
+
 //=============================================================================
 // HASHING OF PARAMETERS
 //=============================================================================
 
 template <typename T>
-inline size_t HashCombine(size_t seed, const T& v)
+static inline size_t HashCombine(size_t seed, const T& v)
 {
     std::hash<T> hasher;
     return seed ^ (hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }
 
-template <typename T> inline size_t HashOf(const T& v)
+template <typename T>
+static inline size_t HashOf(const T& v)
 {
     return std::hash<T>{}(v);
 }
 
 template <typename T, typename... Others>
-inline size_t HashOf(const T& v, const Others&... others)
+static inline size_t HashOf(const T& v, const Others&... others)
 {
     return HashCombine(HashOf(v), HashOf(others...));
 }
 
-template <> inline size_t HashOf(const SimTK::Matrix& matrix)
+template <>
+inline size_t HashOf(const SimTK::Matrix& matrix)
 {
     size_t hash = HashOf(matrix.nrow(), matrix.ncol());
     for (int r = 0; r < matrix.nrow(); ++r) {
@@ -154,8 +158,6 @@ template <> inline size_t HashOf(const SimTK::Matrix& matrix)
     }
     return hash;
 }
-
-} // namespace OpenSim
 
 template <> struct std::hash<SmoothSegmentedFunctionParameters> final
 {
@@ -205,9 +207,13 @@ struct SmoothSegmentedFunctionData
     int _numBezierSections;
 };
 
+} // namespace OpenSim
+
 //=============================================================================
 // DATA LOOKUP
 //=============================================================================
+
+namespace {
 
 // Manages an unordered map of SmoothSegmentedFunction's Data, using the Parameters as key.
 // If the same SmoothSegmentedFunctionParameters were previously used to
@@ -254,7 +260,7 @@ std::shared_ptr<const OpenSim::SmoothSegmentedFunctionData>
     return s_GlobalCache.lookup(params, name);
 }
 
-} // namespace OpenSim
+} // namespace
 
 //=============================================================================
 // RULE OF FIVE

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -78,17 +78,17 @@ struct SmoothSegmentedFunctionParameters
         _intx0x1(intx0x1) {}
 
     // Uninitialized parameters.
-    SmoothSegmentedFunctionParameters():
-    _mX(SimTK::Matrix()),
-    _mY(SimTK::Matrix()),
-    _x0(SimTK::NaN),
-    _x1(SimTK::NaN),
-    _y0(SimTK::NaN),
-    _y1(SimTK::NaN),
-    _dydx0(SimTK::NaN),
-    _dydx1(SimTK::NaN),
-    _computeIntegral(false),
-    _intx0x1(false) {}
+    SmoothSegmentedFunctionParameters() :
+        _mX(SimTK::Matrix()),
+        _mY(SimTK::Matrix()),
+        _x0(SimTK::NaN),
+        _x1(SimTK::NaN),
+        _y0(SimTK::NaN),
+        _y1(SimTK::NaN),
+        _dydx0(SimTK::NaN),
+        _dydx1(SimTK::NaN),
+        _computeIntegral(false),
+        _intx0x1(false) {}
 
     SimTK::Matrix _mX;
     SimTK::Matrix _mY;

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -30,7 +30,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <utility>
-#include <math.h>
+#include <cmath>
 
 //=============================================================================
 // STATICS

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -126,7 +126,7 @@ bool operator==(
     const SmoothSegmentedFunctionParameters& rhs)
 {
     auto equalOrBothNaN = [] (double a, double b) -> bool {
-        return a == b || ( isnan(a) && isnan(b) );
+        return a == b || ( std::isnan(a) && std::isnan(b) );
     };
     return
         lhs._mX == rhs._mX &&

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -51,7 +51,7 @@ static int NUM_SAMPLE_PTS = 100;
 
 // Helper struct containing all parameters required to construct the
 // SmoothSegmentedFunctionData.
-namespace OpenSim {
+namespace {
 struct SmoothSegmentedFunctionParameters
 {
 
@@ -145,7 +145,7 @@ bool operator==(
         lhs._intx0x1 == rhs._intx0x1;
 }
 
-} // namespace OpenSim
+} // namespace
 
 //=============================================================================
 // HASHING OF PARAMETERS

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -314,10 +314,9 @@ private:
     void garbageCollectExpiredData()
     {
         for (auto it=_cache.begin(); it!=_cache.end();) {
-            if ( it->second.expired() ) {
+            if (it->second.expired()) {
                 it = _cache.erase(it);
-            }
-            else {
+            } else {
                 ++it;
             }
         }

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -110,6 +110,8 @@ bool operator==(
     const SmoothSegmentedFunctionParameters& rhs)
 {
     return
+    lhs._mX == rhs._mX &&
+    lhs._mY == rhs._mY &&
     lhs._x0 == rhs._x0 &&
     lhs._x1 == rhs._x1 &&
     lhs._y0 == rhs._y0 &&
@@ -117,9 +119,7 @@ bool operator==(
     lhs._dydx0 == rhs._dydx0 &&
     lhs._dydx1 == rhs._dydx1 &&
     lhs._computeIntegral == rhs._computeIntegral &&
-    lhs._intx0x1 == rhs._intx0x1 &&
-    lhs._mX == rhs._mX &&
-    lhs._mY == rhs._mY;
+    lhs._intx0x1 == rhs._intx0x1;
 }
 
 //=============================================================================

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -300,7 +300,12 @@ private:
     {
         auto it = _cache.find(params);
         if (it != _cache.end()) {
-            return it->second.lock();
+            auto data_ptr = it->second.lock();
+            // We expect expired data to be collected at this point, but check
+            // if expired here to be on the safe side.
+            if (data_ptr) {
+                return data_ptr;
+            }
         }
         return _cache.insert({
                 params,

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -119,28 +119,24 @@ bool operator==(
     return true;
 }
 
+// Does what you expect, with the exception of NaN==NaN resulting in true, for
+// x0, x1, y0, y1, dydxo, dydx1. This is to catch the uninitialized case.
 bool operator==(
     const SmoothSegmentedFunctionParameters& lhs,
     const SmoothSegmentedFunctionParameters& rhs)
 {
+    auto equalOrBothNaN = [] (double a, double b) -> bool {
+        return a == b || ( isnan(a) && isnan(b) );
+    };
     return
         lhs._mX == rhs._mX &&
         lhs._mY == rhs._mY &&
-        ((
-            lhs._x0 == rhs._x0 &&
-            lhs._x1 == rhs._x1 &&
-            lhs._y0 == rhs._y0 &&
-            lhs._y1 == rhs._y1 &&
-            lhs._dydx0 == rhs._dydx0 &&
-            lhs._dydx1 == rhs._dydx1
-        ) || (
-            std::isnan(lhs._x0) && std::isnan(rhs._x0) &&
-            std::isnan(lhs._x1) && std::isnan(rhs._x1) &&
-            std::isnan(lhs._y0) && std::isnan(rhs._y0) &&
-            std::isnan(lhs._y1) && std::isnan(rhs._y1) &&
-            std::isnan(lhs._dydx0) && std::isnan(rhs._dydx0) &&
-            std::isnan(lhs._dydx1) && std::isnan(rhs._dydx1)
-        )) &&
+        equalOrBothNaN(lhs._x0, rhs._x0) &&
+        equalOrBothNaN(lhs._x1, rhs._x1) &&
+        equalOrBothNaN(lhs._y0, rhs._y0) &&
+        equalOrBothNaN(lhs._y1, rhs._y1) &&
+        equalOrBothNaN(lhs._dydx0, rhs._dydx0) &&
+        equalOrBothNaN(lhs._dydx1, rhs._dydx1) &&
         lhs._computeIntegral == rhs._computeIntegral &&
         lhs._intx0x1 == rhs._intx0x1;
 }

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -39,6 +39,21 @@ static double UTOL = (double)SimTK::Eps*1e2;
 static double INTTOL = (double)SimTK::Eps*1e2;
 static int MAXITER = 20;
 static int NUM_SAMPLE_PTS = 100;
+
+//=============================================================================
+// RULE OF FIVE
+//=============================================================================
+
+SmoothSegmentedFunction::SmoothSegmentedFunction(const SmoothSegmentedFunction&) = default;
+
+SmoothSegmentedFunction& SmoothSegmentedFunction::operator=(const SmoothSegmentedFunction&) = default;
+
+SmoothSegmentedFunction::SmoothSegmentedFunction(SmoothSegmentedFunction&&) noexcept = default;
+
+SmoothSegmentedFunction& SmoothSegmentedFunction::operator=(SmoothSegmentedFunction&&) noexcept = default;
+
+SmoothSegmentedFunction::~SmoothSegmentedFunction() noexcept = default;
+
 //=============================================================================
 // UTILITY FUNCTIONS
 //=============================================================================

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -282,14 +282,13 @@ namespace {
 
 class SmoothSegmentedFunctionDataCache final
 {
-
 public:
     std::shared_ptr<const SmoothSegmentedFunctionData> lookup(
             const SmoothSegmentedFunctionParameters& params,
             const std::string& name)
     {
         std::lock_guard<std::mutex> guard{_cacheMutex};
-        cleanup();
+        garbageCollectExpiredData();
         return findOrInsert(params, name);
     }
 
@@ -312,7 +311,7 @@ private:
     }
 
     // Do a pass-over to clean up expired pointers.
-    void cleanup()
+    void garbageCollectExpiredData()
     {
         for (auto it=_cache.begin(); it!=_cache.end();) {
             if ( it->second.expired() ) {

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -554,9 +554,10 @@ ________________________________________________________________________
 
 double SmoothSegmentedFunction::calcValue(double x) const
 {
-    auto& arraySplineUX = _smoothData->_arraySplineUX;
-    auto& mXVec = _smoothData->_mXVec;
-    auto& mYVec = _smoothData->_mYVec;
+    const SimTK::Array_<SimTK::Spline>& arraySplineUX =
+    _smoothData->_arraySplineUX;
+    const SimTK::Array_<SimTK::Vector>& mXVec = _smoothData->_mXVec;
+    const SimTK::Array_<SimTK::Vector>& mYVec = _smoothData->_mYVec;
     double x0 = _smoothData->_x0;
     double x1 = _smoothData->_x1;
     double y0 = _smoothData->_y0;
@@ -631,9 +632,10 @@ double SmoothSegmentedFunction::calcDerivative(double x, int order) const
 
     //QUINTIC SPLINE
 
-    auto& arraySplineUX = _smoothData->_arraySplineUX;
-    auto& mXVec = _smoothData->_mXVec;
-    auto& mYVec = _smoothData->_mYVec;
+    const SimTK::Array_<SimTK::Spline>& arraySplineUX =
+    _smoothData->_arraySplineUX;
+    const SimTK::Array_<SimTK::Vector>& mXVec = _smoothData->_mXVec;
+    const SimTK::Array_<SimTK::Vector>& mYVec = _smoothData->_mYVec;
     double x0 = _smoothData->_x0;
     double x1 = _smoothData->_x1;
     double dydx0 = _smoothData->_dydx0;
@@ -724,7 +726,7 @@ double SmoothSegmentedFunction::calcIntegral(double x) const
         "%s: This curve was not constructed with its integral because"
         "computeIntegral was false",_name.c_str());
 
-    auto& splineYintX = _smoothData->_splineYintX;
+    const SimTK::Spline& splineYintX = _smoothData->_splineYintX;
     double x0 = _smoothData->_x0;
     double x1 = _smoothData->_x1;
     double y0 = _smoothData->_y0;
@@ -802,7 +804,7 @@ void SmoothSegmentedFunction::setName(std::string &name)
 
 SimTK::Vec2 SmoothSegmentedFunction::getCurveDomain() const
 {
-    auto& mXVec = _smoothData->_mXVec;
+    const SimTK::Array_<SimTK::Vector>& mXVec = _smoothData->_mXVec;
 
     SimTK::Vec2 xrange;
     
@@ -859,7 +861,7 @@ SimTK::Matrix SmoothSegmentedFunction::calcSampledMuscleCurve(int maxOrder,
 
     int numBezierSections = _smoothData->_numBezierSections;
     bool computeIntegral = _smoothData->_computeIntegral;
-    auto& mXVec = _smoothData->_mXVec;
+    const SimTK::Array_<SimTK::Vector>& mXVec = _smoothData->_mXVec;
 
     double x0,x1,delta;
     //y,dy,d1y,d2y,d3y,d4y,d5y,d6y,iy

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -215,12 +215,6 @@ struct SmoothSegmentedFunctionData
 
 namespace {
 
-// Manages an unordered map of SmoothSegmentedFunction's Data, using the Parameters as key.
-// If the same SmoothSegmentedFunctionParameters were previously used to
-// construct the SmoothSegmentedFunctionData, a shared pointer to that data is
-// obtained. If the given parameters are new, a new data object is constructed
-// and added. This prevents duplication of the SmoothSegmentedFunction data for
-// identical curves.
 class SmoothSegmentedFunctionDataCache final
 {
 

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -265,8 +265,6 @@ class SmoothSegmentedFunctionDataCache final
 {
 
 public:
-    ~SmoothSegmentedFunctionDataCache() {}
-
     std::shared_ptr<const SmoothSegmentedFunctionData> lookup(
             const SmoothSegmentedFunctionParameters& params,
             const std::string& name)

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -323,27 +323,9 @@ namespace OpenSim {
 
     private:
 
+        /**Data required for performing the calculations. **/
         std::shared_ptr<const SmoothSegmentedFunctionData> _smoothData = nullptr;
 
-        /**The minimum value of the domain*/
-        double _x0;
-        /**The maximum value of the domain*/
-        double _x1;
-        /**The minimum value of the range*/
-        double _y0;
-        /**The maximum value of the range*/
-        double _y1;
-        /**The slope at _x0*/
-        double _dydx0;
-        /**The slope at _x1*/
-        double _dydx1;
-        /**This is the users */
-        bool _computeIntegral;
-
-        /**This variable, when true, indicates that the user wants the integral
-        from left to right (x0 to x1). If it is false, the integral from right
-        to left (x1 to x0) is computed*/
-        bool _intx0x1;
         /**The name of the function**/
         std::string _name;
             

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -70,6 +70,15 @@ namespace OpenSim {
         ///NaN's
         SmoothSegmentedFunction();
 
+        SmoothSegmentedFunction(const SmoothSegmentedFunction&);
+
+        SmoothSegmentedFunction& operator=(const SmoothSegmentedFunction&);
+
+        ~SmoothSegmentedFunction() noexcept;
+
+        SmoothSegmentedFunction(SmoothSegmentedFunction&&) noexcept;
+
+        SmoothSegmentedFunction& operator=(SmoothSegmentedFunction&&) noexcept;
 
 
        /**Calculates the value of the curve this object represents.

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -29,9 +29,9 @@
 namespace OpenSim { 
 
     /**
-    Class containing the data used by SmoothSegmentedFuncion.
+    Struct containing the data used by SmoothSegmentedFuncion.
     */
-    class SmoothSegmentedFunctionData;
+    struct SmoothSegmentedFunctionData;
 
     /**
     This class contains the quintic Bezier curves, x(u) and y(u), that have been

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -24,8 +24,14 @@
  * -------------------------------------------------------------------------- */
 #include "osimCommonDLL.h"
 #include "SegmentedQuinticBezierToolkit.h"
+#include <memory>
 
 namespace OpenSim { 
+
+    /**
+    Class containing the data used by SmoothSegmentedFuncion.
+    */
+    class SmoothSegmentedFunctionData;
 
     /**
     This class contains the quintic Bezier curves, x(u) and y(u), that have been
@@ -316,21 +322,8 @@ namespace OpenSim {
        ///@endcond
 
     private:
-       
-        /**Array of spline fit functions X(u) for each Bezier elbow*/
-        SimTK::Array_<SimTK::Spline> _arraySplineUX;        
-        /**Spline fit of the integral of the curve y(x)*/
-        SimTK::Spline _splineYintX;
-        
-        /**Bezier X1,...,Xn control point locations. Control points are 
-        stored in 6x1 vectors in the order above*/
-        SimTK::Array_<SimTK::Vector> _mXVec; 
-        /**Bezier Y1,...,Yn control point locations. Control points are 
-        stored in 6x1 vectors in the order above*/
-        SimTK::Array_<SimTK::Vector> _mYVec; 
 
-        /**The number of quintic Bezier curves that describe the relation*/
-        int _numBezierSections;
+        std::shared_ptr<const SmoothSegmentedFunctionData> _smoothData = nullptr;
 
         /**The minimum value of the domain*/
         double _x0;


### PR DESCRIPTION
This PR de-duplicates the data held in `SmoothSegmentedFunction` by implementing a global cache for its data, such that when the cache is given identical curve parameters, it returns a read-only, shared copy of the curve data.

The significance of de-duplicating `SmoothSegmentedFunction` is that it's used extensively by muscle components such as `Millard2012EquilibriumMuscle`. The Millard muscle uses 5 different curves, but between individual muscle instances these curves are typically identical. Taking the `RajagopalModel`  as example:

We find the following `SmoothSegmentedFunction` curves in this model, each holding multiple `SimTK::Spline`:
- `ActiveForceLengthCurve` -> 5 splines
- `ForceVelocityInverseCurve` -> 4 splines
- `FiberForceLengthCurve` -> 2 splines
- `TendonForceLengthCurve` -> 2 splines
- `ForceVelocityCurve` -> 4 splines

With each spline ~ 200 doubles = 1.6 kB
Before deduplication the Rajagopal model has ~80 copies of each of the above curves which sums up to ~2MB. Applying deduplication reduces this to ~27kB.

### Brief summary of changes
The changes apply to `SmoothSegmentedFunction.h/cpp`:
- `SmoothSegmentedFunctionParameters` is added to collect all parameters that are used to construct a new smooth function, e.g. `_x0`, `_x1` etc...
- `SmoothSegmentedFunctionData` is added to collect all data required to evaluate the smooth function, e.g. `_arraySplineUX_`, etc. This data can be constructed from the `SmoothSegmentedFunctionParameters`.
- `SmoothSegmentedFunctionDataCache` is added to hold an `unordered_map` of smart pointers to the data, with the hashed-parameters used as key. Whenever a muscle curve is constructed, the parameters are used to obtain a pointer to already existing data, or to construct a new one.
- `SmoothSegmentedFunction` holds a shared pointer to the `SmoothSegmentedFunctionData`.

### Performance Results

Performance was evaluated against current master:

| Test Name | lhs [secs] | σ [secs] | rhs [secs] | σ [secs] | Speedup |
| -------------------------- | ---------- | -------- | ---------- | -------- | ------- |
|`ToyDropLanding_nomuscles` | 0.03 | 0.00 | 0.03 | 0.00 | 1.10 | |
|`passive_dynamic` | 1.79 | 0.00 | 1.79 | 0.00 | 1.00 |
| `RajagopalModel` | 4.66 | 0.00 | 4.35 | 0.01 | 1.07 | 
| `Arm26` | 0.11 | 0.00 | 0.10 | 0.00 | 1.02 | 
| `Gait2354` | 0.14 | 0.00 | 0.14 | 0.00 | 1.02 | 
| `ToyDropLanding` | 4.74 | 0.00 | 4.70 | 0.00 | 1.01 | 
| `passive_dynamic_noanalysis` | 1.17 | 0.00 | 1.18 | 0.00 | 1.00 |

As expected, the `RajagopalModel` can be seen to have the most significant performance boost, because it has many `Millard2012EquilibriumMuscle`s.

### CHANGELOG.md

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3442)
<!-- Reviewable:end -->
