### PR TITLE
Convert `RowVectorView` to `RowVector` in Python bindings `to_numpy()` extension

### DIFF
--- a/Bindings/Python/swig/python_simbody.i
+++ b/Bindings/Python/swig/python_simbody.i
@@ -227,7 +227,10 @@ namespace SimTK {
     void _to_numpy(int n, double* numpyout) const {
         SimTK_ASSERT1_ALWAYS(n == $self->size(), "Size of input must be %i.",
                              $self->size());
-        std::copy_n($self->getContiguousScalarData(), n, numpyout);
+        // RowVectorView does not store data contiguously, so we first convert
+        // to a RowVector to ensure we always have contiguous data.
+        RowVector row = $self->getAsRowVector();
+        std::copy_n(row.getContiguousScalarData(), n, numpyout);
     }
 %pythoncode %{
     def to_numpy(self):

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -104,19 +104,21 @@ class TestSimbody(unittest.TestCase):
     def test_vectorview_typemaps(self):
         # Use a TimeSeriesTable to obtain VectorViews.
         table = osim.TimeSeriesTable()
-        table.setColumnLabels(['a'])
-        table.appendRow(0.0, osim.RowVector([1.5]))
-        table.appendRow(1.0, osim.RowVector([2.5]))
+        table.setColumnLabels(['a', 'b'])
+        table.appendRow(0.0, osim.RowVector([1.5, 2.0]))
+        table.appendRow(1.0, osim.RowVector([2.5, 3.0]))
         column = table.getDependentColumn('a').to_numpy()
         assert len(column) == 2
         assert column[0] == 1.5
         assert column[1] == 2.5
         row = table.getRowAtIndex(0).to_numpy()
-        assert len(row) == 1
+        assert len(row) == 2
         assert row[0] == 1.5
+        assert row[1] == 2.0
         row = table.getRowAtIndex(1).to_numpy()
-        assert len(row) == 1
+        assert len(row) == 2
         assert row[0] == 2.5
+        assert row[1] == 3.0
 
     def test_matrix_typemaps(self):
         npm = np.array([[5, 3], [3, 6], [8, 1]])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Fixed a minor bug when the locally installed package (via `pip`) couldn't find the dependencies (PR #3593). Added `data_files` argument to the `setup.py` to copy all the dependencies into the opensim package folder in the Python environment.
 - Added `PolynomialPathFitter`, A utility class for fitting a set of `FunctionBasedPath`s to existing geometry-path in 
   an OpenSim model using `MultivariatePolynomialFunction`s (#3390)
+- Fixed a bug where using `to_numpy()` to convert `RowVectorView`s to Python arrays returned incorrect data (#3613)
 
 v4.4.1
 ======


### PR DESCRIPTION
Fixes issue #3439

### Brief summary of changes
This PR modifies the Python interface extension `to_numpy` for `RowVectorBase`. This change is needed since `RowVectorView` does not have contiguous data, yet we use `getContiguousScalarData()` to copy the row vector contents into the target Python array. 

### Testing I've completed
Updated `test_simbody.py`. The modified test failed before the fix, and passed after the fix.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3613)
<!-- Reviewable:end -->
