### PR TITLE
Cleanup: Reduce dynamic allocation in Millard Equilibrium Muscle

### DIFF
--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -1037,10 +1037,9 @@ calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
         // Store quantities unique to this Muscle: the passive conservative
         // (elastic) fiber force and the passive non-conservative (damping)
         // fiber force.
-        SimTK::Vector dynExtras = SimTK::Vector(2);
-        dynExtras[0] = p1Fm; //elastic
-        dynExtras[1] = p2Fm; //damping
-        mdi.userDefinedDynamicsExtras = dynExtras;
+        mdi.userDefinedDynamicsExtras.resize(2);
+        mdi.userDefinedDynamicsExtras[0] = p1Fm; //elastic
+        mdi.userDefinedDynamicsExtras[0] = p2Fm; //damping
 
     } catch(const std::exception &x) {
         std::string msg = "Exception caught in Millard2012EquilibriumMuscle::"

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -1039,7 +1039,7 @@ calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
         // fiber force.
         mdi.userDefinedDynamicsExtras.resize(2);
         mdi.userDefinedDynamicsExtras[0] = p1Fm; //elastic
-        mdi.userDefinedDynamicsExtras[0] = p2Fm; //damping
+        mdi.userDefinedDynamicsExtras[1] = p2Fm; //damping
 
     } catch(const std::exception &x) {
         std::string msg = "Exception caught in Millard2012EquilibriumMuscle::"


### PR DESCRIPTION
This PR removes allocating a new `SimTK::Vector` before overwriting `MuscleDynamicsInfo::userDefinedDynamicsExtras` in `Millard2012EquilibriumMuscle.cpp`

### CHANGELOG.md

- no need to update because minor cleanup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3499)
<!-- Reviewable:end -->
