### PR TITLE
Change simbody to 589e931f

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    930ae0feff0adb5aec184af62d14f9d138cacd48
+              GIT_TAG    589e931f4a127830a5876ee4dd8f327b47361504
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Changes simbody to [this](https://github.com/simbody/simbody/commit/589e931f4a127830a5876ee4dd8f327b47361504) commit, which is explained in more detail in [this](https://github.com/simbody/simbody/pull/773) PR.

### Brief summary of changes

- Changes vector growth related to reading vtp files etc., which should help with loading models files that use those mesh assets

### Testing I've completed

- I ran it in OSC on a patched OpenSim branch and it seems to do the trick

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it's a minor perf change related to loading osim files

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3650)
<!-- Reviewable:end -->
