### PR TITLE
Change `AbstractPath` to `AbstractGeometryPath`

### DIFF
--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -109,7 +109,7 @@
 #include <OpenSim/Simulation/Model/ConditionalPathPoint.h>
 #include <OpenSim/Simulation/Model/MovingPathPoint.h>
 #include <OpenSim/Simulation/Model/PointForceDirection.h>
-#include <OpenSim/Simulation/Model/AbstractPath.h>
+#include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
 #include <OpenSim/Simulation/Model/FunctionBasedPath.h>
 #include <OpenSim/Simulation/Model/Ligament.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -193,7 +193,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 
 %include <OpenSim/Simulation/Model/PointForceDirection.h>
 %template(ArrayPointForceDirection) OpenSim::Array<OpenSim::PointForceDirection*>;
-%include <OpenSim/Simulation/Model/AbstractPath.h>
+%include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
 %include <OpenSim/Simulation/Model/GeometryPath.h>
 %include <OpenSim/Simulation/Model/FunctionBasedPath.h>
 %include <OpenSim/Simulation/Model/Ligament.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.5
 ====
-- Added `AbstractPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based forces now 
-own the property `path` of type `AbstractPath` instead of the `GeometryPath` unnamed property. Getters and setters have 
-been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament` and 
-`Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to 
+- Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based 
+forces now own the property `path` of type `AbstractGeometryPath` instead of the `GeometryPath` unnamed property. Getters 
+and setters have been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament`
+and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to 
 `getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
 - Fixed a minor memory leak when calling `OpenSim::CoordinateCouplerConstraint::setFunction` (#3541)
 - Increase the number of input dimensions supported by `MultivariatePolynomialFunction` to 6 (#3386)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.5
 ====
-- Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based 
-forces now own the property `path` of type `AbstractGeometryPath` instead of the `GeometryPath` unnamed property. Getters 
+- Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based
+forces now own the property `path` of type `AbstractGeometryPath` instead of the `GeometryPath` unnamed property. Getters
 and setters have been added to these forces to provide access to concrete path types (e.g., `updPath<T>`). In `Ligament`
-and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to 
-`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.    
+and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`, etc., need to be updated to
+`getGeometryPath`, `updGeometryPath`, etc., or a suitable alternative.
 - Fixed a minor memory leak when calling `OpenSim::CoordinateCouplerConstraint::setFunction` (#3541)
 - Increase the number of input dimensions supported by `MultivariatePolynomialFunction` to 6 (#3386)
 - Added `Assertion.h` and associated `OPENSIM_ASSERT*` macros (#3531)

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -1046,7 +1046,7 @@ void DeGrooteFregly2016Muscle::extendPostScale(
         const SimTK::State& s, const ScaleSet& scaleSet) {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012AccelerationMuscle.cpp
@@ -557,7 +557,7 @@ extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -598,7 +598,7 @@ extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Actuators/ModelFactory.cpp
+++ b/OpenSim/Actuators/ModelFactory.cpp
@@ -315,19 +315,16 @@ void ModelFactory::replacePathsWithFunctionBasedPaths(Model& model,
         auto path = functionBasedPaths.get(i);
             
         // Get the force component associated with this path.
-        OPENSIM_THROW_IF(!model.hasComponent<Force>(path.getName()), 
-                Exception, "Model does not contain a Force at path {}.", 
-                path.getName());
         auto& force = model.updComponent<Force>(path.getName());
-            
-        // Check that the force has a path property.
-        OPENSIM_THROW_IF(
-                !force.hasProperty("path"), Exception,
-                "Force {} does not have a path property.", path.getName());
-            
-        // Update the path.
-        path.setName(fmt::format("{}_path", force.getName()));
-        force.updPropertyByName<AbstractPath>("path").setValue(path);
+
+        // Replace the path.
+        try {
+            force.updPropertyByName<AbstractPath>("path").setValue(path);
+        } catch (const Exception& e) {
+            OPENSIM_THROW(Exception,
+                    "Failed to replace path for force '{}': {}",
+                    force.getAbsolutePathString(), e.getMessage());
+        }
     }
     model.finalizeFromProperties();
     model.finalizeConnections();

--- a/OpenSim/Actuators/ModelFactory.cpp
+++ b/OpenSim/Actuators/ModelFactory.cpp
@@ -319,7 +319,7 @@ void ModelFactory::replacePathsWithFunctionBasedPaths(Model& model,
 
         // Replace the path.
         try {
-            force.updPropertyByName<AbstractPath>("path").setValue(path);
+            force.updPropertyByName<AbstractGeometryPath>("path").setValue(path);
         } catch (const Exception& e) {
             OPENSIM_THROW(Exception,
                     "Failed to replace path for force '{}': {}",

--- a/OpenSim/Actuators/ModelFactory.h
+++ b/OpenSim/Actuators/ModelFactory.h
@@ -96,7 +96,7 @@ public:
     /// FunctionBasedPath%s. The name of each FunctionBasedPath should match the
     /// component path (i.e., '/forceset/soleus_r') of the corresponding Force
     /// in the model. The Force objects in the model must have a property named
-    /// 'path' that stores an object derived from AbstractPath.
+    /// 'path' that stores an object derived from AbstractGeometryPath.
     static void replacePathsWithFunctionBasedPaths(Model& model, 
             const Set<FunctionBasedPath>& functionBasedPaths);
 };

--- a/OpenSim/Actuators/ModelFactory.h
+++ b/OpenSim/Actuators/ModelFactory.h
@@ -94,8 +94,9 @@ public:
     
     /// Replace the paths of the forces in the model with the provided Set of
     /// FunctionBasedPath%s. The name of each FunctionBasedPath should match the
-    /// path of a corresponding Force in the model. The path name is appended
-    /// with "_path" to avoid name ambiguity in the final model.
+    /// component path (i.e., '/forceset/soleus_r') of the corresponding Force
+    /// in the model. The Force objects in the model must have a property named
+    /// 'path' that stores an object derived from AbstractPath.
     static void replacePathsWithFunctionBasedPaths(Model& model, 
             const Set<FunctionBasedPath>& functionBasedPaths);
 };

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -105,11 +105,11 @@ void PolynomialPathFitter::run() {
     Model model = get_model().process(getDocumentDirectory());
     model.initSystem();
 
-    const auto pathList = model.getComponentList<AbstractPath>();
+    const auto pathList = model.getComponentList<AbstractGeometryPath>();
     int numPaths = (int)std::distance(pathList.begin(), pathList.end());
     OPENSIM_THROW_IF_FRMOBJ(!numPaths, Exception,
-            "Expected the model to contain at least one AbstractPath, but it "
-            "does not.")
+            "Expected the model to contain at least one AbstractGeometryPath, "
+            "but it does not.")
 
     const auto fbPathList = model.getComponentList<FunctionBasedPath>();
     int numFunctionBasedPaths = (int)std::distance(fbPathList.begin(),
@@ -675,7 +675,7 @@ void PolynomialPathFitter::computePathLengthsAndMomentArms(
             model, coordinateValues, true, false, false);
 
     // Determine the maximum number of path and moment arm evaluations.
-    const auto& paths = model.getComponentList<AbstractPath>();
+    const auto& paths = model.getComponentList<AbstractGeometryPath>();
     int numPaths = (int)std::distance(paths.begin(), paths.end());
     int numCoordinates = (int)coordinateValues.getNumColumns();
     int numColumns = numPaths + (numPaths * numCoordinates);
@@ -703,9 +703,9 @@ void PolynomialPathFitter::computePathLengthsAndMomentArms(
             int ima = 0;
             for (const auto& force : forces) {
                 if (force.hasProperty("path")) {
-                    const AbstractPath& path =
-                            force.getPropertyByName<AbstractPath>("path")
-                                    .getValue();
+                    const AbstractGeometryPath& path =
+                        force.getPropertyByName<AbstractGeometryPath>("path")
+                            .getValue();
 
                     // Compute path length.
                     results(row, ip++) = path.getLength(state);

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -59,7 +59,7 @@ private:
  * geometry-path in an OpenSim model using `MultivariatePolynomialFunction`s.
  *
  * The primary inputs to this class include a model containing path objects
- * derived from `AbstractPath` (e.g., `GeometryPath`) and a reference
+ * derived from `AbstractGeometryPath` (e.g., `GeometryPath`) and a reference
  * trajectory containing coordinate values for all `Coordinate`s in the model.
  * The path fitting process samples coordinate values around the reference
  * trajectory, computes path lengths and moment arms from the geometry-based
@@ -117,7 +117,7 @@ private:
  * -----
  * The most basic usage of `PolynomialPathFitter` requires the user to provide
  * a model and reference trajectory. The model should contain at least one path
- * object derived from `AbstractPath` and should not contain any
+ * object derived from `AbstractGeometryPath` and should not contain any
  * `FunctionBasedPath` objects. The reference trajectory must contain coordinate
  * values for all `Coordinate`s in the model:
  *
@@ -186,7 +186,7 @@ public:
      * polynomial-based path objects will be fitted.
      *
      * The model should be provided using a `ModelProcessor` object. We expect
-     * the model to contain at least one path object derived from `AbstractPath`
+     * the model to contain at least one path object derived from `AbstractGeometryPath`
      * and does not already contain any `FunctionBasedPath` objects. The bounds
      * for clamped coordinates are obeyed during the fitting process. Locked
      * coordinates are unlocked if data is provided for them, or replaced with

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
@@ -22,7 +22,6 @@
  * -------------------------------------------------------------------------- */
 
 #include "AbstractGeometryPath.h"
-#include "Appearance.h"
 
 using namespace OpenSim;
 
@@ -45,7 +44,7 @@ AbstractGeometryPath::~AbstractGeometryPath() noexcept = default;
 AbstractGeometryPath& AbstractGeometryPath::operator=(
         const AbstractGeometryPath&) = default;
 
-AbstractGeometryPath::AbstractPath(
+AbstractGeometryPath::AbstractGeometryPath(
         AbstractGeometryPath&& other) = default;
 
 AbstractGeometryPath& AbstractGeometryPath::operator=(

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                          OpenSim:  AbstractPath.cpp                        *
+ *                    OpenSim:  AbstractGeometryPath.cpp                      *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -21,7 +21,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "AbstractPath.h"
+#include "AbstractGeometryPath.h"
 #include "Appearance.h"
 
 using namespace OpenSim;
@@ -29,7 +29,7 @@ using namespace OpenSim;
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
-AbstractPath::AbstractPath() : ModelComponent() {
+AbstractGeometryPath::AbstractGeometryPath() : ModelComponent() {
     setAuthors("Nicholas Bianco, Joris Verhagen, Adam Kewley");
 
     Appearance appearance;
@@ -37,41 +37,45 @@ AbstractPath::AbstractPath() : ModelComponent() {
     constructProperty_Appearance(appearance);
 }
 
-AbstractPath::AbstractPath(AbstractPath const&) = default;
+AbstractGeometryPath::AbstractGeometryPath(
+        AbstractGeometryPath const&) = default;
 
-AbstractPath::~AbstractPath() noexcept = default;
+AbstractGeometryPath::~AbstractGeometryPath() noexcept = default;
 
-AbstractPath& AbstractPath::operator=(const AbstractPath&) = default;
+AbstractGeometryPath& AbstractGeometryPath::operator=(
+        const AbstractGeometryPath&) = default;
 
-AbstractPath::AbstractPath(AbstractPath&& other) = default;
+AbstractGeometryPath::AbstractPath(
+        AbstractGeometryPath&& other) = default;
 
-AbstractPath& AbstractPath::operator=(AbstractPath&& other) = default;
+AbstractGeometryPath& AbstractGeometryPath::operator=(
+        AbstractGeometryPath&& other) = default;
 
 //=============================================================================
 // DEFAULTED METHODS
 //=============================================================================
-const SimTK::Vec3& AbstractPath::getDefaultColor() const
+const SimTK::Vec3& AbstractGeometryPath::getDefaultColor() const
 {
     return get_Appearance().get_color();
 }
 
-void AbstractPath::setDefaultColor(const SimTK::Vec3& color)
+void AbstractGeometryPath::setDefaultColor(const SimTK::Vec3& color)
 {
     updProperty_Appearance().setValueIsDefault(false);
     upd_Appearance().set_color(color);
 }
 
-SimTK::Vec3 AbstractPath::getColor(const SimTK::State& s) const
+SimTK::Vec3 AbstractGeometryPath::getColor(const SimTK::State& s) const
 {
     return getDefaultColor();
 }
 
-double AbstractPath::getPreScaleLength(const SimTK::State&) const
+double AbstractGeometryPath::getPreScaleLength(const SimTK::State&) const
 {
     return _preScaleLength;
 }
 
-void AbstractPath::setPreScaleLength(const SimTK::State&,
+void AbstractGeometryPath::setPreScaleLength(const SimTK::State&,
         double preScaleLength)
 {
     _preScaleLength = preScaleLength;

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -1,7 +1,7 @@
-#ifndef OPENSIM_ABSTRACTPATH_H
-#define OPENSIM_ABSTRACTPATH_H
+#ifndef OPENSIM_ABSTRACTGEOMETRYPATH_H
+#define OPENSIM_ABSTRACTGEOMETRYPATH_H
 /* -------------------------------------------------------------------------- *
- *                          OpenSim:  AbstractPath.h                          *
+ *                   OpenSim:  AbstractGeometryPath.h                         *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -39,7 +39,7 @@ namespace OpenSim {
 class Coordinate;
 
 //=============================================================================
-//                              ABSTRACT PATH
+//                         ABSTRACT GEOMETRY PATH
 //=============================================================================
 /**
  * A base class that represents a path that has a computable length and
@@ -50,14 +50,14 @@ class Coordinate;
  * `OpenSim::Ligament`s, etc.
  *
  * This class *only* defines a length and lengthening speed. We do not assume
- * that an `OpenSim::AbstractPath` is a straight line between two points or
- * assume that it is many straight lines between `n` points. The derived
+ * that an `OpenSim::AbstractGeometryPath` is a straight line between two points
+ * or assume that it is many straight lines between `n` points. The derived
  * implementation may define a path using points, or it may define a path using
  * a curve fit. It may also define a path based on analytical functions for the
  * length and lengthening speed.
  */
-class OSIMSIMULATION_API AbstractPath : public ModelComponent {
-OpenSim_DECLARE_ABSTRACT_OBJECT(AbstractPath, ModelComponent);
+class OSIMSIMULATION_API AbstractGeometryPath : public ModelComponent {
+OpenSim_DECLARE_ABSTRACT_OBJECT(AbstractGeometryPath, ModelComponent);
 
 public:
 //=============================================================================
@@ -71,25 +71,25 @@ public:
 // PROPERTIES
 //=============================================================================
     OpenSim_DECLARE_UNNAMED_PROPERTY(Appearance,
-            "Default appearance attributes for this AbstractPath.");
+            "Default appearance attributes for this AbstractGeometryPath.");
 
 //=============================================================================
 // METHODS
 //=============================================================================
     
     // CONSTRUCTION AND DESTRUCTION
-    AbstractPath();
-    ~AbstractPath() noexcept override;
-    
-    AbstractPath(const AbstractPath&);
-    AbstractPath& operator=(const AbstractPath&);
-    
-    AbstractPath(AbstractPath&& other);
-    AbstractPath& operator=(AbstractPath&& other);
+    AbstractGeometryPath();
+    ~AbstractGeometryPath() noexcept override;
+
+    AbstractGeometryPath(const AbstractGeometryPath&);
+    AbstractGeometryPath& operator=(const AbstractGeometryPath&);
+
+    AbstractGeometryPath(AbstractGeometryPath&& other);
+    AbstractGeometryPath& operator=(AbstractGeometryPath&& other);
 
     // INTERFACE METHODS
     //
-    // Concrete implementations of `AbstractPath` *must* provide these.
+    // Concrete implementations of `AbstractGeometryPath` *must* provide these.
 
     /**
      * Get the current length of the path.
@@ -114,7 +114,7 @@ public:
 
     /**
      *  Add in the equivalent body and generalized forces to be applied to the
-     *  multibody system resulting from a tension along the AbstractPath.
+     *  multibody system resulting from a tension along the AbstractGeometryPath.
      *
      *  @param         state           state used to evaluate forces
      *  @param[in]     tension         scalar of the applied (+ve) tensile force
@@ -143,7 +143,7 @@ public:
 
     // DEFAULTED METHODS
     //
-    // These are methods that for which AbstractPath provides default 
+    // These are methods that for which AbstractGeometryPath provides default
     // implementation.
 
     /**
@@ -216,15 +216,16 @@ public:
     
 private:
     // Used by `(get|set)PreLengthScale`. Used during `extend(Pre|Post)Scale` by
-    // downstream users of AbstractPath to cache the length of the path before
-    // scaling.
+    // downstream users of AbstractGeometryPath to cache the length of the path
+    // before scaling.
     //
     // Ideally, downstream classes would perform the caching themselves, because
-    // the AbstractPath API isn't an ideal place to store this information. This
-    // field is mostly here for backwards-compatability with the API.
+    // the AbstractGeometryPath API isn't an ideal place to store this
+    // information. This field is mostly here for backwards-compatability with
+    // the API.
     double _preScaleLength = 0.0;
 };
 
 } // namespace OpenSim
 
-#endif // OPENSIM_ABSTRACTPATH_H
+#endif // OPENSIM_ABSTRACTGEOMETRYPATH_H

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -1,5 +1,5 @@
-#ifndef OPENSIM_ABSTRACTGEOMETRYPATH_H
-#define OPENSIM_ABSTRACTGEOMETRYPATH_H
+#ifndef OPENSIM_ABSTRACT_GEOMETRY_PATH_H
+#define OPENSIM_ABSTRACT_GEOMETRY_PATH_H
 /* -------------------------------------------------------------------------- *
  *                   OpenSim:  AbstractGeometryPath.h                         *
  * -------------------------------------------------------------------------- *
@@ -228,4 +228,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // OPENSIM_ABSTRACTGEOMETRYPATH_H
+#endif // OPENSIM_ABSTRACT_GEOMETRY_PATH_H

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle.cpp
@@ -182,7 +182,7 @@ extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
+++ b/OpenSim/Simulation/Model/ActivationFiberLengthMuscle_Deprecated.cpp
@@ -346,7 +346,7 @@ extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Simulation/Model/Blankevoort1991Ligament.cpp
+++ b/OpenSim/Simulation/Model/Blankevoort1991Ligament.cpp
@@ -130,7 +130,7 @@ void Blankevoort1991Ligament::extendPostScale(
     const SimTK::State& s, const ScaleSet& scaleSet) {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     double slack_length = get_slack_length();
     if (path.getPreScaleLength(s) > 0.0)
     {
@@ -338,7 +338,7 @@ void Blankevoort1991Ligament::computeForce(const SimTK::State& s,
         // total force
         double force_total = getTotalForce(s);
 
-        const AbstractPath &path = getPath();
+        const AbstractGeometryPath&path = getPath();
 
         path.addInEquivalentForces(
                 s, force_total, bodyForces, generalizedForces);

--- a/OpenSim/Simulation/Model/Blankevoort1991Ligament.h
+++ b/OpenSim/Simulation/Model/Blankevoort1991Ligament.h
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
 #include <OpenSim/Simulation/Model/Force.h>
-#include <OpenSim/Simulation/Model/AbstractPath.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
 
 namespace OpenSim {
@@ -178,7 +178,7 @@ public:
 // PROPERTIES
 //=============================================================================
     
-    OpenSim_DECLARE_PROPERTY(path, AbstractPath,
+    OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
         "The path defines the length and lengthening speed of the ligament.")
     OpenSim_DECLARE_PROPERTY(linear_stiffness, double,
         "The slope of the linear region of the force-strain curve. " 
@@ -238,8 +238,8 @@ public:
         double linear_stiffness, double slack_length);
 
     // Path
-    AbstractPath& updPath() { return upd_path(); }
-    const AbstractPath& getPath() const { return get_path(); }
+    AbstractGeometryPath& updPath() { return upd_path(); }
+    const AbstractGeometryPath& getPath() const { return get_path(); }
 
     template <typename PathType>
     PathType& updPath() {

--- a/OpenSim/Simulation/Model/Force.cpp
+++ b/OpenSim/Simulation/Model/Force.cpp
@@ -83,7 +83,7 @@ Force::updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber) {
             // GeometryPath objects (PathActuator, PathSpring, Ligament,
             // and Blankevoort1991Ligament) changed: the 'GeometryPath` unnamed
             // property was replaced with the named property 'path', which is of
