### PR TITLE
Convert testTRCFileAdapter (minimally) to use Catch (#3555)

### DIFF
--- a/OpenSim/Common/Test/testTRCFileAdapter.cpp
+++ b/OpenSim/Common/Test/testTRCFileAdapter.cpp
@@ -20,8 +20,11 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "OpenSim/Common/Adapters.h"
+#include <OpenSim/Common/Adapters.h>
 #include <OpenSim/Common/IO.h>
+
+#define CATCH_CONFIG_MAIN
+#include <OpenSim/Auxiliary/catch/catch.hpp>
 
 #include <fstream>
 #include <cstdio>
@@ -120,7 +123,8 @@ void compareFiles(const std::string& filenameA,
     } // end while
 }
 
-int main() {
+TEST_CASE("TRCFileAdapter (all)")
+{
     using namespace OpenSim;
 
     std::vector<std::string> filenames{};
@@ -186,7 +190,7 @@ int main() {
         }
     }
 
-    if (failed) return 1;
+    if (failed) throw std::runtime_error{"Failure detected"};
     std::cout << "Testing TimeSeriesTable::trim() " << std::endl;
 
     TimeSeriesTable_<SimTK::Vec3> table(tmpfile);
@@ -206,6 +210,4 @@ int main() {
     std::remove(("trimmed_" + tmpfile).c_str());
     std::remove(tmpfile.c_str());
     std::cout << "\nAll tests passed!" << std::endl;
-
-    return 0;
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

- Changes `testTRCFileAdapter.cpp` to use Catch
- Does not reorganize each part into separate `TEST_CASE`s (that step should be done separately from #3555)

### Testing I've completed

- Ran before, ran after

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3632)
<!-- Reviewable:end -->
