### PR TITLE
Added `OpenSim::AbstractSocket::canConnectTo(Object const&) const` (#3451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ v4.5
 - Drop support for 32-bit Matlab in build system since Matlab stopped providing 32-bit distributions (issue #3373).
 - Hotfixed body inertia not being updated after changing the 'inertia' property of a body (Issue #3395).
 - Fixed segfault that can occur when working with OpenSim::Models that are initialized from invalid XML (osim) data (#3409)
+- Added `OpenSim::AbstractSocket::canConnectTo(Object const&) const`, for faster socket connectivity checks (#3451)
 
 v4.4
 ====

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -145,6 +145,10 @@ public:
         OPENSIM_THROW(Exception, "Not supported for this type of socket.");
     }
 
+    /** Returns `true` if the socket can connect to the object (i.e. because
+        the object is a matching type for the socket) */
+    virtual bool canConnectTo(const Object&) const = 0;
+
     /** Connect this %Socket to the provided connectee object. If this is a
         list socket, the connectee is appended to the list of connectees;
         otherwise, the provided connectee replaces the single connectee. */
@@ -363,6 +367,10 @@ public:
     Return a const reference to the object connected to this Socket */
     const T& getConnectee() const;
 
+    bool canConnectTo(const Object& object) const override {
+        return dynamic_cast<const T*>(&object) != nullptr;
+    }
+
     /** Connect this Socket to the provided connectee object */
     void connect(const Object& object) override {
         const T* objT = dynamic_cast<const T*>(&object);
@@ -498,6 +506,12 @@ public:
     // Change the return type of clone(). This is similar to what the Object
     // macros do (see OpenSim_OBJECT_ABSTRACT_DEFS).
     AbstractInput* clone() const override = 0;
+
+    bool canConnectTo(OpenSim::Object const&) const override {
+        // see `connect`: you cannot connect an object to an input: must
+        // be an `AbstractOutput`
+        return false;
+    }
 
     // Socket interface
     void connect(const Object& object) override {

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -926,6 +926,50 @@ void testListSockets() {
     // TODO redo with the property list / the reference connect().
 }
 
+void testSocketCanConnectTo() {
+    TheWorld theWorld;
+    theWorld.setName("world");
+
+    Foo& foo = *new Foo(); foo.setName("foo"); foo.set_mass(2.0);
+    theWorld.add(&foo);
+
+    Foo& foo2 = *new Foo(); foo2.setName("foo2"); foo2.set_mass(3.0);
+    theWorld.add(&foo2);
+
+    Bar& bar = *new Bar(); bar.setName("bar");
+    theWorld.add(&bar);
+
+    SimTK_TEST(bar.getSocket("parentFoo").canConnectTo(foo));
+    SimTK_TEST(bar.getSocket("childFoo").canConnectTo(foo2));
+
+    // `theWorld` is an invalid type for the socket, so `canConnectTo` should
+    // return `false`
+    SimTK_TEST(!bar.getSocket("parentFoo").canConnectTo(theWorld));
+    SimTK_TEST(!bar.getSocket("childFoo").canConnectTo(theWorld));
+}
+
+void testInputCanConnectTo() {
+    TheWorld theWorld;
+    theWorld.setName("world");
+
+    Foo& foo = *new Foo(); foo.setName("foo"); foo.set_mass(2.0);
+    theWorld.add(&foo);
+
+    Foo& foo2 = *new Foo(); foo2.setName("foo2"); foo2.set_mass(3.0);
+    theWorld.add(&foo2);
+
+    Bar& bar = *new Bar(); bar.setName("bar");
+    theWorld.add(&bar);
+
+    // an arbitrary object cannot be connected to an input (the
+    // argument must at least be an AbstractOutput), so these
+    // should return `false`, always.
+    SimTK_TEST(!foo.getInput("input1").canConnectTo(theWorld));
+    SimTK_TEST(!foo.getInput("input1").canConnectTo(foo));
+    SimTK_TEST(!foo.getInput("input1").canConnectTo(foo2));
+    SimTK_TEST(!foo.getInput("input1").canConnectTo(bar));
+}
+
 void testComponentPathNames()
 {
     Foo foo;
@@ -2551,6 +2595,8 @@ int main() {
         SimTK_SUBTEST(testExceptionsFinalizeFromPropertiesAfterCopy);
         SimTK_SUBTEST(testListInputs);
         SimTK_SUBTEST(testListSockets);
+        SimTK_SUBTEST(testSocketCanConnectTo);
+        SimTK_SUBTEST(testInputCanConnectTo);
         SimTK_SUBTEST(testComponentPathNames);
         SimTK_SUBTEST(testFindComponent);
         SimTK_SUBTEST(testTraversePathToComponent);


### PR DESCRIPTION
Fixes issue #3451

### Brief summary of changes

- Adds `OpenSim::AbstractSocket::canConnectTo(Object const&) const` to the socket API
- Adds basic tests for the functionality

### Testing I've completed

- Basic unit testing - it is assumed that the code is otherwise simple enough

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3452)
<!-- Reviewable:end -->
