### PR TITLE
Update the Moco tests to use `<OpenSim/Auxiliary/catch.hpp>` (#3555)

### DIFF
--- a/OpenSim/Moco/Test/Testing.h
+++ b/OpenSim/Moco/Test/Testing.h
@@ -19,12 +19,7 @@
  * -------------------------------------------------------------------------- */
 
 #include <OpenSim/Common/osimCommon.h>
-
-// TODO: The more recent version of catch has issues with Approx() being
-// ambiguous.
-// TODO #include <OpenSim/Auxiliary/catch.hpp>
-#include <Vendors/tropter/external/catch/catch.hpp>
-
+#include <OpenSim/Auxiliary/catch.hpp>
 
 // Helper functions for comparing vectors.
 // ---------------------------------------

--- a/OpenSim/Moco/Test/testMocoActuators.cpp
+++ b/OpenSim/Moco/Test/testMocoActuators.cpp
@@ -22,10 +22,10 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include "OpenSim/Tools/CMC_TaskSet.h"
+#include "OpenSim/Tools/CMC_Joint.h"
 
 #define CATCH_CONFIG_MAIN
-#include "Testing.h"
-#include "OpenSim/Tools/CMC_Joint.h"
+#include <OpenSim/Auxiliary/catch.hpp>
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/Test/testMocoActuators.cpp
+++ b/OpenSim/Moco/Test/testMocoActuators.cpp
@@ -25,7 +25,7 @@
 #include "OpenSim/Tools/CMC_Joint.h"
 
 #define CATCH_CONFIG_MAIN
-#include <OpenSim/Auxiliary/catch.hpp>
+#include "Testing.h"
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/Test/testMocoAnalytic.cpp
+++ b/OpenSim/Moco/Test/testMocoAnalytic.cpp
@@ -16,12 +16,12 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define CATCH_CONFIG_MAIN
-#include "Testing.h"
-
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/SpringGeneralizedForce.h>
 #include <OpenSim/Moco/osimMoco.h>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -16,11 +16,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define CATCH_CONFIG_MAIN
-#include "Testing.h"
-using Catch::Contains;
 #include <simbody/internal/Constraint.h>
-
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Actuators/ModelOperators.h>
@@ -32,6 +28,10 @@ using Catch::Contains;
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/osimSimulation.h>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
+using Catch::Contains;
 
 using namespace OpenSim;
 using SimTK::State;

--- a/OpenSim/Moco/Test/testMocoContact.cpp
+++ b/OpenSim/Moco/Test/testMocoContact.cpp
@@ -17,11 +17,11 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include <OpenSim/Moco/osimMoco.h>
+#include <OpenSim/Simulation/Manager/Manager.h>
+
 #define CATCH_CONFIG_MAIN
 #include "Testing.h"
-#include <OpenSim/Moco/osimMoco.h>
-
-#include <OpenSim/Simulation/Manager/Manager.h>
 
 const double FRICTION_COEFFICIENT = 0.7;
 

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -16,9 +16,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define CATCH_CONFIG_MAIN
-#include "Testing.h"
-
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Actuators/PointActuator.h>
@@ -26,6 +23,9 @@
 #include <OpenSim/Moco/MocoOutputConstraint.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -16,14 +16,13 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 #define CATCH_CONFIG_MAIN
-#include "Testing.h"
+#include <OpenSim/Auxiliary/catch.hpp>
 
-#include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Moco/Components/AccelerationMotion.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
-#include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
+#include <OpenSim/Common/LinearFunction.h>
 
 using namespace OpenSim;
 using namespace Catch;
@@ -163,7 +162,7 @@ TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
 
         // Solutions are approximately equal.
         CHECK(solutionImplicit.getFinalTime() ==
-                Approx(solution.getFinalTime()).margin(1e-2));
+                Detail::Approx(solution.getFinalTime()).margin(1e-2));
         CHECK(stateError < 2.0);
         CHECK(controlError < 30.0);
 
@@ -306,7 +305,7 @@ SCENARIO("Using MocoTrajectory with the implicit dynamics mode",
         }
         THEN("RMS error is computed correctly") {
             REQUIRE(iterA.compareContinuousVariablesRMS(iterB) ==
-                    Approx(valueA - valueB));
+                    Detail::Approx(valueA - valueB));
         }
     }
 }
@@ -319,7 +318,7 @@ TEST_CASE("AccelerationMotion") {
     state.updQ()[0] = -SimTK::Pi / 2;
     model.realizeAcceleration(state);
     // Default.
-    CHECK(state.getUDot()[0] == Approx(0).margin(1e-10));
+    CHECK(state.getUDot()[0] == Detail::Approx(0).margin(1e-10));
 
     // Enable.
     accel->setEnabled(state, true);
@@ -327,12 +326,12 @@ TEST_CASE("AccelerationMotion") {
     udot[0] = SimTK::Random::Uniform(-1, 1).getValue();
     accel->setUDot(state, udot);
     model.realizeAcceleration(state);
-    CHECK(state.getUDot()[0] == Approx(udot[0]).margin(1e-10));
+    CHECK(state.getUDot()[0] == Detail::Approx(udot[0]).margin(1e-10));
 
     // Disable.
     accel->setEnabled(state, false);
     model.realizeAcceleration(state);
-    CHECK(state.getUDot()[0] == Approx(0).margin(1e-10));
+    CHECK(state.getUDot()[0] == Detail::Approx(0).margin(1e-10));
 }
 
 // This class implements a custom component with simple dynamics in implicit

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -15,14 +15,15 @@
  * See the License for the specific language governing permissions and        *
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
-#define CATCH_CONFIG_MAIN
-#include <OpenSim/Auxiliary/catch.hpp>
 
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Moco/Components/AccelerationMotion.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Common/LinearFunction.h>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
 
 using namespace OpenSim;
 using namespace Catch;

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -16,10 +16,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define CATCH_CONFIG_MAIN
-#include "Testing.h"
-#include <fstream>
-
 #include <OpenSim/Actuators/BodyActuator.h>
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/ModelFactory.h>
@@ -29,6 +25,11 @@
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/ScapulothoracicJoint.h>
+
+#include <fstream>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
 
 using namespace OpenSim;
 

--- a/OpenSim/Moco/Test/testMocoParameters.cpp
+++ b/OpenSim/Moco/Test/testMocoParameters.cpp
@@ -16,13 +16,14 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#define CATCH_CONFIG_MAIN
-#include "Testing.h"
-
 #include <OpenSim/Actuators/SpringGeneralizedForce.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
+
+#define CATCH_CONFIG_MAIN
+#include "Testing.h"
+
 using namespace OpenSim;
 
 // Resharper is a JetBrains add-on to Visual Studio that allows running tests


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

All the Moco tests already used `catch`, but they were using the `.hpp` located at `Vendors/tropter/external/catch/catch.hpp`. This PR updates these tests to use `OpenSim/Auxiliary/catch.hpp` instead (via `Testing.h`). I've also done some minor header rearranging to make header usage consistent for these tests.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal testing changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3558)
<!-- Reviewable:end -->
