### PR TITLE
Try apple silicon build without moco

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -379,6 +379,130 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac-11
         path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
 
+      macM1NoMoco:
+        name: MacM1
+    
+        runs-on: macos-13-xlarge
+    
+        steps:
+        - uses: actions/checkout@v3
+        
+        - uses: actions/setup-python@v4
+          with:
+            python-version: '3.8'
+            
+        - name: Install Homebrew packages
+          # Save the gfortran version to a file so we can use it in the cache key.
+          run: |
+            brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+            brew reinstall gcc
+            pip3 install numpy==1.20.2
+            gfortran -v
+            mkdir gfortran_version
+            gfortran -v &> gfortran_version/gfortran_version.txt
+    
+        - name: Cache SWIG
+          id: cache-swig
+          uses: actions/cache@v3
+          with:
+            path: ~/swig
+            key: ${{ runner.os }}-swig
+    
+        - name: Install SWIG
+          # if: steps.cache-swig.outputs.cache-hit != 'true'
+          run: |
+            mkdir ~/swig-source && cd ~/swig-source
+            wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+            tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+            sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+            make && make -j4 install
+    
+        - name: Cache dependencies
+          id: cache-dependencies
+          uses: actions/cache@v3
+          with:
+            path: ~/opensim_dependencies_install
+            # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
+            # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
+            # undefined.
+            key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
+    
+        - name: Build dependencies
+          if: steps.cache-dependencies.outputs.cache-hit != 'true'
+          run: |
+            mkdir $GITHUB_WORKSPACE/../build_deps
+            cd $GITHUB_WORKSPACE/../build_deps
+            DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+            DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+            DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+            DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+            DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
+            DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
+            DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
+            DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+            printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+            cmake "${DEP_CMAKE_ARGS[@]}"
+            make --jobs 4
+    
+        - name: Configure opensim-core
+          id: configure
+          run: |
+            mkdir $GITHUB_WORKSPACE/../build
+            cd $GITHUB_WORKSPACE/../build
+            OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+            OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+            OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+            OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+            OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+            OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+            OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+            OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
+            OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+            OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+            # TODO: Update to simbody.github.io/latest
+            OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+            OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
+            printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+            cmake "${OSIM_CMAKE_ARGS[@]}"
+            VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+            echo $VERSION
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+    
+        - name: Build opensim-core
+          run: |
+            cd $GITHUB_WORKSPACE/../build
+            make --jobs 4
+    
+        - name: Test opensim-core
+          run: |
+            cd $GITHUB_WORKSPACE/../build
+            ctest --parallel 4 --output-on-failure
+    
+        - name: Install opensim-core
+          run: |
+            cd $GITHUB_WORKSPACE/../build
+            make doxygen
+            make install
+            cd $GITHUB_WORKSPACE
+            mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+            zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip opensim-core-${{ steps.configure.outputs.version }}
+            mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+    
+        - name: Test Python bindings
+          run: |
+            cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+            # Run the python tests, verbosely.
+            python3 -m unittest discover --start-directory opensim/tests --verbose
+    
+        - name: Upload opensim-core
+          uses: actions/upload-artifact@v3
+          with:
+            # The upload-artifact zipping does not preserve symlinks or executable
+            # bits. So we zip ourselves, even though this causes a double-zip.
+            name: opensim-core-${{ steps.configure.outputs.version }}-mac-m1-11
+            path: opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip
+      
   ubuntu20:
     name: Ubuntu2004
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -379,10 +379,10 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac-11
         path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
 
-  macM1NoMoco:
+  mac-m1:
     name: MacM1
 
-    runs-on: macos-13-xlarge
+    runs-on: macos-latest-xlarge
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -379,129 +379,129 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac-11
         path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
 
-      macM1NoMoco:
-        name: MacM1
+  macM1NoMoco:
+    name: MacM1
+
+    runs-on: macos-13-xlarge
+
+    steps:
+    - uses: actions/checkout@v3
     
-        runs-on: macos-13-xlarge
-    
-        steps:
-        - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
         
