### PR TITLE
Suppress remaining `gcc` compiler warnings

### DIFF
--- a/OpenSim/Actuators/FiberForceLengthCurve.cpp
+++ b/OpenSim/Actuators/FiberForceLengthCurve.cpp
@@ -305,7 +305,6 @@ double FiberForceLengthCurve::calcCurvinessOfBestFit(double e0,   double e1,
     int maxIter   = 20;
     int iter      = 0;
     int localIter = 0;
-    int evalIter  = 0;
 
     while(iter < maxIter && abs(err) > relTol) {
         flag_improvement = false;
@@ -389,8 +388,6 @@ double FiberForceLengthCurve::calcCurvinessOfBestFit(double e0,   double e1,
                 flag_Newton = false;
             }
         }
-
-        evalIter += localIter;
 
         step = step/2.0;
         iter++;

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -379,11 +379,12 @@ void simulateMuscle(
     model.getMultibodySystem().realize(si, SimTK::Stage::Acceleration);
 
     double Emuscle0 = muscWorkProbe->getProbeOutputs(si)(0);
-    //cout << "Muscle initial energy = " << Emuscle0 << endl;
+    log_debug("Muscle initial energy = {}", Emuscle0);
     double Esys0 = model.getMultibodySystem().calcEnergy(si);
     Esys0 += (Emuscle0 + jointWorkProbe->getProbeOutputs(si)(0));
-    /*double PEsys0 = */model.getMultibodySystem().calcPotentialEnergy(si);
-    //cout << "Total initial system energy = " << Esys0 << endl; 
+    double PEsys0 = model.getMultibodySystem().calcPotentialEnergy(si);
+    log_debug("Total initial system energy = {}", Esys0);
+    log_debug("System potential energy = {}", PEsys0);
 
 //==========================================================================
 // 4. SIMULATION Integration

--- a/OpenSim/Analyses/BodyKinematics.cpp
+++ b/OpenSim/Analyses/BodyKinematics.cpp
@@ -189,7 +189,7 @@ constructDescription()
     strcat(descrip, "velocities and angular velocities, or");
     strcat(descrip, " accelerations and angular accelerations)\n");
     strcat(descrip, "of the centers of mass");
-    sprintf(tmp, " of the body segments in model %s.\n",
+    snprintf(tmp, MAXLEN, " of the body segments in model %s.\n",
         _model->getName().c_str());
     strcat(descrip, tmp);
     strcat(descrip, "\nBody segment orientations are described using");

--- a/OpenSim/Analyses/ForceReporter.cpp
+++ b/OpenSim/Analyses/ForceReporter.cpp
@@ -416,12 +416,12 @@ void ForceReporter::tidyForceNames()
             bool validNameFound=false;
             char pad[100];
             // Make up a candidate name
-            sprintf(pad, "%s%d", 
+            snprintf(pad, 100, "%s%d",
                     forces.get(i).getConcreteClassName().c_str(), j++);
             while(!validNameFound){
                 validNameFound = (forceNames.findIndex(string(pad))== -1);
                 if (!validNameFound){
-                    sprintf(pad, "Force%d", j++);
+                    snprintf(pad, 100, "Force%d", j++);
                 }
             }
             string newName(pad);

--- a/OpenSim/Common/GCVSplineSet.cpp
+++ b/OpenSim/Common/GCVSplineSet.cpp
@@ -84,7 +84,6 @@ void GCVSplineSet::construct(int aDegree,
 
     // GET COLUMN NAMES
     const Array<std::string> &labels = aStore->getColumnLabels();
-    char tmp[32];
     std::string name;
 
     // LOOP THROUGH THE STATES
@@ -111,7 +110,8 @@ void GCVSplineSet::construct(int aDegree,
         if(i+1 < labels.getSize()) {
             name = labels[i+1];
         } else {
-            sprintf(tmp,"data_%d",i);
+            char tmp[32];
+            snprintf(tmp, 32, "data_%d", i);
             name = tmp;
         }
 
@@ -178,7 +178,7 @@ Storage* GCVSplineSet::constructStorage(int aDerivOrder,double aDX) {
         spline = getGCVSpline(i);
         if(spline==NULL) {
             char cName[32];
-            sprintf(cName,"data_%d",i);
+            snprintf(cName, 32, "data_%d", i);
             labels.append(std::string(cName));
         } else {
             labels.append(spline->getName());

--- a/OpenSim/Common/PropertyTransform.cpp
+++ b/OpenSim/Common/PropertyTransform.cpp
@@ -229,7 +229,7 @@ toString() const
     char pad[256];
     double rawData[6];
     getRotationsAndTranslationsAsArray6(rawData);
-    sprintf(pad, "%g %g %g %g %g %g", rawData[0], rawData[1], rawData[2], rawData[3], rawData[4], rawData[5]);
+    snprintf(pad, 256, "%g %g %g %g %g %g", rawData[0], rawData[1], rawData[2], rawData[3], rawData[4], rawData[5]);
     str += string(pad);
     str += ")";
     return str;

--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -636,7 +636,7 @@ DerivativeValues calcSelectedDerivatives(
             MAXITER);
 
         const SimTK::Array_<SimTK::Vec6>& ctrlPtsY = smoothData->_ctrlPtsY;
-        for (size_t i = 0; i < y.size(); ++i) {
+        for (int i = 0; i < static_cast<int>(y.size()); ++i) {
             if (selectedOrders[i]) {
                 y.at(i) = SegmentedQuinticBezierToolkit::
                     calcQuinticBezierCurveDerivDYDX(

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
@@ -109,11 +109,8 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
                 "model.");
     } else {
 
-        int cid, mp, mv, ma;
+        int cid, mv, ma;
         int multIndexThisConstraint;
-        int total_mp = 0;
-        int total_mv = 0;
-        int total_ma = 0;
         std::vector<KinematicLevel> kinLevels;
         const bool enforceConstraintDerivs =
                 mocoCasADiSolver.get_enforce_constraint_derivatives();
@@ -121,7 +118,6 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
             const auto& kc = problemRep.getKinematicConstraint(kcName);
             const auto& multInfos = problemRep.getMultiplierInfos(kcName);
             cid = kc.getSimbodyConstraintIndex();
-            mp = kc.getNumPositionEquations();
             mv = kc.getNumVelocityEquations();
             ma = kc.getNumAccelerationEquations();
             kinLevels = kc.getKinematicLevels();
@@ -141,10 +137,6 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
                     "acceleration-level scalar constraints associated with the "
                     "model Constraint at ConstraintIndex {}.",
                     ma, cid);
-
-            total_mp += mp;
-            total_mv += mv;
-            total_ma += ma;
 
             // Loop through all scalar constraints associated with the model
             // constraint and corresponding path constraints to the optimal

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -280,7 +280,6 @@ TimeSeriesTable OpenSim::createExternalLoadsTableForGait(Model model,
         const std::vector<std::string>& forcePathsLeftFoot) {
     model.initSystem();
     TimeSeriesTableVec3 externalForcesTable;
-    int count = 0;
     for (const auto& state : trajectory) {
         model.realizeDynamics(state);
         SimTK::Vec3 sphereForcesRight(0);
@@ -339,7 +338,6 @@ TimeSeriesTable OpenSim::createExternalLoadsTableForGait(Model model,
         row(4) = sphereTorquesRight;
         row(5) = sphereTorquesLeft;
         externalForcesTable.appendRow(state.getTime(), row);
-        ++count;
     }
     // Create table.
     std::vector<std::string> labels{"ground_force_r_v", "ground_force_r_p",

--- a/OpenSim/Simulation/Control/ControlLinear.cpp
+++ b/OpenSim/Simulation/Control/ControlLinear.cpp
@@ -698,11 +698,11 @@ simplify(const PropertySet &aProperties)
 
     // ADD NEW NODES
     int newSize = t.getSize();
-    char name[32];
     ControlLinearNode *node;
     for(i=0;i<newSize;i++) {
+        char name[32];
         node = new ControlLinearNode(t[i],xFilt[i]);
-        sprintf(name,"%d",i);
+        snprintf(name, 32, "%d", i);
         node->setName(name);
         _xNodes.append(node);
     }

--- a/OpenSim/Simulation/Control/ControlLinearNode.cpp
+++ b/OpenSim/Simulation/Control/ControlLinearNode.cpp
@@ -293,11 +293,11 @@ toString()
     const char *format = IO::GetDoubleOutputFormat();
 
     strcpy(string,"t=");
-    sprintf(tmp,format,_t);
+    snprintf(tmp,128,format,_t);
     strcat(string,tmp);
 
     strcat(string," value=");
-    sprintf(tmp,format,_value);
+    snprintf(tmp,128,format,_value);
     strcat(string,tmp);
 
     return(string);

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -292,10 +292,10 @@ void GeometryPath::constructProperties()
  */
 void GeometryPath::namePathPoints(int aStartingIndex)
 {
-    char indx[5];
     for (int i = aStartingIndex; i < get_PathPointSet().getSize(); i++)
     {
-        sprintf(indx,"%d",i+1);
+        char indx[5];
+        snprintf(indx,5,"%d",i+1);
         AbstractPathPoint& point = get_PathPointSet().get(i);
         if (point.getName()=="" && hasOwner()) {
             point.setName(getOwner().getName() + "-P" + indx);

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -294,8 +294,8 @@ void GeometryPath::namePathPoints(int aStartingIndex)
 {
     for (int i = aStartingIndex; i < get_PathPointSet().getSize(); i++)
     {
-        char indx[5];
-        snprintf(indx,5,"%d",i+1);
+        char indx[32];
+        snprintf(indx,32,"%d",i+1);
         AbstractPathPoint& point = get_PathPointSet().get(i);
         if (point.getName()=="" && hasOwner()) {
             point.setName(getOwner().getName() + "-P" + indx);

--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
@@ -286,7 +286,7 @@ void CoordinateCouplerConstraint::extendAddToSystem(SimTK::MultibodySystem& syst
     mob_bodies.push_back(aCoordinate._bodyIndex);
     mob_qs.push_back(SimTK::MobilizerQIndex(aCoordinate._mobilizerQIndex));
 
-    if (!mob_qs.size() & (mob_qs.size() != mob_bodies.size())) {
+    if (!mob_qs.size() && (mob_qs.size() != mob_bodies.size())) {
         errorMessage = "CoordinateCouplerConstraint:: requires at least one body and coordinate." ;
         throw (Exception(errorMessage));
     }

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -525,11 +525,12 @@ void simulateMuscle(
     model.getMultibodySystem().realize(si, SimTK::Stage::Acceleration);
 
     double Emuscle0 = muscWorkProbe->getProbeOutputs(si)(0);
-    //cout << "Muscle initial energy = " << Emuscle0 << endl;
+    log_debug("Muscle initial energy = {}", Emuscle0);
     double Esys0 = model.getMultibodySystem().calcEnergy(si);
     Esys0 += (Emuscle0 + jointWorkProbe->getProbeOutputs(si)(0));
-    /*double PEsys0 = */model.getMultibodySystem().calcPotentialEnergy(si);
-    //cout << "Total initial system energy = " << Esys0 << endl; 
+    double PEsys0 = model.getMultibodySystem().calcPotentialEnergy(si);
+    log_debug("Total system initial energy = {}", Esys0);
+    log_debug("System potential energy = {}", PEsys0);
 
     //==========================================================================
     // 4. SIMULATION Integration


### PR DESCRIPTION
### Brief summary of changes

This PR is mainly intended to address any remaining `gcc` compiler warnings not suppressed in the previous two PRs (#3657 and #3658). The changes include:

- Adding `sprintf` to `snprintf` conversions that I missed in #3658.
- Fixed unused variable warnings. For variables that had no apparant use at all, I removed them entirely. For others in test cases, I replaced commented out `cout` statement with active logging statements.
- Fixed a boolean operation in `CoordinateCouplerConstraint` that using `&` instead of `&&`.
- Converted a `size_t` iterator to `int` in `SmoothSegmentedFunction` (to avoid an implicit conversion in the loop).

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...not user facing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3659)
<!-- Reviewable:end -->
