### PR TITLE
Add normalization methods to `MocoGoal`

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -9,7 +9,7 @@ Moco Change Log
 - 2023-08-25: Added the pseudospectral transcription schemes 
               `CasOCLegendreGauss` and `CasOCLegendreGaussRadau`, which are 
               compatible with `MocoCasADiSolver`.
-q
+
 1.2.1
 -----
 - 2023-03-21: Fixed a bug where failing `MocoProblem`s with path constraints returned

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,10 +3,13 @@ Moco Change Log
 
 1.2.2
 -----
+- 2023-09-20: Moved `setDivideByDisplacement` and `setDivideByMass` to base 
+              `MocoGoal` class and added `MocoGoal::setDivideByDuration`. All 
+              `MocoGoal`s can now use these methods to normalize goal values.
 - 2023-08-25: Added the pseudospectral transcription schemes 
               `CasOCLegendreGauss` and `CasOCLegendreGaussRadau`, which are 
               compatible with `MocoCasADiSolver`.
-
+q
 1.2.1
 -----
 - 2023-03-21: Fixed a bug where failing `MocoProblem`s with path constraints returned

--- a/OpenSim/Moco/MocoGoal/MocoControlGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoControlGoal.cpp
@@ -29,7 +29,6 @@ void MocoControlGoal::constructProperties() {
     constructProperty_control_weights(MocoWeightSet());
     constructProperty_control_weights_pattern(MocoWeightSet());
     constructProperty_exponent(2);
-    constructProperty_divide_by_displacement(false);
 }
 
 void MocoControlGoal::setWeightForControl(
@@ -112,9 +111,7 @@ void MocoControlGoal::initializeOnModelImpl(const Model& model) const {
         };
     }
 
