### PR TITLE
Undo binding of model getCoordinatesInMultibodyTreeOrder and introduc…

### DIFF
--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -206,7 +206,7 @@ class TestSimbody(unittest.TestCase):
                 model.calcMassCenterPosition(s)[2])
 
         coordNames = model.getCoordinateNamesInMultibodyTreeOrder();
-        print('firstCoord', coordNames.get(0));
+        print('firstCoord', coordNames.getElt(0));
         
         J = osim.Matrix()
         smss.calcSystemJacobian(s, J)

--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -205,6 +205,9 @@ class TestSimbody(unittest.TestCase):
         assert (smss.calcSystemMassCenterLocationInGround(s)[2] == 
                 model.calcMassCenterPosition(s)[2])
 
+        coordNames = model.getCoordinateNamesInMultibodyTreeOrder();
+        print('firstCoord', coordNames.get(0));
+        
         J = osim.Matrix()
         smss.calcSystemJacobian(s, J)
         # 6 * number of mobilized bodies
@@ -248,3 +251,5 @@ class TestSimbody(unittest.TestCase):
         assert residual.size() == s.getNU()
         for i in range(residual.size()):
             assert abs(residual[i]) < 1e-10
+
+    

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -177,9 +177,6 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/ModelVisualPreferences.h>
 %include <OpenSim/Simulation/Model/ModelVisualizer.h>
 %copyctor OpenSim::Model;
-%include <SimTKcommon/internal/ReferencePtr.h>
-%template(ReferencePtrCoordinate) SimTK::ReferencePtr<const OpenSim::Coordinate>;
-%template(StdVectorReferencePtrCoordinate) std::vector<SimTK::ReferencePtr<const OpenSim::Coordinate>>;
 %include <OpenSim/Simulation/Model/Model.h>
 
 %include <OpenSim/Simulation/Model/AbstractPathPoint.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Deleting elements from an `OpenSim::Coordinate` range now throws an exception during `finalizeFromProperties` (previously:
   it would let you do it, and throw later when `Coordinate::getMinRange()` or `Coordinate::getMaxRange()` were called, #3532)
 - Added `FunctionBasedPath`, a class for representing paths in `Force`s based on `Function` objects (#3389)
-- Fixed bindings to expose the method Model::getCoordinatesInMultibodyTreeOrder to scripting users (#3569)
+- Fixed bindings to expose the method Model::getCoordinateNamesInMultibodyTreeOrder to scripting users (#3569)
 - Fixed a bug where constructing a `ModelProcessor` from a `Model` object led to an invalid `Model`
 - Added `LatinHypercubeDesign`, a class for generating Latin hypercube designs using random and algorithm methods (#3570)
 - Refactor c3dExport.m file as a Matlab function (#3501), also expose method to allow some operations on tableColumns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Deleting elements from an `OpenSim::Coordinate` range now throws an exception during `finalizeFromProperties` (previously:
   it would let you do it, and throw later when `Coordinate::getMinRange()` or `Coordinate::getMaxRange()` were called, #3532)
 - Added `FunctionBasedPath`, a class for representing paths in `Force`s based on `Function` objects (#3389)
-- Fixed bindings to expose the method Model::getCoordinateNamesInMultibodyTreeOrder to scripting users (#3569)
+- Introduced the method `Model::getCoordinateNamesInMultibodyTreeOrder` for convenient access to internal coordinate ordering for scripting users (#3569)
 - Fixed a bug where constructing a `ModelProcessor` from a `Model` object led to an invalid `Model`
 - Added `LatinHypercubeDesign`, a class for generating Latin hypercube designs using random and algorithm methods (#3570)
 - Refactor c3dExport.m file as a Matlab function (#3501), also expose method to allow some operations on tableColumns

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -947,7 +947,7 @@ public:
     SimTK::Array_<std::string> getCoordinateNamesInMultibodyTreeOrder() {
         SimTK::Array_<std::string> namesArray;
         auto coords = getCoordinatesInMultibodyTreeOrder();
-        for (int i=0; i < coords.size(); ++i)
+        for (auto i=0; i < coords.size(); ++i)
             namesArray.push_back(coords[i]->getName());
         return namesArray;
     }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -943,6 +943,14 @@ public:
     std::vector<SimTK::ReferencePtr<const OpenSim::Coordinate>>
         getCoordinatesInMultibodyTreeOrder() const;
 
+    /** A variant of getCoordinatesInMultibodyTreeOrder that returns names for Scripting users */
+    SimTK::Array_<std::string> getCoordinateNamesInMultibodyTreeOrder() {
+        SimTK::Array_<std::string> namesArray;
+        auto coords = getCoordinatesInMultibodyTreeOrder();
+        for (auto coord : coords)
+            namesArray.push_back(coord->getName());
+        return namesArray;
+    }
     /** Get a warning message if any Coordinates have a MotionType that is NOT
         consistent with its previous user-specified value that existed in 
         Model files prior to OpenSim 4.0 */

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -947,7 +947,7 @@ public:
     SimTK::Array_<std::string> getCoordinateNamesInMultibodyTreeOrder() {
         SimTK::Array_<std::string> namesArray;
         auto coords = getCoordinatesInMultibodyTreeOrder();
-        for (auto i=0; i < coords.size(); ++i)
+        for (int i=0; i < (int)coords.size(); ++i)
             namesArray.push_back(coords[i]->getName());
         return namesArray;
     }

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -947,8 +947,8 @@ public:
     SimTK::Array_<std::string> getCoordinateNamesInMultibodyTreeOrder() {
         SimTK::Array_<std::string> namesArray;
         auto coords = getCoordinatesInMultibodyTreeOrder();
-        for (auto coord : coords)
-            namesArray.push_back(coord->getName());
+        for (int i=0; i < coords.size(); ++i)
+            namesArray.push_back(coords[i]->getName());
         return namesArray;
     }
     /** Get a warning message if any Coordinates have a MotionType that is NOT

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -134,6 +134,7 @@ void testAssembleModelWithConstraints(string modelFile)
     auto coordsInOrder = model.getCoordinateNamesInMultibodyTreeOrder();
     cout << coordsInOrder << std::endl;
 
+    assert(coords.getSize()==coordsInOrder.size());
     // Initial coordinates after initial assembly
     Vector q0 = state.getQ();
 

--- a/OpenSim/Simulation/Test/testAssemblySolver.cpp
+++ b/OpenSim/Simulation/Test/testAssemblySolver.cpp
@@ -131,6 +131,8 @@ void testAssembleModelWithConstraints(string modelFile)
     for(int i=0; i< coords.getSize(); i++) {
         cout << "Coordinate " << coords[i].getName() << " get value = " << coords[i].getValue(state) << endl;
     }
+    auto coordsInOrder = model.getCoordinateNamesInMultibodyTreeOrder();
+    cout << coordsInOrder << std::endl;
 
     // Initial coordinates after initial assembly
     Vector q0 = state.getQ();


### PR DESCRIPTION
…e getCoordinateNamesInMultibodyTreeOrder for scripting users

Fixes issue #0
### Brief summary of changes
Using SimTK::ReferencePtr across binding was problematic due to methods optimized out. Adding a method to return names of coordinates instead to sidestep the memory management issue across the binding interface.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3656)
<!-- Reviewable:end -->
