### PR TITLE
Add `calc` methods and `Output`s for whole-body momentum to `Model`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ v4.5
 - Fixed runtime segfault that can occur when trying to use a `WrapObject` that is not a child of a `PhysicalFrame` (#3465)
 - Fixed issues #3083 #2575 where analog data is not pulled out from c3d files, a a new function getAnalogDataTable() has been added to the C3DFileAdapter
 - Fixed segfault that can occur when building models with unusual joint topologies (it now throws an `OpenSim::Exception` instead, #3299)
+- Add `calcMomentum`, `calcAngularMomentum`, `calcLinearMomentum`, and associated `Output`s to `Model` (#3474)
 
 
 v4.4

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2235,14 +2235,14 @@ SimTK::SpatialVec Model::calcMomentum(const SimTK::State &s) const
  *
  */
 SimTK::Vec3 Model::calcAngularMomentum(const SimTK::State& s) const {
-    return getMatterSubsystem().calcSystemCentralMomentum(s).get(0);
+    return calcMomentum(s).get(0);
 }
 /**
  * Return the linear momentum expressed in Ground.
  *
  */
 SimTK::Vec3 Model::calcLinearMomentum(const SimTK::State& s) const {
-    return getMatterSubsystem().calcSystemCentralMomentum(s).get(1);
+    return calcMomentum(s).get(1);
 }
 
 

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2167,87 +2167,55 @@ void Model::realizeReport(const SimTK::State& state) const
     getSystem().realize(state, Stage::Report);
 }
 
-
-/**
- * Compute the derivatives of the generalized coordinates and speeds.
- */
+//------------------------------------------------------------------------------
+// Subsystem computations
+//------------------------------------------------------------------------------
 void Model::computeStateVariableDerivatives(const SimTK::State &s) const
 {
     realizeAcceleration(s);
 }
 
-/**
- * Get the total mass of the model
- *
- * @return the mass of the model
- */
 double Model::getTotalMass(const SimTK::State &s) const
 {
     return getMatterSubsystem().calcSystemMass(s);
 }
-/**
- * getInertiaAboutMassCenter
- *
- */
+
 SimTK::Inertia Model::getInertiaAboutMassCenter(const SimTK::State &s) const
 {
-    SimTK::Inertia inertia = getMatterSubsystem().calcSystemCentralInertiaInGround(s);
+    SimTK::Inertia inertia =
+            getMatterSubsystem().calcSystemCentralInertiaInGround(s);
 
     return inertia;
 }
-/**
- * Return the position vector of the system mass center, measured from the Ground origin, and expressed in Ground.
- *
- */
+
 SimTK::Vec3 Model::calcMassCenterPosition(const SimTK::State &s) const
 {
     getMultibodySystem().realize(s, Stage::Position);
     return getMatterSubsystem().calcSystemMassCenterLocationInGround(s);
 }
-/**
- * Return the velocity vector of the system mass center, measured from the Ground origin, and expressed in Ground.
- *
- */
+
 SimTK::Vec3 Model::calcMassCenterVelocity(const SimTK::State &s) const
 {
     getMultibodySystem().realize(s, Stage::Velocity);
     return getMatterSubsystem().calcSystemMassCenterVelocityInGround(s);
 }
-/**
- * Return the acceleration vector of the system mass center, measured from the Ground origin, and expressed in Ground.
- *
- */
+
 SimTK::Vec3 Model::calcMassCenterAcceleration(const SimTK::State &s) const
 {
     getMultibodySystem().realize(s, Stage::Acceleration);
     return getMatterSubsystem().calcSystemMassCenterAccelerationInGround(s);
 }
-/**
- * Return the spatial momentum about the system mass center expressed in Ground.
- *
- */
+
 SimTK::SpatialVec Model::calcMomentum(const SimTK::State &s) const
 {
+    getMultibodySystem().realize(s, Stage::Velocity);
     return getMatterSubsystem().calcSystemCentralMomentum(s);
 }
-/**
- * Return the angular momentum about the system mass center expressed in Ground.
- *
- */
+
 SimTK::Vec3 Model::calcAngularMomentum(const SimTK::State& s) const {
     return calcMomentum(s).get(0);
 }
-/**
- * Return the linear momentum expressed in Ground.
- *
- */
+
 SimTK::Vec3 Model::calcLinearMomentum(const SimTK::State& s) const {
     return calcMomentum(s).get(1);
 }
-
-
-/**
-* Construct outputs
-*
-**/
-

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2201,6 +2201,7 @@ SimTK::Inertia Model::getInertiaAboutMassCenter(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterPosition(const SimTK::State &s) const
 {
+    getMultibodySystem().realize(s, Stage::Position);
     return getMatterSubsystem().calcSystemMassCenterLocationInGround(s);
 }
 /**
@@ -2209,6 +2210,7 @@ SimTK::Vec3 Model::calcMassCenterPosition(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterVelocity(const SimTK::State &s) const
 {
+    getMultibodySystem().realize(s, Stage::Velocity);
     return getMatterSubsystem().calcSystemMassCenterVelocityInGround(s);
 }
 /**
@@ -2217,6 +2219,7 @@ SimTK::Vec3 Model::calcMassCenterVelocity(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterAcceleration(const SimTK::State &s) const
 {
+    getMultibodySystem().realize(s, Stage::Acceleration);
     return getMatterSubsystem().calcSystemMassCenterAccelerationInGround(s);
 }
 /**

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2201,8 +2201,7 @@ SimTK::Inertia Model::getInertiaAboutMassCenter(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterPosition(const SimTK::State &s) const
 {
-    getMultibodySystem().realize(s, Stage::Position);
-    return getMatterSubsystem().calcSystemMassCenterLocationInGround(s);    
+    return getMatterSubsystem().calcSystemMassCenterLocationInGround(s);
 }
 /**
  * Return the velocity vector of the system mass center, measured from the Ground origin, and expressed in Ground.
@@ -2210,8 +2209,7 @@ SimTK::Vec3 Model::calcMassCenterPosition(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterVelocity(const SimTK::State &s) const
 {
-    getMultibodySystem().realize(s, Stage::Velocity);
-    return getMatterSubsystem().calcSystemMassCenterVelocityInGround(s);    
+    return getMatterSubsystem().calcSystemMassCenterVelocityInGround(s);
 }
 /**
  * Return the acceleration vector of the system mass center, measured from the Ground origin, and expressed in Ground.
@@ -2219,8 +2217,7 @@ SimTK::Vec3 Model::calcMassCenterVelocity(const SimTK::State &s) const
  */
 SimTK::Vec3 Model::calcMassCenterAcceleration(const SimTK::State &s) const
 {
-    getMultibodySystem().realize(s, Stage::Acceleration);
-    return getMatterSubsystem().calcSystemMassCenterAccelerationInGround(s);    
+    return getMatterSubsystem().calcSystemMassCenterAccelerationInGround(s);
 }
 /**
  * Return the spatial momentum about the system mass center expressed in Ground.

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -2222,6 +2222,29 @@ SimTK::Vec3 Model::calcMassCenterAcceleration(const SimTK::State &s) const
     getMultibodySystem().realize(s, Stage::Acceleration);
     return getMatterSubsystem().calcSystemMassCenterAccelerationInGround(s);    
 }
+/**
+ * Return the spatial momentum about the system mass center expressed in Ground.
+ *
+ */
+SimTK::SpatialVec Model::calcMomentum(const SimTK::State &s) const
+{
+    return getMatterSubsystem().calcSystemCentralMomentum(s);
+}
+/**
+ * Return the angular momentum about the system mass center expressed in Ground.
+ *
+ */
+SimTK::Vec3 Model::calcAngularMomentum(const SimTK::State& s) const {
+    return getMatterSubsystem().calcSystemCentralMomentum(s).get(0);
+}
+/**
+ * Return the linear momentum expressed in Ground.
+ *
+ */
+SimTK::Vec3 Model::calcLinearMomentum(const SimTK::State& s) const {
+    return getMatterSubsystem().calcSystemCentralMomentum(s).get(1);
+}
+
 
 /**
 * Construct outputs

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -237,7 +237,16 @@ public:
             calcKineticEnergy, SimTK::Stage::Position);
 
     OpenSim_DECLARE_OUTPUT(potential_energy, double,
-        calcPotentialEnergy, SimTK::Stage::Velocity);
+            calcPotentialEnergy, SimTK::Stage::Velocity);
+
+    OpenSim_DECLARE_OUTPUT(momentum, SimTK::SpatialVec,
+            calcMomentum, SimTK::Stage::Velocity);
+
+    OpenSim_DECLARE_OUTPUT(angular_momentum, SimTK::Vec3,
+            calcAngularMomentum, SimTK::Stage::Velocity);
+
+    OpenSim_DECLARE_OUTPUT(linear_momentum, SimTK::Vec3,
+            calcLinearMomentum, SimTK::Stage::Velocity);
 
 
 //=============================================================================
@@ -833,6 +842,9 @@ public:
     SimTK::Vec3 calcMassCenterPosition(const SimTK::State &s) const;
     SimTK::Vec3 calcMassCenterVelocity(const SimTK::State &s) const;
     SimTK::Vec3 calcMassCenterAcceleration(const SimTK::State &s) const;
+    SimTK::SpatialVec calcMomentum(const SimTK::State &s) const;
+    SimTK::Vec3 calcAngularMomentum(const SimTK::State &s) const;
+    SimTK::Vec3 calcLinearMomentum(const SimTK::State &s) const;
     /** return the total Kinetic Energy for the underlying system.*/
     double calcKineticEnergy(const SimTK::State &s) const {
         return getMultibodySystem().calcKineticEnergy(s);

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -836,20 +836,65 @@ public:
     //--------------------------------------------------------------------------
     // Subsystem computations
     //--------------------------------------------------------------------------
+    /**
+     * Compute the derivatives of the generalized coordinates and speeds.
+     */
     void computeStateVariableDerivatives(const SimTK::State &s) const override;
+
+    /**
+     * Get the total mass of the model.
+     *
+     * @return the mass of the model.
+     */
     double getTotalMass(const SimTK::State &s) const;
+
+    /**
+     * Get the whole-body inertia of the model about the center of mass,
+     * expressed in the Ground frame.
+     */
     SimTK::Inertia getInertiaAboutMassCenter(const SimTK::State &s) const;
+
+    /**
+     * Return the position vector of the system mass center, measured from the
+     * Ground origin, and expressed in Ground.
+     */
     SimTK::Vec3 calcMassCenterPosition(const SimTK::State &s) const;
+
+    /**
+     * Return the velocity vector of the system mass center, measured from the
+     * Ground origin, and expressed in Ground.
+     */
     SimTK::Vec3 calcMassCenterVelocity(const SimTK::State &s) const;
+
+    /**
+     * Return the acceleration vector of the system mass center, measured from
+     * the Ground origin, and expressed in Ground.
+     */
     SimTK::Vec3 calcMassCenterAcceleration(const SimTK::State &s) const;
+
+    /**
+     * Return the spatial momentum about the system mass center expressed in
+     * Ground.
+     */
     SimTK::SpatialVec calcMomentum(const SimTK::State &s) const;
+
+    /**
+     * Return the angular momentum about the system mass center expressed in
+     * Ground.
+     */
     SimTK::Vec3 calcAngularMomentum(const SimTK::State &s) const;
+
+    /**
+     * Return the linear momentum expressed in Ground.
+     */
     SimTK::Vec3 calcLinearMomentum(const SimTK::State &s) const;
-    /** return the total Kinetic Energy for the underlying system.*/
+
+    /** Return the total Kinetic Energy for the underlying system.*/
     double calcKineticEnergy(const SimTK::State &s) const {
         return getMultibodySystem().calcKineticEnergy(s);
-    }    
-    /** return the total Potential Energy for the underlying system.*/
+    }
+
+    /** Return the total Potential Energy for the underlying system.*/
     double calcPotentialEnergy(const SimTK::State &s) const {
         return getMultibodySystem().calcPotentialEnergy(s);
     }


### PR DESCRIPTION
Fixes issue #3474

### Brief summary of changes
This PR introduces methods and `Output`s for computing whole-body momentum (about the center of mass, expressed in ground) on `Model`. 

### Testing I've completed
Successfuly ran an optimization problem using `MocoOutputGoal` with the new momentum `Output`s.

### Looking for feedback on...
I noticed that `calcMassCenterPosition`, `calcMassCenterVelocity`, and `calcMassCenterAcceleration` all call `realize` within each method. This might lead to `realize` being called twice when using `Output`s, since `Output` require a `SimTK::Stage` dependency. I _think_ that this means that `realize` will automatically be called for these `Output`s, or at least an "invalid stage" error will be thrown. Either way, I don't think the `realize` calls should be baked into these methods, so I'm inclined to remove them, which I could append to this PR.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3487)
<!-- Reviewable:end -->
