### PR TITLE
Added SIMBODY_EXTRA_CMAKE_ARGS to dependencies/ (#3455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ v4.5
 - Deduplicated `SmoothSegmentedFunction` data when constructing the muscle curves (#3442).
 - Added `OpenSim::AbstractSocket::canConnectTo(Object const&) const`, for faster socket connectivity checks (#3451)
 - Fixed the `CoordinateCouplerConstraint` bug preventing functions with multiple independent coordinates (#3435)
+- Added `SIMBODY_EXTRA_CMAKE_ARGS` to `dependencies/CMakeLists.txt`, which lets integrators customize Simbody via the OpenSim superbuild (#3455)
 
 
 v4.4

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -13,7 +13,7 @@ include(CMakeDependentOption)
 set(
     SIMBODY_EXTRA_CMAKE_ARGS ""
     CACHE STRING
-    "extra args to forward when configuring Simbody with CMake. The format must be: VARNAME1:TYPE1=VALUE1;VARNAME2:TYPE2=VALUE2"
+    "extra arguments to forward when configuring Simbody's build. The format must be: VARNAME1:TYPE1=VALUE1;VARNAME2:TYPE2=VALUE2 (e.g. '-DSIMBODY_EXTRA_CMAKE_ARGS=-DSIMBODY_BUILD_VISUALIZER:BOOL=OFF;-DBUILD_USING_OTHER_LAPACK:PATH=/some/path'")
 )
 
 # Set the default for CMAKE_INSTALL_PREFIX.

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -10,6 +10,12 @@ include(ExternalProject)
 include(CMakeParseArguments)
 include(CMakeDependentOption)
 
+set(
+    SIMBODY_EXTRA_CMAKE_ARGS ""
+    CACHE STRING
+    "extra args to forward when configuring Simbody with CMake. The format must be: VARNAME1:TYPE1=VALUE1;VARNAME2:TYPE2=VALUE2"
+)
+
 # Set the default for CMAKE_INSTALL_PREFIX.
 function(SetDefaultCMakeInstallPrefix)
     get_filename_component(BASE_DIR ${CMAKE_SOURCE_DIR} DIRECTORY)
@@ -178,7 +184,8 @@ AddDependency(NAME       simbody
               GIT_URL    https://github.com/simbody/simbody.git
               GIT_TAG    e855d954a786128c3271a3406d7bda782e7c4c4f
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
-                         -DBUILD_TESTING:BOOL=OFF)
+                         -DBUILD_TESTING:BOOL=OFF
+                         ${SIMBODY_EXTRA_CMAKE_ARGS})
 
 AddDependency(NAME       docopt
               DEFAULT    ON

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -13,7 +13,7 @@ include(CMakeDependentOption)
 set(
     SIMBODY_EXTRA_CMAKE_ARGS ""
     CACHE STRING
-    "extra arguments to forward when configuring Simbody's build. The format must be: VARNAME1:TYPE1=VALUE1;VARNAME2:TYPE2=VALUE2 (e.g. '-DSIMBODY_EXTRA_CMAKE_ARGS=-DSIMBODY_BUILD_VISUALIZER:BOOL=OFF;-DBUILD_USING_OTHER_LAPACK:PATH=/some/path'")
+    "extra arguments to forward when configuring Simbody's build. The format must be: VARNAME1:TYPE1=VALUE1;VARNAME2:TYPE2=VALUE2 (e.g. '-DSIMBODY_EXTRA_CMAKE_ARGS=-DSIMBODY_BUILD_VISUALIZER:BOOL=OFF;-DBUILD_USING_OTHER_LAPACK:PATH=/some/path')"
 )
 
 # Set the default for CMAKE_INSTALL_PREFIX.


### PR DESCRIPTION
Fixes issue #3455 

### Brief summary of changes

- Adds `SIMBODY_EXTRA_CMAKE_ARGS` to `dependencies/CMakeLists.txt`
- This enables customizing the simbody build when creating a superbuild of the dependencies

### Testing I've completed

- "Works on my machine"
- "Probably simple enough to not cause problems"

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3456)
<!-- Reviewable:end -->
