### PR TITLE
Fix typo in Linux/MacOS build scripts

### DIFF
--- a/OpenSim/Simulation/BufferedOrientationsReference.h
+++ b/OpenSim/Simulation/BufferedOrientationsReference.h
@@ -79,7 +79,7 @@ public:
             SimTK::Array_<SimTK::Rotation_<double>>& values) const override;
 
     /** add passed in values to data procesing Queue */
-    void putValues(double time, const SimTK::RowVector_<SimTK::Rotation>& dataRow);
+    void putValues(double time, const SimTK::RowVector_<SimTK::Rotation_<double>>& dataRow);
 
     double getNextValuesAndTime(
             SimTK::Array_<SimTK::Rotation_<double>>& values) override;
@@ -91,7 +91,7 @@ public:
     };
 private:
     // Use a specialized data structure for holding the orientation data
-    mutable DataQueue_<SimTK::Rotation> _orientationDataQueue;
+    mutable DataQueue_<SimTK::Rotation_<double>> _orientationDataQueue;
     bool _finished{false};
     //=============================================================================
 };  // END of class BufferedOrientationsReference

--- a/scripts/build/opensim-core-linux-build-script.sh
+++ b/scripts/build/opensim-core-linux-build-script.sh
@@ -18,7 +18,7 @@ Help() {
     echo "    -d         Debug Type. Available Options:"
     echo "                   Release (Default): No debugger symbols. Optimized."
     echo "                   Debug: Debugger symbols. No optimizations (>10x slower). Library names ending with _d."
-    echo "                   RelWithDefInfo: Debugger symbols. Optimized. Bigger than Release, but not slower."
+    echo "                   RelWithDebInfo: Debugger symbols. Optimized. Bigger than Release, but not slower."
     echo "                   MinSizeRel: No debugger symbols. Minimum size. Optimized."
     echo "    -j         Number of jobs to use when building libraries (>=1)."
     echo "    -s         Simple build without moco (Tropter and Casadi disabled)."

--- a/scripts/build/opensim-core-macos-build-script.sh
+++ b/scripts/build/opensim-core-macos-build-script.sh
@@ -18,7 +18,7 @@ Help() {
     echo "    -d         Debug Type. Available Options:"
     echo "                   Release (Default): No debugger symbols. Optimized."
     echo "                   Debug: Debugger symbols. No optimizations (>10x slower). Library names ending with _d."
-    echo "                   RelWithDefInfo: Debugger symbols. Optimized. Bigger than Release, but not slower."
+    echo "                   RelWithDebInfo: Debugger symbols. Optimized. Bigger than Release, but not slower."
     echo "                   MinSizeRel: No debugger symbols. Minimum size. Optimized."
     echo "    -j         Number of jobs to use when building libraries (>=1)."
     echo "    -s         Simple build without moco (Tropter and Casadi disabled)."


### PR DESCRIPTION
Fixes issue N/A

### Brief summary of changes

In the help text for the linux build script, there was a typo. The help text did not agree with the rest of the code. It also did not agree with the Windows version of the build script. 

### Testing I've completed

Since this is just a change to the help text, I don't think that rigorous testing is needed. 

### CHANGELOG.md (choose one)

I don't think that it is needed to add this to the change log.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3640)
<!-- Reviewable:end -->
