### PR TITLE
Update simbody to include C++20 fixes (#3619)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Fixed a bug where using `to_numpy()` to convert `RowVectorView`s to Python arrays returned incorrect data (#3613)
 - Bumped the version of `ezc3d` which can now Read Kistler files
 - Updated scripting method addTableMetaDataString to support overwriting metadata value for an existing key (#3589)
+- Simbody was updated such that the headers it transitively exposes to downstream projects are compatible with C++20 (#3619)
 
 v4.4.1
 ======

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    e855d954a786128c3271a3406d7bda782e7c4c4f
+              GIT_TAG    f31933bcd056a62cc7b81679368dc437bde12d3e
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Fixes issue #3619

### Brief summary of changes

- Updates simbody to include [this](https://github.com/simbody/simbody/pull/767) PR's changes
- Issue that explains why it's necessary under C++20: https://github.com/simbody/simbody/issues/766

### Testing I've completed

- I have been using this patch to build [OpenSim Creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator) with C++20 features for the last few weeks with no issues

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.
