### PR TITLE
Change testOutputReporter to use Catch (#3555)

### DIFF
--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -27,6 +27,9 @@
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Analyses/OutputReporter.h>
 
+#define CATCH_CONFIG_MAIN
+#include <OpenSim/Auxiliary/catch/catch.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
@@ -50,52 +53,13 @@ static const double Activation0 = 0.01,
 Deactivation0 = 0.4;
 
 /*
-This function performs a simulation of a muscle.
+Main simulation driver used to generate Outputs and report them
+
 @param muscle   a muscle model that satisfies the Muscle interface
 @param act0     the initial i of the muscle
 @param accuracy the desired accuracy of the integrated solution
 @param printResults print the osim model associated with this test.
 */
-void simulateMuscle(const Muscle& muscle,
-                    double integrationAccuracy,
-                    bool printResults);
-
-int main()
-{
-    SimTK::Array_<std::string> failures;
-
-    try {
-        Millard2012EquilibriumMuscle muscle("muscle",
-                        MaxIsometricForce0,
-                        OptimalFiberLength0,
-                        TendonSlackLength0,
-                        PennationAngle0);
-
-        muscle.setActivationTimeConstant(Activation0);
-        muscle.setDeactivationTimeConstant(Deactivation0);
-
-        simulateMuscle( muscle,
-                        IntegrationAccuracy,
-                        true);
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testOutputReporter");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-
-    cout << "testOutputReporter Done" << endl;
-    return 0;
-}
-
-//=============================================================================
-// Main simulation driver used to generate Outputs and report them
-//=============================================================================
 void simulateMuscle(
         const Muscle &muscModel,
         double integrationAccuracy,
@@ -281,4 +245,20 @@ void simulateMuscle(
     ASSERT_EQUAL(ke, val_ke, SimTK::Eps);
     ASSERT_EQUAL(ang_acc, val_omega, SimTK::Eps);
     ASSERT_EQUAL(reaction, val_jrf, SimTK::Eps);
+}
+
+TEST_CASE("Output Reporter")
+{
+    Millard2012EquilibriumMuscle muscle("muscle",
+        MaxIsometricForce0,
+        OptimalFiberLength0,
+        TendonSlackLength0,
+        PennationAngle0);
+
+    muscle.setActivationTimeConstant(Activation0);
+    muscle.setDeactivationTimeConstant(Deactivation0);
+
+    simulateMuscle( muscle,
+        IntegrationAccuracy,
+        true);
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

- Changes `testOutputReporter.cpp` to use Catch's `TEST_CASE` rather than a `main` with `try` etc.

### Testing I've completed

- Ran before ran after

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3634)
<!-- Reviewable:end -->
