### PR TITLE
Support Python local installation and visualizer path

### DIFF
--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -3,7 +3,9 @@ import os
 if (sys.platform.startswith('win')):
     curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
-    os.add_dll_directory(os.path.join(os.path.dirname(sys.executable),'Scripts'))
+    opensimCMD = os.path.join(os.path.dirname(sys.executable), 'Scripts', 'opensim-cmd.exe')
+    if os.path.isfile(opensimCMD):
+        os.add_dll_directory(os.path.dirname(opensimCMD))
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import os
 if (sys.platform.startswith('win')):
+    curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
     os.add_dll_directory(os.path.join(os.path.dirname(sys.executable),'Scripts'))
 

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -3,7 +3,16 @@ import os
 if (sys.platform.startswith('win')):
     curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
-    os.environ['PATH'] = curFolder+os.pathsep+os.environ['PATH']
+    # when installed locally via "python -m pip install ."
+    if os.path.isfile(os.path.join(curFolder, 'opensim-cmd.exe')):
+        os.environ['PATH'] = curFolder+os.pathsep+os.environ['PATH']
+    # for Python bindings tests
+    install_path = os.path.join(curFolder, "../../../bin")
+    if (os.path.exists(install_path)):
+        os.add_dll_directory(install_path)
+    dev_path = os.path.join(curFolder, "../../../../Release")
+    if (os.path.exists(dev_path)):
+        os.add_dll_directory(dev_path)
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,15 +1,19 @@
 import sys
 import os
-if (sys.platform.startswith('win')):
-      curFolder = os.path.dirname(os.path.realpath(__file__))
-      os.add_dll_directory(curFolder)
-      # in install env, add relative path from init.py to bin, in build environment, we also add "../../../../Release"
-      install_path = os.path.join(curFolder, "../../../bin")
-      if (os.path.exists(install_path)):
-          os.add_dll_directory(install_path)
-      dev_path = os.path.join(curFolder, "../../../../Release")
-      if (os.path.exists(dev_path)):
-          os.add_dll_directory(dev_path)
+
+if sys.platform.startswith('win'):
+    curFolder = os.path.dirname(os.path.realpath(__file__))
+    os.add_dll_directory(curFolder)
+    # in install env, add relative path from init.py to bin, in build environment, we also add "../../../../Release"
+    try: # pass only if DLL_PATH is updated by setup.py in local installation
+        bin_path = DLL_PATH
+        os.add_dll_directory(bin_path)
+        os.environ["PATH"] = bin_path+os.pathsep+os.environ["PATH"] # add to the beginning
+        dev_path = os.path.join(bin_path, "../Release")
+        if (os.path.exists(dev_path)):
+            os.add_dll_directory(dev_path)
+    except:
+        pass
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,15 +1,8 @@
 import sys
 import os
 if (sys.platform.startswith('win')):
-      curFolder = os.path.dirname(os.path.realpath(__file__))
-      os.add_dll_directory(curFolder)
-      # in install env, add relative path from init.py to bin, in build environment, we also add "../../../../Release"
-      install_path = os.path.join(curFolder, "../../../bin")
-      if (os.path.exists(install_path)):
-          os.add_dll_directory(install_path)
-      dev_path = os.path.join(curFolder, "../../../../Release")
-      if (os.path.exists(dev_path)):
-          os.add_dll_directory(dev_path)
+    os.add_dll_directory(curFolder)
+    os.add_dll_directory(os.path.join(os.path.dirname(sys.executable),'Scripts'))
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -1,19 +1,15 @@
 import sys
 import os
-
-if sys.platform.startswith('win'):
-    curFolder = os.path.dirname(os.path.realpath(__file__))
-    os.add_dll_directory(curFolder)
-    # in install env, add relative path from init.py to bin, in build environment, we also add "../../../../Release"
-    try: # pass only if DLL_PATH is updated by setup.py in local installation
-        bin_path = DLL_PATH
-        os.add_dll_directory(bin_path)
-        os.environ["PATH"] = bin_path+os.pathsep+os.environ["PATH"] # add to the beginning
-        dev_path = os.path.join(bin_path, "../Release")
-        if (os.path.exists(dev_path)):
-            os.add_dll_directory(dev_path)
-    except:
-        pass
+if (sys.platform.startswith('win')):
+      curFolder = os.path.dirname(os.path.realpath(__file__))
+      os.add_dll_directory(curFolder)
+      # in install env, add relative path from init.py to bin, in build environment, we also add "../../../../Release"
+      install_path = os.path.join(curFolder, "../../../bin")
+      if (os.path.exists(install_path)):
+          os.add_dll_directory(install_path)
+      dev_path = os.path.join(curFolder, "../../../../Release")
+      if (os.path.exists(dev_path)):
+          os.add_dll_directory(dev_path)
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -3,10 +3,11 @@ import os
 if (sys.platform.startswith('win')):
     curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
