### PR TITLE
Add tryGet/UpdSocket and tryGet/UpdOutput to the Component interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
+Upcoming Release
+================
+
+- Added `tryGetSocket` and `tryUpdSocket` to the `Component` interface, which provides a non-throwing way of
+  querying a component's sockets by name (#3673)
+- Added `tryGetOutput` and `tryUpdOutput` to the `Component` interface, which provides a non-throwing way of
+  querying a component's outputs by name (#3673)
+
 v4.5
 ====
 - Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -979,6 +979,52 @@ TEST_CASE("Component Interface List Sockets")
     // TODO redo with the property list / the reference connect().
 }
 
+TEST_CASE("Component Interface tryGetSocket")
+{
+    Bar bar;
+    REQUIRE(bar.tryGetSocket("parentFoo") != nullptr);
+    REQUIRE(bar.tryGetSocket("childFoo") != nullptr);
+    REQUIRE(bar.tryGetSocket("NonExistentFoo") == nullptr);
+}
+
+TEST_CASE("Component Interface getSocket")
+{
+    Bar bar;
+    REQUIRE_NOTHROW(bar.getSocket("parentFoo"));
+    REQUIRE_NOTHROW(bar.getSocket("childFoo"));
+    REQUIRE_THROWS_AS(bar.getSocket("NonExistentFoo"), SocketNotFound);
+}
+
+TEST_CASE("Component Interface tryUpdSocket")
+{
+    Bar bar;
+    REQUIRE(bar.tryUpdSocket("parentFoo") != nullptr);
+    REQUIRE(bar.tryUpdSocket("childFoo") != nullptr);
+    REQUIRE(bar.tryUpdSocket("NonExistentFoo") == nullptr);
+}
+
+TEST_CASE("Component Interface updSocket")
+{
+    Bar bar;
+    REQUIRE_NOTHROW(bar.updSocket("parentFoo"));
+    REQUIRE_NOTHROW(bar.updSocket("childFoo"));
+    REQUIRE_THROWS_AS(bar.updSocket("NonExistentFoo"), SocketNotFound);
+}
+
+TEST_CASE("Component Interface tryGetOutput")
+{
+    Foo foo;
+    REQUIRE(foo.tryGetOutput("Output1") != nullptr);
+    REQUIRE(foo.tryGetOutput("NonExistentOutput") == nullptr);
+}
+
+TEST_CASE("Component Interface tryUpdOutput")
+{
+    Foo foo;
+    REQUIRE(foo.tryUpdOutput("Output1") != nullptr);
+    REQUIRE(foo.tryUpdOutput("NonExistentOutput") == nullptr);
+}
+
 TEST_CASE("Component Interface Socket::canConnectTo")
 {
     TheWorld theWorld;


### PR DESCRIPTION
Fixes having to use a `try {} catch (...) {}`  to find a socket/output on a Component.

### Brief summary of changes

- Added `tryGetSocket`, `tryUpdSocket`, `tryGetOutput`, and `tryUpdOutput` to the `Component` interface
- `try`, because they will return `nullptr` if the socket/output cannot be found on the component
- There doesn't (appear to be?) a way of doing this without `try...catch` or allocating memory (e.g. with `getOutputs`) and searching in downstream code

### Testing I've completed

- Added basic tests
- Added methods
- Refactored existing methods to use the new ones
- If the tests pass in CI, then it should be fine

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3673)
<!-- Reviewable:end -->
