### PR TITLE
XML memory leak fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 - Added `LatinHypercubeDesign`, a class for generating Latin hypercube designs using random and algorithm methods (#3570)
 - Refactor c3dExport.m file as a Matlab function (#3501), also expose method to allow some operations on tableColumns
   (multiplyAssign) to speed up data processing.
+- Fixed xml-related memory leaks that were occuring when deserializing
+  Rajagopal2015.osim, an OpenSim v3.0 full-body model. (Issue #3537, PR #3594)
 
 v4.4.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.5
 ====
-- Added `AbstractPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based forces now 
-own the property `path` of type `AbstractPath` instead of the `GeometryPath` unnamed property. Getters and setters have 
-been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and 
-`Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to 
-`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
+- Added `AbstractPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based forces now
+own the property `path` of type `AbstractPath` instead of the `GeometryPath` unnamed property. Getters and setters have
+been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and
+`Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to
+`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.
 - Fixed a minor memory leak when calling `OpenSim::CoordinateCouplerConstraint::setFunction` (#3541)
 - Increase the number of input dimensions supported by `MultivariatePolynomialFunction` to 6 (#3386)
 - Added `Assertion.h` and associated `OPENSIM_ASSERT*` macros (#3531)
@@ -28,6 +28,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 - Fixed bindings to expose the method Model::getCoordinatesInMultibodyTreeOrder to scripting users (#3569)
 - Fixed a bug where constructing a `ModelProcessor` from a `Model` object led to an invalid `Model`
 - Added `LatinHypercubeDesign`, a class for generating Latin hypercube designs using random and algorithm methods (#3570)
+- Fixed memory leaks that occurred when deserializing v3.0 models (e.g., Rajagopal2015.osim). (issue #3537)
 
 v4.4.1
 ======
@@ -79,11 +80,11 @@ v4.4
 
 v4.3
 ====
-- Introduced IMU component that models a typical Inertial Measurement Unit (IMU) with corresponding outputs for orientation, accelerometer, and gyroscope signals. 
+- Introduced IMU component that models a typical Inertial Measurement Unit (IMU) with corresponding outputs for orientation, accelerometer, and gyroscope signals.
 - Introduced IMUDataReporter (analysis) to record signals from IMU components placed on models.
 - Fixed a bug with Actuation analysis that would lead to extra columns in the output when an actuator is disabled (Issue #2977).
 - Fix issue where including path in output file name caused output to not be written without warning, now warning is given and file is written (Issue #3042).
-- Fix copy-paste bug in reporting orientation errors (Issue #2893, fixed by Henrik-Norgren). 
+- Fix copy-paste bug in reporting orientation errors (Issue #2893, fixed by Henrik-Norgren).
 - Upgrade bindings to use SWIG version 4.0 (allowing doxygen comments to carry over to Java/Python files).
 - Added createSyntheticIMUAccelerationSignals() to SimulationUtilities to generate "synthetic" IMU accelerations based on passed in state trajectory.
 - Fixed incorrect header information in BodyKinematics file output
@@ -97,7 +98,7 @@ v4.2
 - Fixed a bug in Millard2012EquilibriumMuscle::extendFinalizeFromProperties(): the end point slopes on the inverse force velocity curves are constrained to yield a valid curve. A warning is noted in the log if the slopes are small enough that numerical integration might be slow.
 - Added logging to Millard2012EquilibriumMuscle::extendFinalizeFromProperties(): whenever an internal setting is changed automatically these changes are noted in the log. To avoid seeing these messages, update the corresponding properties in the .osim file to the values noted in the log message.
 - Introduced new logging system based on spdlog https://github.com/gabime/spdlog.git. The transition should be transparent to end users with default settings except that the name of the log file is now opensim.log. Main features are:
-  - The ability to customize error level for reporting (in increasing level of verbosity): Off, Critical, Error, Warn, Info, Debug, Trace 
+  - The ability to customize error level for reporting (in increasing level of verbosity): Off, Critical, Error, Warn, Info, Debug, Trace
   - The ability to start logging to a specified file on the fly.
   - Log file messages are time stamped and the format can be changed by users
   - More details and additional functionality is described in the Developer's Guide, and Doxygen pages of OpenSim::Logger class.
@@ -127,8 +128,8 @@ v4.2
 - Improved the performance of `ComponentPath` (PR #2844)
   - This improves the performance of component-heavy models by ~5-10 %
   - The behavior and interface of `ComponentPath` should remain the same
-- The new Matlab CustomStaticOptimization.m guides the user to build their own custom static optimization code. 
-- Dropped support for separate Kinematics for application of External Loads. ([PR #2770] (https://github.com/opensim-org/opensim-core/pull/2770)). 
+- The new Matlab CustomStaticOptimization.m guides the user to build their own custom static optimization code.
+- Dropped support for separate Kinematics for application of External Loads. ([PR #2770] (https://github.com/opensim-org/opensim-core/pull/2770)).
 - Refactored InverseKinematicsSolver to allow for adding (live) Orientation data to track, introduced BufferedOrientationsReference to queue data (PR #2855)
 - `opensim.log` will only be created/opened when the first message is logged to it (PR #2880):
   - Previously, `opensim.log` would always be created, even if nothing was logged
@@ -151,16 +152,16 @@ v4.1
 - Model files from very old versions (pre 1.8.1) are not supported, an exception is thrown rather than fail quietly (issue #2395).
 - Initializing a Component from an existing Component with correct socket connectees yields invalid paths (issue #2418).
 - Reading DataTables from files has been simplified. Reading one table from a file typically uses the Table constructor except when the data-source/file contains multiple tables. (In these cases e.g. C3D files, use C3DFileAdapter.read method, then use functions in C3DFileAdapter to get the individual TimeSeriesTable(s)). Writing tables to files has not changed.
-- Exposed convertMillimeters2Meters() in osimC3D.m. This function converts COP and moment data from mm to m and now must be invoked prior to writing force data to file. Previously, this was automatically performed during writing forces to file. 
+- Exposed convertMillimeters2Meters() in osimC3D.m. This function converts COP and moment data from mm to m and now must be invoked prior to writing force data to file. Previously, this was automatically performed during writing forces to file.
 - Methods that operate on SimTK::Vec<n> are now available through Java/Matlab and python bindings to add/subtract/divide/multiply vec<n> contents with a scalar (PR #2558)
 - The new Stopwatch class allows C++ API users to easily measure the runtime of their code.
 - If finalizeConnections() method was not called on a model after making changes and before printing, an exception is thrown to avoid creating corrupt model files quietly (PR #2529)
 - Updated the docopt.cpp dependency so that OpenSim can be compiled with Visual C++ from Visual Studio 2019.
-- Added `Blankevoort1991Ligament` force component which represents ligament fibers as non-linear path springs. The force-strain curve has a quadratic toe region at low strains and a linear stiffness region at high strains. (PR #2632)  
+- Added `Blankevoort1991Ligament` force component which represents ligament fibers as non-linear path springs. The force-strain curve has a quadratic toe region at low strains and a linear stiffness region at high strains. (PR #2632)
 - Updated Simbody to 3.7 to fix an issue with the simbody-visualizer on macOS 10.15 Catalina.
 - On Mac and Linux, we include a shell script opensim-install-command-line.sh to make OpenSim's command-line tools easily accessible.
 - Added the compliant SmoothSphereHalfSpaceForce component, for use with direct collocation and Moco.
- 
+
 
 Converting from v4.0 to v4.1
 ----------------------------
@@ -172,7 +173,7 @@ Converting from v4.0 to v4.1
 Bug Fixes
 ---------
 - Fixed bug in osimTable2Struct.m for renaming unlabelled markers (PR #2491)
-- Fixed bug that resulted in an exception when reading C3D files without forces. Now, if the C3D doesn't contain markers or forces, an empty table will be returned (PR #2421) 
+- Fixed bug that resulted in an exception when reading C3D files without forces. Now, if the C3D doesn't contain markers or forces, an empty table will be returned (PR #2421)
 - Fix bug that resulted in activations and forces reported for Actuators that are disabled during StaticOptimization (issue #2438) Disabled actuators are now ignored in StaticOptimization.
 - OpenSim no longer supports model file formats predating version 1.8.1 (PR #2498)
 - FunctionBasedBushingForce now applies damping if specified (it was incorrectly ignored in 4.0) issue #2512
@@ -185,7 +186,7 @@ Documentation
 Other Changes
 -------------
 - Performance of reading large data files has been significantly improved. A 50MB .sto file would take 10-11 min to read now takes 2-3 seconds. (PR #2399)
-- Added Matlab example script of plotting the Force-length properties of muscles in a models; creating an Actuator file from a model; 
+- Added Matlab example script of plotting the Force-length properties of muscles in a models; creating an Actuator file from a model;
 building and simulating a simple arm model;  using OutputReporters to record and write marker location and coordinate values to file.
 - Added Python example that demonstrates how to run an optimization using the cma package and how to avoid an expensive call to `initSystem()` within the objective function. (PR #2604)
 - OpenSim 4.1 ships with Python3 bindings as default. It is still possible to create bindings for Python2 if desired by setting CMake variable OPENSIM_PYTHON_VERSION to 2
@@ -359,7 +360,7 @@ New Classes
 - Created Frame, PhysicalFrame, OffsetFrame, PhysicalOffsetFrame, Station and Marker ModelComponents (PR #188, PR #325, PR #339). Marker did not previously comply with the Model Component interface.
 - A Body is a PhysicalFrame
 - Connections to Bodies upgraded to PhysicalFrames and locations on these frames are now represented by PhysicalOffsetFrame (PR #370)
-- Joints were refactored so that the base Joint manages the parent and child frame connections, including the definition of local PhysicalOffsetFrames to handle offsets defined as separate location and orientation properties. (PR #589)  
+- Joints were refactored so that the base Joint manages the parent and child frame connections, including the definition of local PhysicalOffsetFrames to handle offsets defined as separate location and orientation properties. (PR #589)
 - The WeldConstraint and BushingForces (BushingForce, CoupledBushingForce, FunctionBasedBushingForce, and ExpressionBasedBushingForce) were similarly unified (like Joints) to handle the two Frames that these classes require to operate. A LinkTwoFrames intermediate class was introduced to house the common operations. Convenience constructors for WeldConstraint and BushingFrames were affected and now require the name of the Component as the first argument. (PR #649)
 - The new StatesTrajectory class allows users to load an exact representation of previously-computed states from a file. (PR #730)
 - Added Point as a new base class for all points, which include: Station, Marker, and PathPoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@ been added to these forces to provide access to concrete path types (e.g., `updP
 - Added `LatinHypercubeDesign`, a class for generating Latin hypercube designs using random and algorithm methods (#3570)
 - Refactor c3dExport.m file as a Matlab function (#3501), also expose method to allow some operations on tableColumns
   (multiplyAssign) to speed up data processing.
-- Fixed xml-related memory leaks that were occuring when deserializing
-  Rajagopal2015.osim, an OpenSim v3.0 full-body model. (Issue #3537, PR #3594)
+- Fixed xml-related memory leaks that were occuring when deserializing OpenSim models. (Issue #3537, PR #3594)
 
 v4.4.1
 ======

--- a/OpenSim/Simulation/Model/ContactGeometry.cpp
+++ b/OpenSim/Simulation/Model/ContactGeometry.cpp
@@ -189,6 +189,8 @@ void ContactGeometry::updateFromXMLNode(SimTK::Xml::Element& node,
             }
             if (addAppearanceNode) 
                 node.insertNodeAfter(node.element_end(), appearanceNode);
+            else if (appearanceNode.isOrphan())
+                appearanceNode.clearOrphan();
         }
     }
     Super::updateFromXMLNode(node, versionNumber);

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -158,7 +158,7 @@ void Muscle::constructProperties()
     // By default the min and max controls on muscle are 0.0 and 1.0
     setMinControl(0.0);
     setMaxControl(1.0);
-    upd_GeometryPath().setDefaultColor(DefaultMuscleColor);
+    updPath().setDefaultColor(DefaultMuscleColor);
 }
 
 

--- a/OpenSim/Simulation/Model/Muscle.cpp
+++ b/OpenSim/Simulation/Model/Muscle.cpp
@@ -26,7 +26,7 @@
 //=============================================================================
 #include "Muscle.h"
 
-#include "GeometryPath.h"
+
 #include "Model.h"
 #include <OpenSim/Common/XMLDocument.h>
 

--- a/OpenSim/Simulation/Model/PhysicalFrame.cpp
+++ b/OpenSim/Simulation/Model/PhysicalFrame.cpp
@@ -62,7 +62,7 @@ const SimTK::MobilizedBody& PhysicalFrame::getMobilizedBody() const
     return getModel().getMatterSubsystem().getMobilizedBody(_mbIndex);
 }
 
-SimTK::MobilizedBody& PhysicalFrame::updMobilizedBody() 
+SimTK::MobilizedBody& PhysicalFrame::updMobilizedBody()
 {
     return updModel().updMatterSubsystem().updMobilizedBody(_mbIndex);
 }
@@ -76,7 +76,7 @@ void PhysicalFrame::setMobilizedBodyIndex(const SimTK::MobilizedBodyIndex& mbix)
 
 /*
 * Implementation of Frame interface by PhysicalFrame.
-* 
+*
 */
 SimTK::Transform PhysicalFrame::
     calcTransformInGround(const SimTK::State& s) const
@@ -134,7 +134,7 @@ void PhysicalFrame::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNum
 {
     if (versionNumber < XMLDocument::getLatestVersion()) {
         if (versionNumber < 30502) {
-            // Find node for <VisibleObject> remove it then create Geometry for the 
+            // Find node for <VisibleObject> remove it then create Geometry for the
             SimTK::Xml::element_iterator iIter = aNode.element_begin("VisibleObject");
             if (iIter != aNode.element_end()) {
                 SimTK::Xml::Element visObjElement = SimTK::Xml::Element::getAs(aNode.removeNode(iIter));
@@ -186,6 +186,8 @@ void PhysicalFrame::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNum
                         geomSetIter->setElementTag("geometry");
                     }
                 }
+                if(visObjElement.isOrphan())
+                    visObjElement.clearOrphan();
             }
         }
     }
@@ -224,7 +226,7 @@ void PhysicalFrame::convertDisplayGeometryToGeometryXML(SimTK::Xml::Element& bod
             if (innerXformIter != displayGeomIter->element_end()) {
                 innerXformVec6 = innerXformIter->getValueAs<SimTK::Vec6>();
             }
-            // Old geometry/visibleObject could specify 2 transforms one per DisplayGeometry 
+            // Old geometry/visibleObject could specify 2 transforms one per DisplayGeometry
             // and one for the whole visibleObject.
             // We'll attach to the frame only if both transforms are identity
             attachToThisFrame = (innerXformVec6.norm() < SimTK::Eps)
@@ -323,7 +325,7 @@ void PhysicalFrame::convertDisplayGeometryToGeometryXML(SimTK::Xml::Element& bod
             // Insert Mesh into parent
             if (attachToThisFrame)
                 geometrySetNode.insertNodeAfter(geometrySetNode.element_end(), meshNode);
-                        
+
             displayGeomIter++;
             counter++;
         }

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -92,7 +92,7 @@ void Body::extendFinalizeFromProperties()
 void Body::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
-    
+
     int nslaves = (int)_slaves.size();
 
     if (nslaves){
@@ -142,11 +142,11 @@ const SimTK::Inertia& Body::getInertia() const
         else{
             try {
                 _inertia = SimTK::Inertia(Ivec.getSubVec<3>(0), Ivec.getSubVec<3>(3));
-            } 
+            }
             catch (const std::exception& ex){
                 // Should throw an Exception but we have models we have released with
                 // bad inertias. E.g. early gait23 models had an error in the inertia
-                // of the toes Body. We cannot allow failures with our models so 
+                // of the toes Body. We cannot allow failures with our models so
                 // raise a warning and do something sensible with the values at hand.
                 log_warn("Body {} has invalid inertia. ", getName());
                 log_error(ex.what());
@@ -156,7 +156,7 @@ const SimTK::Inertia& Body::getInertia() const
 
                 // and then assume a spherical shape.
                 _inertia = SimTK::Inertia(Vec3(diag), Vec3(0));
-                
+
                 log_warn("{} Body's inertia being reset to: {}",
                     getName(), _inertia);
             }
@@ -369,7 +369,7 @@ SimTK::MassProperties Body::getMassProperties() const
             // shift if com has nonzero distance from b
             Ib = Icom.shiftFromMassCenter(com, m);
         }
-    
+
         return SimTK::MassProperties(m, com, Ib);
     }
     catch (const std::exception& ex) {
@@ -394,6 +394,7 @@ void Body::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                 if (iIter != aNode.element_end()) {
                     newInertia[i] = iIter->getValueAs<double>();
                     aNode.removeNode(iIter);
+                    iIter->clearOrphan();
                 }
             }
             std::ostringstream strs;
@@ -418,7 +419,7 @@ Body* Body::addSlave()
     name << getName() << "_slave_" << count;
     slave->setName(name.str());
 
-    //add to internal list of references 
+    //add to internal list of references
     _slaves.push_back(SimTK::ReferencePtr<Body>(slave));
 
     //add to list of subcomponents to automatically add to system and initialize

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -26,7 +26,6 @@
 //=============================================================================
 #include "Coordinate.h"
 #include "CoordinateCouplerConstraint.h"
-#include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/Joint.h>
 #include "simbody/internal/Constraint.h"
@@ -44,7 +43,7 @@ using namespace OpenSim;
  */
 class ModifiableConstant : public SimTK::Function_<SimTK::Real>{
 public:
-    ModifiableConstant(const SimTK::Real& value, int argumentSize) : 
+    ModifiableConstant(const SimTK::Real& value, int argumentSize) :
         argumentSize(argumentSize), value(value) { }
 
     ModifiableConstant* clone() const override {
@@ -52,15 +51,15 @@ public:
     }
 
     SimTK::Real calcValue(const SimTK::Vector& x) const override {
-        OPENSIM_ASSERT(x.size() == argumentSize);
+        assert(x.size() == argumentSize);
         return value;
     }
 
-    SimTK::Real calcDerivative(const std::vector<int>& derivComponents, 
+    SimTK::Real calcDerivative(const std::vector<int>& derivComponents,
         const SimTK::Vector& x) const {
         return calcDerivative(SimTK::ArrayViewConst_<int>(derivComponents),x);
     }
-    SimTK::Real calcDerivative(const SimTK::Array_<int>& derivComponents, 
+    SimTK::Real calcDerivative(const SimTK::Array_<int>& derivComponents,
         const SimTK::Vector& x) const override {
         return 0;
     }
@@ -88,7 +87,7 @@ private:
 /**
  * Default constructor.
  */
-Coordinate::Coordinate() 
+Coordinate::Coordinate()
 {
     constructProperties();
 }
@@ -142,14 +141,6 @@ void Coordinate::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-    // eagerly check if outside code has somehow managed to remove elements
-    // from this coordinate's `range` property (issue #3532)
-    OPENSIM_THROW_IF(
-        getProperty_range().size() != 2,
-        Exception,
-        "A coordinate range must contain exactly two elements (minimum, maximum)"
-    );
-
     string prefix = "Coordinate("+getName()+")::extendFinalizeFromProperties:";
 
     // Make sure the default value is within the range when clamped
@@ -160,12 +151,12 @@ void Coordinate::extendFinalizeFromProperties()
 
         double dv = get_default_value();
         SimTK_ERRCHK2_ALWAYS(dv > (get_range(0) - SimTK::SqrtEps), prefix.c_str(),
-            "Default coordinate value is less than range minimum.\n" 
+            "Default coordinate value is less than range minimum.\n"
             "Default value = %g  < min = %g.", dv,  get_range(0));
 
         SimTK_ERRCHK2_ALWAYS(dv < (get_range(1) + SimTK::SqrtEps), prefix.c_str(),
             "Default coordinate value is greater than range maximum.\n"
-            "Default value = %g > max = %g.", dv, get_range(1));    
+            "Default value = %g > max = %g.", dv, get_range(1));
     }
 
     _lockedWarningGiven=false;
@@ -185,31 +176,31 @@ void Coordinate::extendAddToSystem(SimTK::MultibodySystem& system) const
     // Define the locked value for the constraint as a function.
     // The PrescribedMotion will take ownership, but we'll keep a reference
     // pointer here to allow for later modification.
-    std::unique_ptr<ModifiableConstant> 
+    std::unique_ptr<ModifiableConstant>
         funcOwner(new ModifiableConstant(get_default_value(), 1));
     mutableThis->_lockFunction = funcOwner.get();
-    
+
     // The underlying SimTK constraint
-    SimTK::Constraint::PrescribedMotion 
-        lock(system.updMatterSubsystem(), 
-             funcOwner.release(),   // give up ownership 
-             _bodyIndex, 
+    SimTK::Constraint::PrescribedMotion
+        lock(system.updMatterSubsystem(),
+             funcOwner.release(),   // give up ownership
+             _bodyIndex,
              SimTK::MobilizerQIndex(_mobilizerQIndex));
 
     // Save the index so we can access the SimTK::Constraint later
     mutableThis->_lockedConstraintIndex = lock.getConstraintIndex();
-            
+
     if(!getProperty_prescribed_function().empty()){
         //create prescribed motion constraint automatically
-        SimTK::Constraint::PrescribedMotion prescribe( 
-                _model->updMatterSubsystem(), 
-                get_prescribed_function().createSimTKFunction(), 
-                _bodyIndex, 
+        SimTK::Constraint::PrescribedMotion prescribe(
+                _model->updMatterSubsystem(),
+                get_prescribed_function().createSimTKFunction(),
+                _bodyIndex,
                 SimTK::MobilizerQIndex(_mobilizerQIndex));
         mutableThis->_prescribedConstraintIndex = prescribe.getConstraintIndex();
     }
     else if(get_prescribed()){
-        // if prescribed is set to true, and there is no prescribed 
+        // if prescribed is set to true, and there is no prescribed
         // function defined, then it cannot be prescribed (set to false).
         mutableThis->upd_prescribed() = false;
     }
@@ -221,13 +212,13 @@ void Coordinate::extendAddToSystem(SimTK::MultibodySystem& system) const
         getModel().getMatterSubsystem().getMySubsystemIndex();
 
     //Expose coordinate state variable
-    CoordinateStateVariable* csv 
+    CoordinateStateVariable* csv
         = new CoordinateStateVariable("value", *this,
                                        sbsix, _mobilizerQIndex );
     addStateVariable(csv);
 
-    //Expose coordinate's speed state variable  
-    SpeedStateVariable* ssv = 
+    //Expose coordinate's speed state variable
+    SpeedStateVariable* ssv =
         new SpeedStateVariable("speed", *this, sbsix, _mobilizerQIndex);
     addStateVariable(ssv);
 }
@@ -379,10 +370,6 @@ const std::string&  Coordinate::getSpeedName() const
     return _speedName;
 }
 
-double Coordinate::getQDotValue(const SimTK::State& s) const {
-    return _model->getMatterSubsystem().getMobilizedBody(_bodyIndex).getOneQDot(s,_mobilizerQIndex);
-}
-
 double Coordinate::getAccelerationValue(const SimTK::State& s) const
 {
     return getModel().getMatterSubsystem().getMobilizedBody(_bodyIndex).getOneUDot(s, _mobilizerQIndex);
@@ -404,7 +391,7 @@ void Coordinate::setRange(double aRange[2])
     }
     else
         throw Exception("Coordinate::setRange, range is invalid, "
-            "min range value exceeds max."); 
+            "min range value exceeds max.");
 }
 
 //_____________________________________________________________________________
@@ -479,7 +466,7 @@ void Coordinate::setPrescribedFunction(const OpenSim::Function& function)
 
     for(int i=0; i<_model->getConstraintSet().getSize(); i++){
         Constraint& constraint = _model->getConstraintSet().get(i);
-        CoordinateCouplerConstraint* couplerp = 
+        CoordinateCouplerConstraint* couplerp =
             dynamic_cast<CoordinateCouplerConstraint*>(&constraint);
         if(couplerp) {
             if (couplerp->getDependentCoordinateName() == getName())
@@ -517,7 +504,7 @@ void Coordinate::setLocked(SimTK::State& s, bool aLocked) const
     if(aLocked == getLocked(s)){
         return;
     }
-    
+
     _lockedWarningGiven=false;  // reset flag in case needed later
     SimTK::Constraint *lock = NULL;
 
@@ -576,7 +563,7 @@ void Coordinate::setIsPrescribed(SimTK::State& s, bool isPrescribed) const
 {
     // Do nothing if the same
     if(isPrescribed == this->isPrescribed(s) ) return;
-    
+
     // The underlying SimTK constraint
     SimTK::Constraint *prescribe = NULL;
 
@@ -591,7 +578,7 @@ void Coordinate::setIsPrescribed(SimTK::State& s, bool isPrescribed) const
     }
 
     // Now enable if prescribed motion constraint otherwise disable
-    if(isPrescribed){   
+    if(isPrescribed){
         prescribe->enable(s);
         setLocked(s, false);
     }
@@ -608,7 +595,7 @@ bool Coordinate::isPrescribed(const SimTK::State& s) const
     else{
         return get_prescribed();
     }
-    
+
 }
 
 //-----------------------------------------------------------------------------
@@ -644,7 +631,7 @@ double Coordinate::CoordinateStateVariable::
     getDerivative(const SimTK::State& state) const
 {
     //TODO: update to get qdot value from the mobilized body
-    return ((Coordinate *)&getOwner())->getSpeedValue(state); 
+    return ((Coordinate *)&getOwner())->getSpeedValue(state);
 }
 
 
@@ -702,7 +689,7 @@ void Coordinate::updateFromXMLNode(SimTK::Xml::Element& aNode,
         if (versionNumber < 30514) {
             SimTK::Xml::element_iterator iter = aNode.element_begin("motion_type");
             if (iter != aNode.element_end()) {
-                SimTK::Xml::Element motionTypeElm = 
+                SimTK::Xml::Element motionTypeElm =
                     SimTK::Xml::Element::getAs(aNode.removeNode(iter));
                 std::string typeName = motionTypeElm.getValue();
 
@@ -714,6 +701,8 @@ void Coordinate::updateFromXMLNode(SimTK::Xml::Element& aNode,
                     _userSpecifiedMotionTypePriorTo40 = Coupled;
                 else
                     _userSpecifiedMotionTypePriorTo40 = Undefined;
+
+                iter->clearOrphan();
             }
         }
     }

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -26,6 +26,7 @@
 //=============================================================================
 #include "Coordinate.h"
 #include "CoordinateCouplerConstraint.h"
+#include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/Joint.h>
 #include "simbody/internal/Constraint.h"
@@ -51,7 +52,7 @@ public:
     }
 
     SimTK::Real calcValue(const SimTK::Vector& x) const override {
-        assert(x.size() == argumentSize);
+        OPENSIM_ASSERT(x.size() == argumentSize);
         return value;
     }
 
@@ -140,6 +141,14 @@ void Coordinate::constructProperties(void)
 void Coordinate::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
+
+    // eagerly check if outside code has somehow managed to remove elements
+    // from this coordinate's `range` property (issue #3532)
+    OPENSIM_THROW_IF(
+        getProperty_range().size() != 2,
+        Exception,
+        "A coordinate range must contain exactly two elements (minimum, maximum)"
+    );
 
     string prefix = "Coordinate("+getName()+")::extendFinalizeFromProperties:";
 
@@ -368,6 +377,10 @@ void Coordinate::setSpeedValue(SimTK::State& s, double aValue) const
 const std::string&  Coordinate::getSpeedName() const
 {
     return _speedName;
+}
+
+double Coordinate::getQDotValue(const SimTK::State& s) const {
+    return _model->getMatterSubsystem().getMobilizedBody(_bodyIndex).getOneQDot(s,_mobilizerQIndex);
 }
 
 double Coordinate::getAccelerationValue(const SimTK::State& s) const

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -74,6 +74,9 @@ void WrapObject::constructProperties()
 
 const PhysicalFrame& WrapObject::getFrame() const
 {
+    if (!_frame) {
+        OPENSIM_THROW_FRMOBJ(OpenSim::Exception, "Tried to call WrapObject::getFrame before the frame has been set. Make sure that `OpenSim::WrapObject::setFrame` is called on the `WrapObject` before doing any operations with the `WrapObject`.");
+    }
     return _frame.getRef();
 }
 
@@ -214,7 +217,7 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                     node.element_begin("color");
             if (colorIter != node.element_end()) {
                 color.setValue(colorIter->getValue());
-                node.removeNode(colorIter);  // FC
+                node.removeNode(colorIter);
                 colorIter->clearOrphan();
                 appearanceModified = true;
             }

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -266,11 +266,15 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                 appearanceNode.insertNodeAfter(appearanceNode.element_end(),
                         visibleNode);
                 appearanceModified = true;
+            } else if (visibleNode.isOrphan()) {
+                visibleNode.clearOrphan();
             }
 
             // Add Appearance to the WrapObject.
             if (appearanceModified) {
                 node.insertNodeAfter(node.element_end(), appearanceNode);
+            } else if (appearanceNode.isOrphan()) {
+                appearanceNode.clearOrphan();
             }
         }
     }

--- a/OpenSim/Simulation/Wrap/WrapObject.cpp
+++ b/OpenSim/Simulation/Wrap/WrapObject.cpp
@@ -74,9 +74,6 @@ void WrapObject::constructProperties()
 
 const PhysicalFrame& WrapObject::getFrame() const
 {
-    if (!_frame) {
-        OPENSIM_THROW_FRMOBJ(OpenSim::Exception, "Tried to call WrapObject::getFrame before the frame has been set. Make sure that `OpenSim::WrapObject::setFrame` is called on the `WrapObject` before doing any operations with the `WrapObject`.");
-    }
     return _frame.getRef();
 }
 
@@ -143,9 +140,9 @@ void WrapObject::extendFinalizeFromProperties()
     }
 }
 
-int WrapObject::wrapPathSegment(const SimTK::State& s, 
+int WrapObject::wrapPathSegment(const SimTK::State& s,
                                 AbstractPathPoint& aPoint1, AbstractPathPoint& aPoint2,
-                                const PathWrap& aPathWrap, 
+                                const PathWrap& aPathWrap,
                                 WrapResult& aWrapResult) const
 {
    int return_code = noWrap;
@@ -157,7 +154,7 @@ int WrapObject::wrapPathSegment(const SimTK::State& s,
     // to, to the frame of the wrap object's body
     pt1 = aPoint1.getParentFrame()
         .findStationLocationInAnotherFrame(s, aPoint1.getLocation(s), getFrame());
-    
+
     pt2 = aPoint2.getParentFrame()
         .findStationLocationInAnotherFrame(s, aPoint2.getLocation(s), getFrame());
 
@@ -193,7 +190,7 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
             // We ignore most of VisibleObject's other properties (e.g.,
             // transform), since it would be misleading to draw the wrap object
             // in the wrong place.
-            SimTK::Xml::Element appearanceNode("Appearance"); 
+            SimTK::Xml::Element appearanceNode("Appearance");
             // Use the correct defaults for WrapObject's appearance, which
             // are different from the default Appearance.
             SimTK::Xml::Element color("color");
@@ -217,7 +214,8 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                     node.element_begin("color");
             if (colorIter != node.element_end()) {
                 color.setValue(colorIter->getValue());
-                node.removeNode(colorIter);
+                node.removeNode(colorIter);  // FC
+                colorIter->clearOrphan();
                 appearanceModified = true;
             }
 
@@ -237,6 +235,7 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                     appearanceModified = true;
                 }
                 node.removeNode(dispPrefIter);
+                dispPrefIter->clearOrphan();
             }
             SimTK::Xml::element_iterator visObjIter =
                     node.element_begin("VisibleObject");
@@ -247,7 +246,7 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                     if (voDispPrefIter->getValueAs<int>() == 0) {
                         visibleNode.setValue("false");
                         appearanceModified = true;
-                    } else if (rep.getValue() == "3" && 
+                    } else if (rep.getValue() == "3" &&
                             voDispPrefIter->getValueAs<int>() < 4) {
                         // Set `representation`.
                         // The representation still has its default value,
@@ -258,6 +257,7 @@ void WrapObject::updateFromXMLNode(SimTK::Xml::Element& node,
                     }
                 }
                 node.removeNode(visObjIter);
+                visObjIter->clearOrphan();
             }
             if (visibleNode.getValue() != "") {
                 appearanceNode.insertNodeAfter(appearanceNode.element_end(),


### PR DESCRIPTION
XML-related memory leaks were reported when deserializing Rajagopal2015.osim, an OpenSim v3.0 full-body model.  See issue #3537.

I used WinCRT to help find the memory leaks.  Since WinCRT is platform specific (i.e., runs only on Windows) and requires some changes to the source code to leak test effectively, this PR only includes the leak fixes (not the modified code that I used to identify the leaks and verify that they were fixed).

None of the observed leaks associated with deserializing Rajagopal2015.osim were due to coding errors in SimTK::Xml. SimTK::Xml looks like it is working fine, with no intrinsic leaks.  (@adamkewley and I did find a constructor in SimTK::Xml that should be revised, but it is not the source of any leaks that I can identity).

The reported memory leaks were occurring in OpenSim in various ```updateFromXMLNode()``` calls. In particular, ```updateFromXMLNode()```  for ```OpenSim::Body```, ```OpenSim::Coordinate```, ```OpenSim::ContactGeometry```, ```OpenSim::Muscle```, ```OpenSim::PhysicalFrame```, and ```OpenSim::WrapObject```.

The leaks were related to converting from an older version of OpenSim (i.e., from v3.0) to the current version.  Thus, the memory leaks can be sidestepped by converting old models to the current version (by deserializing them and then saving to a new .osim model file).  This sort of sidestepping doesn't address a situation in which an old version model is repeatedly deserialized, however.

Fortunately, all of the leaks had something in common and so were not tooooo difficult to find. In each case, a new element was created and not freed, or an element was removed from the XML document, was not inserted elsewhere in the model hierarchy, and was not freed. In all these cases, the fix was simply to call ```clearOrphan()``` on the element in question.

Rajogopal2015.osim, whether v3.0 or the current version, is now deserializing without memory leaks.

Fixes issue #3537

@adamkewley tested for memory leaks when deserializing a number of other OpenSim models (i.e., models other than Rajagopal2015.osim) and found more leaks! He then added ```clearOrphan()``` calls to fix those leaks as well! Those fixes are included in this PR. See "(added)" line numbers in the section, **"Brief summary of fixes"**, below.

So, it looks like most, if not all, memory leaks associated with deserializing any OpenSim model have been fixed.

### Brief summary of fixes
In the files listed below, I inserted calls to ```clearOrphan()```. To make these calls easier to find, amidst all the trailing whitespaces that were removed, I included the line numbers of the insertions.

1. SimbodyEngine/Body.cpp : line 397
2. SimbodyEngine/Coordinate.cpp : line 705
3. Model/ContactGeometry.cpp : line 192 (added) 
4. Model/Muscle.cpp : lines 110, 121
5. Model/PhysicalFrame.cpp : line 190
6. Wrap/WrapObject.cpp : lines 218, 238, 260, 269 (added), 276 (added)

### Testing completed
- In Simbody, I mimicked the operations that are commonly performed in OpenSim during deserialization and verified that no leaks within SimTK::Xml occur. In every case I've encountered, the leaks occur because an orphaned node is not cleared, which is the responsibility of the caller.
- For a few simple models (those that I am using to test my exponential contact model), I verified that no leaks occur during deserialization.
- For the new ```StatesDocument``` class I'm developing, I verified that no leaks occur when states trajectories are de/serialized.  Class ```StatesDocument``` uses SimTK::Xml as the basis for serialization.
- For Rajagopal2015.osim (v3.0), I verified that deserialization created leaks before the above fixes and that no leaks were created after the fixes.
- For Rajagopal2015.osim, I verified that serialization of the model to a new file produced identical output before and after the above fixes.  That is, the fixes appear not to be altering execution; they're just freeing abandoned memory blocks.
- @adamkewley tested more extensively for memory leaks using libASAN on many OpenSim models. He confirms that all leaks when deserializing Rajagopal2015.osim were eliminated and, after the addition of 3 more ```clearOrphan()``` calls (noted above in the summary of fixes as "added"), all memory leaks for the other models were eliminated as well.

### CHANGELOG.md (choose one)
- updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3594)
<!-- Reviewable:end -->
