### PR TITLE
Allow zeroth order derivative for Bezier Curve

### DIFF
--- a/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
+++ b/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
@@ -242,46 +242,7 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveVal(
     double u,
     const SimTK::Vec6& pts)
 {
-    double val = -1;
-
-
-    SimTK_ERRCHK1_ALWAYS( (u>=0 && u <= 1) , 
-        "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveVal", 
-        "Error: double argument u must be between 0.0 and 1.0"
-        "but %f was entered.",u);
-
-    //Compute the Bezier point
-    double p0 = pts(0);
-    double p1 = pts(1);
-    double p2 = pts(2);
-    double p3 = pts(3);
-    double p4 = pts(4);
-    double p5 = pts(5);
-
-    double u5 = 1;
-    double u4 = u;
-    double u3 = u4*u;
-    double u2 = u3*u;
-    double u1 = u2*u;
-    double u0 = u1*u;
-
-    //See lines 1-6 of MuscleCurveCodeOpt_20120210
-    double t2 = u1 * 0.5e1;
-    double t3 = u2 * 0.10e2;
-    double t4 = u3 * 0.10e2;
-    double t5 = u4 * 0.5e1;
-    double t9 = u0 * 0.5e1;
-    double t10 = u1 * 0.20e2;
-    double t11 = u2 * 0.30e2;
-    double t15 = u0 * 0.10e2;
-    val = p0 * (u0 * (-0.1e1) + t2 - t3 + t4 - t5 + u5 * 0.1e1) 
-        + p1 * (t9 - t10 + t11 + u3 * (-0.20e2) + t5) 
-        + p2 * (-t15 + u1 * 0.30e2 - t11 + t4) 
-        + p3 * (t15 - t10 + t3) 
-        + p4 * (-t9 + t2) + p5 * u0 * 0.1e1;
-
-
-    return val;
+    return calcQuinticBezierCurveDerivU(u, pts, 0);
 }
 
 /*
@@ -368,9 +329,9 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
         "Error: double argument u must be between 0.0 and 1.0.");
 
-    SimTK_ERRCHK_ALWAYS( (order >= 1),
+    SimTK_ERRCHK_ALWAYS( (order >= 0),
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
-        "Error: order must be greater than.");
+        "Error: order must be greater than zero.");
 
     SimTK_ERRCHK_ALWAYS( (order <= 6),
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
@@ -380,7 +341,14 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
     //localCaller.append(".calcQuinticBezierCurveDerivDYDX");
     //Compute the derivative d^n y/ dx^n
      switch(order){
-        case 1: //Calculate dy/dx 
+        case 0: // Calculate y.
+            {
+                double y = calcQuinticBezierCurveDerivU(u, ypts, 0);
+
+                val = y;
+            }
+            break;
+        case 1: // Calculate dy/dx
             { 
                 double dxdu =calcQuinticBezierCurveDerivU(u,xpts,1);
                 double dydu =calcQuinticBezierCurveDerivU(u,ypts,1);
@@ -638,9 +606,9 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU(
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
         "Error: double argument u must be between 0.0 and 1.0.");
 
-    SimTK_ERRCHK_ALWAYS( (order >= 1),
-        "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
-        "Error: order must be greater than, or equal to 1");
+    SimTK_ERRCHK_ALWAYS( (order >= 0),
+        "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU",
+        "Error: order must be greater than, or equal to 0");
 
     //Compute the Bezier point
     double p0 = pts(0);
@@ -651,6 +619,31 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU(
     double p5 = pts(5);
 
     switch(order){
+        case 0:
+            {
+                double u5 = 1;
+                double u4 = u;
+                double u3 = u4*u;
+                double u2 = u3*u;
+                double u1 = u2*u;
+                double u0 = u1*u;
+
+                //See lines 1-6 of MuscleCurveCodeOpt_20120210
+                double t2 = u1 * 0.5e1;
+                double t3 = u2 * 0.10e2;
+                double t4 = u3 * 0.10e2;
+                double t5 = u4 * 0.5e1;
+                double t9 = u0 * 0.5e1;
+                double t10 = u1 * 0.20e2;
+                double t11 = u2 * 0.30e2;
+                double t15 = u0 * 0.10e2;
+                val = p0 * (u0 * (-0.1e1) + t2 - t3 + t4 - t5 + u5 * 0.1e1)
+                    + p1 * (t9 - t10 + t11 + u3 * (-0.20e2) + t5)
+                    + p2 * (-t15 + u1 * 0.30e2 - t11 + t4)
+                    + p3 * (t15 - t10 + t3)
+                    + p4 * (-t9 + t2) + p5 * u0 * 0.1e1;
+            }
+            break;
         case 1: 
             {  
                 double t1 = u*u;//u ^ 2;

--- a/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
+++ b/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
@@ -331,7 +331,7 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
 
     SimTK_ERRCHK_ALWAYS( (order >= 0),
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
-        "Error: order must be greater than zero.");
+        "Error: order must be greater than or equal to zero.");
 
     SimTK_ERRCHK_ALWAYS( (order <= 6),
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 

--- a/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
+++ b/OpenSim/Common/SegmentedQuinticBezierToolkit.cpp
@@ -323,7 +323,7 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
     int order)
 {
     double val = SimTK::NaN;
-   
+
     //Bounds checking on the input
     SimTK_ERRCHK_ALWAYS( (u>=0 && u <= 1) , 
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU", 
@@ -340,8 +340,8 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
     //std::string localCaller = caller;
     //localCaller.append(".calcQuinticBezierCurveDerivDYDX");
     //Compute the derivative d^n y/ dx^n
-     switch(order){
-        case 0: // Calculate y.
+     switch (order) {
+        case 0: // Calculate y
             {
                 double y = calcQuinticBezierCurveDerivU(u, ypts, 0);
 
@@ -608,7 +608,7 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU(
 
     SimTK_ERRCHK_ALWAYS( (order >= 0),
         "SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU",
-        "Error: order must be greater than, or equal to 0");
+        "Error: order must be greater than, or equal to 0.");
 
     //Compute the Bezier point
     double p0 = pts(0);
@@ -618,7 +618,7 @@ double SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivU(
     double p4 = pts(4);
     double p5 = pts(5);
 
-    switch(order){
+    switch (order) {
         case 0:
             {
                 double u5 = 1;

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -588,7 +588,7 @@ double SmoothSegmentedFunction::calcDerivative(double x, int order) const
         const double y0 = _smoothData->_y0;
         const double x0 = _smoothData->_x0;
         const double dydx0 = _smoothData->_dydx0;
-        if(x < x0){
+        if (x < x0) {
             switch (order) {
                 case 0: return y0 + dydx0*(x-x0);
                 case 1: return dydx0;
@@ -601,7 +601,7 @@ double SmoothSegmentedFunction::calcDerivative(double x, int order) const
         const double x1 = _smoothData->_x1;
         const double y1 = _smoothData->_y1;
         const double dydx1 = _smoothData->_dydx1;
-        if(x > x1){
+        if (x > x1) {
             switch (order) {
                 case 0: return y1 + dydx1*(x-x1);
                 case 1: return dydx1;
@@ -613,14 +613,21 @@ double SmoothSegmentedFunction::calcDerivative(double x, int order) const
     const SimTK::Array_<SimTK::Vec6>& ctrlPtsX = _smoothData->_ctrlPtsX;
     const int idx  = SegmentedQuinticBezierToolkit::calcIndex(x,ctrlPtsX);
 
-    const SimTK::Array_<SimTK::Spline>& arraySplineUX = _smoothData->_arraySplineUX;
-    const double u = SegmentedQuinticBezierToolkit::
-        calcU(x,ctrlPtsX[idx], arraySplineUX[idx], UTOL,MAXITER);
+    const SimTK::Array_<SimTK::Spline>& arraySplineUX =
+        _smoothData->_arraySplineUX;
+    const double u = SegmentedQuinticBezierToolkit::calcU(
+            x,
+            ctrlPtsX[idx],
+            arraySplineUX[idx],
+            UTOL,
+            MAXITER);
 
     const SimTK::Array_<SimTK::Vec6>& ctrlPtsY = _smoothData->_ctrlPtsY;
-    return SegmentedQuinticBezierToolkit::
-        calcQuinticBezierCurveDerivDYDX(u, ctrlPtsX[idx],
-                ctrlPtsY[idx], order);
+    return SegmentedQuinticBezierToolkit::calcQuinticBezierCurveDerivDYDX(
+            u,
+            ctrlPtsX[idx],
+            ctrlPtsY[idx],
+            order);
 }
 
 double SmoothSegmentedFunction::

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -538,38 +538,9 @@ If x is in the linear region
 ________________________________________________________________________
 
 */
