### PR TITLE
Cleanup: Muscle state estimate return type in `Millard2012QuilibriumMuscle`

### DIFF
--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -1598,6 +1598,7 @@ Millard2012EquilibriumMuscle::MuscleStateEstimate
     MuscleStateEstimate result;
     result.solutionError = ferr;
 
+    // Check if solution converged.
     if(abs(ferr) < aSolTolerance) {
         result.status = MuscleStateEstimate::Status::Success_Converged;
 
@@ -1608,6 +1609,7 @@ Millard2012EquilibriumMuscle::MuscleStateEstimate
         return result;
     }
 
+    // Check if fiberlength is at or exceeds lower bound.
     if (lce <= getMinimumFiberLength()) {
         result.status = MuscleStateEstimate::Status::
             Warning_FiberAtLowerBound;
@@ -1627,6 +1629,7 @@ Millard2012EquilibriumMuscle::MuscleStateEstimate
         return result;
     }
 
+    // Solution failed to converge.
     result.status = MuscleStateEstimate::Status::
         Failure_MaxIterationsReached;
     return result;

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -568,7 +568,7 @@ computeFiberEquilibrium(SimTK::State& s, bool solveForVelocity) const
     if (result.status ==
         MuscleStateEstimate::Status::Failure_MaxIterationsReached) {
             std::ostringstream oss;
-            oss << "Internal exception encountered:\n"
+            oss << "Failed to compute muscle equilibrium state:\n"
                 << "    Solution error " << std::abs(result.solutionError)
                 << " exceeds tolerance of " << tol << "\n"
                 << "    Newton iterations reached limit of " << maxIter << "\n"

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -761,8 +761,7 @@ private:
     @param staticSolution set to true to calculate the static equilibrium
            solution, setting fiber and tendon velocities to zero
     */
-    MuscleStateEstimate
-        estimateMuscleFiberState(const double aActivation,
+    MuscleStateEstimate estimateMuscleFiberState(const double aActivation,
                                  const double pathLength,
                                  const double pathLengtheningSpeed,
                                  const double aSolTolerance,

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -734,17 +734,18 @@ private:
     // length.
     double clampFiberLength(double lce) const;
 
-    // Status flag returned by estimateMuscleFiberState().
-    enum StatusFromEstimateMuscleFiberState {
-        Success_Converged,
-        Warning_FiberAtLowerBound,
-        Failure_MaxIterationsReached
-    };
+    struct MuscleStateEstimatorResult {
+        double solution_error = SimTK::NaN;
+        double fiber_length = SimTK::NaN;
+        double fiber_velocity = SimTK::NaN;
+        double tendon_force = SimTK::NaN;
 
-    // Associative array of values returned by estimateMuscleFiberState():
-    // solution_error, iterations, fiber_length, fiber_velocity, and
-    // tendon_force.
-    typedef std::map<std::string, double> ValuesFromEstimateMuscleFiberState;
+        enum Status {
+            Success_Converged,
+            Warning_FiberAtLowerBound,
+            Failure_MaxIterationsReached
+        } status = Failure_MaxIterationsReached;
+    };
 
     /* Solves fiber length and velocity to satisfy the equilibrium equations.
     The velocity of the entire musculotendon actuator is shared between the
@@ -760,8 +761,7 @@ private:
     @param staticSolution set to true to calculate the static equilibrium
            solution, setting fiber and tendon velocities to zero
     */
-    std::pair<StatusFromEstimateMuscleFiberState,
-              ValuesFromEstimateMuscleFiberState>
+    MuscleStateEstimatorResult
         estimateMuscleFiberState(const double aActivation,
                                  const double pathLength,
                                  const double pathLengtheningSpeed,

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -740,11 +740,11 @@ private:
         double tendonVelocity = SimTK::NaN;
         double tendonForce = SimTK::NaN;
 
-        enum Status {
+        enum class Status {
             Success_Converged,
             Warning_FiberAtLowerBound,
             Failure_MaxIterationsReached
-        } status = Failure_MaxIterationsReached;
+        } status = Status::Failure_MaxIterationsReached;
     };
 
     /* Solves fiber length and velocity to satisfy the equilibrium equations.

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -734,11 +734,11 @@ private:
     // length.
     double clampFiberLength(double lce) const;
 
-    struct MuscleStateEstimatorResult {
-        double solution_error = SimTK::NaN;
-        double fiber_length = SimTK::NaN;
-        double fiber_velocity = SimTK::NaN;
-        double tendon_force = SimTK::NaN;
+    struct MuscleStateEstimate {
+        double solutionError = SimTK::NaN;
+        double fiberLength = SimTK::NaN;
+        double tendonVelocity = SimTK::NaN;
+        double tendonForce = SimTK::NaN;
 
         enum Status {
             Success_Converged,
@@ -761,7 +761,7 @@ private:
     @param staticSolution set to true to calculate the static equilibrium
            solution, setting fiber and tendon velocities to zero
     */
-    MuscleStateEstimatorResult
+    MuscleStateEstimate
         estimateMuscleFiberState(const double aActivation,
                                  const double pathLength,
                                  const double pathLengtheningSpeed,


### PR DESCRIPTION
This PR adds a struct for capturing the output of the internal function `Millard2012QuilibriumMuscle::estimateMuscleFiberState`.

Previously the output was stored in a `std::pair`, with the second field a `std::map`. This made it less clear what exactly the returned values are. Since the returned information was always the same, this PR adds a struct to hold it.

### Brief summary of changes

Adds `MuscleStateEstimate` to capture the output of `Millard2012QuilibriumMuscle::estimateMuscleFiberState`.

### Testing I've completed

Visual verification that Rajagopal model simulation gives same result before and after change.
Passed the unit tests.

### CHANGELOG.md

- no need to update because minor internal refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3500)
<!-- Reviewable:end -->
