### PR TITLE
Simultaneously compute value and derivative of smooth-segmented-function

### DIFF
--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -604,7 +604,7 @@ static_assert(
 DerivativeValues calcSelectedDerivatives(
     double x,
     const SelectedDerivativeOrders& selectedOrders,
-    const std::shared_ptr<const SmoothSegmentedFunctionData> smoothData)
+    const std::shared_ptr<const SmoothSegmentedFunctionData>& smoothData)
 {
     const double x0 = smoothData->_x0;
     const double x1 = smoothData->_x1;

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -587,12 +587,12 @@ namespace
 {
 
 // Used to select which derivative orders to compute:
-// e.g. selectedOrders = {true, false, false, true, false, false} selects the
-// zeroth and third order derivative.
-using SelectedDerivativeOrders = std::array<bool, 6>;
+// e.g. selectedOrders = {true, false, false, true, false, false, false}
+// selects the zeroth and third order derivative.
+using SelectedDerivativeOrders = std::array<bool, 7>;
 // Array with the element index corresponding to the derivative-order,
 // i.e. the first element is the zeroth-order derivative, etc.
-using DerivativeValues = std::array<double, 6>;
+using DerivativeValues = std::array<double, 7>;
 static_assert(
     SelectedDerivativeOrders{}.size() == DerivativeValues{}.size(),
     "Size of SelectedDerivativeOrders and DerivativeValues must match");

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -137,6 +137,13 @@ namespace OpenSim {
        */
        double calcDerivative(double x, int order) const;       
 
+       // Pair containing curve value and first derivative together.
+       using ValueAndDerivative = std::pair<double, double>;
+
+       /// Returns the same as calcValue(x) and calcDerivative(x, 1), but more
+       // efficient than calling them separately.
+       ValueAndDerivative calcValueAndFirstDerivative(double x) const;
+
 #ifndef SWIG
        /// Allow the more general calcDerivative from the base class to be used.
        // This helps avoid the -Woverloaded-virtual warning with Clang.

--- a/OpenSim/Common/SmoothSegmentedFunction.h
+++ b/OpenSim/Common/SmoothSegmentedFunction.h
@@ -137,8 +137,12 @@ namespace OpenSim {
        */
        double calcDerivative(double x, int order) const;       
 
-       // Pair containing curve value and first derivative together.
-       using ValueAndDerivative = std::pair<double, double>;
+       // Helper struct containing curve value and first derivative together.
+       struct ValueAndDerivative final
+       {
+           double value;
+           double derivative;
+       };
 
        /// Returns the same as calcValue(x) and calcDerivative(x, 1), but more
        // efficient than calling them separately.


### PR DESCRIPTION
In Millard2012EquilibriumMuscle the muscle curves are evaluated for the value and first derivative.
In SmoothSegmentedFunction these calls will recompute the exact same spline index, and intermediate variable "u".
This PR adds a function to SmoothSegmentedFunction `calcValueAndFirstDerivative` which computes them both at the same time,  such that the spline index and intermediate variable "u" are only computed once.

Later on this function can then be used by Millard's muscle.

### Brief summary of changes

- Adds anonymous function `calcSelectedDerivatives` to generalize computing different orders of derivative values.
- Adds `SmoothSegmentedFunction::calcValueAndFirstDerivative(x)`

### Testing I've completed

Passed unittests, and checked no change in simulating Rajagopal.

### CHANGELOG.md

- no need to update because minor internal change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3615)
<!-- Reviewable:end -->
