### PR TITLE
Template instantiate SetFunctionBasedPath to remove spurious classes

### DIFF
--- a/Bindings/actuators.i
+++ b/Bindings/actuators.i
@@ -12,6 +12,7 @@
 %include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>
 %include <OpenSim/Actuators/McKibbenActuator.h>
 %include <OpenSim/Actuators/DeGrooteFregly2016Muscle.h>
+%template (SetFunctionBasedPath) OpenSim::Set<OpenSim::FunctionBasedPath>;
 
 %include <OpenSim/Actuators/ModelFactory.h>
 

--- a/Bindings/actuators.i
+++ b/Bindings/actuators.i
@@ -12,7 +12,7 @@
 %include <OpenSim/Actuators/Millard2012AccelerationMuscle.h>
 %include <OpenSim/Actuators/McKibbenActuator.h>
 %include <OpenSim/Actuators/DeGrooteFregly2016Muscle.h>
-%template (SetFunctionBasedPath) OpenSim::Set<OpenSim::FunctionBasedPath>;
+%template (SetFunctionBasedPaths) OpenSim::Set<OpenSim::FunctionBasedPath>;
 
 %include <OpenSim/Actuators/ModelFactory.h>
 


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
template instantiate SetFunctionBasedPath in interface file so swig results are usable in scripting and not bloated with unusable classes
### Testing I've completed
None other than the change/fix f=to the java produced classes

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3608)
<!-- Reviewable:end -->
