### PR TITLE
Update simbody to 24b5fa

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    f31933bcd056a62cc7b81679368dc437bde12d3e
+              GIT_TAG    24b5fa4abcc87d8ff0b5f889deab4ea3e42b6560
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Fixes issue N/A

Latest simbody contains useful fixes:

- https://github.com/simbody/simbody/pull/771
  - Tells CMake that `simbody` targets, on Windows, depend on `libgcc_s_sjlj-1.dll` etc.
- https://github.com/simbody/simbody/pull/770
  - Removes `std::iterator` from an XML class, because `std::iterator` is detected as deprecated by MSVC when warnings are increased

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3638)
<!-- Reviewable:end -->