-        - uses: actions/setup-python@v4
-          with:
-            python-version: '3.8'
-            
-        - name: Install Homebrew packages
-          # Save the gfortran version to a file so we can use it in the cache key.
-          run: |
-            brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
-            brew reinstall gcc
-            pip3 install numpy==1.20.2
-            gfortran -v
-            mkdir gfortran_version
-            gfortran -v &> gfortran_version/gfortran_version.txt
-    
-        - name: Cache SWIG
-          id: cache-swig
-          uses: actions/cache@v3
-          with:
-            path: ~/swig
-            key: ${{ runner.os }}-swig
-    
-        - name: Install SWIG
-          # if: steps.cache-swig.outputs.cache-hit != 'true'
-          run: |
-            mkdir ~/swig-source && cd ~/swig-source
-            wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-            tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-            sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-            make && make -j4 install
-    
-        - name: Cache dependencies
-          id: cache-dependencies
-          uses: actions/cache@v3
-          with:
-            path: ~/opensim_dependencies_install
-            # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
-            # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
-            # undefined.
-            key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
-    
-        - name: Build dependencies
-          if: steps.cache-dependencies.outputs.cache-hit != 'true'
-          run: |
-            mkdir $GITHUB_WORKSPACE/../build_deps
-            cd $GITHUB_WORKSPACE/../build_deps
-            DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-            DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-            DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-            DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-            DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
-            DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
-            DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
-            DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-            printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-            cmake "${DEP_CMAKE_ARGS[@]}"
-            make --jobs 4
-    
-        - name: Configure opensim-core
-          id: configure
-          run: |
-            mkdir $GITHUB_WORKSPACE/../build
-            cd $GITHUB_WORKSPACE/../build
-            OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-            OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-            OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-            OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-            OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-            OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-            OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-            OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
-            OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-            OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-            # TODO: Update to simbody.github.io/latest
-            OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-            OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
-            printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-            cmake "${OSIM_CMAKE_ARGS[@]}"
-            VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-            echo $VERSION
-            echo "VERSION=$VERSION" >> $GITHUB_ENV
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-    
-        - name: Build opensim-core
-          run: |
-            cd $GITHUB_WORKSPACE/../build
-            make --jobs 4
-    
-        - name: Test opensim-core
-          run: |
-            cd $GITHUB_WORKSPACE/../build
-            ctest --parallel 4 --output-on-failure
-    
-        - name: Install opensim-core
-          run: |
-            cd $GITHUB_WORKSPACE/../build
-            make doxygen
-            make install
-            cd $GITHUB_WORKSPACE
-            mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-            zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip opensim-core-${{ steps.configure.outputs.version }}
-            mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
-    
-        - name: Test Python bindings
-          run: |
-            cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-            # Run the python tests, verbosely.
-            python3 -m unittest discover --start-directory opensim/tests --verbose
-    
-        - name: Upload opensim-core
-          uses: actions/upload-artifact@v3
-          with:
-            # The upload-artifact zipping does not preserve symlinks or executable
-            # bits. So we zip ourselves, even though this causes a double-zip.
-            name: opensim-core-${{ steps.configure.outputs.version }}-mac-m1-11
-            path: opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip
+    - name: Install Homebrew packages
+      # Save the gfortran version to a file so we can use it in the cache key.
+      run: |
+        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew reinstall gcc
+        pip3 install numpy==1.20.2
+        gfortran -v
+        mkdir gfortran_version
+        gfortran -v &> gfortran_version/gfortran_version.txt
+
+    - name: Cache SWIG
+      id: cache-swig
+      uses: actions/cache@v3
+      with:
+        path: ~/swig
+        key: ${{ runner.os }}-swig
+
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
+        # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
+        # undefined.
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
+
+    - name: Build dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
+        DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
+
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
+
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        ctest --parallel 4 --output-on-failure
+
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip opensim-core-${{ steps.configure.outputs.version }}
+        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+
+    - name: Test Python bindings
+      run: |
+        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+        # Run the python tests, verbosely.
+        python3 -m unittest discover --start-directory opensim/tests --verbose
+
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v3
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ steps.configure.outputs.version }}-mac-m1-11
+        path: opensim-core-${{ steps.configure.outputs.version }}-m1-11.zip
       
   ubuntu20:
     name: Ubuntu2004


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Added option to build opensim-core on apple silicon (without moco)

### Testing I've completed
None, this is only ci to see what breaks, to be useful for Matlab will likely need to change jdk to coretto

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3661)
<!-- Reviewable:end -->
