### PR TITLE
Fixed out-of-bounds state assignment in testAssemblySolver (#3460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ v4.5
 - Deduplicated `SmoothSegmentedFunction` data when constructing the muscle curves (#3442).
 - Added `OpenSim::AbstractSocket::canConnectTo(Object const&) const`, for faster socket connectivity checks (#3451)
 - Fixed the `CoordinateCouplerConstraint` bug preventing functions with multiple independent coordinates (#3435)
+- Fixed out-of-bounds memory access in testAssemblySolver (#3460)
 
 
 v4.4

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -966,7 +966,7 @@ void Component::
 
     int nsv = getNumStateVariables();
 
-    SimTK_ASSERT(values.size() == nsv,
+    SimTK_ASSERT_ALWAYS(values.size() == nsv,
         "Component::setStateVariableValues() number values does not match the "
         "number of state variables.");
 

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -405,7 +405,7 @@ void testCoordinateCouplerCompoundFunction() {
         auto model = createConstrainedPendulumModel(function);
         // Set the initial state to a random value.
         auto state = model.initSystem();
-        SimTK::Vector q_rand = SimTK::Test::randVector(3);
+        SimTK::Vector q_rand = SimTK::Test::randVector(model.getNumStateVariables());
         model.setStateVariableValues(state, q_rand);
         model.assemble(state);
         // Compute the constraint error.
@@ -430,7 +430,7 @@ void testCoordinateCouplerCompoundFunction() {
         auto model = createConstrainedPendulumModel(multiPoly);
         // Set the initial state to a random value.
         auto state = model.initSystem();
-        SimTK::Vector q_rand = SimTK::Test::randVector(3);
+        SimTK::Vector q_rand = SimTK::Test::randVector(model.getNumStateVariables());
         model.setStateVariableValues(state, q_rand);
         model.assemble(state);
         // Compute the constraint error.


### PR DESCRIPTION
Fixes issue #3460 

### Brief summary of changes

- Hardened bounds check in `OpenSim::Component::setStateVariableValues`, so that it cannot run if there is a potential out-of-bounds access
- Fixed bug in `testAssemblySolver.cpp`

### Testing I've completed

- BEFORE: I ran `testAssemblySolver` with libASAN, which detected the bug:

```text
==20744==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030009e8e88 at pc 0x7f94444f3fa2 bp 0x7fffe2ef3370 sp 0x7fffe2ef3360
READ of size 8 at 0x6030009e8e88 thread T0
    #0 0x7f94444f3fa1 in OpenSim::Component::setStateVariableValues(SimTK::State&, SimTK::Vector_<double> const&) const /home/adam/opensim-core/OpenSim/Common/Component.cpp:984
    #1 0x5619d44df212 in testCoordinateCouplerCompoundFunction() /home/adam/opensim-core/OpenSim/Simulation/Test/testAssemblySolver.cpp:409
    #2 0x5619d44cc11c in main /home/adam/opensim-core/OpenSim/Simulation/Test/testAssemblySolver.cpp:59
    #3 0x7f94410bdd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #4 0x7f94410bde3f in __libc_start_main_impl ../csu/libc-start.c:392
    #5 0x5619d44cc334 in _start (/home/adam/osim-build/testAssemblySolver+0x35334)

0x6030009e8e88 is located 0 bytes to the right of 24-byte region [0x6030009e8e70,0x6030009e8e88)
allocated by thread T0 here:
    #0 0x7f94472f8337 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:102
    #1 0x7f94423afe29 in SimTK::MatrixHelperRep<double>::allocateMemory(long) const /home/adam/opensim-core/dependencies/simbody/SimTKcommon/BigMatrix/src/MatrixHelperRep.h:475
    #2 0x7f94423afe29 in SimTK::MatrixHelperRep<double>::allocateData(long) /home/adam/opensim-core/dependencies/simbody/SimTKcommon/BigMatrix/src/MatrixHelperRep.h:453
    #3 0x7f94426202b7  (/home/adam/osim-deps-install/simbody/lib/libSimTKcommon.so.3.8+0x8522b7)
```

- AFTER: I re-ran `testAssemblySolver` with libASAN, which detected no bugs

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3461)
<!-- Reviewable:end -->
