### PR TITLE
set next release version to 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
-v4.5
+v4.4.1
 ======
 - IMU::calcGyroscopeSignal() now reports angular velocities in the IMU frame.
 - Update `report.py` to set specific colors for plotted trajectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ include(FeatureSummary)
 # OpenSim version.
 # ----------------
 set(OPENSIM_MAJOR_VERSION 4)
-set(OPENSIM_MINOR_VERSION 5)
-set(OPENSIM_PATCH_VERSION 0)
+set(OPENSIM_MINOR_VERSION 4)
+set(OPENSIM_PATCH_VERSION 1)
 
 # Don't include the patch version if it is 0.
 set(PATCH_VERSION_STRING)


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Changelog and make files now refer to 4.4.1 our actual next planned release

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3513)
<!-- Reviewable:end -->
