### PR TITLE
Modify bindings interface to define ReferencePtr and instantiate temp…

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -177,6 +177,9 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/ModelVisualPreferences.h>
 %include <OpenSim/Simulation/Model/ModelVisualizer.h>
 %copyctor OpenSim::Model;
+%include <SimTKcommon/internal/ReferencePtr.h>
+%template(ReferencePtrCoordinate) SimTK::ReferencePtr<const OpenSim::Coordinate>;
+%template(StdVectorReferencePtrCoordinate) std::vector<SimTK::ReferencePtr<const OpenSim::Coordinate>>;
 %include <OpenSim/Simulation/Model/Model.h>
 
 %include <OpenSim/Simulation/Model/AbstractPathPoint.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 - Deleting elements from an `OpenSim::Coordinate` range now throws an exception during `finalizeFromProperties` (previously:
   it would let you do it, and throw later when `Coordinate::getMinRange()` or `Coordinate::getMaxRange()` were called, #3532)
 - Added `FunctionBasedPath`, a class for representing paths in `Force`s based on `Function` objects (#3389)
+- Fixed bindings to expose the method Model::getCoordinatesInMultibodyTreeOrder to scripting users (#3569)
 
 v4.4.1
 ======

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -926,7 +926,7 @@ public:
         in order of the Multibody Tree and now that can be attributed to 
         corresponding generalized Coordinates of the Model. 
         Throws if the MultibodySystem is not valid. */
-    std::vector<SimTK::ReferencePtr<const Coordinate>>
+    std::vector<SimTK::ReferencePtr<const OpenSim::Coordinate>>
         getCoordinatesInMultibodyTreeOrder() const;
 
     /** Get a warning message if any Coordinates have a MotionType that is NOT


### PR DESCRIPTION
…lates to get the correct method signature

Fixes issue #3569 

### Brief summary of changes
Modify swig interface file to include ReferencePtr definition, instantiate templates for types used across the interface, to obtain the correct signature
### Testing I've completed
Method has correct signature in Java where it's easy to see classes/usage/signatures clearly

### Looking for feedback on...
If usable in python or if this has other unexpected side-effects
### CHANGELOG.md (choose one)

- Updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3575)
<!-- Reviewable:end -->
