### PR TITLE
Replace usages of `sprintf` with `snprintf`

### DIFF
--- a/OpenSim/Analyses/PointKinematics.cpp
+++ b/OpenSim/Analyses/PointKinematics.cpp
@@ -223,12 +223,12 @@ constructDescription()
     strcat(descrip,"(position, velocity, or acceleration) of\n");
     
     if(_relativeToBody){
-        sprintf(tmp,"point (%lf, %lf, %lf) on body %s relative to body %s of model %s.\n",
+        snprintf(tmp, BUFFER_LENGTH, "point (%lf, %lf, %lf) on body %s relative to body %s of model %s.\n",
             _point[0],_point[1],_point[2],_body->getName().c_str(),
             _relativeToBody->getName().c_str(), _model->getName().c_str());
     }
     else{
-        sprintf(tmp,"point (%lf, %lf, %lf) on the %s of model %s.\n",
+        snprintf(tmp, BUFFER_LENGTH, "point (%lf, %lf, %lf) on the %s of model %s.\n",
             _point[0],_point[1],_point[2],_body->getName().c_str(),
             _model->getName().c_str());
     }

--- a/OpenSim/Common/About.cpp
+++ b/OpenSim/Common/About.cpp
@@ -128,7 +128,7 @@ static const char* OpenSimVersion = GET_OSIM_VERSION;
 
 std::string GetVersionAndDate() { 
     char buffer[256];
-    sprintf(buffer,"version %s, build date %s %s",
+    snprintf(buffer, 256, "version %s, build date %s %s",
             OpenSimVersion, __TIME__, __DATE__);
     return std::string(buffer);
 }

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -282,18 +282,22 @@ void IO::
 ConstructDoubleOutputFormat()
 {
     if(_GFormatForDoubleOutput) {
-        snprintf(_DoubleFormat, 256, "%%g");
+        snprintf(_DoubleFormat, IO_DBLFMTLEN, "%%g");
     } else if(_Scientific) {
         if(_Pad<0) {
-            snprintf(_DoubleFormat, 256, "%%.%dle", _Precision);
+            snprintf(_DoubleFormat, IO_DBLFMTLEN,
+                     "%%.%dle", _Precision);
         } else {
-            snprintf(_DoubleFormat, 256, "%%%d.%dle", _Pad+_Precision, _Precision);
+            snprintf(_DoubleFormat, IO_DBLFMTLEN,
+                     "%%%d.%dle", _Pad+_Precision, _Precision);
         }
     } else {
         if(_Pad<0) {
-            snprintf(_DoubleFormat, 256, "%%.%dlf", _Precision);
+            snprintf(_DoubleFormat, IO_DBLFMTLEN,
+                     "%%.%dlf", _Precision);
         } else {
-            snprintf(_DoubleFormat, 256, "%%%d.%dlf", _Pad+_Precision, _Precision);
+            snprintf(_DoubleFormat, IO_DBLFMTLEN,
+                     "%%%d.%dlf", _Pad+_Precision, _Precision);
         }
     }
 }

--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -90,7 +90,7 @@ ConstructDateAndTimeStamp()
 
     // CONSTRUCT STAMP
     char *stamp = new char[64];
-    sprintf(stamp,"%d%02d%02d_%02d%02d%02d",
+    snprintf(stamp, 64, "%d%02d%02d_%02d%02d%02d",
         timeStruct->tm_year+1900,timeStruct->tm_mon+1,timeStruct->tm_mday,
         timeStruct->tm_hour,timeStruct->tm_min,timeStruct->tm_sec);
 
@@ -282,18 +282,18 @@ void IO::
 ConstructDoubleOutputFormat()
 {
     if(_GFormatForDoubleOutput) {
-        sprintf(_DoubleFormat,"%%g");
+        snprintf(_DoubleFormat, 256, "%%g");
     } else if(_Scientific) {
         if(_Pad<0) {
-            sprintf(_DoubleFormat,"%%.%dle",_Precision);
+            snprintf(_DoubleFormat, 256, "%%.%dle", _Precision);
         } else {
-            sprintf(_DoubleFormat,"%%%d.%dle",_Pad+_Precision,_Precision);
+            snprintf(_DoubleFormat, 256, "%%%d.%dle", _Pad+_Precision, _Precision);
         }
     } else {
         if(_Pad<0) {
-            sprintf(_DoubleFormat,"%%.%dlf",_Precision);
+            snprintf(_DoubleFormat, 256, "%%.%dlf", _Precision);
         } else {
-            sprintf(_DoubleFormat,"%%%d.%dlf",_Pad+_Precision,_Precision);
+            snprintf(_DoubleFormat, 256, "%%%d.%dlf", _Pad+_Precision, _Precision);
         }
     }
 }

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -34,7 +34,8 @@
 #include <vector>
 
 // DEFINES
-const int IO_STRLEN = 2048;
+constexpr int IO_STRLEN = 2048;
+constexpr int IO_DBLFMTLEN = 256;
 
 
 namespace OpenSim { 
@@ -62,7 +63,7 @@ private:
     /** Specifies the precision of number output. */
     static int _Precision;
     /** The output format string. */
-    static char _DoubleFormat[256];
+    static char _DoubleFormat[IO_DBLFMTLEN];
     /** Whether offline documents should also be printed when Object::print is called. */
     static bool _PrintOfflineDocuments;
 

--- a/OpenSim/Common/PropertyDbl.cpp
+++ b/OpenSim/Common/PropertyDbl.cpp
@@ -187,7 +187,7 @@ toString() const
 {
     if (SimTK::isFinite(_value)) {
         char dbl[256];
-        sprintf(dbl, "%g", _value);
+        snprintf(dbl, 256, "%g", _value);
         return dbl;
     }
 

--- a/OpenSim/Common/PropertyDblArray.cpp
+++ b/OpenSim/Common/PropertyDblArray.cpp
@@ -216,7 +216,7 @@ toString() const
     string str = "(";
     char dbl[256];
     for(int i=0; i < _array.getSize(); i++){
-        sprintf(dbl, "%g", _array[i]);
+        snprintf(dbl, 256, "%g", _array[i]);
         str += (i>0?" ":"") + string(dbl);
     }
     str += ")";

--- a/OpenSim/Common/PropertyInt.cpp
+++ b/OpenSim/Common/PropertyInt.cpp
@@ -185,6 +185,6 @@ string PropertyInt::
 toString() const
 {
     char intString[32];
-    sprintf(intString, "%d", _value);
+    snprintf(intString, 32, "%d", _value);
     return intString;
 }

--- a/OpenSim/Common/PropertyIntArray.cpp
+++ b/OpenSim/Common/PropertyIntArray.cpp
@@ -214,7 +214,7 @@ toString() const
     string str = "(";
     char intString[256];
     for(int i=0; i < _array.getSize(); i++){
-        sprintf(intString, "%d", _array[i]);
+        snprintf(intString, 256, "%d", _array[i]);
         str += (i>0?" ":"") + string(intString);
     }
     str += ")";

--- a/OpenSim/Common/StateVector.cpp
+++ b/OpenSim/Common/StateVector.cpp
@@ -543,7 +543,7 @@ print(FILE *fp) const
 
     // TIME
     char format[IO_STRLEN];
-    sprintf(format,"%s",IO::GetDoubleOutputFormat());
+    snprintf(format, IO_STRLEN, "%s", IO::GetDoubleOutputFormat());
     int n=0,nTotal=0;
     n = fprintf(fp,format,_t);
     if(n<0) {
@@ -553,7 +553,7 @@ print(FILE *fp) const
     nTotal += n;
 
     // STATES
-    sprintf(format,"\t%s",IO::GetDoubleOutputFormat());
+    snprintf(format, IO_STRLEN, "\t%s", IO::GetDoubleOutputFormat());
     for(int i=0;i<_data.getSize();i++) {
         n = fprintf(fp,format,_data[i]);
         if(n<0) {

--- a/OpenSim/Common/Storage.cpp
+++ b/OpenSim/Common/Storage.cpp
@@ -3404,7 +3404,7 @@ bool Storage::makeStorageLabelsUnique() {
             int c = 1;
             while (exist) {
                 char cString[20];
-                sprintf(cString,"%d", c);
+                snprintf(cString, 20, "%d", c);
                 newName = std::string(cString) + "_" + offending;
                 exist = (lbls.findIndex(newName) != -1);
                 c++;

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -220,7 +220,7 @@ getVersionAsString(const int aVersion, std::string& aString)
     for(int i=0; i<3; i++)
     {
         int digits = ver / div;
-        sprintf(pad, "%02d",digits); 
+        snprintf(pad, 3, "%02d", digits);
         ver -= div*(ver / div);
         div /=100;
         aString += string(pad);

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -822,7 +822,8 @@ std::string AbstractTool::createExternalLoadsFile(const std::string& oldFile,
             ExternalForce* xf = new ExternalForce();
             xf->setAppliedToBodyName((f==0)?body1:body2);
             char pad[3];
-            sprintf(pad,"%d", f+1);
+            snprintf(pad, 3, "%d", f+1);
+
             std::string suffix = "ExternalForce_"+string(pad);
             xf->setName(suffix);
             _externalLoads.adoptAndAppend(xf);


### PR DESCRIPTION
### Brief summary of changes

As the title suggests, `snprintf` replaces all usages of `sprintf`, which can be dangerous because it can potentially output more characters than can fit in the allocation size of the buffer string. The change suppresses a `gcc` compiler warning (which was the main motivation for the PR).

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...not user facing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3658)
<!-- Reviewable:end -->