-    # when installed locally via "python -m pip install ."
+    # When installed locally via "python -m pip install ." in Windows
     if os.path.isfile(os.path.join(curFolder, 'opensim-cmd.exe')):
-        os.environ['PATH'] = curFolder+os.pathsep+os.environ['PATH']
-    # for Python bindings tests
+        # This only sets the PATH for the Python environment (not permanent)
+        os.environ['PATH'] = curFolder + os.pathsep + os.environ['PATH']
+    # For local testing
     install_path = os.path.join(curFolder, "../../../bin")
     if (os.path.exists(install_path)):
         os.add_dll_directory(install_path)

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -3,9 +3,7 @@ import os
 if (sys.platform.startswith('win')):
     curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
-    opensimCMD = os.path.join(sys.exec_prefix, 'Scripts', 'opensim-cmd.exe')
-    if os.path.isfile(opensimCMD):
-        os.add_dll_directory(os.path.dirname(opensimCMD))
+    os.environ['PATH'] = curFolder+os.pathsep+os.environ['PATH']
 
 from .simbody import *
 from .common import *

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -3,7 +3,7 @@ import os
 if (sys.platform.startswith('win')):
     curFolder = os.path.dirname(os.path.realpath(__file__))
     os.add_dll_directory(curFolder)
-    opensimCMD = os.path.join(os.path.dirname(sys.executable), 'Scripts', 'opensim-cmd.exe')
+    opensimCMD = os.path.join(sys.exec_prefix, 'Scripts', 'opensim-cmd.exe')
     if os.path.isfile(opensimCMD):
         os.add_dll_directory(os.path.dirname(opensimCMD))
 

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -3,7 +3,6 @@
 import os
 import sys
 from setuptools import setup
-from pathlib import Path
 
 opensimCMD = '../../bin/opensim-cmd.exe' # local installation
 if os.path.isfile(opensimCMD):

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -3,6 +3,20 @@
 import os
 import sys
 from setuptools import setup
+from pathlib import Path
+
+# find path to bin folder
+if  list(Path('..').rglob('opensim-cmd.exe')):
+    bin_path = os.path.dirname(os.path.relpath(up1[0]))
+    bin_files = []
+    print('conda installation.', 'Relative path to the bin directory =', bin_path)
+elif list(Path('../..').rglob('opensim-cmd.exe')):
+    bin_path = os.path.dirname(os.path.relpath(up2[0]))
+    bin_files = [os.path.join(bin_path, i).replace(os.sep,'/') for i in os.listdir(bin_path)]
+    print('pip installation', 'Relative path to the bin directory =', bin_path)
+else:
+    raise NotADirectoryError('Cannot find the bin directory')
+
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:
     execfile('opensim/version.py')