-    setRequirements(1, 1,
-            get_divide_by_displacement() ? SimTK::Stage::Position
-                                         : SimTK::Stage::Model);
+    setRequirements(1, 1, SimTK::Stage::Model);
 }
 
 void MocoControlGoal::calcIntegrandImpl(
@@ -132,10 +129,6 @@ void MocoControlGoal::calcIntegrandImpl(
 void MocoControlGoal::calcGoalImpl(
         const GoalInput& input, SimTK::Vector& cost) const {
     cost[0] = input.integral;
-    if (get_divide_by_displacement()) {
-        cost[0] /=
-                calcSystemDisplacement(input.initial_state, input.final_state);
-    }
 }
 
 void MocoControlGoal::printDescriptionImpl() const {

--- a/OpenSim/Moco/MocoGoal/MocoControlGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoControlGoal.h
@@ -86,13 +86,6 @@ public:
     void setExponent(int exponent) { set_exponent(exponent); }
     double getExponent() const { return get_exponent(); }
 
-    /** Set if the goal should be divided by the displacement of the system's
-    center of mass over the phase. */
-    void setDivideByDisplacement(bool tf) { set_divide_by_displacement(tf); }
-    bool getDivideByDisplacement() const {
-        return get_divide_by_displacement();
-    }
-
 protected:
     void initializeOnModelImpl(const Model&) const override;
     void calcIntegrandImpl(
@@ -108,13 +101,10 @@ private:
             "the weight for unspecified controls is 1.");
     OpenSim_DECLARE_PROPERTY(control_weights_pattern, MocoWeightSet,
             "Set control weights for all controls matching a regular "
-            "expression.")
+            "expression.");
     OpenSim_DECLARE_PROPERTY(
             exponent, int, "The exponent on controls; greater than or equal to "
                            "2 (default: 2).");
-    OpenSim_DECLARE_PROPERTY(divide_by_displacement, bool,
-            "Divide by the model's displacement over the phase (default: "
-            "false)");
     mutable std::vector<double> m_weights;
     mutable std::vector<int> m_controlIndices;
     mutable std::vector<std::string> m_controlNames;

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -63,4 +63,7 @@ void MocoGoal::constructProperties() {
     constructProperty_mode();
     constructProperty_MocoConstraintInfo(MocoConstraintInfo());
     constructProperty_scale_factors();
+    constructProperty_divide_by_displacement(false);
+    constructProperty_divide_by_duration(false);
+    constructProperty_divide_by_mass(false);
 }

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -47,12 +47,11 @@ void MocoGoal::printDescription() const {
     printDescriptionImpl();
 }
 
-double MocoGoal::calcSystemDisplacement(const SimTK::State& initialState,
-        const SimTK::State& finalState) const {
+double MocoGoal::calcSystemDisplacement(const GoalInput& input) const {
     const SimTK::Vec3 comInitial =
-            getModel().calcMassCenterPosition(initialState);
+            getModel().calcMassCenterPosition(input.initial_state);
     const SimTK::Vec3 comFinal =
-            getModel().calcMassCenterPosition(finalState);
+            getModel().calcMassCenterPosition(input.final_state);
     // TODO: Use distance squared for convexity.
     return (comFinal - comInitial).norm();
 }
@@ -61,8 +60,8 @@ double MocoGoal::calcDuration(const GoalInput& input) const {
     return input.final_time - input.initial_time;
 }
 
-double MocoGoal::calcSystemMass(const SimTK::State& state) const {
-    return getModel().getTotalMass(state);
+double MocoGoal::calcSystemMass(const GoalInput& input) const {
+    return getModel().getTotalMass(input.initial_state);
 }
 
 void MocoGoal::constructProperties() {

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -57,6 +57,14 @@ double MocoGoal::calcSystemDisplacement(const SimTK::State& initialState,
     return (comFinal - comInitial).norm();
 }
 
+double MocoGoal::calcDuration(const GoalInput& input) const {
+    return input.final_time - input.initial_time;
+}
+
+double MocoGoal::calcSystemMass(const SimTK::State& state) const {
+    return getModel().getTotalMass(state);
+}
+
 void MocoGoal::constructProperties() {
     constructProperty_enabled(true);
     constructProperty_weight(1);

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -251,20 +251,15 @@ public:
 
         calcGoalImpl(input, goal);
         
+        // Apply normalizations.
         if (get_divide_by_displacement()) {
-            const double displacement = calcSystemDisplacement(
-                    input.initial_state, input.final_state);
-            goal /= displacement;
+            goal /= calcSystemDisplacement(input);
         }
-        
         if (get_divide_by_duration()) {
-            const double duration = calcDuration(input);
-            goal /= duration;
+            goal /= calcDuration(input);
         }
-        
         if (get_divide_by_mass()) {
-            const double mass = calcSystemMass(input.initial_state);
-            goal /= mass;
+            goal /= calcSystemMass(input);
         }
 
         if (input.initial_state.getSystemStage() > initialStageBefore) {
@@ -447,12 +442,13 @@ protected:
         return m_model.getRef();
     }
 
-    double calcSystemDisplacement(
-            const SimTK::State& initial, const SimTK::State& final) const;
-    
+    /// Calculate the displacement of the system's center of mass over the
+    /// phase.
+    double calcSystemDisplacement(const GoalInput& input) const;
+    /// Calculate the duration of the phase.
     double calcDuration(const GoalInput& input) const;
-    
-    double calcSystemMass(const SimTK::State& state) const;
+    /// Calculate the mass of the system.
+    double calcSystemMass(const GoalInput& input) const;
 
     /// Append a MocoScaleFactor to this MocoGoal.
     void appendScaleFactor(const MocoScaleFactor& scaleFactor) {
@@ -564,8 +560,7 @@ protected:
     void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& values) const override {
         // Calculate average gait speed.
-        const double displacement = calcSystemDisplacement(
-                input.initial_state, input.final_state);
+        const double displacement = calcSystemDisplacement(input);
         const double duration = calcDuration(input);
         values[0] = get_desired_average_speed() - (displacement / duration);
         if (getModeIsCost()) { values[0] = SimTK::square(values[0]); }

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -157,11 +157,6 @@ void MocoOutputBase::printDescriptionImpl() const {
 // MocoOutputGoal
 // ============================================================================
 
-void MocoOutputGoal::constructProperties() {
-    constructProperty_divide_by_displacement(false);
-    constructProperty_divide_by_mass(false);
-}
-
 void MocoOutputGoal::initializeOnModelImpl(const Model& output) const {
     initializeOnModelBase();
     setRequirements(1, 1, getDependsOnStage());
@@ -175,13 +170,6 @@ void MocoOutputGoal::calcIntegrandImpl(
 void MocoOutputGoal::calcGoalImpl(
         const MocoGoal::GoalInput& input, SimTK::Vector& values) const {
     values[0] = input.integral;
-    if (get_divide_by_displacement()) {
-        values[0] /=
-                calcSystemDisplacement(input.initial_state, input.final_state);
-    }
-    if (get_divide_by_mass()) {
-        values[0] /= getModel().getTotalMass(input.initial_state);
-    }
 }
 
 // ============================================================================
@@ -189,8 +177,6 @@ void MocoOutputGoal::calcGoalImpl(
 // ============================================================================
 
 void MocoOutputExtremumGoal::constructProperties() {
-    constructProperty_divide_by_displacement(false);
-    constructProperty_divide_by_mass(false);
     constructProperty_extremum_type("minimum");
     constructProperty_smoothing_factor(1);
 }
@@ -244,13 +230,6 @@ void MocoOutputExtremumGoal::calcIntegrandImpl(
 void MocoOutputExtremumGoal::calcGoalImpl(
         const MocoGoal::GoalInput& input, SimTK::Vector& values) const {
     values[0] = input.integral;
-    if (get_divide_by_displacement()) {
-        values[0] /=
-                calcSystemDisplacement(input.initial_state, input.final_state);
-    }
-    if (get_divide_by_mass()) {
-        values[0] /= getModel().getTotalMass(input.initial_state);
-    }
 }
 
 // ============================================================================

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.h
@@ -161,27 +161,10 @@ class OSIMMOCO_API MocoOutputGoal : public MocoOutputBase {
     OpenSim_DECLARE_CONCRETE_OBJECT(MocoOutputGoal, MocoOutputBase);
 
 public:
-    MocoOutputGoal() { constructProperties(); }
-    MocoOutputGoal(std::string name) : MocoOutputBase(std::move(name)) {
-        constructProperties();
-    }
+    MocoOutputGoal() {}
+    MocoOutputGoal(std::string name) : MocoOutputBase(std::move(name)) {}
     MocoOutputGoal(std::string name, double weight)
-            : MocoOutputBase(std::move(name), weight) {
-        constructProperties();
-    }
-
-    /** Set if the goal should be divided by the displacement of the system's
-    center of mass over the phase. */
-    void setDivideByDisplacement(bool tf) { set_divide_by_displacement(tf); }
-    bool getDivideByDisplacement() const {
-        return get_divide_by_displacement();
-    }
-
-    /** Set if the goal should be divided by the total mass of the model. */
-    void setDivideByMass(bool tf) { set_divide_by_mass(tf); }
-    bool getDivideByMass() const {
-        return get_divide_by_mass();
-    }
+            : MocoOutputBase(std::move(name), weight) {}
 
 protected:
     void initializeOnModelImpl(const Model&) const override;
@@ -193,14 +176,6 @@ protected:
     Mode getDefaultModeImpl() const override {
         return Mode::Cost;
     }
-
-private:
-    OpenSim_DECLARE_PROPERTY(divide_by_displacement, bool,
-            "Divide by the model's displacement over the phase (default: "
-            "false)");
-    OpenSim_DECLARE_PROPERTY(divide_by_mass, bool,
-            "Divide by the model's total mass (default: false)");
-    void constructProperties();
 };
 
 /** This goal permits the integration of only positive or negative values from a
@@ -245,17 +220,6 @@ public:
         constructProperties();
     }
 
-    /** Set if the goal should be divided by the displacement of the system's
-    center of mass over the phase. */
-    void setDivideByDisplacement(bool tf) { set_divide_by_displacement(tf); }
-    bool getDivideByDisplacement() const {
-        return get_divide_by_displacement();
-    }
-
-    /** Set if the goal should be divided by the total mass of the model. */
-    void setDivideByMass(bool tf) { set_divide_by_mass(tf); }
-    bool getDivideByMass() const { return get_divide_by_mass(); }
-
     /** Set the type of extremum ('minimum' or 'maximum') to be applied to the 
     output variable of choice. */
     void setExtremumType(std::string extremum_type) {
@@ -282,11 +246,6 @@ protected:
     Mode getDefaultModeImpl() const override { return Mode::Cost; }
 
 private:
-    OpenSim_DECLARE_PROPERTY(divide_by_displacement, bool,
-            "Divide by the model's displacement over the phase (default: "
-            "false)");
-    OpenSim_DECLARE_PROPERTY(divide_by_mass, bool,
-            "Divide by the model's total mass (default: false)");
     OpenSim_DECLARE_PROPERTY(extremum_type, std::string,
             "The type of extremum to be taken in the goal."
             "'minimum' or 'maximum'"

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -1046,9 +1046,9 @@ protected:
     }
     void calcGoalImpl(
             const GoalInput& in, SimTK::Vector& values) const override {
-        values[0] = calcSystemDisplacement(in.initial_state, in.final_state);
+        values[0] = calcSystemDisplacement(in);
         values[1] = calcDuration(in);
-        values[2] = calcSystemMass(in.initial_state);
+        values[2] = calcSystemMass(in);
     }
 };
 

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -1033,3 +1033,56 @@ TEST_CASE("MocoGoal stage dependency") {
     CHECK_THROWS_WITH(goal.calcGoal(input, goalValue),
             Catch::Contains("calcGoal()") && Catch::Contains("final_state"));
 }
+
+/// This goal calculates the displacement of the system between the initial and
+/// final states, the duration of the phase, and the mass of the system.
+class MocoDivideByTestingGoal : public MocoGoal {
+    OpenSim_DECLARE_CONCRETE_OBJECT(MocoDivideByTestingGoal, MocoGoal);
+public:
+    MocoDivideByTestingGoal() = default;
+protected:
+    void initializeOnModelImpl(const Model&) const override {
+        setRequirements(0, 3, SimTK::Stage::Position);
+    }
+    void calcGoalImpl(
+            const GoalInput& in, SimTK::Vector& values) const override {
+        values[0] = calcSystemDisplacement(in.initial_state, in.final_state);
+        values[1] = calcDuration(in);
+        values[2] = calcSystemMass(in.initial_state);
+    }
+};
+
+// Ensure that the "divide by" methods return the correct values.
+TEST_CASE("MocoGoal divide by displacement/duration/mass") {
+    Model model = ModelFactory::createSlidingPointMass();
+    SimTK::State state = model.initSystem();
+    const double mass = model.getTotalMass(state);
+    MocoDivideByTestingGoal goal;
+    goal.initializeOnModel(model);
+    state.invalidateAll(SimTK::Stage::Instance);
+    auto initialState = state;
+    auto finalState = state;
+    
+    // Initial and final time.
+    const double initial_time = 0.0;
+    const double final_time = 2.5;
+    const double duration = final_time - initial_time;
+    initialState.setTime(initial_time);
+    finalState.setTime(final_time);
+
+    // Initial and final position.
+    const double initial_position = 0.12;
+    const double final_position = 0.74;
+    const double displacement = final_position - initial_position;
+    initialState.updQ()[0] = initial_position;
+    finalState.updQ()[0] = final_position;
+
+    MocoGoal::GoalInput input{initial_time, initialState, SimTK::Vector(), 
+                final_time, finalState, SimTK::Vector(), 0};
+    SimTK::Vector goalValues;
+    goal.calcGoal(input, goalValues);
+
+    CHECK_THAT(goalValues[0], Catch::WithinAbs(displacement, SimTK::Eps));
+    CHECK_THAT(goalValues[1], Catch::WithinAbs(duration, SimTK::Eps));
+    CHECK_THAT(goalValues[2], Catch::WithinAbs(mass, SimTK::Eps));
+}


### PR DESCRIPTION
Fixes issue #3165

### Brief summary of changes
Moves `setDivideByDisplacement` and `setDivideByMass` to the base `MocoGoal` class, and adds `MocoGoal::setDivideByDuration`.

### Testing I've completed
Add test to `testMocoGoals.cpp`

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3560)
<!-- Reviewable:end -->
