### PR TITLE
Wrap Cylinder Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ v4.5
 - Fixed issues #3083 #2575 where analog data is not pulled out from c3d files, a a new function getAnalogDataTable() has been added to the C3DFileAdapter
 - Fixed segfault that can occur when building models with unusual joint topologies (it now throws an `OpenSim::Exception` instead, #3299)
 - Add `calcMomentum`, `calcAngularMomentum`, `calcLinearMomentum`, and associated `Output`s to `Model` (#3474)
+- Added a cylinder wrapping test: `testWrapCylinder.cpp` (#3498)
 
 
 v4.4

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -43,8 +43,8 @@ namespace {
             end(endPoint)
         {}
 
-        SimTK::Vec3 start {0., 0., 0.};
-        SimTK::Vec3 end {0., 0., 0.};
+        SimTK::Vec3 start {SimTK::NaN};
+        SimTK::Vec3 end {SimTK::NaN};
     };
 
     std::ostream& operator<<(

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -96,7 +96,7 @@ namespace {
     struct WrappingTolerances final {
         WrappingTolerances() = default;
 
-        WrappingTolerances(double eps):
+        WrappingTolerances(double eps) :
             position(eps),
             length(eps)
         {}

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -226,7 +226,6 @@ namespace {
         const SimTK::State& state = model.initSystem();
 
         if (visualize) {
-            model.realizeVelocity(state);
             model.getVisualizer().show(state);
         }
 

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -105,7 +105,7 @@ namespace {
         double length = 1e-9;
     };
 
-    bool IsEqual(
+    bool IsEqualWithinTolerance(
         double lhs,
         double rhs,
         double tolerance)
@@ -113,26 +113,26 @@ namespace {
         return std::abs(lhs - rhs) < tolerance;
     }
 
-    bool IsEqual(
+    bool IsEqualWithinTolerance(
         const SimTK::Vec3& lhs,
         const SimTK::Vec3& rhs,
         double tolerance)
     {
-        return IsEqual(lhs[0], rhs[0], tolerance)
-            && IsEqual(lhs[1], rhs[1], tolerance)
-            && IsEqual(lhs[2], rhs[2], tolerance);
+        return IsEqualWithinTolerance(lhs[0], rhs[0], tolerance)
+            && IsEqualWithinTolerance(lhs[1], rhs[1], tolerance)
+            && IsEqualWithinTolerance(lhs[2], rhs[2], tolerance);
     }
 
-    bool IsEqual(
+    bool IsEqualWithinTolerance(
         const PathSegment& lhs,
         const PathSegment& rhs,
         double tolerance)
     {
-        return IsEqual(lhs.start, rhs.start, tolerance)
-            && IsEqual(lhs.end, rhs.end, tolerance);
+        return IsEqualWithinTolerance(lhs.start, rhs.start, tolerance)
+            && IsEqualWithinTolerance(lhs.end, rhs.end, tolerance);
     }
 
-    bool IsEqual(
+    bool IsEqualWithinTolerance(
         const WrapTestResult& lhs,
         const WrapTestResult& rhs,
         const WrappingTolerances& tolerance)
@@ -140,8 +140,8 @@ namespace {
         if (lhs.noWrap && rhs.noWrap) {
             return true;
         }
-        return IsEqual(lhs.path, rhs.path, tolerance.position)
-            && IsEqual(lhs.length, rhs.length, tolerance.length)
+        return IsEqualWithinTolerance(lhs.path, rhs.path, tolerance.position)
+            && IsEqualWithinTolerance(lhs.length, rhs.length, tolerance.length)
             && lhs.noWrap == rhs.noWrap;
     }
 
@@ -255,7 +255,7 @@ namespace {
 
         WrapTestResult result = solve(input, visualize);
 
-        if (!IsEqual(result, expected, tol.position)) {
+        if (!IsEqualWithinTolerance(result, expected, tol.position)) {
             std::ostringstream oss;
             oss << "\nFAILED: case = " << testCase;
             oss << "\n    input = " << input;

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -230,8 +230,9 @@ namespace {
             model.getVisualizer().show(state);
         }
 
-        model.updComponent<PathSpring>("spring").getLength(state);
-        WrapResult wrapResult = model.updComponent<PathSpring>("spring")
+        // Trigger computing the wrapping path (realizing the state will not).
+        model.getComponent<PathSpring>("spring").getLength(state);
+        const WrapResult wrapResult = model.getComponent<PathSpring>("spring")
                 .getGeometryPath()
                 .getWrapSet()
                 .get("pathwrap")

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -309,11 +309,13 @@ int main()
     name = "Perpendicular";
     input.path = {{2, -2, 0}, {-2, 2.1, 0}};
 
+    // Solution obtained from copy-pasting the solution (OpenSim 4.5).
     expected.path = {
-        {0.911437827766148, 0.411437827766148, 0},
-        {0.441911556159667, 0.897058624913969, 0}
+        {0.911437827766147, 0.411437827766148, 0.},
+        {0.441911556159668, 0.897058624913969, 0.},
     };
     expected.length = 0.689036814042993;
+
     expected.noWrap = false;
 
     failLog.push_back(TestWrapping(input, expected, tolerance, name));

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -110,7 +110,7 @@ namespace {
         double rhs,
         double tolerance)
     {
-        return std::abs(lhs - rhs) < tolerance;
+        return std::abs(lhs - rhs) <= tolerance;
     }
 
     bool IsEqualWithinTolerance(

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -314,13 +314,16 @@ int main()
     // =========================================================================
 
     name = "Perpendicular";
-    input.path = {{2, 0.9, 0}, {-2, 1.0, 0}};
+    input.path = {{2, -2, 0}, {-2, 2.1, 0}};
 
-    expected.path = { {0.0505759009075089, 0.998720220205536, 0}, {0, 1, 0} };
-    expected.length = 0.0505974872969326;
+    expected.path = {
+        {0.911437827766148, 0.411437827766148, 0},
+        {0.441911556159667, 0.897058624913969, 0}
+    };
+    expected.length = 0.689036814042993;
     expected.noWrap = false;
 
-    failLog += TestWrapping(input, expected, tolerance, name, true);
+    failLog += TestWrapping(input, expected, tolerance, name);
 
     // =========================================================================
     // ====================== Handling of Test Results =========================

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -45,8 +45,8 @@ namespace {
             end(endPoint)
         {}
 
-        SimTK::Vec3 start {SimTK::NaN};
-        SimTK::Vec3 end {SimTK::NaN};
+        SimTK::Vec3 start{SimTK::NaN};
+        SimTK::Vec3 end{SimTK::NaN};
     };
 
     std::ostream& operator<<(
@@ -74,7 +74,7 @@ namespace {
         // Path segment on cylinder surface.
         PathSegment path;
         // Path segment length.
-        double length = NAN;
+        double length = SimTK::NaN;
         // True if there is no wrapping (the other fields don't matter).
         bool noWrap = false;
     };
@@ -191,7 +191,7 @@ namespace {
 
         // Add a spring to create the wrapping path.
         {
-            std::unique_ptr<PathSpring> spring (
+            std::unique_ptr<PathSpring> spring(
                 new PathSpring("spring", 1., 1., 1.));
             spring->updGeometryPath().appendNewPathPoint(
                 "startPoint",

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -32,7 +32,7 @@
 
 using namespace OpenSim;
 
-// Section with geometry related helper functions and classes.
+// Section with geometry related class and functions.
 namespace {
 
     // A path segment determined in terms of the start and end point.
@@ -65,6 +65,7 @@ namespace {
         return os <<
             "PathSegment{start: " << path.start << ", end: " << path.end << "}";
     }
+
 }
 
 // Section with helpers for evaluating the wrapping result in the upcoming test.
@@ -159,6 +160,7 @@ namespace {
             && IsEqual(lhs.length, rhs.length, tolerance.length)
             && lhs.noWrap == rhs.noWrap;
     }
+
 }
 
 // Section on configuring and simulating a specific wrapping scenario.
@@ -254,9 +256,6 @@ namespace {
         return result;
     }
 
-}
-
-namespace {
     // Simulates and tests a wrapping case:
     // - Computes the wrapping result given the input.
     // - Tests if computed result is equal to the expected result.

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -36,6 +36,8 @@ namespace {
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {
+        PathSegment() = default;
+
         PathSegment(
             const SimTK::Vec3& startPoint,
             const SimTK::Vec3& endPoint) :
@@ -70,7 +72,7 @@ namespace {
         }
 
         // Path segment on cylinder surface.
-        PathSegment path = {{}, {}};
+        PathSegment path;
         // Path segment length.
         double length = NAN;
         // True if there is no wrapping (the other fields don't matter).

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -1,0 +1,337 @@
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim:  testWrapCylinder.cpp                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2022 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/OpenSim.h>
+#include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <string>
+#include <iostream>
+#include <cmath>
+#include <sstream>
+#include <functional>
+#include <memory>
+
+using namespace OpenSim;
+
+// Section with geometry related helper functions and classes.
+namespace {
+
+    // A path segment determined in terms of the start and end point.
+    struct PathSegment final {
+        PathSegment(
+            SimTK::Vec3 startPoint,
+            SimTK::Vec3 endPoint) :
+            start(startPoint),
+            end(endPoint)
+        {}
+
+        SimTK::Vec3 start {};
+        SimTK::Vec3 end {};
+    };
+
+    PathSegment operator*(
+        const SimTK::Rotation& rot,
+        const PathSegment& path)
+    {
+        return PathSegment {
+            rot * path.start,
+            rot * path.end
+        };
+    }
+
+    std::ostream& operator<<(
+        std::ostream& os,
+        const PathSegment& path)
+    {
+        return os <<
+            "PathSegment{start: " << path.start << ", end: " << path.end << "}";
+    }
+}
+
+// Section with helpers for evaluating the wrapping result in the upcoming test.
+namespace {
+
+    // Struct for holding the result of the wrapping solution.
+    struct WrapTestResult final {
+
+        static WrapTestResult NoWrap() {
+            WrapTestResult result;
+            result.noWrap = true;
+            return result;
+        }
+
+        // Path segment on cylinder surface.
+        PathSegment path = {{}, {}};
+        // Path segment length.
+        double length = NAN;
+        // True if there is no wrapping (the other fields don't matter).
+        bool noWrap = false;
+    };
+
+    std::ostream& operator<<(
+        std::ostream& os,
+        const WrapTestResult& result)
+    {
+        if (result.noWrap) {
+            return os << "WrapTestResult{noWrap = true}";
+        }
+        return os <<
+            "WrapTestResult{" <<
+            "path: " << result.path << ", " <<
+            "length: " << result.length << "}";
+    }
+
+    // Struct holding the tolerances when asserting the wrapping result.
+    struct WrappingTolerances final {
+        WrappingTolerances() = default;
+
+        WrappingTolerances(double eps):
+            position(eps),
+            length(eps)
+        {}
+
+        double position = 1e-9;
+        double length = 1e-9;
+    };
+
+    std::ostream& operator<<(std::ostream& os, const WrappingTolerances& tol) {
+        return os <<
+            "WrappingTolerances{" <<
+            "position: " << tol.position << ", " <<
+            "length: " << tol.length << "}";
+    }
+
+    bool IsEqual(
+        double lhs,
+        double rhs,
+        double tolerance)
+    {
+        return std::abs(lhs - rhs) < tolerance;
+    }
+
+    bool IsEqual(
+        const SimTK::Vec3& lhs,
+        const SimTK::Vec3& rhs,
+        double tolerance)
+    {
+        return IsEqual(lhs[0], rhs[0], tolerance)
+            && IsEqual(lhs[1], rhs[1], tolerance)
+            && IsEqual(lhs[2], rhs[2], tolerance);
+    }
+
+    bool IsEqual(
+        const PathSegment& lhs,
+        const PathSegment& rhs,
+        double tolerance)
+    {
+        return IsEqual(lhs.start, rhs.start, tolerance)
+            && IsEqual(lhs.end, rhs.end, tolerance);
+    }
+
+    bool IsEqual(
+        const WrapTestResult& lhs,
+        const WrapTestResult& rhs,
+        const WrappingTolerances& tolerance)
+    {
+        if (lhs.noWrap && rhs.noWrap) {
+            return true;
+        }
+        return IsEqual(lhs.path, rhs.path, tolerance.position)
+            && IsEqual(lhs.length, rhs.length, tolerance.length)
+            && lhs.noWrap == rhs.noWrap;
+    }
+}
+
+// Section on configuring and simulating a specific wrapping scenario.
+namespace {
+
+    // Parameterization of the scenario for testing the wrapping.
+    //
+    // The simulated scene is one with a cylinder at the origin, with a user
+    // defined radius, length, active quadrant, and relative orientation.
+    // A specific wrapping case can be configured by choosing the start and end
+    // points of the path.
+    struct WrapInput final {
+
+        SimTK::Rotation cylinderOrientation() const {
+            SimTK::Rotation orientation;
+            orientation.setRotationToBodyFixedXYZ(eulerRotations);
+            return orientation;
+        }
+
+        // Endpoints of the total path:
+        PathSegment path = {{}, {}};
+
+        // Wrapping cylinder parameters:
+        double radius = 1.;
+        double cylinderLength = 1.;
+        std::string quadrant = "all";
+        SimTK::Vec3 eulerRotations = {0., 0., 0.};
+    };
+
+    std::ostream& operator<<(std::ostream& os, const WrapInput& input) {
+        return os <<
+            "WrapInput{" <<
+            "path: " << input.path << ", " <<
+            "radius: " << input.radius << ", " <<
+            "cylinderLength: " << input.cylinderLength << ", " <<
+            "quadrant: " << input.quadrant << ", " <<
+            "eulerRotations: " << input.eulerRotations << "}";
+    }
+
+    // Simulates the wrapping scenario as configured by the WrapInput.
+    WrapTestResult solve(const WrapInput& input, bool visualize) {
+        Model model;
+        model.setName("testWrapCylinderModel");
+
+        std::unique_ptr<WrapCylinder> cylinder(new WrapCylinder());
+        cylinder->setName("cylinder");
+        cylinder->set_radius(input.radius);
+        cylinder->set_length(input.cylinderLength);
+        cylinder->set_quadrant(input.quadrant);
+        cylinder->set_xyz_body_rotation(input.eulerRotations);
+        cylinder->setFrame(model.getGround());
+
+        std::unique_ptr<PathSpring> spring (new PathSpring("spring", 1., 1., 1.));
+        spring->updGeometryPath().appendNewPathPoint(
+            "startPoint",
+            model.get_ground(),
+            input.path.start);
+        spring->updGeometryPath().appendNewPathPoint(
+            "endPoint",
+            model.get_ground(),
+            input.path.end);
+        spring->updGeometryPath().addPathWrap(*cylinder.get());
+
+        model.addComponent(spring.release());
+        model.updGround().addWrapObject(cylinder.release());
+
+        model.finalizeConnections();
+        model.setUseVisualizer(visualize);
+
+        const SimTK::State& state = model.initSystem();
+
+        if (visualize) {
+            model.realizeVelocity(state);
+            model.getVisualizer().show(state);
+        }
+
+        model.updComponent<PathSpring>("spring").getLength(state);
+        WrapResult wrapResult = model.updComponent<PathSpring>("spring")
+                .getGeometryPath()
+                .getWrapSet()
+                .get("pathwrap")
+                .getPreviousWrap();
+
+        // Convert the WrapResult to a WrapTestResult for convenient assertions.
+        WrapTestResult result;
+        result.path = PathSegment{
+            wrapResult.r1,
+            wrapResult.r2,
+        };
+        result.length = wrapResult.wrap_path_length;
+        result.noWrap = wrapResult.wrap_pts.size() == 0;
+
+        return result;
+    }
+
+}
+
+namespace {
+    // Simulates and tests a wrapping case:
+    // - Computes the wrapping result given the input.
+    // - Tests if computed result is equal to the expected result.
+    // - Returns a string containing info on the failed test, or an empty string
+    // if succesful.
+    std::string TestWrapping(
+        const WrapInput& input,
+        const WrapTestResult& expected,
+        WrappingTolerances tol,
+        std::string testCase,
+        bool visualize = false)
+    {
+
+        WrapTestResult result = solve(input, visualize);
+
+        if (!IsEqual(result, expected, tol.position)) {
+            std::ostringstream oss;
+            oss << "\nFAILED: case = " << testCase;
+            oss << "\n    input = " << input;
+            oss << "\n    result = " << result;
+            oss << "\n    expected = " << expected;
+            oss << "\n    caused by: "
+                << "Expected and simulated result not equal to within tolerance = "
+                << tol.position;
+            return oss.str();
+        }
+
+        return std::string{};
+    }
+
+}
+
+int main()
+{
+    std::string failLog;
+    WrappingTolerances tolerance;
+
+    WrapInput input {};
+    input.radius = 1.;
+    input.cylinderLength = 10.;
+
+    // =========================================================================
+    // ======================== No-Wrapping Case ===============================
+    // =========================================================================
+
+    // Placing the path inside the cylinder results in a no-wrap.
+    std::string name = "Inside cylinder";
+    input.path = {{}, {}};
+
+    WrapTestResult expected = WrapTestResult::NoWrap();
+
+    failLog += TestWrapping(input, expected, tolerance, name);
+
+    // =========================================================================
+    // ======================= Perpendicular Case ==============================
+    // =========================================================================
+
+    name = "Perpendicular";
+    input.path = {{2, 0.9, 0}, {-2, 1.0, 0}};
+
+    expected.path = { {0.0505759009075089, 0.998720220205536, 0}, {0, 1, 0} };
+    expected.length = 0.0505974872969326;
+    expected.noWrap = false;
+
+    failLog += TestWrapping(input, expected, tolerance, name, true);
+
+    // =========================================================================
+    // ====================== Handling of Test Results =========================
+    // =========================================================================
+
+    if (!failLog.empty()) {
+        std::cerr << failLog << std::endl;
+        return 1;
+    }
+
+    std::cout << "Wrap Cylinder Test Done." << std::endl;
+    return 0;
+}

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -283,7 +283,7 @@ namespace {
 
 int main()
 {
-    std::string failLog;
+    std::vector<std::string> failLog;
     WrappingTolerances tolerance;
 
     WrapInput input {};
@@ -300,7 +300,7 @@ int main()
 
     WrapTestResult expected = WrapTestResult::NoWrap();
 
-    failLog += TestWrapping(input, expected, tolerance, name);
+    failLog.push_back(TestWrapping(input, expected, tolerance, name));
 
     // =========================================================================
     // ======================= Perpendicular Case ==============================
@@ -316,17 +316,27 @@ int main()
     expected.length = 0.689036814042993;
     expected.noWrap = false;
 
-    failLog += TestWrapping(input, expected, tolerance, name);
+    failLog.push_back(TestWrapping(input, expected, tolerance, name));
 
     // =========================================================================
     // ====================== Handling of Test Results =========================
     // =========================================================================
 
-    if (!failLog.empty()) {
-        std::cerr << failLog << std::endl;
+    size_t failedCount = 0;
+    for (size_t i = 0; i < failLog.size(); ++i) {
+        if (!failLog[i].empty()) {
+            ++failedCount;
+            std::cerr << failLog[i] << std::endl;
+        }
+    }
+
+    if (failedCount > 0) {
+        std::cout << "Wrap Cylinder Test: Failed " << failedCount << " out of "
+            << failLog.size() << " tests." << std::endl;
         return 1;
     }
 
-    std::cout << "Wrap Cylinder Test Done." << std::endl;
+    std::cout << "Wrap Cylinder Test: Passed " << failLog.size() << " tests." <<
+        std::endl;
     return 0;
 }

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -36,8 +36,15 @@ namespace {
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {
-        SimTK::Vec3 start;
-        SimTK::Vec3 end;
+        PathSegment(
+            const SimTK::Vec3& startPoint,
+            const SimTK::Vec3& endPoint) :
+            start(startPoint),
+            end(endPoint)
+        {}
+
+        SimTK::Vec3 start {0., 0., 0.};
+        SimTK::Vec3 end {0., 0., 0.};
     };
 
     std::ostream& operator<<(

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -32,31 +32,13 @@
 
 using namespace OpenSim;
 
-// Section with geometry related class and functions.
 namespace {
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {
-        PathSegment(
-            SimTK::Vec3 startPoint,
-            SimTK::Vec3 endPoint) :
-            start(startPoint),
-            end(endPoint)
-        {}
-
-        SimTK::Vec3 start {};
-        SimTK::Vec3 end {};
+        SimTK::Vec3 start;
+        SimTK::Vec3 end;
     };
-
-    PathSegment operator*(
-        const SimTK::Rotation& rot,
-        const PathSegment& path)
-    {
-        return PathSegment {
-            rot * path.start,
-            rot * path.end
-        };
-    }
 
     std::ostream& operator<<(
         std::ostream& os,
@@ -113,13 +95,6 @@ namespace {
         double position = 1e-9;
         double length = 1e-9;
     };
-
-    std::ostream& operator<<(std::ostream& os, const WrappingTolerances& tol) {
-        return os <<
-            "WrappingTolerances{" <<
-            "position: " << tol.position << ", " <<
-            "length: " << tol.length << "}";
-    }
 
     bool IsEqual(
         double lhs,


### PR DESCRIPTION
This PR contains a new test for the cylinder wrapping algorithm.

It serves as a starting point for a more rigorous testing of the cylinder wrapping, but currently it contains two simple test cases: One in which the start and end points are inside the cylinder (no-wrapping), and the other where the points are perpendicular to the cylinder (have no axial components) resulting in a simple wrapping:

![testWrapCylinder-perpendicular-unconstrained-quarter](https://github.com/opensim-org/opensim-core/assets/46680867/82effa76-59c2-471c-a63f-cc3645d69a4e)

The resulting wrapped path points obtained from the simulation are compared against the expected answer, given a tolerance. The expected answer was obtained from the solution as is now. The tolerance was chosen arbitrarily, and might change as more tests are added.

The next improvements I planned to include (in different PRs) are:
- [ ] Assert wrapping direction.
- [ ] Assert geodesic path properties, such as the path length, and gradient.
- [ ] Add more test cases,
- [ ] Add permutations to the test cases, such as rotating the scene, or reversing the start and end points.
- [ ] Merging with the cylinder wrapping test currently in `testWrappingAlgorithm.cpp`.

### Brief summary of changes

A basic test for cylinder wrapping is added: `testWrapCylinder.cpp`

### Looking for feedback on...

More ideas on what to test for are welcome!

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3498)
<!-- Reviewable:end -->
