### PR TITLE
Move cmake_minimum_required above project line and upgrade minmum cma…

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -2,9 +2,10 @@
 # compile and install all OpenSim dependencies. Using super-build is optional.
 # OpenSim does not use this file directly.
 
-project(OpenSimDependencies)
 # We require a version of CMake that supports Visual Studio 2015.
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
+
+project(OpenSimDependencies)
 
 include(ExternalProject)
 include(CMakeParseArguments)


### PR DESCRIPTION
Minor drive-by change.

When building `dependencies` with a modern cmake/VisualStudio etc. you'll see these two warnings.

The first is because `cmake_minimum_required()` must be called before `project()`

```text
$ cmake -S dependencies -B deps-build -DCMAKE_INSTALL_PREFIX=${PWD}/deps-install -G"Visual Studio 17 2022" -A x64 -DOPENSIM_WITH_CASADI=OFF -DOPENSIM_WITH_TROPTER=OFF
CMake Warning (dev) at CMakeLists.txt:5 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Deprecation Warning at CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/adamk/Desktop/opensim-core/deps-build
```

The second is because modern cmake is deprecating cmake <3.4:

```text
$ cmake -S dependencies -B deps-build -DCMAKE_INSTALL_PREFIX=${PWD}/deps-install -G"Visual Studio 17 2022" -A x64 -DOPENSIM_WITH_CASADI=OFF -DOPENSIM_WITH_TROPTER=OFF
CMake Deprecation Warning at CMakeLists.txt:6 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Configuring done (0.1s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/adamk/Desktop/opensim-core/deps-build
```

This changeset stops those warnings from popping up