### PR TITLE
Fixed CMC_TaskSet leak source in PropertySet (#3457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ v4.5
 - Deduplicated `SmoothSegmentedFunction` data when constructing the muscle curves (#3442).
 - Added `OpenSim::AbstractSocket::canConnectTo(Object const&) const`, for faster socket connectivity checks (#3451)
 - Fixed the `CoordinateCouplerConstraint` bug preventing functions with multiple independent coordinates (#3435)
+- Fixed `CMC_TaskSet` memory leak whenever it is copied (#3457)
 
 
 v4.4

--- a/OpenSim/Common/PropertySet.cpp
+++ b/OpenSim/Common/PropertySet.cpp
@@ -57,16 +57,31 @@ PropertySet::PropertySet()
  */
 PropertySet::PropertySet(const PropertySet &aSet)
 {
-    _array = aSet._array;
-    _array.setMemoryOwner(false);
-
+    // CARE: the copy constructor/assignment implementation
+    // for _array will unconditionally take ownership of the
+    // array's contents (see: #3457, #3247)
+    //
+    // long-term, Array::setMemoryOwner should be removed (#3275)
+    _array.setSize(0);
+    for (int i = 0; i < aSet._array.getSize(); ++i)
+    {
+        _array.append(aSet._array[i]);
+    }
 }
 
 PropertySet& PropertySet::operator=(const PropertySet& aSet)
 {
    if (this != &aSet) {
-       _array = aSet._array;
-       _array.setMemoryOwner(false);
+       // CARE: the copy constructor/assignment implementation
+       // for _array will unconditionally take ownership of the
+       // array's contents (see: #3457, #3247)
+       //
+       // long-term, Array::setMemoryOwner should be removed (#3275)
+       _array.setSize(0);
+       for (int i = 0; i < aSet._array.getSize(); ++i)
+       {
+           _array.append(aSet._array[i]);
+       }
    }
    return *this;
 }

--- a/OpenSim/Common/PropertySet.h
+++ b/OpenSim/Common/PropertySet.h
@@ -92,7 +92,6 @@ public:
     PropertySet();
     PropertySet(const PropertySet &aSet);
     PropertySet& operator=(const PropertySet& aSet);
-    virtual ~PropertySet() { _array.setSize(0); };
 
     //--------------------------------------------------------------------------
     // OPERATORS


### PR DESCRIPTION
Fixes issue #3457

### Brief summary of changes

- Modified `OpenSim::PropertySet`'s copy constructor to manually copy the un-owned pointers
- This is because `OpenSim::ArrayPtrs<T>`'s copy constructor/assignment unconditionally `clone`s the contents and takes ownership
- Downstream code (e.g. in `PropertySet`) will perform the copy (clone + ownership) followed by calling `setMemoryOwner(false)`
- This then causes a memory leak, because `setMemoryOwner(false)` does not clear owned contents etc.

### Testing I've completed

- The existing test suite

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3458)
<!-- Reviewable:end -->
