### PR TITLE
Fix bug after constructing a `ModelProcessor` from a `Model` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
   it would let you do it, and throw later when `Coordinate::getMinRange()` or `Coordinate::getMaxRange()` were called, #3532)
 - Added `FunctionBasedPath`, a class for representing paths in `Force`s based on `Function` objects (#3389)
 - Fixed bindings to expose the method Model::getCoordinatesInMultibodyTreeOrder to scripting users (#3569)
+- Fixed a bug where constructing a `ModelProcessor` from a `Model` object led to an invalid `Model`
 
 v4.4.1
 ======

--- a/OpenSim/Actuators/ModelOperators.h
+++ b/OpenSim/Actuators/ModelOperators.h
@@ -81,9 +81,6 @@ class OSIMACTUATORS_API ModOpRemoveMuscles : public ModelOperator {
 
 public:
     void operate(Model& model, const std::string&) const override {
-        // Without finalizeFromProperties(), an exception is raised
-        // about the model not having any subcomponents.
-        model.finalizeFromProperties();
         model.finalizeConnections();
         ModelFactory::removeMuscles(model);
     }
@@ -180,9 +177,6 @@ class OSIMACTUATORS_API ModOpReplaceMusclesWithPathActuators
 
 public:
     void operate(Model& model, const std::string&) const override {
-        // Without finalizeFromProperties(), an exception is raised
-        // about the model not having any subcomponents.
-        model.finalizeFromProperties();
         model.finalizeConnections();
         ModelFactory::replaceMusclesWithPathActuators(model);
     }

--- a/OpenSim/Actuators/ModelProcessor.h
+++ b/OpenSim/Actuators/ModelProcessor.h
@@ -110,6 +110,8 @@ public:
         if (get_filepath().empty()) {
             if (!getProperty_model().empty()) {
                 model = get_model();
+                model.finalizeFromProperties();
+                model.finalizeConnections();
             } else {
                 OPENSIM_THROW_FRMOBJ(Exception, "No source model.");
             }


### PR DESCRIPTION
Discovered by @mattpetrucci.

### Brief summary of changes
- Added `model.finalizeFromProperties()` and `model.finalizeConnections()` after constructing a `ModelProcessor` from a `Model` object. Without these calls, some `ModelOperator`s lead to an error complaining that the model had no subcomponents. This now matches the behavior when loading a model from a file.
- Removed some `finalizeFromProperties` calls in `ModelOperators.h`.

### Testing I've completed
- Ran `testModelProcessor.cpp` without the fix and it failed. Added the fix and it passed.

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3577)
<!-- Reviewable:end -->
