### PR TITLE
Fix PathSpring overwriting any user-set appearance for its GeometryPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and `Blankevoort1991Ligament`, usages of `get_GeometryPath`, `upd_GeometryPath`,
 - Simbody was updated such that the headers it transitively exposes to downstream projects are compatible with C++20 (#3619)
 - Moved speed computation from `computeForce` in children of `ScalarActuator` to dedicated `getSpeed` function.
 - Fix type problem with BufferedOrientationReference (Issue #3415, PR #3644)
+- Fixed setting the color of a PathSpring's GeometryPath should now update the color of the PathSpring geometry
 
 
 v4.4.1

--- a/OpenSim/Simulation/Model/PathSpring.cpp
+++ b/OpenSim/Simulation/Model/PathSpring.cpp
@@ -33,8 +33,6 @@ using namespace std;
 using namespace OpenSim;
 using SimTK::Vec3;
 
-static const Vec3 DefaultPathSpringColor(0, 1, 0); // Green for backward compatibility
-
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
@@ -66,6 +64,10 @@ void PathSpring::constructProperties()
     constructProperty_resting_length(SimTK::NaN);
     constructProperty_stiffness(SimTK::NaN);
     constructProperty_dissipation(SimTK::NaN);
+
+    // override default GeometryPath color (at time of writing, grey) with
+    // green for backwards-compatibility
+    upd_path().upd_Appearance().set_color({0, 1, 0});
 }
 
 //_____________________________________________________________________________
@@ -103,8 +105,6 @@ void PathSpring::setDissipation(double dissipation)
 void PathSpring::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
-
-    updPath().setDefaultColor(DefaultPathSpringColor);
 
     OPENSIM_THROW_IF_FRMOBJ(
         (SimTK::isNaN(get_resting_length()) || get_resting_length() < 0),


### PR DESCRIPTION
Fixes issue: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/818

Minor nit noticed by a user who's making a model containing path springs: if you change the `Appearance` of the path spring's `GeometryPath` it has no effect.

The reason why this is a bug is because `finalizeFromProperties` is called _after_ properties are updated (e.g. from loading an XML file or editing in OpenSim GUI or OpenSim Creator) - the existing implementation will then unconditionally overwrite the color of the pathspring with green.

The fix instead sets the default in the constructor, which is usually called _before_ properties are updated (e.g. when the object is loaded from an XML file it effectively sets properties on an already-constructed prototype).

### Brief summary of changes

### Testing I've completed

I hotfixed it into an OSC build and it now correctly shows a green spring _unless_ the user specifies a different color in the XML file.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3668)
<!-- Reviewable:end -->
