### PR TITLE
Fixes bug introduced by #3596 when handling NaNs.

### DIFF
--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -628,8 +628,8 @@ double SmoothSegmentedFunction::calcDerivative(double x, int order) const
         }
     }
 
-    // In case of NaN return zero.
-    return 0.;
+    // In case of NaN return NaN.
+    return SimTK::NaN;
 }
 
 double SmoothSegmentedFunction::

--- a/OpenSim/Common/Test/testSmoothSegmentedFunctionFactory.cpp
+++ b/OpenSim/Common/Test/testSmoothSegmentedFunctionFactory.cpp
@@ -1122,6 +1122,22 @@ void testMonotonicity(SimTK::Matrix mcfSample)
     cout << endl;
 }
 
+/*
+ 5. Tests the output when NaN is the input.
+*/
+template<typename F>
+void testMuscleCurveNaNBehavior(const F& curve)
+{
+    cout << "   TEST: NaN behavior. " << endl;
+
+    // Curve value at NaN gives NaN.
+    SimTK_TEST(std::isnan(curve.calcValue(SimTK::NaN)));
+    SimTK_TEST(std::isnan(curve.calcDerivative(SimTK::NaN, 1)));
+    SimTK_TEST(std::isnan(curve.calcDerivative(SimTK::NaN, 2)));
+
+    cout << "    passed testing NaN behavior." << endl;
+}
+
 //______________________________________________________________________________
 /**
  * Create a muscle bench marking system. The bench mark consists of a single muscle 
@@ -1209,8 +1225,10 @@ int main(int argc, char* argv[])
             testMuscleCurveC2Continuity(tendonCurve,tendonCurveSample);
         //4. Test for monotonicity where appropriate
             testMonotonicity(tendonCurveSample);
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(tendonCurve);
 
-        //5. Testing Exceptions
+        //6. Testing Exceptions
             cout << endl;
             cout << "   Exception Testing" << endl;
             SimTK_TEST_MUST_THROW(/*SmoothSegmentedFunction* tendonCurveEX
@@ -1279,8 +1297,10 @@ int main(int argc, char* argv[])
         //4. Test for monotonicity where appropriate
 
             testMonotonicity(fiberFLCurveSample);
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberFLCurve);
 
-        //5. Testing Exceptions
+        //6. Testing Exceptions
             cout << endl;
             cout << "   Exception Testing" << endl;
             SimTK_TEST_MUST_THROW(/*SmoothSegmentedFunction* fiberFLCurveEX 
@@ -1348,7 +1368,9 @@ int main(int argc, char* argv[])
         //4. Test for monotonicity where appropriate
 
             testMonotonicity(fiberCECurveSample);
-        //5. Testing Exceptions
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberCECurve);
+        //6. Testing Exceptions
             cout << endl;
             cout << "   Exception Testing" << endl;
             SimTK_TEST_MUST_THROW(/*SmoothSegmentedFunction* fiberCECurveEX 
@@ -1412,7 +1434,9 @@ int main(int argc, char* argv[])
             testMuscleCurveC2Continuity(fiberCEPhiCurve,fiberCEPhiCurveSample);
         //4. Test for monotonicity where appropriate
             testMonotonicity(fiberCEPhiCurveSample);
-        //5. Testing Exceptions
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberCEPhiCurve);
+        //6. Testing Exceptions
             cout << endl;
             cout << "   Exception Testing" << endl;
             SimTK_TEST_MUST_THROW(/*SmoothSegmentedFunction* fiberCEPhiCurveEX 
@@ -1485,7 +1509,9 @@ int main(int argc, char* argv[])
         //4. Test for monotonicity where appropriate
 
             testMonotonicity(fiberCECosPhiCurveSample);
-        //5. Test exceptions
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberCECosPhiCurve);
+        //6. Test exceptions
             cout << endl;
         cout << "   Exception Testing" << endl;
             SimTK_TEST_MUST_THROW(/*SmoothSegmentedFunction* fiberCECosPhiCurveEX 
@@ -1575,7 +1601,9 @@ int main(int argc, char* argv[])
         //4. Test for monotonicity where appropriate
 
             testMonotonicity(fiberFVCurveSample);
-        //5. Exception testing
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberFVCurve);
+        //6. Exception testing
             cout << endl;    
             cout << "   Exception Testing" << endl;
                 
@@ -1686,8 +1714,10 @@ int main(int argc, char* argv[])
         //4. Test for monotonicity where appropriate
 
             testMonotonicity(fiberFVInvCurveSample);
+        //5. Test NaN behavior.
+            testMuscleCurveNaNBehavior(fiberFVInvCurve);
 
-        //5. Testing the exceptions
+        //6. Testing the exceptions
 
             //5. Exception testing
             cout << endl;


### PR DESCRIPTION
My Pr #3596 introduced a bug, or triggered a bug elsewhere, when handling NaN's in SmoothSegmentedFunction.

Not sure when NaNs will be injected, and if that even makes sense, but before #3596 that was OK, but currently main will raise an exception. This PR makes it fine again, as was before #3596.

I noticed when trying to visualize my result from a CMC, which raised an exception now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3600)
<!-- Reviewable:end -->
