### PR TITLE
Upgrade to use of Matplotlib colormaps in `report.py`

### DIFF
--- a/Bindings/Python/report.py
+++ b/Bindings/Python/report.py
@@ -166,9 +166,9 @@ class Report(object):
 
         if self.colors is None:
             self.colors = list()
-            import matplotlib.cm as cm
+            import matplotlib
             cmap_samples = np.linspace(0.1, 0.9, len(self.refs)+1)
-            cmap = cm.get_cmap('jet')
+            cmap = matplotlib.colormaps['jet']
             for sample in cmap_samples:
                 self.colors.append(cmap(sample))
 
@@ -621,9 +621,9 @@ def main():
     if ref_files != None: refs = ref_files
     colormap = args.colormap
     if colormap is None: colormap = 'jet'
-    import matplotlib.cm as cm
+    import matplotlib
     cmap_samples = np.linspace(0.1, 0.9, len(refs)+1)
-    cmap = cm.get_cmap(colormap)
+    cmap = matplotlib.colormaps['jet']
     for sample in cmap_samples:
         colors.append(cmap(sample))
 


### PR DESCRIPTION
### Brief summary of changes
This PR upgrades usages of colormaps from the current usages, which will eventually be deprecatd by Matplotlib.

### Testing I've completed
Tested locally by running `exampleMocoInverse.py`, which uses the `report.py` module.

### CHANGELOG.md (choose one)

- no need to update because...minor upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3495)
<!-- Reviewable:end -->
