### PR TITLE
Wrap Cylinder Test: Adds rotation direction assertion

### DIFF
--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -227,7 +227,7 @@ namespace {
         }
 
         // Endpoints of the total path:
-        PathSegment path = {{}, {}};
+        PathSegment path;
 
         // Wrapping cylinder parameters:
         double radius = 1.;

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -46,6 +46,17 @@ namespace {
             end(endPoint)
         {}
 
+        // Returns PathSegment with start and end swapped.
+        PathSegment getReversed() const
+        {
+            return PathSegment{end, start};
+        }
+
+        void setReversed()
+        {
+            *this = getReversed();
+        }
+
         SimTK::Vec3 start{SimTK::NaN};
         SimTK::Vec3 end{SimTK::NaN};
     };
@@ -374,6 +385,13 @@ int main()
     expected.length = 0.689036814042993;
 
     expected.noWrap = false;
+
+    failLog.push_back(TestWrapping(input, expected, tolerance, name));
+
+    // Swapping start and end should not change the path:
+    input.path.setReversed();
+    expected.path.setReversed();
+    expected.positiveDirection = false;
 
     failLog.push_back(TestWrapping(input, expected, tolerance, name));
 

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -33,7 +33,7 @@
 using namespace OpenSim;
 
 namespace {
-    constexpr double c_TAU = 2. * M_PI;
+    const double c_TAU = 2. * SimTK::Pi;
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {
@@ -104,7 +104,7 @@ namespace {
         return AngularDistance(
             std::atan2(start[1], start[0]),
             std::atan2(end[1], end[0]),
-            true) <= M_PI;
+            true) <= SimTK::Pi;
     }
 
     bool DirectionOfShortestAngularDistanceAboutZAxis(const PathSegment& path)

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -33,7 +33,7 @@
 using namespace OpenSim;
 
 namespace {
-    static constexpr double c_TAU = 2. * M_PI;
+    constexpr double c_TAU = 2. * M_PI;
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -33,7 +33,7 @@
 using namespace OpenSim;
 
 namespace {
-    const double c_TAU = 2. * SimTK::Pi;
+    constexpr double c_TAU = 2. * SimTK_PI;
 
     // A path segment determined in terms of the start and end point.
     struct PathSegment final {

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -46,20 +46,14 @@ namespace {
             end(endPoint)
         {}
 
-        // Returns PathSegment with start and end swapped.
-        PathSegment getReversed() const
-        {
-            return PathSegment{end, start};
-        }
-
-        void setReversed()
-        {
-            *this = getReversed();
-        }
-
         SimTK::Vec3 start{SimTK::NaN};
         SimTK::Vec3 end{SimTK::NaN};
     };
+
+    // Returns PathSegment with start and end swapped.
+    PathSegment Reversed(const PathSegment& path) {
+        return PathSegment{path.end, path.start};
+    }
 
     std::ostream& operator<<(
         std::ostream& os,
@@ -389,8 +383,8 @@ int main()
     failLog.push_back(TestWrapping(input, expected, tolerance, name));
 
     // Swapping start and end should not change the path:
-    input.path.setReversed();
-    expected.path.setReversed();
+    input.path = Reversed(input.path);
+    expected.path = Reversed(expected.path);
     expected.positiveDirection = false;
 
     failLog.push_back(TestWrapping(input, expected, tolerance, name));

--- a/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapCylinder.cpp
@@ -75,7 +75,7 @@ namespace {
     {
         return PathSegment{
             rot * path.start,
-            rot * path.end
+            rot * path.end,
         };
     }
 


### PR DESCRIPTION
This PR adds rotation direction assertion to `testWrapCylinder.cpp`.

The rotation direction of the wrapping of the cylinder (positive or negative wrt the cylinder-axis) is computed from the simulation result. This is done by looking at the first straight-line-segment, so the first two points of the total path. These two points will never have an angle > 180 between them as seen from the cylinder frame. This should be indicative of the wrapping direction.
This wrapping direction is then asserted against the expected direction.

The expected wrapping direction can be seen by visualizing the wrapping path:

![testWrapCylinder-perpendicular-unconstrained-quarter](https://github.com/opensim-org/opensim-core/assets/46680867/1ba83248-2803-42dd-8cd7-8ffd6185d162)

Since the point starts from `[2, -2, 0]` we would expect a positive direction.

This change allows for a permutation of existing tests: If we swap the start and end points of the path, we should get the same path, but with flipped rotation direction. So this was added as well.

This was the first item on the list for improving the testWrapCylinder:

- [x] Assert wrapping direction.
- [ ] Assert geodesic path properties, such as the path length, and gradient.
- [ ] Add more test cases,
- [ ] Add permutations to the test cases, such as rotating the scene, or reversing the start and end points.
- [ ] Merging with the cylinder wrapping test currently in testWrappingAlgorithm.cpp.

### Brief summary of changes

Assert the rotation direction of the cylinder wrapping algorithm in `testWrapCylinder.cpp`.

### CHANGELOG.md

- no need to update because new tests for wrapping a cylinder was previously added to the changelog.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3504)
<!-- Reviewable:end -->