@@ -17,6 +31,7 @@ setup(name='opensim',
       url='http://opensim.stanford.edu/',
       license='Apache 2.0',
       packages=['opensim'],
+      data_files = [('Scripts', bin_files)],
       # The last 3 entries are for if OPENSIM_PYTHON_STANDALONE is ON.
       # The asterisk after the extension is to handle version numbers on Linux.
       package_data={'opensim': ['_*.*', '*.dylib', '*.dll', '*.so*']},

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -4,7 +4,9 @@ import os
 import sys
 from setuptools import setup
 
-if os.path.isfile('../../bin/opensim-cmd.exe'): # local installation
+# This provides a list of relative paths to all the dependencies in the bin folder.
+# Only when installed locally via "python -m pip install ." in Windows
+if os.path.isfile('../../bin/opensim-cmd.exe'):
     bin_files = [os.path.join('../../bin', i).replace(os.sep,'/') for i in os.listdir('../../bin')]
 else:
     bin_files = []
@@ -23,6 +25,7 @@ setup(name='opensim',
       url='http://opensim.stanford.edu/',
       license='Apache 2.0',
       packages=['opensim'],
+      # Copy the bin_files into the opensim package directory
       data_files = [('Lib/site-packages/opensim', bin_files)],
       # The last 3 entries are for if OPENSIM_PYTHON_STANDALONE is ON.
       # The asterisk after the extension is to handle version numbers on Linux.

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -3,6 +3,16 @@
 import os
 import sys
 from setuptools import setup
+import fileinput
+
+# update __init__.py in local installation
+install_path = os.path.abspath('../../bin').replace(os.sep, '/')
+if (sys.platform.startswith('win') and os.path.exists(install_path)):
+    print ('install path found as '+ install_path)
+    with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
+        for line in file:
+            print(line.replace('DLL_PATH', "'" + install_path + "'"), end='')
+
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:
     execfile('opensim/version.py')

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -26,7 +26,7 @@ setup(name='opensim',
       license='Apache 2.0',
       packages=['opensim'],
       # Copy the bin_files into the opensim package directory
-      data_files = [('Lib/site-packages/opensim', bin_files)],
+      data_files=[('Lib/site-packages/opensim', bin_files)],
       # The last 3 entries are for if OPENSIM_PYTHON_STANDALONE is ON.
       # The asterisk after the extension is to handle version numbers on Linux.
       package_data={'opensim': ['_*.*', '*.dylib', '*.dll', '*.so*']},

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -4,12 +4,10 @@ import os
 import sys
 from setuptools import setup
 
-opensimCMD = '../../bin/opensim-cmd.exe' # local installation
-if os.path.isfile(opensimCMD):
-	bin_path  = os.path.dirname(os.path.relpath(opensimCMD))
-	bin_files = [os.path.join(bin_path, i).replace(os.sep,'/') for i in os.listdir(bin_path)]
+if os.path.isfile('../../bin/opensim-cmd.exe'): # local installation
+    bin_files = [os.path.join('../../bin', i).replace(os.sep,'/') for i in os.listdir('../../bin')]
 else:
-	bin_files = []
+    bin_files = []
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:
@@ -25,7 +23,7 @@ setup(name='opensim',
       url='http://opensim.stanford.edu/',
       license='Apache 2.0',
       packages=['opensim'],
-      data_files = [('Scripts', bin_files)],
+      data_files = [('Lib/site-packages/opensim', bin_files)],
       # The last 3 entries are for if OPENSIM_PYTHON_STANDALONE is ON.
       # The asterisk after the extension is to handle version numbers on Linux.
       package_data={'opensim': ['_*.*', '*.dylib', '*.dll', '*.so*']},

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -5,17 +5,12 @@ import sys
 from setuptools import setup
 from pathlib import Path
 
-# find path to bin folder
-if  list(Path('..').rglob('opensim-cmd.exe')):
-    bin_path = os.path.dirname(os.path.relpath(up1[0]))
-    bin_files = []
-    print('conda installation.', 'Relative path to the bin directory =', bin_path)
-elif list(Path('../..').rglob('opensim-cmd.exe')):
-    bin_path = os.path.dirname(os.path.relpath(up2[0]))
-    bin_files = [os.path.join(bin_path, i).replace(os.sep,'/') for i in os.listdir(bin_path)]
-    print('pip installation', 'Relative path to the bin directory =', bin_path)
+opensimCMD = '../../bin/opensim-cmd.exe' # local installation
+if os.path.isfile(opensimCMD):
+	bin_path  = os.path.dirname(os.path.relpath(opensimCMD))
+	bin_files = [os.path.join(bin_path, i).replace(os.sep,'/') for i in os.listdir(bin_path)]
 else:
-    raise NotADirectoryError('Cannot find the bin directory')
+	bin_files = []
 
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:

--- a/Bindings/Python/setup.py
+++ b/Bindings/Python/setup.py
@@ -3,16 +3,6 @@
 import os
 import sys
 from setuptools import setup
-import fileinput
-
-# update __init__.py in local installation
-install_path = os.path.abspath('../../bin').replace(os.sep, '/')
-if (sys.platform.startswith('win') and os.path.exists(install_path)):
-    print ('install path found as '+ install_path)
-    with fileinput.FileInput('opensim/__init__.py', inplace=True, backup='.bak') as file:
-        for line in file:
-            print(line.replace('DLL_PATH', "'" + install_path + "'"), end='')
-
 # This provides the variable `__version__`.
 if sys.version_info[0] < 3:
     execfile('opensim/version.py')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 - Refactor c3dExport.m file as a Matlab function (#3501), also expose method to allow some operations on tableColumns
   (multiplyAssign) to speed up data processing.
 - Fixed xml-related memory leaks that were occuring when deserializing OpenSim models. (Issue #3537, PR #3594)
-- Fixed a minor bug when the locally installed package (via `pip`) couldn't find the dependencies (#3593).
-  Added `data_files` argument to the `setup.py` to copy all the dependencies into the opensim package folder in the Python environment.
+- Fixed a minor bug when the locally installed package (via `pip`) couldn't find the dependencies (PR #3593). Added `data_files` argument to the `setup.py` to copy all the dependencies into the opensim package folder in the Python environment.
 
 v4.4.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.5
 ====
+- Fixed a minor bug when the locally installed package (via `pip`) couldn't find the dependencies (#3593). Added `data_files` argument to the `setup.py` to copy all the dependencies into the opensim package folder in the Python environment.
 - Added `AbstractPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based forces now 
 own the property `path` of type `AbstractPath` instead of the `GeometryPath` unnamed property. Getters and setters have 
 been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and 


### PR DESCRIPTION
Update `setup.py` and `__init__.py` files to fix issues related to local installation and path to the `simbody-visualizer.exe`.

This should work for both Conda and local installation.

Fixes issue #3344

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3593)
<!-- Reviewable:end -->
