### PR TITLE
Add rule-of-five to `IKMarkerTask` and `OrientationWeightSet`

### DIFF
--- a/OpenSim/Tools/IKMarkerTask.h
+++ b/OpenSim/Tools/IKMarkerTask.h
@@ -41,6 +41,9 @@ OpenSim_DECLARE_CONCRETE_OBJECT(IKMarkerTask, IKTask);
 public:
     IKMarkerTask() = default;
     IKMarkerTask(const IKMarkerTask&) = default;
+    IKMarkerTask(IKMarkerTask&&) = default;
+    IKMarkerTask& operator=(const IKMarkerTask&) = default;
+    IKMarkerTask& operator=(IKMarkerTask&&) = default;
     //=============================================================================
 };  // END of class IKMarkerTask
 //=============================================================================

--- a/OpenSim/Tools/IMUInverseKinematicsTool.h
+++ b/OpenSim/Tools/IMUInverseKinematicsTool.h
@@ -58,6 +58,9 @@ public:
     // default copy, assignment operator, and destructor
     OrientationWeightSet() = default;
     OrientationWeightSet(const OrientationWeightSet&) = default;
+    OrientationWeightSet(OrientationWeightSet&&) = default;
+    OrientationWeightSet& operator=(const OrientationWeightSet&) = default;
+    OrientationWeightSet& operator=(OrientationWeightSet&&) = default;
     //=============================================================================
 }; 
         //=============================================================================


### PR DESCRIPTION
### Brief summary of changes

Adds move constructors, copy assignment operators, and move assignment operators to `IKMarkerTask` and `OrientationWeightSet`.  This suppresses `gcc` compiler warnings complaining about no user-defined assignment operator when a user-defined copy-assignment operator is present.

`ProbeMeasure` issues a similar warning, but I think it can be ignored. It uses [a Simbody macro](https://github.com/simbody/simbody/blob/589e931f4a127830a5876ee4dd8f327b47361504/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h#L64) to define custom copy assignment operators and copy constructors. The macro uses the terms `shallowAssign` and `deepAssign` to define its copy constructors, since these do not use the typical constructor syntax, `gcc` complains.

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...not user facing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3657)
<!-- Reviewable:end -->