-
 double SmoothSegmentedFunction::calcValue(double x) const
 {
-    const SimTK::Array_<SimTK::Spline>& arraySplineUX =
-    _smoothData->_arraySplineUX;
-    const SimTK::Array_<SimTK::Vec6>& ctrlPtsX = _smoothData->_ctrlPtsX;
-    const SimTK::Array_<SimTK::Vec6>& ctrlPtsY = _smoothData->_ctrlPtsY;
-    double x0 = _smoothData->_x0;
-    double x1 = _smoothData->_x1;
-    double y0 = _smoothData->_y0;
-    double y1 = _smoothData->_y1;
-    double dydx0 = _smoothData->_dydx0;
-    double dydx1 = _smoothData->_dydx1;
-
-    double yVal = 0;
-
-    if(x >= x0 && x <= x1 )
-    {
-        int idx  = SegmentedQuinticBezierToolkit::calcIndex(x,ctrlPtsX);
-        double u = SegmentedQuinticBezierToolkit::
-                 calcU(x,ctrlPtsX[idx], arraySplineUX[idx], UTOL,MAXITER);
-        yVal = SegmentedQuinticBezierToolkit::
-                 calcQuinticBezierCurveVal(u,ctrlPtsY[idx]);
-    }else{
-        if(x < x0){
-            yVal = y0 + dydx0*(x-x0);
-        }else{
-            yVal = y1 + dydx1*(x-x1);
-        }    
-    }
-
-    return yVal;
+    return calcDerivative(x, 0);
 }
 
 double SmoothSegmentedFunction::calcValue(const SimTK::Vector& ax) const