-            // type 'AbstractPath'. Since 'path' is still a one object property,
+            // type 'AbstractGeometryPath'. Since 'path' is still a one object property,
             // the property will still be serialized using the concrete type
             // (e.g., 'GeometryPath') and with name attribute set to 'path'.
             // Therefore, we can simply update the name attribute of any

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -31,7 +31,7 @@ using namespace OpenSim;
 //=============================================================================
 // CONSTRUCTOR
 //=============================================================================
-FunctionBasedPath::FunctionBasedPath() : AbstractPath()
+FunctionBasedPath::FunctionBasedPath() : AbstractGeometryPath()
 {
     setAuthors("Nicholas Bianco");
     constructProperties();

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "OpenSim/Simulation/Model/AbstractPath.h"
 #include "OpenSim/Common/Function.h"
+#include "OpenSim/Simulation/Model/AbstractGeometryPath.h"
 
 namespace OpenSim {
 
@@ -111,8 +111,8 @@ namespace OpenSim {
  *       Volume 7B: 9th International Conference on Multibody Systems,
  *       Nonlinear Dynamics, and Control.
  */
-class OSIMSIMULATION_API FunctionBasedPath : public AbstractPath {
-OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPath, AbstractPath);
+class OSIMSIMULATION_API FunctionBasedPath : public AbstractGeometryPath {
+OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPath, AbstractGeometryPath);
 
 public:
 //=============================================================================

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -1,5 +1,5 @@
-#ifndef OPENSIM_FUNCTIONBASEDPATH_H
-#define OPENSIM_FUNCTIONBASEDPATH_H
+#ifndef OPENSIM_FUNCTION_BASED_PATH_H
+#define OPENSIM_FUNCTION_BASED_PATH_H
 /* -------------------------------------------------------------------------- *
  *                      OpenSim:  FunctionBasedPath.h                         *
  * -------------------------------------------------------------------------- *
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "OpenSim/Common/Function.h"
 #include "OpenSim/Simulation/Model/AbstractGeometryPath.h"
+#include "OpenSim/Common/Function.h"
 
 namespace OpenSim {
 
@@ -221,4 +221,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // OPENSIM_FUNCTIONBASEDPATH_H
+#endif // OPENSIM_FUNCTION_BASED_PATH_H

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -135,7 +135,7 @@ static void PopulatePathElementLookup(
 /*
  * Default constructor.
  */
-GeometryPath::GeometryPath() : AbstractPath()
+GeometryPath::GeometryPath() : AbstractGeometryPath()
 {
     setAuthors("Peter Loan");
     constructProperties();

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -25,11 +25,11 @@
 
 
 // INCLUDE
-#include "OpenSim/Simulation/Model/AbstractPath.h"
+#include "OpenSim/Simulation/Model/AbstractGeometryPath.h"
 #include "PathPointSet.h"
-#include <OpenSim/Simulation/Wrap/PathWrapSet.h>
-#include <OpenSim/Simulation/MomentArmSolver.h>
 
+#include <OpenSim/Simulation/MomentArmSolver.h>
+#include <OpenSim/Simulation/Wrap/PathWrapSet.h>
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -54,8 +54,8 @@ class WrapObject;
  *
  * @author Peter Loan
  */
-class OSIMSIMULATION_API GeometryPath : public AbstractPath {
-OpenSim_DECLARE_CONCRETE_OBJECT(GeometryPath, AbstractPath);
+class OSIMSIMULATION_API GeometryPath : public AbstractGeometryPath {
+OpenSim_DECLARE_CONCRETE_OBJECT(GeometryPath, AbstractGeometryPath);
 
 //=============================================================================
 // DATA

--- a/OpenSim/Simulation/Model/Ligament.cpp
+++ b/OpenSim/Simulation/Model/Ligament.cpp
@@ -193,7 +193,7 @@ void Ligament::extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);

--- a/OpenSim/Simulation/Model/Ligament.h
+++ b/OpenSim/Simulation/Model/Ligament.h
@@ -27,8 +27,8 @@
 //=============================================================================
 // INCLUDES
 //=============================================================================
+#include "AbstractGeometryPath.h"
 #include "Force.h"
-#include "AbstractPath.h"
 #include "GeometryPath.h"
 
 #ifdef SWIG
@@ -47,7 +47,7 @@ class ScaleSet;
 //=============================================================================
 /**
  * A class implementing a ligament. The path of the ligament is
- * stored in an object derived from AbstractPath.
+ * stored in an object derived from AbstractGeometryPath.
  */
 class OSIMSIMULATION_API Ligament : public Force {
 OpenSim_DECLARE_CONCRETE_OBJECT(Ligament, Force);
@@ -55,7 +55,7 @@ public:
 //=============================================================================
 // PROPERTIES
 //=============================================================================
-    OpenSim_DECLARE_PROPERTY(path, AbstractPath,
+    OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
         "The path defines the length and lengthening speed of the PathSpring");
     OpenSim_DECLARE_PROPERTY(resting_length, double,
         "resting length of the ligament");
@@ -76,8 +76,8 @@ public:
     //--------------------------------------------------------------------------
     // PATH
     //--------------------------------------------------------------------------
-    AbstractPath& updPath() { return upd_path(); }
-    const AbstractPath& getPath() const { return get_path(); }
+    AbstractGeometryPath& updPath() { return upd_path(); }
+    const AbstractGeometryPath& getPath() const { return get_path(); }
 
     template <typename PathType>
     PathType& updPath() {

--- a/OpenSim/Simulation/Model/PathActuator.h
+++ b/OpenSim/Simulation/Model/PathActuator.h
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "AbstractGeometryPath.h"
 #include "Actuator.h"
-#include "AbstractPath.h"
 #include "GeometryPath.h"
 
 //=============================================================================
@@ -49,7 +49,7 @@ public:
 //=============================================================================
 // PROPERTIES
 //=============================================================================
-    OpenSim_DECLARE_PROPERTY(path, AbstractPath,
+    OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
         "The path of the actuator which defines length and lengthening speed.");
     OpenSim_DECLARE_PROPERTY(optimal_force, double,
         "The maximum force this actuator can produce.");
@@ -68,8 +68,8 @@ public:
     // GET AND SET
     //--------------------------------------------------------------------------
     // Path
-    AbstractPath& updPath() { return upd_path(); }
-    const AbstractPath& getPath() const { return get_path(); }
+    AbstractGeometryPath& updPath() { return upd_path(); }
+    const AbstractGeometryPath& getPath() const { return get_path(); }
 
     template <typename PathType>
     PathType& updPath() {

--- a/OpenSim/Simulation/Model/PathSpring.cpp
+++ b/OpenSim/Simulation/Model/PathSpring.cpp
@@ -171,13 +171,13 @@ extendPostScale(const SimTK::State& s, const ScaleSet& scaleSet)
 {
     Super::extendPostScale(s, scaleSet);
 
-    AbstractPath& path = updPath();
+    AbstractGeometryPath& path = updPath();
     if (path.getPreScaleLength(s) > 0.0)
     {
         double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);
         upd_resting_length() *= scaleFactor;
 
-        // Clear the pre-scale length that was stored in the AbstractPath.
+        // Clear the pre-scale length that was stored in the AbstractGeometryPath.
         path.setPreScaleLength(s, 0.0);
     }
 }
@@ -200,7 +200,7 @@ void PathSpring::computeForce(const SimTK::State& s,
                               SimTK::Vector_<SimTK::SpatialVec>& bodyForces, 
                               SimTK::Vector& generalizedForces) const
 {
-    const AbstractPath& path = getPath();
+    const AbstractGeometryPath& path = getPath();
     const double& tension = getTension(s);
     path.addInEquivalentForces(s, tension, bodyForces, generalizedForces);
 }

--- a/OpenSim/Simulation/Model/PathSpring.h
+++ b/OpenSim/Simulation/Model/PathSpring.h
@@ -27,8 +27,8 @@
 //=============================================================================
 // INCLUDES
 //=============================================================================
+#include "AbstractGeometryPath.h"
 #include "Force.h"
-#include "AbstractPath.h"
 #include "GeometryPath.h"
 
 namespace OpenSim {
@@ -39,7 +39,7 @@ class ScaleSet;
 //=============================================================================
 /**
  * A class implementing a PathSpring. The path of the PathSpring is
- * determined by an object derived from AbstractPath. A PathSpring is a
+ * determined by an object derived from AbstractGeometryPath. A PathSpring is a
  * massless Force element which applies tension along a path connected to bodies
  * and can wrap over surfaces.  The tension is proportional to its stretch
  * beyond its resting length and the amount of dissipation scales with amount of
@@ -63,7 +63,7 @@ public:
         "The linear stiffness (N/m) of the PathSpring");
     OpenSim_DECLARE_PROPERTY(dissipation, double,
         "The dissipation factor (s/m) of the PathSpring");
-    OpenSim_DECLARE_PROPERTY(path, AbstractPath,
+    OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
         "The path defines the length and lengthening speed of the PathSpring");
 
 //=============================================================================
@@ -119,8 +119,8 @@ public:
     void setDissipation(double dissipation);
 
     /** get/set the path object */
-    AbstractPath& updPath() { return upd_path(); }
-    const AbstractPath& getPath() const { return get_path(); }
+    AbstractGeometryPath& updPath() { return upd_path(); }
+    const AbstractGeometryPath& getPath() const { return get_path(); }
 
     template <typename PathType>
     PathType& updPath() {


### PR DESCRIPTION
### Brief summary of changes
Replaced the name `AbstractPath` with `AbstractGeometryPath` to avoid ambiguity with other classes (e.g., `ComponentPath`).

### Testing I've completed
Ran test suite.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3602)
<!-- Reviewable:end -->
