### PR TITLE
Update `MocoTrajectory::generateSpeedsFromValues()` to not override auxiliary states

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -1,8 +1,11 @@
 Moco Change Log
 ===============
 
-1.2.2
+1.3.0
 -----
+- 2023-11-08: Fixed a bug where `MocoTrajectory::generateSpeedsFromValues()` was
+              accidentally deleting auxiliary state values.
+
 - 2023-10-25: Fixed a bug preventing deserialization of `MocoFrameDistanceConstraint`.
 
 - 2023-10-25: Locked coordinates are now explicitly disallowed in `MocoProblem`s, 

--- a/OpenSim/Moco/MocoTrajectory.h
+++ b/OpenSim/Moco/MocoTrajectory.h
@@ -472,7 +472,18 @@ public:
     }
 
     int getNumSpeeds() const {
+        ensureUnsealed();
         return (int)getSpeedIndices().size();
+    }
+
+    int getNumMultibodyStates() const {
+        ensureUnsealed();
+        return (int)getMultibodyStateIndices().size();
+    }
+
+    int getNumAuxiliaryStates() const {
+        ensureUnsealed();
+        return (int)getAuxiliaryStateIndices().size();
     }
 
     int getNumAccelerations() const {
@@ -527,6 +538,29 @@ public:
             }
         }
         return speedNames;
+    }
+    std::vector<std::string> getMultibodyStateNames() const {
+        ensureUnsealed();
+        std::vector<std::string> multibodyStateNames;
+        for (const auto& name : m_state_names) {
+            if (name.find("/value") != std::string::npos) {
+                multibodyStateNames.push_back(name);
+            } else if (name.find("/speed") != std::string::npos) {
+                multibodyStateNames.push_back(name);
+            }
+        }
+        return multibodyStateNames;
+    }
+    std::vector<std::string> getAuxiliaryStateNames() const {
+        ensureUnsealed();
+        std::vector<std::string> auxiliaryStateNames;
+        for (const auto& name : m_state_names) {
+            if (name.find("/value") == std::string::npos &&
+                    name.find("/speed") == std::string::npos) {
+                auxiliaryStateNames.push_back(name);
+            }
+        }
+        return auxiliaryStateNames;
     }
     std::vector<std::string> getAccelerationNames() const {
         ensureUnsealed();
@@ -588,6 +622,20 @@ public:
         if (indices.empty()) indices.push_back(0);
         return {m_states.block(0, indices[0],
                 m_states.nrow(), getNumSpeeds())};
+    }
+    SimTK::Matrix getMultibodyStatesTrajectory() const {
+        ensureUnsealed();
+        auto indices = getMultibodyStateIndices();
+        if (indices.empty()) indices.push_back(0);
+        return {m_states.block(0, indices[0],
+                m_states.nrow(), getNumMultibodyStates())};
+    }
+    SimTK::Matrix getAuxiliaryStatesTrajectory() const {
+        ensureUnsealed();
+        auto indices = getAuxiliaryStateIndices();
+        if (indices.empty()) indices.push_back(0);
+        return {m_states.block(0, indices[0],
+                m_states.nrow(), getNumAuxiliaryStates())};
     }
     SimTK::Matrix getAccelerationsTrajectory() const {
         ensureUnsealed();
@@ -876,6 +924,31 @@ private:
             }
         }
         return speedIndices;
+    }
+    std::vector<int> getMultibodyStateIndices() const {
+        ensureUnsealed();
+        std::vector<int> multibodyStateIndices;
+        auto valueIndices = getValueIndices();
+        auto speedIndices = getSpeedIndices();
+        multibodyStateIndices.reserve(
+                valueIndices.size() + speedIndices.size());
+        multibodyStateIndices.insert(multibodyStateIndices.end(),
+                valueIndices.begin(), valueIndices.end());
+        multibodyStateIndices.insert(multibodyStateIndices.end(),
+                speedIndices.begin(), speedIndices.end());
+        return multibodyStateIndices;
+    }
+    std::vector<int> getAuxiliaryStateIndices() const {
+        ensureUnsealed();
+        std::vector<int> auxiliaryStateIndices;
+        for (int i = 0; i < (int)m_state_names.size(); ++i) {
+            const auto& name = m_state_names[i];
+            if (name.find("/value") == std::string::npos &&
+                    name.find("/speed") == std::string::npos) {
+                auxiliaryStateIndices.push_back(i);
+            }
+        }
+        return auxiliaryStateIndices;
     }
     std::vector<int> getAccelerationIndices() const {
         ensureUnsealed();

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -2126,8 +2126,41 @@ TEST_CASE("Objective breakdown", "[casadi]") {
     CHECK(solution.getObjectiveTerm("goal_b") == Approx(0.01 * 7.3));
 }
 
+TEST_CASE("generateSpeedsFromValues() does not overwrite auxiliary states.") {
+    int N = 20;
+    SimTK::Vector time = createVectorLinspace(20, 0.0, 1.0);
+    std::vector<std::string> snames{"/jointset/joint/coord/value",
+                                    "/jointset/joint/coord/speed",
+                                    "/forceset/muscle/normalized_tendon_force"};
+    std::vector<std::string> cnames{"/forceset/muscle"};
+    std::vector<std::string> dnames{
+        "/forceset/muscle/implicitderiv_normalized_tendon_force"};
+    SimTK::Matrix states = SimTK::Test::randMatrix(N, 3);
+    SimTK::Matrix controls = SimTK::Test::randMatrix(N, 1);
+    SimTK::Matrix derivatives = SimTK::Test::randMatrix(N, 1);
+    MocoTrajectory traj(time, snames, cnames, {}, dnames, {}, states, controls,
+            SimTK::Matrix(), derivatives, SimTK::RowVector());
+
+    traj.generateSpeedsFromValues();
+    CHECK(traj.getNumStates() == 3);
+    CHECK(traj.getStateNames() == snames);
+    CHECK(traj.getNumDerivatives() == 1);
+    CHECK(traj.getDerivativeNames() == dnames);
+    CHECK(traj.getNumAuxiliaryStates() == 1);
+    std::vector<std::string>
+            auxnames{"/forceset/muscle/normalized_tendon_force"};
+    CHECK(traj.getAuxiliaryStateNames() == auxnames);
+
+    SimTK::Matrix auxiliaryStates = traj.getAuxiliaryStatesTrajectory();
+    double error = 0.0;
+    for (int irow = 0; irow < states.nrow(); ++irow) {
+        error += pow(states(irow, 2) - auxiliaryStates(irow, 0), 2);
+    }
+    SimTK_TEST_EQ(error, 0.0);
+}
+
 TEST_CASE("generateAccelerationsFromXXX() does not overwrite existing "
-          "non-accleration derivatives.") {
+          "non-acceleration derivatives.") {
     int N = 20;
     SimTK::Vector time = createVectorLinspace(20, 0.0, 1.0);
     std::vector<std::string> snames{"/jointset/joint/coord/value",


### PR DESCRIPTION
Fixes issue #3477

### Brief summary of changes
This PR updates the logic in `MocoTrajectory::generateSpeedsFromValues()` so that any auxiliary (e.g., muscle-related) states do not get overridden. I've added some accessors to MocoTrajectory to make this fix more convenient, but these are nice additions beyond this fix.

### Testing I've completed
- Added test to `testMocoInterface.cpp`

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3603)
<!-- Reviewable:end -->
