### PR TITLE
Make std::regex parsing have a static lifetime

### DIFF
--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -1174,20 +1174,23 @@ void Component::updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber)
 
         }
         if (versionNumber <= 30516) {
+            static const std::regex s_ConnecteeNamePattern("(socket_|input_)(.*)(_connectee_name)");
+            static const std::regex s_ConnecteeNamesPattern("(input_)(.*)(_connectee_names)");
+
             // Rename xml tags for socket_*_connectee_name to socket_*
             std::string connecteeNameString = "_connectee_name";
             for (auto iter = node.element_begin();
                 iter != node.element_end();
                 ++iter) {
                 auto tagname = iter->getElementTag();
-                if (std::regex_match(tagname, std::regex("(socket_|input_)(.*)(_connectee_name)"))) {
+                if (std::regex_match(tagname, s_ConnecteeNamePattern)) {
                     auto pos = tagname.find(connecteeNameString);
                     if (pos != std::string::npos) {
                         tagname.replace(pos, connecteeNameString.length(), "");
                         iter->setElementTag(tagname);
                     }
                 }
-                else if (std::regex_match(tagname, std::regex("(input_)(.*)(_connectee_names)"))) {
+                else if (std::regex_match(tagname, s_ConnecteeNamesPattern)) {
                     auto pos = tagname.find(connecteeNameString);
                     if (pos != std::string::npos) {
                         tagname.replace(pos, connecteeNameString.length()+1, "");


### PR DESCRIPTION
Fixes issue N/A

Minor nit I spotted when I am running applications that load many osim files (e.g. OSC's test suite) - the profiler notices that it's spending a large amount of time (5 % or so) compiling regex strings on the lines that are changed by this diff. This speedup only really affects initially loading older osim files (e.g. many of the example files in OpenSim/OSC).

### Brief summary of changes

- Make constructing a `std::regex` from a pattern string have a static function-scoped lifetime so it only happens once per application boot.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because minor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3667)
<!-- Reviewable:end -->
