### PR TITLE
Fix types for methods in BufferedOrientationReference

### DIFF
--- a/Bindings/Python/tests/test_opensense.py
+++ b/Bindings/Python/tests/test_opensense.py
@@ -33,6 +33,10 @@ class TestOpenSense(unittest.TestCase):
         constraint_var = .0001
         ikSolver = osim.InverseKinematicsSolver(model, mRefs, oRefs, coordinateReferences, constraint_var)
         print("Created InverseKinematicsSolver object..")
+        oRefs = osim.BufferedOrientationsReference()
+        print("Created BufferedOrientationsReference object..")
+        ikSolver = osim.InverseKinematicsSolver(model, mRefs, oRefs, coordinateReferences, constraint_var)
+        print("Created InverseKinematicsSolver object with BufferedOrientationsReference..")
 
     def test_vector_rowvector(self):
         print()

--- a/Bindings/Python/tests/test_opensense.py
+++ b/Bindings/Python/tests/test_opensense.py
@@ -47,3 +47,19 @@ class TestOpenSense(unittest.TestCase):
                 col[1] == row[1] and
                 col[2] == row[2] and
                 col[3] == row[3])
+
+    def test_BufferedOrientationReferencePut(self):
+        # Make sure that we can append new data to the BufferedOrientationReference object
+        quatTable = osim.TimeSeriesTableQuaternion(os.path.join(test_dir,'orientation_quats.sto'))
+        print("Created TimeSeriesTableQuaternion object..")
+        orientationsData = osim.OpenSenseUtilities.convertQuaternionsToRotations(quatTable)
+        print("Convert Quaternions to orientationsData")
+        time = 0
+        rowVecView = orientationsData.getNearestRow(time)
+        print("Sliced orientationData")
+        rowVec = osim.RowVectorRotation(rowVecView)
+        print("Converted slice to row vector")
+        oRefs = osim.BufferedOrientationsReference()
+        print("Created BufferedOrienationReference object")
+        oRefs.putValues(time, rowVec)
+        print("Added row vector to BufferedOrientationReference object")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Exposed simbody methods to obtain GravityForces, MobilityForces and BodyForces (#3490)
 - Simbody was updated such that the headers it transitively exposes to downstream projects are compatible with C++20 (#3619)
 - Moved speed computation from `computeForce` in children of `ScalarActuator` to dedicated `getSpeed` function.
+- Fix type problem with BufferedOrientationReference (Issue #3415, PR #3644)
 
 
 v4.4.1

--- a/OpenSim/Simulation/BufferedOrientationsReference.h
+++ b/OpenSim/Simulation/BufferedOrientationsReference.h
@@ -33,7 +33,7 @@ namespace OpenSim {
 //=============================================================================
 /**
  * Subclass of OrientationsReference that handles live data by providing a DataQueue
- * that allows clients to push data into and allows the InverseKinematicsSolver to 
+ * that allows clients to push data into and allows the InverseKinematicsSolver to
  * draw data from for solving.
  * Ideally this would be templatized, allowing for all Reference classes to leverage it.
  *
@@ -79,19 +79,19 @@ public:
             SimTK::Array_<SimTK::Rotation_<double>>& values) const override;
 
     /** add passed in values to data procesing Queue */
-    void putValues(double time, const SimTK::RowVector_<SimTK::Rotation>& dataRow);
+    void putValues(double time, const SimTK::RowVector_<SimTK::Rotation_<double>>& dataRow);
 
     double getNextValuesAndTime(
             SimTK::Array_<SimTK::Rotation_<double>>& values) override;
 
     virtual bool hasNext() const override { return !_finished; };
 
-    void setFinished(bool finished) { 
+    void setFinished(bool finished) {
         _finished = finished;
     };
 private:
     // Use a specialized data structure for holding the orientation data
-    mutable DataQueue_<SimTK::Rotation> _orientationDataQueue;
+    mutable DataQueue_<SimTK::Rotation_<double>> _orientationDataQueue;
     bool _finished{false};
     //=============================================================================
 };  // END of class BufferedOrientationsReference


### PR DESCRIPTION
Fixes issue #3415

### Brief summary of changes

The interface to BufferedOrientationReferene is defined here: 

https://github.com/opensim-org/opensim-core/blob/2aa34e167990226142b3765f3e188c3f332f93c1/Bindings/simulation.i#L242-L242

In BufferedOrientationReference.h, there were missing `_<double>` type annotations for `SimTK::RowVector_<SimTK::Rotation>`. I think that when swig pulled in the header file for defining the interface, it was not sure how to handle some methods including the `putValues` since that did not have the `_<double>` type on it. Ref: 26e9f22

Also, I noticed that the python opensense testing file did not include any tests for the initialization of the `BufferedOrienationReference`, so I added some tests for that. To make sure that the ikSolver initializes well with the `BufferedOrienationReference`, I also added a test using it to initialize it.

### Testing I've completed
I have built with these changes locally using the linux build script, and all tests have passed. 

I have made minor changes to [Patrick's code](https://github.com/pslade2/RealTimeKin) to incorporate the new `BufferedOrientationReference`, and it runs with no problems. 

### Looking for feedback on...

### CHANGELOG.md 

- Updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3644)
<!-- Reviewable:end -->
