### PR TITLE
testMocoInverse: recompute inverse solution

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.2.1
 -----
+- 2023-06-06: Instead of reading from file, changed to recompute the inverse
+              solution in `testMocoInverse` before testing imu-outputs.
+
 - 2023-03-21: Fixed a bug where failing `MocoProblem`s with path constraints returned
               a zero time vector.
 

--- a/OpenSim/Moco/Test/testMocoInverse.cpp
+++ b/OpenSim/Moco/Test/testMocoInverse.cpp
@@ -230,8 +230,6 @@ TEST_CASE("Test IMUDataReporter for gait") {
     inverse.set_mesh_interval(0.025);
     inverse.set_constraint_tolerance(1e-4);
     inverse.set_convergence_tolerance(1e-4);
-    inverse.set_output_paths(0, ".*tendon_force.*");
-    inverse.set_output_paths(1, ".*fiber_force_along_tendon.*");
 
     MocoInverseSolution inverseSolution = inverse.solve();
     MocoTrajectory std = inverseSolution.getMocoSolution();


### PR DESCRIPTION
This pr changes the *Test IMUDataReporter for gait* test case in `testMocoInverse.cpp` to recompute the inverse solution instead of reading it from file.

If I understand correctly, the purpose of this test is to compare the imu outputs obtained from the inverse solution against the acceleration obtained from a motion file. Since the inverse solution is not computed (but read from a file), it will not pick up on changes in the inverting-algorithm.

I assume that this test should pick up on changes in the algorithm, such that it fails when needed, but also passes when needed (see #3463).

### Testing I've completed

The test passes, and signals were visually inspected (they look the same).

### Looking for feedback on...

Perhaps I misinterpreted this test?

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3476)
<!-- Reviewable:end -->
