### PR TITLE
Prevent zero-mass bodies and locked coordinates + support `MocoFrameDistanceConstraint` serialization

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,9 +3,16 @@ Moco Change Log
 
 1.2.2
 -----
+- 2023-10-25: Fixed a bug preventing deserialization of `MocoFrameDistanceConstraint`.
+
+- 2023-10-25: Locked coordinates and bodies with zero mass are now explicitly
+              excluded from a `MocoProblem`, since they lead to NaNs values
+              during optimization.
+
 - 2023-09-20: Moved `setDivideByDisplacement` and `setDivideByMass` to base 
               `MocoGoal` class and added `MocoGoal::setDivideByDuration`. All 
               `MocoGoal`s can now use these methods to normalize goal values.
+
 - 2023-08-25: Added the pseudospectral transcription schemes 
               `CasOCLegendreGauss` and `CasOCLegendreGaussRadau`, which are 
               compatible with `MocoCasADiSolver`.

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -71,6 +71,27 @@ void MocoProblemRep::initialize() {
     const auto& ph0 = m_problem->getPhase(0);
     // TODO: Provide directory from which to load model file.
     m_model_base = ph0.getModelProcessor().process();
+    m_model_base.initSystem();
+
+    // Check for bodies with zero mass.
+    for (const auto& body : m_model_base.getComponentList<Body>()) {
+        if (body.getMass() == 0) {
+            OPENSIM_THROW(Exception, "Body '{}' has zero mass, but Moco "
+                                     "does not support bodies with zero mass.",
+                    body.getAbsolutePathString());
+        }
+    }
+
+    // Check for locked coordinates.
+    for (const auto& coordinate : m_model_base.getComponentList<Coordinate>()) {
+        if (coordinate.get_locked()) {
+            OPENSIM_THROW(Exception, "Coordinate '{}' is locked, but Moco "
+                                     "does not support locked coordinates. "
+                                     "Consider replacing the joint for this "
+                                     "coordinate with a WeldJoint instead.",
+                    coordinate.getAbsolutePathString());
+        }
+    }
 
     auto discreteControllerBaseUPtr = make_unique<DiscreteController>();
     m_discrete_controller_base.reset(discreteControllerBaseUPtr.get());

--- a/OpenSim/Moco/RegisterTypes_osimMoco.cpp
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.cpp
@@ -109,6 +109,7 @@ OSIMMOCO_API void RegisterTypes_osimMoco() {
 
         Object::registerType(MocoControlBoundConstraint());
         Object::registerType(MocoFrameDistanceConstraint());
+        Object::registerType(MocoFrameDistanceConstraintPair());
 
         Object::registerType(MocoCasADiSolver());
 

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -1086,3 +1086,20 @@ TEST_CASE("MocoGoal divide by displacement/duration/mass") {
     CHECK_THAT(goalValues[1], Catch::WithinAbs(duration, SimTK::Eps));
     CHECK_THAT(goalValues[2], Catch::WithinAbs(mass, SimTK::Eps));
 }
+
+TEST_CASE("MocoFrameDistanceConstraint de/serialization") {
+
+    {
+        auto study = createStudy(0, {0, 100.0});
+        auto& problem = study.updProblem();
+        auto* con = problem.addPathConstraint<MocoFrameDistanceConstraint>();
+        con->setName("distance_constraint");
+        con->addFramePair("/body", "/ground", 0, 1);
+        study.print("testMocoGoals_MocoFrameDistanceConstraint_study.omoco");
+    }
+
+    {
+        MocoStudy study(
+                "testMocoGoals_MocoFrameDistanceConstraint_study.omoco");
+    }
+}

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -39,50 +39,55 @@ using namespace OpenSim;
 // - model_file vs model.
 // - test problems without controls (including with setting guesses).
 
-std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
-    model->setName("sliding_mass");
-    model->set_gravity(SimTK::Vec3(0, 0, 0));
-    auto* body = new Body("body", 10.0, SimTK::Vec3(0), SimTK::Inertia(0));
-    model->addComponent(body);
+// HELPER FUNCTIONS
+namespace {
+    std::unique_ptr<Model> createSlidingMassModel(
+            double mass = 10.0, bool lock_coordinate = false) {
+        auto model = make_unique<Model>();
+        model->setName("sliding_mass");
+        model->set_gravity(SimTK::Vec3(0, 0, 0));
+        auto* body = new Body("body", mass, SimTK::Vec3(0), SimTK::Inertia(0));
+        model->addComponent(body);
 
-    // Allows translation along x.
-    auto* joint = new SliderJoint("slider", model->getGround(), *body);
-    auto& coord = joint->updCoordinate(SliderJoint::Coord::TranslationX);
-    coord.setName("position");
-    model->addComponent(joint);
+        // Allows translation along x.
+        auto* joint = new SliderJoint("slider", model->getGround(), *body);
+        auto& coord = joint->updCoordinate(SliderJoint::Coord::TranslationX);
+        coord.setName("position");
+        if (lock_coordinate) { coord.set_locked(true); }
+        model->addComponent(joint);
 
-    auto* actu = new CoordinateActuator();
-    actu->setCoordinate(&coord);
-    actu->setName("actuator");
-    actu->setOptimalForce(1);
-    actu->setMinControl(-10);
-    actu->setMaxControl(10);
-    model->addComponent(actu);
+        auto* actu = new CoordinateActuator();
+        actu->setCoordinate(&coord);
+        actu->setName("actuator");
+        actu->setOptimalForce(1);
+        actu->setMinControl(-10);
+        actu->setMaxControl(10);
+        model->addComponent(actu);
 
-    return model;
-}
+        return model;
+    }
 
-template <typename SolverType = MocoTropterSolver>
-MocoStudy createSlidingMassMocoStudy(
-        const std::string& transcriptionScheme = "trapezoidal",
-        int numMeshIntervals = 19) {
-    MocoStudy study;
-    study.setName("sliding_mass");
-    study.set_write_solution("false");
-    MocoProblem& mp = study.updProblem();
-    mp.setModel(createSlidingMassModel());
-    mp.setTimeBounds(MocoInitialBounds(0), MocoFinalBounds(0, 10));
-    mp.setStateInfo("/slider/position/value", MocoBounds(0, 1),
-            MocoInitialBounds(0), MocoFinalBounds(1));
-    mp.setStateInfo("/slider/position/speed", {-100, 100}, 0, 0);
-    mp.addGoal<MocoFinalTimeGoal>();
+    template <typename SolverType = MocoTropterSolver>
+    MocoStudy createSlidingMassMocoStudy(
+            const std::string& transcriptionScheme = "trapezoidal",
+            int numMeshIntervals = 19) {
+        MocoStudy study;
+        study.setName("sliding_mass");
+        study.set_write_solution("false");
+        MocoProblem& mp = study.updProblem();
+        mp.setModel(createSlidingMassModel());
+        mp.setTimeBounds(MocoInitialBounds(0), MocoFinalBounds(0, 10));
+        mp.setStateInfo("/slider/position/value", MocoBounds(0, 1),
+                MocoInitialBounds(0), MocoFinalBounds(1));
+        mp.setStateInfo("/slider/position/speed", {-100, 100}, 0, 0);
+        mp.addGoal<MocoFinalTimeGoal>();
 
-    auto& ms = study.initSolver<SolverType>();
-    ms.set_num_mesh_intervals(numMeshIntervals);
-    ms.set_transcription_scheme(transcriptionScheme);
-    ms.set_enforce_constraint_derivatives(false);
-    return study;
+        auto& ms = study.initSolver<SolverType>();
+        ms.set_num_mesh_intervals(numMeshIntervals);
+        ms.set_transcription_scheme(transcriptionScheme);
+        ms.set_enforce_constraint_derivatives(false);
+        return study;
+    }
 }
 
 TEMPLATE_TEST_CASE("Non-uniform mesh", "", MocoCasADiSolver, MocoTropterSolver) {
@@ -2182,6 +2187,32 @@ TEST_CASE("Solver isAvailable()") {
 #endif
 }
 
+TEMPLATE_TEST_CASE("Locked coordinates ", "",
+        MocoCasADiSolver, MocoTropterSolver) {
+    MocoStudy study;
+    auto& problem = study.updProblem();
+    auto model = createSlidingMassModel(10.0, true);
+    problem.setModel(std::move(model));
+    CHECK_THROWS_WITH(problem.createRep(),
+            Catch::Contains("Coordinate '/slider/position' is locked"));
+}
+
+TEMPLATE_TEST_CASE("Zero-mass bodies ", "",
+        MocoCasADiSolver, MocoTropterSolver) {
+    MocoStudy study;
+    auto& problem = study.updProblem();
+    Model model("subject_walk_armless_18musc.osim");
+    model.initSystem();
+    // Simbody allows zero-mass patella bodies (presumably because they are
+    // driven by CoordinateCouplerConstraints).
+    auto& body = model.updBodySet().get("patella_r");
+    body.setMass(0);
+    body.setInertia(SimTK::Inertia(0));
+    model.finalizeFromProperties();
+    problem.setModel(make_unique<Model>(model));
+    CHECK_THROWS_WITH(problem.createRep(),
+            Catch::Contains("Body '/bodyset/patella_r' has zero mass"));
+}
 
 /*
 TEMPLATE_TEST_CASE("Controllers in the model", "",


### PR DESCRIPTION
Fixes issue #3542, #3579 

### Brief summary of changes
This PR adds some checks to prevent bugs (e.g., NaNs in CasADi) due to locked coordinates and bodies with zero mass. I also fixed a minor bug preventing serialization of `MocoFrameDistanceConstraint`.

### Testing I've completed
Added tests to `testMocoInterface.cpp` and `testMocoGoals.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.
