### PR TITLE
Fix init order error found by libASAN's check_initialization_order

### DIFF
--- a/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
+++ b/OpenSim/Simulation/Wrap/WrapCylinderObst.cpp
@@ -35,12 +35,6 @@ static const char* wrapTypeName = "cylinderObst";
 static const double TwoPi = 2.0*SimTK::Pi;
 static const double max_wrap_pts_circle_ang = (5.0/360.0)*TwoPi;
 
-// The following variables could be used for speedy wrap_pts definitions (NOT CURRENTLY USED)
-static const int num_circle_wrap_pts = 36;  // Number of circle points in 360 degrees
-static double circle_wrap_pts_sin[num_circle_wrap_pts];
-static double circle_wrap_pts_cos[num_circle_wrap_pts];
-static bool circle_wrap_pts_inited = false;
-
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
@@ -68,12 +62,7 @@ WrapCylinderObst::~WrapCylinderObst()
 //_____________________________________________________________________________
 /** Initialize static data variables used for speedy definition of wrap_pts (for graphics mainly) */
 void WrapCylinderObst::initCircleWrapPts()
-{   int i;  double q;
-    for(i=0; i<num_circle_wrap_pts; i++) {
-        q = TwoPi*(double)(i)/(double)(num_circle_wrap_pts);
-        circle_wrap_pts_sin[i] = sin(q);
-        circle_wrap_pts_cos[i] = cos(q);
-    }   circle_wrap_pts_inited = true;
+{
 }
 
 //_____________________________________________________________________________


### PR DESCRIPTION
Fixes issue (not worth writing up)

### Brief summary of changes

- Removes unused static variables that trigger libASAN's `check_initialization_order` tests
- The reason it's UB is because the arrays that are defined here (e.g. `num_circle_wrap_points`) are VLAs, because their size is parameterized with a non-`constexpr` value
- The variables are ultimately unused anyway, so this change has no effect

### Testing I've completed

- Ran OpenSim Creator with: `ASAN_OPTIONS=detect_container_overflow=1:malloc_context_size=30:check_initialization_order=true:detect_stack_use_after_return=true ./osc-build/apps/osc/osc`
- It failed to boot because this code was triggering UB
- I removed the code and recompiled OpenSim
- Things worked again

### Looking for feedback on...

N/A

### CHANGELOG.md (choose one)

- no need to update because it would bore 99 % of readers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3510)
<!-- Reviewable:end -->