@@ -613,50 +584,44 @@ ________________________________________________________________________
 
 double SmoothSegmentedFunction::calcDerivative(double x, int order) const
 {
-    //return calcDerivative( SimTK::Array_<int>(order,0),
-      //                     SimTK::Vector(1,x));
-    double yVal = 0;
-
-    //QUINTIC SPLINE
-
-    const SimTK::Array_<SimTK::Spline>& arraySplineUX =
-    _smoothData->_arraySplineUX;
-    const SimTK::Array_<SimTK::Vec6>& ctrlPtsX = _smoothData->_ctrlPtsX;
-    const SimTK::Array_<SimTK::Vec6>& ctrlPtsY = _smoothData->_ctrlPtsY;
-    double x0 = _smoothData->_x0;
-    double x1 = _smoothData->_x1;
-    double dydx0 = _smoothData->_dydx0;
-    double dydx1 = _smoothData->_dydx1;
-
-    if(order==0){
-                yVal = calcValue(x);
-    }else{
-            if(x >= x0 && x <= x1){
-                int idx  = SegmentedQuinticBezierToolkit::calcIndex(x,ctrlPtsX);
-                double u = SegmentedQuinticBezierToolkit::
-                                calcU(x,ctrlPtsX[idx], arraySplineUX[idx],
-                                UTOL,MAXITER);
-                yVal = SegmentedQuinticBezierToolkit::
-                            calcQuinticBezierCurveDerivDYDX(u, ctrlPtsX[idx],
-                            ctrlPtsY[idx], order);
-/*
-                            std::cout << _ctrlPtsX(3, idx) << std::endl;
-                            std::cout << _ctrlPtsX(idx) << std::endl;*/
-            }else{
-                    if(order == 1){
-                        if(x < x0){
-                            yVal = dydx0;
-                        }else{
-                            yVal = dydx1;}
-                    }else{
-                        yVal = 0;}   
-                }
+    {
+        const double y0 = _smoothData->_y0;
+        const double x0 = _smoothData->_x0;
+        const double dydx0 = _smoothData->_dydx0;
+        if(x < x0){
+            switch (order) {
+                case 0: return y0 + dydx0*(x-x0);
+                case 1: return dydx0;
+                default: return 0.;
+            }
         }
+    }
 
-    return yVal;
+    {
+        const double x1 = _smoothData->_x1;
+        const double y1 = _smoothData->_y1;
+        const double dydx1 = _smoothData->_dydx1;
+        if(x > x1){
+            switch (order) {
+                case 0: return y1 + dydx1*(x-x1);
+                case 1: return dydx1;
+                default: return 0.;
+            }
+        }
+    }
+
+    const SimTK::Array_<SimTK::Vec6>& ctrlPtsX = _smoothData->_ctrlPtsX;
+    const int idx  = SegmentedQuinticBezierToolkit::calcIndex(x,ctrlPtsX);
+
+    const SimTK::Array_<SimTK::Spline>& arraySplineUX = _smoothData->_arraySplineUX;
+    const double u = SegmentedQuinticBezierToolkit::
+        calcU(x,ctrlPtsX[idx], arraySplineUX[idx], UTOL,MAXITER);
+
+    const SimTK::Array_<SimTK::Vec6>& ctrlPtsY = _smoothData->_ctrlPtsY;
+    return SegmentedQuinticBezierToolkit::
+        calcQuinticBezierCurveDerivDYDX(u, ctrlPtsX[idx],
+                ctrlPtsY[idx], order);
 }
-
-
 
 double SmoothSegmentedFunction::
     calcDerivative(const SimTK::Array_<int>& derivComponents,

--- a/OpenSim/Common/Test/testSmoothSegmentedFunctionFactory.cpp
+++ b/OpenSim/Common/Test/testSmoothSegmentedFunctionFactory.cpp
@@ -565,7 +565,7 @@ void testQuinticBezier_Exceptions(){
     SimTK_TEST_MUST_THROW(/*double tst = */SegmentedQuinticBezierToolkit::
         calcQuinticBezierCurveDerivU(uEX2, xPts, (int)1));
     SimTK_TEST_MUST_THROW(/*double tst = */SegmentedQuinticBezierToolkit::
-        calcQuinticBezierCurveDerivU(0.5, xPts, 0));
+        calcQuinticBezierCurveDerivU(0.5, xPts, -1));
 
     //=========================================================================
     //Test exceptions for calcQuinticBezierCurveDerivDYDX
@@ -576,7 +576,7 @@ void testQuinticBezier_Exceptions(){
     SimTK_TEST_MUST_THROW(/*double test= */SegmentedQuinticBezierToolkit::
         calcQuinticBezierCurveDerivDYDX(uEX2,xPts,yPts,1));
     SimTK_TEST_MUST_THROW(/*double test= */SegmentedQuinticBezierToolkit::
-        calcQuinticBezierCurveDerivDYDX(0.5,xPts,yPts,0));
+        calcQuinticBezierCurveDerivDYDX(0.5,xPts,yPts,-1));
     SimTK_TEST_MUST_THROW(/*double test= */SegmentedQuinticBezierToolkit::
         calcQuinticBezierCurveDerivDYDX(0.5,xPts,yPts,7));
     


### PR DESCRIPTION
This PR changes `calcValue` to be a special case of `calcDerivative` with order zero.

This allows for less if / else switches further down the line and focuses calculations to a single function body.
Otherwise does not change the output of `calcValue` or `calcDerivative`.

### Brief summary of changes

In `SmoothSegmentedFunction`
- `calcDerivative` allows order zero.
- `calcValue` calls `calcDerivative` with order zero.

Similarly, in `SegmentedQuinticBezierToolkit`:
- `calcQuinticBezierCurveDerivU` and `calcQuinticBezierCurveDYDX` allow for order zero.
- `calcQuinticBezierCurveCurveVal` calls `calcQuinticBezierCurveDerivU` with order zero.

Changed `MustThrow` unit test accordingly.

### Testing I've completed

- Unit tests are still running.
- No significant change in performance (wall clock time) when simulating Rajagopal.
- No change in simulation result of Rajagopal.

### CHANGELOG.md

Change too minor?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3596)
<!-- Reviewable:end -->
