### PR TITLE
Add bounds-checking to ObjectProperty and appropriate tests against r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 `getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
 - Fixed a minor memory leak when calling `OpenSim::CoordinateCouplerConstraint::setFunction` (#3541)
 - Increase the number of input dimensions supported by `MultivariatePolynomialFunction` to 6 (#3386)
+- Fixed mis-indexing into an `OpenSim::ObjectProperty` now throws an exception rather than segfaulting (#3347)
 
 v4.4.1
 ======

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1449,7 +1449,7 @@ ObjectProperty<T>::setValueAsObject(const Object& obj, int index) {
             + " which can't be stored in this " + objectClassName
             + " property " + this->getName());
 
-    objects[index] = newObjT;
+    objects.at(index) = newObjT;
 }
 /** @endcond **/
 

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -1151,13 +1151,13 @@ public:
     const Object& getValueAsObject(int index=-1) const override final {
         if (index < 0 && this->getMinListSize()==1 && this->getMaxListSize()==1)
             index = 0;
-        return *objects[index];
+        return *objects.at(index);
     }
 
     Object& updValueAsObject(int index=-1) override final {
         if (index < 0 && this->getMinListSize()==1 && this->getMaxListSize()==1)
             index = 0;
-        return *objects[index];
+        return *objects.at(index);
     }
 
     static bool isA(const AbstractProperty& prop) 
@@ -1187,17 +1187,17 @@ public:
     }
     // Remove value at specific index
     void removeValueAtIndexVirtual(int index) override {
-        objects.erase(&objects[index]);
+        objects.erase(&objects.at(index));
     }
 private:
     // Base class checks the index.
     const T& getValueVirtual(int index) const override final 
-    {   return *objects[index]; }
+    {   return *objects.at(index); }
     T& updValueVirtual(int index) override final 
-    {   return *objects[index]; }
+    {   return *objects.at(index); }
     void setValueVirtual(int index, const T& obj) override final
-    {   objects[index].reset((T*)nullptr);
-        objects[index] = obj; }
+    {   objects.at(index).reset((T*)nullptr);
+        objects.at(index) = obj; }
     int appendValueVirtual(const T& obj) override final
     {   objects.push_back();        // add empty element
         objects.back() = obj;       // insert a copy

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -934,6 +934,21 @@ void testCoordinateCouplerConstraint()
 
     // Forces were held in storage during simulation, now write to file
     forceReport->printResults("CouplerModelForces");
+
+    // repro for #3347: creating a `CoordinateCouplerConstraint` with no
+    // `coupled_coordinates_function` should throw a runtime exception
+    // rather than segfault
+    {
+        OpenSim::Model m;
+        m.addConstraint(new OpenSim::CoordinateCouplerConstraint{});
+
+        try {
+            // this shouldn't segfault...
+            m.buildSystem();
+        } catch (const std::exception&) {
+            // ... but it is permitted to throw
+        }
+    }
 }
 
 void testRollingOnSurfaceConstraint()


### PR DESCRIPTION
Fixes issue #3347

### Brief summary of changes

- Used `.at` to add bounds-checking to `OpenSim::ObjectProperty`, so that mis-indexing into one (e.g. by calling `get_property()` or similar) causes a runtime exception rather than a segfault
- Added tests to `testComponentInterface.cpp` and `testConstraints.cpp` to ensure the behavior doesn't regress

### Testing I've completed

- I added the test to `testConstraints.cpp`
- It did not segfault, because a previous fix hotfixed it (here: https://github.com/opensim-org/opensim-core/commit/4fa4493cca0a4e11880c8b6538109fe6fd45eed7)
- I then added tests to `testComponentInterface.cpp`
- The `SimpleProperty` one did not segfault, because it was fixed in https://github.com/opensim-org/opensim-core/pull/3411
- The `ObjectProperty` one did segfault
- Then I added the bounds checking to `Object.h` (i.e. swap index accessors for `.at`)
- Then the test passed

### Looking for feedback on...

### CHANGELOG.md

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3554)
<!-- Reviewable:end -->
