### PR TITLE
Remove `CoordinateActuator::CreateForceSetOfCoordinateActuatorsForModel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Added `PolynomialPathFitter`, A utility class for fitting a set of `FunctionBasedPath`s to existing geometry-path in 
   an OpenSim model using `MultivariatePolynomialFunction`s (#3390)
 - Bumped the version of `ezc3d` which can now Read Kistler files
+- Removed `CoordinateActuator::CreateForceSetOfCoordinateActuatorsForModel` (#3612). Please use a `ModelProcessor` with 
+  `ModOpAddReserves` to add a set of `CoordinateActuators` to a `Model`.
 
 v4.4.1
 ======

--- a/OpenSim/Actuators/CoordinateActuator.cpp
+++ b/OpenSim/Actuators/CoordinateActuator.cpp
@@ -151,32 +151,6 @@ double CoordinateActuator::computeActuation( const SimTK::State& s ) const
 
 
 //==============================================================================
-// UTILITY
-//==============================================================================
-//_____________________________________________________________________________
-/**
- */
-ForceSet *CoordinateActuator::
-CreateForceSetOfCoordinateActuatorsForModel(const SimTK::State& s, Model& aModel,double aOptimalForce,bool aIncludeLockedAndConstrainedCoordinates)
-{
-    ForceSet& as = aModel.updForceSet();
-    as.setSize(0);
-    auto coordinates = aModel.getCoordinatesInMultibodyTreeOrder();
-    for(size_t i=0u; i < coordinates.size(); ++i) {
-        const Coordinate& coord = *coordinates[i];
-        if(!aIncludeLockedAndConstrainedCoordinates && (coord.isConstrained(s))) continue;
-        CoordinateActuator *actuator = new CoordinateActuator();
-        actuator->setCoordinate(const_cast<Coordinate*>(&coord));
-        actuator->setName(coord.getName()+"_actuator");
-        actuator->setOptimalForce(aOptimalForce);
-        as.append(actuator);
-    }
-
-    aModel.invalidateSystem();
-    return &as;
-}
-
-//==============================================================================
 // APPLICATION
 //==============================================================================
 //_____________________________________________________________________________

--- a/OpenSim/Actuators/CoordinateActuator.h
+++ b/OpenSim/Actuators/CoordinateActuator.h
@@ -71,11 +71,6 @@ public:
     /** Get the current setting of the 'optimal_force' property. **/
     double getOptimalForce() const override; // part of Actuator interface
 
-    //--------------------------------------------------------------------------
-    // UTILITY
-    //--------------------------------------------------------------------------
-    static ForceSet* CreateForceSetOfCoordinateActuatorsForModel(const SimTK::State& s, Model& aModel,double aOptimalForce = 1,bool aIncludeLockedAndConstrainedCoordinates = true);
-
     bool isCoordinateValid() const;
     double getSpeed( const SimTK::State& s) const override;
 


### PR DESCRIPTION
Fixes issue #3598

### Brief summary of changes

Removes `CoordinateActuator::CreateForceSetOfCoordinateActuatorsForModel`, which is problematic for a few reasons:
- It returns a raw pointer to a new `ForceSet` which is memory-unsafe, especially for scripting users who might not realize this needs to be adopted by a `Model`. 
- Even if you did add this to a `Model`, it would completely overwrite the existing `ForceSet`. A better alternative is `ModOpAddReserves`, which _appends_ a set of `CoordinateActuator`s to the model. 

### Testing I've completed
n/a

### Looking for feedback on...
As far as I know, not many users use this method, but it has been in the codebase for a long time so this could be a breaking change for some. 

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3612)
<!-- Reviewable:end -->
