### PR TITLE
Allow the user to hide the ellipsoid drawn by EllipsoidJoint::generateDecorations()

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.cpp
@@ -82,6 +82,10 @@ void EllipsoidJoint::constructProperties()
     setAuthors("Ajay Seth");
     SimTK::Vec3 radii(NaN);
     constructProperty_radii_x_y_z(radii);
+
+    Appearance appearance;
+    appearance.set_visible(true);
+    constructProperty_Appearance(appearance);
 }
 
 //=============================================================================
@@ -176,6 +180,7 @@ void EllipsoidJoint::generateDecorations
     // since this method is called with fixed={true, false}
     if (!fixed) return; 
     // Construct the visible Ellipsoid
+    if (!get_Appearance().get_visible()) return;
     SimTK::DecorativeEllipsoid ellipsoid(get_radii_x_y_z());
     const OpenSim::PhysicalFrame& frame = getParentFrame();
     ellipsoid.setColor(Vec3(0.0, 1.0, 1.0));

--- a/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/EllipsoidJoint.h
@@ -79,6 +79,9 @@ public:
         Rotation3Z = 2u  ///< 2
     };
 
+    OpenSim_DECLARE_UNNAMED_PROPERTY(Appearance,
+        "Default appearance attributes for this EllipsoidJoint");
+
 private:
     /** Specify the Coordinates of the EllipsoidJoint */
     CoordinateIndex rx{ constructCoordinate(Coordinate::MotionType::Rotational,
@@ -119,6 +122,11 @@ public:
 
     //Set properties
     void setEllipsoidRadii(const SimTK::Vec3& radii);
+
+    /** Turn on/off the ellipsoid drawn by generateDecorations(). */
+    void setEllipsoidVisible(bool visible) {
+        upd_Appearance().set_visible(visible);
+    };
 
     /** Exposes getCoordinate() method defined in base class (overloaded below).
         @see Joint */


### PR DESCRIPTION
Fixes [Issue 1440 in GUI repo](https://github.com/opensim-org/opensim-gui/issues/1440)

### Brief summary of changes
See discussion [here](https://github.com/opensim-org/opensim-gui/issues/1440).

### Testing I've completed

### Looking for feedback on...
How to test this without building the GUI from source…

### CHANGELOG.md (choose one)
No need to update because minor change for small number of users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3445)
<!-- Reviewable:end -->
