### PR TITLE
Fix deleting an element from OpenSim::Coordinate's causes getMinRange…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ v4.5
 own the property `path` of type `AbstractPath` instead of the `GeometryPath` unnamed property. Getters and setters have 
 been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and 
 `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be been updated to 
-`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
+`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.
+- Deleting elements from an `OpenSim::Coordinate` range now throws an exception during `finalizeFromProperties` (previously:
+  it would let you do it, and throw later when `Coordinate::getMinRange()` or `Coordinate::getMaxRange()` were called, #3532)
 
 v4.4.1
 ======

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -141,6 +141,14 @@ void Coordinate::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
+    // eagerly check if outside code has somehow managed to remove elements
+    // from this coordinate's `range` property (issue #3532)
+    OPENSIM_THROW_IF(
+        getProperty_range().size() < 2,
+        Exception,
+        "A coordinate range must contain at least two elements (minimum, maximum)"
+    );
+
     string prefix = "Coordinate("+getName()+")::extendFinalizeFromProperties:";
 
     // Make sure the default value is within the range when clamped


### PR DESCRIPTION
Fixes issue #3532

### Brief summary of changes

- Adds a runtime check for the error condition to `OpenSim::Coordinate::extendFinalizeFromProperties`

### Testing I've completed

- Added the reproduction code in issue #3532 to `testJoints`
- The test failed
- Added the runtime check
- The test passed

### CHANGELOG.md (choose one)

- updated.
