### PR TITLE
Check if metadata key exists and if so "Remove" before "add"

### DIFF
--- a/Bindings/Java/Matlab/Utilities/osimC3D.m
+++ b/Bindings/Java/Matlab/Utilities/osimC3D.m
@@ -179,8 +179,8 @@ classdef osimC3D < matlab.mixin.SetGet
                     % Divide by 1000
                     columnData.multiplyAssign(.001);           
                 end
-                % todo fix units in table/trc file to correspond to data
-                
+                % Fix units in table/trc file to correspond to data
+                self.markers.addTableMetaDataString("Units", "M");
             end
             disp('Point and Torque values convert from mm and Nmm to m and Nm, respectively')
         end

--- a/Bindings/Java/tests/TestC3DFileAdapter.java
+++ b/Bindings/Java/tests/TestC3DFileAdapter.java
@@ -18,8 +18,6 @@ class TestC3DFileAdapter {
 
         // convert data to meters and write a copy
         TimeSeriesTableVec3 markerTableInMeters = new TimeSeriesTableVec3(markerTable);
-        if (markerTableInMeters.hasTableMetaDataKey("Units"))
-            markerTableInMeters.removeTableMetaDataKey("Units");
         markerTableInMeters.addTableMetaDataString("Units", "M");
         for (int col=0; col < markerTableInMeters.getNumColumns(); col++)
             markerTableInMeters.updDependentColumnAtIndex(col).multiplyAssign(.001);

--- a/Bindings/Java/tests/TestC3DFileAdapter.java
+++ b/Bindings/Java/tests/TestC3DFileAdapter.java
@@ -18,6 +18,9 @@ class TestC3DFileAdapter {
 
         // convert data to meters and write a copy
         TimeSeriesTableVec3 markerTableInMeters = new TimeSeriesTableVec3(markerTable);
+        if (markerTableInMeters.hasTableMetaDataKey("Units"))
+            markerTableInMeters.removeTableMetaDataKey("Units");
+        markerTableInMeters.addTableMetaDataString("Units", "M");
         for (int col=0; col < markerTableInMeters.getNumColumns(); col++)
             markerTableInMeters.updDependentColumnAtIndex(col).multiplyAssign(.001);
         String markersInMetersFileName = new String("markersMeters.mot");

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -167,6 +167,8 @@ namespace OpenSim {
 
     void addTableMetaDataString(const std::string& key,
                                 const std::string& value) {
+         if ($self->hasTableMetaDataKey(key))
+            $self->removeTableMetaDataKey(key);
         $self->addTableMetaData<std::string>(key, value);
     }
     
@@ -202,15 +204,7 @@ namespace OpenSim {
 %ignore OpenSim::DataTable_::DataTable_(const DataTable_<double, double>&,
                                         const std::vector<std::string>&);
 %ignore OpenSim::DataTable_<double, double>::flatten;
-// A version of SWIG between 3.0.6 and 3.0.12 broke the ability to extend class
-// templates with more than 1 template parameter, so we must enumerate the
-// possible template arguments (not necesary for TimeSeriesTable's clone; that
-// template has only 1 param.).
-//%extend OpenSim::DataTable_ {
-//    OpenSim::DataTable_<ETX, ETY>* clone() const {
-//        return new OpenSim::DataTable_<ETX, ETY>{*$self};
-//    }
-//}
+
 %define DATATABLE_CLONE(ETX, ETY)
 %extend OpenSim::DataTable_<ETX, ETY> {
     OpenSim::DataTable_<ETX, ETY>* clone() const {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Added `PolynomialPathFitter`, A utility class for fitting a set of `FunctionBasedPath`s to existing geometry-path in 
   an OpenSim model using `MultivariatePolynomialFunction`s (#3390)
 - Bumped the version of `ezc3d` which can now Read Kistler files
-- Added method to addTableMetaDataString through Scripting (#3589)
+- Updated scripting method addTableMetaDataString to support overwriting metadata value for an existing key (#3589)
 
 v4.4.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Added `PolynomialPathFitter`, A utility class for fitting a set of `FunctionBasedPath`s to existing geometry-path in 
   an OpenSim model using `MultivariatePolynomialFunction`s (#3390)
 - Bumped the version of `ezc3d` which can now Read Kistler files
+- Added method to addTableMetaDataString through Scripting (#3589)
 
 v4.4.1
 ======


### PR DESCRIPTION
Fixes issue #3589 

### Brief summary of changes
Actually it's possible to addMetaData for units but only if it doesn't exist. I modified the test case and the method in bindings to exercise this workflow. Will update the c3dExport file once we agree on what to include.

### Testing I've completed
Updated Java test case to change units to Meters
### Looking for feedback on...
Whether update the .i file considering that the name of the method starting with "add", or leave alone and update the test code/sample accordingly basically leaving door for future confusion!

### CHANGELOG.md (choose one)

- no need to update yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3611)
<!-- Reviewable:end -->
