### PR TITLE
Combines computing value and derivative of muscle curves in Millard

### DIFF
--- a/OpenSim/Actuators/ActiveForceLengthCurve.cpp
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.cpp
@@ -158,6 +158,15 @@ double ActiveForceLengthCurve::calcValue(double normFiberLength) const
     return m_curve.calcValue(normFiberLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative ActiveForceLengthCurve::
+    calcValueAndDerivative(double normFiberLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberLength);
+}
+
 double ActiveForceLengthCurve::calcDerivative(double normFiberLength,
                                               int order) const
 {

--- a/OpenSim/Actuators/ActiveForceLengthCurve.cpp
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.cpp
@@ -153,7 +153,8 @@ void ActiveForceLengthCurve::setMinValue(double minimumValue)
 //==============================================================================
 double ActiveForceLengthCurve::calcValue(double normFiberLength) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValue(normFiberLength);
 }
@@ -161,8 +162,8 @@ double ActiveForceLengthCurve::calcValue(double normFiberLength) const
 SmoothSegmentedFunction::ValueAndDerivative ActiveForceLengthCurve::
     calcValueAndDerivative(double normFiberLength) const
 {
-    SimTK_ASSERT(
-        isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValueAndFirstDerivative(normFiberLength);
 }
@@ -170,7 +171,8 @@ SmoothSegmentedFunction::ValueAndDerivative ActiveForceLengthCurve::
 double ActiveForceLengthCurve::calcDerivative(double normFiberLength,
                                               int order) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
     SimTK_ERRCHK1_ALWAYS(order >= 0 && order <= 2,
         "ActiveForceLengthCurve::calcDerivative",
@@ -188,7 +190,8 @@ double ActiveForceLengthCurve::
 
 SimTK::Vec2 ActiveForceLengthCurve::getCurveDomain() const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ActiveForceLengthCurve: Curve is not up-to-date with its properties");
 
     return m_curve.getCurveDomain();

--- a/OpenSim/Actuators/ActiveForceLengthCurve.h
+++ b/OpenSim/Actuators/ActiveForceLengthCurve.h
@@ -209,6 +209,11 @@ public:
     'normFiberLength'. */
     double calcValue(double normFiberLength) const;
 
+    /** Evaluates the active-force-length curve value and derivative at a
+     * normalized fiber length of 'normFiberLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberLength) const;
+
 
     /** Calculates the derivative of the active-force-length multiplier with
     respect to the normalized fiber length.

--- a/OpenSim/Actuators/FiberForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberForceLengthCurve.cpp
@@ -214,7 +214,8 @@ void FiberForceLengthCurve::setOptionalProperties(double aStiffnessAtLowForce,
 //==============================================================================
 double FiberForceLengthCurve::calcValue(double normFiberLength) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "FiberForceLengthCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValue(normFiberLength);
 }
@@ -222,8 +223,8 @@ double FiberForceLengthCurve::calcValue(double normFiberLength) const
 SmoothSegmentedFunction::ValueAndDerivative FiberForceLengthCurve::
     calcValueAndDerivative(double normFiberLength) const
 {
-    SimTK_ASSERT(
-        isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "FiberForceLengthCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValueAndFirstDerivative(normFiberLength);
 }
@@ -231,7 +232,8 @@ SmoothSegmentedFunction::ValueAndDerivative FiberForceLengthCurve::
 double FiberForceLengthCurve::calcDerivative(double normFiberLength,
                                              int order) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "FiberForceLengthCurve: Curve is not up-to-date with its properties");
     SimTK_ERRCHK1_ALWAYS(order >= 0 && order <= 2,
         "FiberForceLengthCurve::calcDerivative",
@@ -249,7 +251,8 @@ double FiberForceLengthCurve::
 
 double FiberForceLengthCurve::calcIntegral(double normFiberLength) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "FiberForceLengthCurve: Curve is not up-to-date with its properties");
 
     if(!m_curve.isIntegralAvailable()) {
@@ -263,7 +266,8 @@ double FiberForceLengthCurve::calcIntegral(double normFiberLength) const
 
 SimTK::Vec2 FiberForceLengthCurve::getCurveDomain() const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "FiberForceLengthCurve: Curve is not up-to-date with its properties");
     return m_curve.getCurveDomain();
 }

--- a/OpenSim/Actuators/FiberForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberForceLengthCurve.cpp
@@ -219,6 +219,15 @@ double FiberForceLengthCurve::calcValue(double normFiberLength) const
     return m_curve.calcValue(normFiberLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative FiberForceLengthCurve::
+    calcValueAndDerivative(double normFiberLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "FiberForceLengthCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberLength);
+}
+
 double FiberForceLengthCurve::calcDerivative(double normFiberLength,
                                              int order) const
 {

--- a/OpenSim/Actuators/FiberForceLengthCurve.h
+++ b/OpenSim/Actuators/FiberForceLengthCurve.h
@@ -279,6 +279,11 @@ public:
     'normFiberLength'. */
     double calcValue(double normFiberLength) const;
 
+    /** Evaluates the fiber-force-length curve value and derivative at a
+    normalized fiber length of 'normFiberLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberLength) const;
+
     /** Calculates the derivative of the fiber-force-length multiplier with
     respect to the normalized fiber length.
     @param normFiberLength

--- a/OpenSim/Actuators/ForceVelocityCurve.cpp
+++ b/OpenSim/Actuators/ForceVelocityCurve.cpp
@@ -171,7 +171,8 @@ void ForceVelocityCurve::setEccentricCurviness(double aEccentricCurviness)
 //==============================================================================
 double ForceVelocityCurve::calcValue(double normFiberVelocity) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ForceVelocityCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValue(normFiberVelocity);
 }
@@ -179,8 +180,8 @@ double ForceVelocityCurve::calcValue(double normFiberVelocity) const
 SmoothSegmentedFunction::ValueAndDerivative ForceVelocityCurve::
     calcValueAndDerivative(double normFiberVelocity) const
 {
-    SimTK_ASSERT(
-        isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ForceVelocityCurve: Curve is not up-to-date with its properties");
     return m_curve.calcValueAndFirstDerivative(normFiberVelocity);
 }
@@ -188,7 +189,8 @@ SmoothSegmentedFunction::ValueAndDerivative ForceVelocityCurve::
 double ForceVelocityCurve::calcDerivative(double normFiberVelocity,
                                           int order) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ForceVelocityCurve: Curve is not up-to-date with its properties");
     SimTK_ERRCHK1_ALWAYS(order >= 0 && order <= 2,
         "ForceVelocityCurve::calcDerivative",
@@ -206,7 +208,8 @@ double ForceVelocityCurve::
 
 SimTK::Vec2 ForceVelocityCurve::getCurveDomain() const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "ForceVelocityCurve: Curve is not up-to-date with its properties");
     return m_curve.getCurveDomain();
 }

--- a/OpenSim/Actuators/ForceVelocityCurve.cpp
+++ b/OpenSim/Actuators/ForceVelocityCurve.cpp
@@ -176,6 +176,15 @@ double ForceVelocityCurve::calcValue(double normFiberVelocity) const
     return m_curve.calcValue(normFiberVelocity);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative ForceVelocityCurve::
+    calcValueAndDerivative(double normFiberVelocity) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "ForceVelocityCurve: Curve is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(normFiberVelocity);
+}
+
 double ForceVelocityCurve::calcDerivative(double normFiberVelocity,
                                           int order) const
 {

--- a/OpenSim/Actuators/ForceVelocityCurve.h
+++ b/OpenSim/Actuators/ForceVelocityCurve.h
@@ -305,6 +305,11 @@ public:
     'normFiberVelocity'. */
     double calcValue(double normFiberVelocity) const;
 
+    /** Evaluates the force-velocity curve value and derivative at a normalized
+    fiber velocity of 'normFiberVelocity'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double normFiberVelocity) const;
+
     /** Calculates the derivative of the force-velocity multiplier with respect
     to the normalized fiber velocity.
     @param normFiberVelocity

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -225,7 +225,7 @@ DampedFiberVelocityCalculationResult calcDampedNormFiberVelocity(
     @param fiso the maximum isometric force the fiber can generate
     @param a activation
     @param fv the fiber force-velocity multiplier
-    @param fpe_dlceN the fiber force-length multiplier derivative
+    @param dfpe_dlceN the fiber force-length multiplier derivative
     @param dfal_dlceN the fiber active-force-length multiplier derivative
     @param optFibLen the optimal fiber length
 */
@@ -1138,13 +1138,9 @@ calcMuscleDynamicsInfo(const SimTK::State& s, MuscleDynamicsInfo& mdi) const
             mvi.userDefinedVelocityExtras[MVIIsFiberStateClamped];
 
         // Get the properties of this muscle.
-        double tendonSlackLen = getTendonSlackLength();
         double optFiberLen    = getOptimalFiberLength();
         double fiso           = getMaxIsometricForce();
         double beta           = getFiberDamping();
-
-        //double penHeight      = penMdl.getParallelogramHeight();
-        const TendonForceLengthCurve& fseCurve = get_TendonForceLengthCurve();
 
         // Compute dynamic quantities.
         double a = SimTK::NaN;

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -33,11 +33,11 @@ const string Millard2012EquilibriumMuscle::
     STATE_FIBER_LENGTH_NAME = "fiber_length";
 const double MIN_NONZERO_DAMPING_COEFFICIENT = 0.001;
 
-const static int MLIFiberForceLengthCurveDerivative  = 0;
-const static int MLIActiveForceLengthCurveDerivative = 1;
-const static int MVIIsFiberStateClamped         = 0;
-const static int MVITendonForceLengthMultiplier = 1;
-const static int MVITendonStiffness             = 2;
+static constexpr int MLIFiberForceLengthCurveDerivative  = 0;
+static constexpr int MLIActiveForceLengthCurveDerivative = 1;
+static constexpr int MVIIsFiberStateClamped         = 0;
+static constexpr int MVITendonForceLengthMultiplier = 1;
+static constexpr int MVITendonStiffness             = 2;
 
 //==============================================================================
 // HELPER FUNCTIONS

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.cpp
@@ -960,7 +960,7 @@ calcFiberVelocityInfo(const SimTK::State& s, FiberVelocityInfo& fvi) const
 
         // Compute tendon force length multiplier, and tendon stiffness. Tendon
         // stiffness is computed here, because it is cheaper to evaluate the
-        // curve value and derivative simultaneously.
+        // curve value and derivative simultaneously (see opensim-core/3653).
         double fse = SimTK::NaN; // NaN for rigid tendon.
         double tendonStiffness = SimTK::Infinity; // Inf for rigid tednon.
         if (!get_ignore_tendon_compliance()) { // In case of compliant tendon.

--- a/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
+++ b/OpenSim/Actuators/Millard2012EquilibriumMuscle.h
@@ -586,23 +586,6 @@ private:
                           double fpe,
                           double dlceN) const;
 
-    /*  @param fiso the maximum isometric force the fiber can generate
-        @param a activation
-        @param fal the fiber active-force-length multiplier
-        @param fv the fiber force-velocity multiplier
-        @param fpe the fiber force-length multiplier
-        @param sinphi the sine of the pennation angle
-        @param cosphi the cosine of the pennation angle
-        @param lce the fiber length
-        @param lceN the normalized fiber length
-        @param optFibLen the optimal fiber length
-        @returns the stiffness of the fiber in the direction of the fiber */
-    double calcFiberStiffness(double fiso,
-                              double a,
-                              double fv,
-                              double lceN,
-                              double optFibLen) const;
-
     /*  @param fiberForce the force, in Newtons, developed by the fiber
         @param fiberStiffness the stiffness, in N/m, of the fiber
         @param lce the fiber length

--- a/OpenSim/Actuators/TendonForceLengthCurve.cpp
+++ b/OpenSim/Actuators/TendonForceLengthCurve.cpp
@@ -223,6 +223,15 @@ double TendonForceLengthCurve::calcValue(double aNormLength) const
     return m_curve.calcValue(aNormLength);
 }
 
+SmoothSegmentedFunction::ValueAndDerivative TendonForceLengthCurve::
+    calcValueAndDerivative(double aNormLength) const
+{
+    SimTK_ASSERT(
+        isObjectUpToDateWithProperties(),
+        "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
+    return m_curve.calcValueAndFirstDerivative(aNormLength);
+}
+
 double TendonForceLengthCurve::calcDerivative(double aNormLength,
                                               int order) const
 {

--- a/OpenSim/Actuators/TendonForceLengthCurve.cpp
+++ b/OpenSim/Actuators/TendonForceLengthCurve.cpp
@@ -218,7 +218,8 @@ SimTK::Function* TendonForceLengthCurve::createSimTKFunction() const
 //==============================================================================
 double TendonForceLengthCurve::calcValue(double aNormLength) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
     return m_curve.calcValue(aNormLength);
 }
@@ -226,8 +227,8 @@ double TendonForceLengthCurve::calcValue(double aNormLength) const
 SmoothSegmentedFunction::ValueAndDerivative TendonForceLengthCurve::
     calcValueAndDerivative(double aNormLength) const
 {
-    SimTK_ASSERT(
-        isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
     return m_curve.calcValueAndFirstDerivative(aNormLength);
 }
@@ -235,7 +236,8 @@ SmoothSegmentedFunction::ValueAndDerivative TendonForceLengthCurve::
 double TendonForceLengthCurve::calcDerivative(double aNormLength,
                                               int order) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
     SimTK_ERRCHK1_ALWAYS(order >= 0 && order <= 2,
         "TendonForceLengthCurve::calcDerivative",
@@ -253,7 +255,8 @@ double TendonForceLengthCurve::
 
 double TendonForceLengthCurve::calcIntegral(double aNormLength) const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
 
     if (!m_curve.isIntegralAvailable()) {
@@ -267,7 +270,8 @@ double TendonForceLengthCurve::calcIntegral(double aNormLength) const
 
 SimTK::Vec2 TendonForceLengthCurve::getCurveDomain() const
 {
-    SimTK_ASSERT(isObjectUpToDateWithProperties(),
+    OPENSIM_ASSERT(
+        isObjectUpToDateWithProperties() &&
         "TendonForceLengthCurve: Tendon is not up-to-date with its properties");
     return m_curve.getCurveDomain();
 }

--- a/OpenSim/Actuators/TendonForceLengthCurve.h
+++ b/OpenSim/Actuators/TendonForceLengthCurve.h
@@ -263,6 +263,11 @@ public:
     'aNormLength'. */
     double calcValue(double aNormLength) const;
 
+    /** Evaluates the tendon-force-length curve value and derivative at a
+    normalized tendon length of 'aNormLength'. */
+    SmoothSegmentedFunction::ValueAndDerivative calcValueAndDerivative(
+        double aNormLength) const;
+
     /** Calculates the derivative of the tendon-force-length multiplier with
     respect to the normalized tendon length.
     @param aNormLength


### PR DESCRIPTION
This PR replaces separate calls to `calcValue` and `calcDerivative` on the muscle curves in `Millard2012EquilibriumMuscle` by `calcValueAndDerivative`, which is more efficient.

The `MuscleLengthInfo::userDefinedLengthExtras` and  `FiberVelocityInfo::userDefinedVelocityExtras` buffers are used to store the derivatives of the curves until needed.

Measuring the wallclock time of Rajagopal forward integration, and CMC running-model (using Millard muscles) shows around 10% perf benefit:

| | main | with this PR |
|---|---|---|
|CMC-Running Model | 25.8 [s] | 22.9 [s] (-12.4%) |
|Rajagopal Forward Integration | 6.4 [s] | 5.8 [s] ( -9.8% ) |

### Brief summary of changes

There are 4 relevant muscle curves in `Millard2012EquilibriumMuscle` which are calling `calcValue` and `calcDerivative`, which is combined to `calcValueAndDerivative` by this PR:

- Added `calcValueAndDerivative` method to:
    - `ActiveForceLengthCurve.h`
    - `TendonForceLengthCurve.h`
    - `FiberForceLengthCurve.h`
    - `TendonForceLengthCurve.h`

- Regarding the `ActiveForceLengthCurve` and `TendonForceLengthCurve`:
    - moved computing curve derivative to `calcMuscleLengthInfo`, and store result in `MuscleLengthInfo::userDefinedLengthExtras`
    - moved `Millard2012EquilibriumMuscle::calcFiberStiffness` to anonymous namespace (this was using the derivative values)

- Regarding the `ForceVelocityCurve`:
    - use `calcValueAndDerivative` during `calcDampedNormFiberVelocity()` instead of `calcValue` followed by `calcDerivative`.
    - return last evaluation of `fiberForceVelocityCurve` from `calcDampedNormFiberVelocity()`

- Regarding the `TendonForceLengthCurve`:
    - Compute fiberstiffness and tendonforcelength multiplier during `calcFiberVelocityInfo()` and store in `FiberVelocityInfo::userDefinedVelocityExtras`

### Testing I've completed

Unit tests are passing, and Rajagopal forward simulation as well as CMC on running-model gives no change in results.

### CHANGELOG.md

- no need to update because too minor change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3653)
<!-- Reviewable:end -->
