### PR TITLE
Downgraded segfault when using WrapObject outside a PhysicalFrame (#3…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ v4.5
 - Fixed `CMC_TaskSet` memory leak whenever it is copied (#3457)
 - Added `SIMBODY_EXTRA_CMAKE_ARGS` to `dependencies/CMakeLists.txt`, which lets integrators customize Simbody via the OpenSim superbuild (#3455)
 - Fixed out-of-bounds memory access in testAssemblySolver (#3460)
+- Fixed runtime segfault that can occur when trying to use a `WrapObject` that is not a child of a `PhysicalFrame` (#3465)
 
 
 v4.4

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -75,7 +75,7 @@ void WrapObject::constructProperties()
 const PhysicalFrame& WrapObject::getFrame() const
 {
     if (!_frame) {
-        OPENSIM_THROW_FRMOBJ(OpenSim::Exception, "Tried to call WrapObject::getFrame before the frame has been set. This can happen if the WrapObject is part of the WrapObjectSet of a PhysicalFrame (see: opensim-core issue #3465)");
+        OPENSIM_THROW_FRMOBJ(OpenSim::Exception, "Tried to call WrapObject::getFrame before the frame has been set. Make sure that `OpenSim::WrapObject::setFrame` is called on the `WrapObject` before doing any operations with the `WrapObject`.");
     }
     return _frame.getRef();
 }

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -74,6 +74,9 @@ void WrapObject::constructProperties()
 
 const PhysicalFrame& WrapObject::getFrame() const
 {
+    if (!_frame) {
+        OPENSIM_THROW_FRMOBJ(OpenSim::Exception, "Tried to call WrapObject::getFrame before the frame has been set. This can happen if the WrapObject is part of the WrapObjectSet of a PhysicalFrame (see: opensim-core issue #3465)");
+    }
     return _frame.getRef();
 }
 


### PR DESCRIPTION
Fixes issue #3465 

### Brief summary of changes

- Adds a unit test that exercises #3465
- Adds a runtime check to `OpenSim::WrapObject::getFrame`
- The runtime check throws an exception if the caller tries to call `getFrame` before `OpenSim::WrapObject::_frame` has been set
- That error condition can occur when using a `WrapObject` outside of a `PhysicalFrame`, or when using it within a `PhysicalFrame` before `finalizeConnections` is called

### Testing I've completed

- The reproduction code in #3465 was copied into a unit test
- The unit test failed because of the described bug
- The codebase was modified with the additional runtime check
- The unit test then passed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3466)
<!-- Reviewable:end -->
