### PR TITLE
Fix memory leak in OpenSim::CoordinateCouplerConstraint::setFunction …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ own the property `path` of type `AbstractPath` instead of the `GeometryPath` unn
 been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and 
 `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be been updated to 
 `getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
+- Fixed a minor memory leak when calling `OpenSim::CoordinateCouplerConstraint::setFunction` (#3541)
 
 v4.4.1
 ======

--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.h
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.h
@@ -109,7 +109,7 @@ public:
         return function.getValue(); 
     }
     void setFunction(const Function &aFunction)
-        { set_coupled_coordinates_function(*aFunction.clone());}
+        { set_coupled_coordinates_function(aFunction); }
     void setFunction(Function *aFunction)
         { set_coupled_coordinates_function(*aFunction); }
 


### PR DESCRIPTION
Fixes issue #3541

### Brief summary of changes

- Removes unnecessary `.clone()` call, which was creating a leaking temporary

### Testing I've completed

- None (hopefully it's obvious?)

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3547)
<!-- Reviewable:end -->
