### PR TITLE
Update continuous_integration.yml to disambiguate artifacts on windows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -116,7 +116,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
-        path: opensim-core-${{ steps.configure.outputs.version }}-2019.zip
+        path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
     # TODO: Must be relative to the workspace?
     # - name: Upload opensim-moco dependencies

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -115,8 +115,8 @@ jobs:
     - name: Upload opensim-core
       uses: actions/upload-artifact@v3
       with:
-        name: opensim-core-${{ steps.configure.outputs.version }}-win
-        path: opensim-core-${{ steps.configure.outputs.version }}.zip
+        name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
+        path: opensim-core-${{ steps.configure.outputs.version }}-2019.zip
 
     # TODO: Must be relative to the workspace?
     # - name: Upload opensim-moco dependencies


### PR DESCRIPTION
Fixes issue #<issue_number>

### Brief summary of changes
We build ci on windows 2019 and 2022 but both builds result in the same artifact name causing one to be inaccessible, this PR disambiguates the two.
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because ci

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3514)
<!-- Reviewable:end -->
