### PR TITLE
Add more string-like operations to ComponentPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
+Upcoming Release
+================
+
+- Added `ComponentPath::root()`, which returns a `ComponentPath` equivalent to "/"
+- `ComponentPath` is now less-than (`<`) comparable, making it usable in (e.g.) `std::map`
+- `ComponentPath` now has a `std::hash<T>` implementation, making it usable in (e.g.) `std::unordered_map`
+- Added `.clear()` and `.empty()` to `ComponentPath` for more parity with `std::string`'s semantics
+
 v4.5
 ====
 - Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based

--- a/OpenSim/Common/ComponentPath.cpp
+++ b/OpenSim/Common/ComponentPath.cpp
@@ -264,7 +264,10 @@ namespace {
     }
 }
 
-ComponentPath::ComponentPath() = default;
+ComponentPath ComponentPath::root()
+{
+    return ComponentPath{"/"};
+}
 
 ComponentPath::ComponentPath(std::string path) :
     _path{normalize(std::move(path))} {
@@ -273,14 +276,6 @@ ComponentPath::ComponentPath(std::string path) :
 ComponentPath::ComponentPath(const std::vector<std::string>& pathVec,
                              bool isAbsolute) :
     _path{normalize(stringifyPath(pathVec, isAbsolute))} {
-}
-
-bool ComponentPath::operator==(const ComponentPath& other) const {
-    return _path == other._path;
-}
-
-bool ComponentPath::operator!=(const ComponentPath& other) const {
-    return _path != other._path;
 }
 
 char ComponentPath::getSeparator() const {
@@ -423,10 +418,6 @@ std::string ComponentPath::getComponentName() const {
     }
 
     return _path.substr(start);
-}
-
-const std::string& ComponentPath::toString() const {
-    return _path;
 }
 
 bool ComponentPath::isAbsolute() const {

--- a/OpenSim/Common/ComponentPath.h
+++ b/OpenSim/Common/ComponentPath.h
@@ -48,19 +48,21 @@ namespace OpenSim {
  * @author Carmichael Ong
  */
 class OSIMCOMMON_API ComponentPath {
-private:
-    std::string _path;
-
 public:
+    /**
+     * Returns the root component path (i.e. "/")
+     */
+    static ComponentPath root();
+
     /**
      * Default constructor that constructs an empty path ("").
      */
-    ComponentPath();
+    ComponentPath() = default;
 
     /**
      * Construct a ComponentPath from a path string (e.g. "/a/b/component").
      */
-    ComponentPath(std::string path);
+    ComponentPath(std::string);
 
     /**
      * Construct a ComponentPath from a vector of its elements.
@@ -69,8 +71,24 @@ public:
      */
     ComponentPath(const std::vector<std::string>& pathVec, bool isAbsolute);
 
-    bool operator==(const ComponentPath&) const;
-    bool operator!=(const ComponentPath&) const;
+    friend bool operator==(const ComponentPath& lhs, const ComponentPath& rhs) {
+        return lhs._path == rhs._path;
+    }
+
+    friend bool operator!=(const ComponentPath& lhs, const ComponentPath& rhs) {
+        return lhs._path != rhs._path;
+    }
+
+    friend bool operator<(const ComponentPath& lhs, const ComponentPath& rhs) {
+        return lhs._path < rhs._path;
+    }
+
+    /**
+     * Clears the content of the ComponentPath
+     */
+    void clear() {
+        _path.clear();
+    }
 
     char getSeparator() const;
 
@@ -128,7 +146,16 @@ public:
      * Returns a string representation of the ComponentPath
      * (e.g. "/a/b/component").
      */
-    const std::string& toString() const;
+    const std::string& toString() const {
+        return _path;
+    }
+
+    /**
+     * Returns true if the path is empty
+     */
+    bool empty() const {
+        return _path.empty();
+    }
 
     /**
      * Returns true if the path is absolute (effectively, if it begins
@@ -164,6 +191,17 @@ public:
         // noop: here for legacy purposes: the path is always
         // internally normalized
     }
+
+private:
+    std::string _path;
 };
 } // end of namespace OpenSim
+
+template<>
+struct std::hash<OpenSim::ComponentPath> {
+    size_t operator()(OpenSim::ComponentPath const& p) {
+        return std::hash<std::string>{}(p.toString());
+    }
+};
+
 #endif // OPENSIM_COMPONENT_PATH_H_

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -328,3 +328,52 @@ TEST_CASE("Component Path Behaves as Expected")
         }
     }
 }
+
+TEST_CASE("ComponentPath::operator== works as expected")
+{
+    REQUIRE(ComponentPath{"some/path"} == ComponentPath{"some/path"});
+    REQUIRE(!(ComponentPath{"some/path"} == ComponentPath{"some/other/path"}));
+}
+
+TEST_CASE("ComponentPath::operator!= works as expected")
+{
+    REQUIRE(ComponentPath{"some/path"} != ComponentPath{"some/other/path"});
+    REQUIRE(!(ComponentPath{"some/path"} != ComponentPath{"some/path"}));
+}
+
+TEST_CASE("ComponentPath::operator< works as expected")
+{
+    REQUIRE(ComponentPath{"a"} < ComponentPath{"b"});
+    REQUIRE(!(ComponentPath{"a"} < ComponentPath{"a"}));
+}
+
+TEST_CASE("ComponentPath::root returns root component path")
+{
+    REQUIRE(ComponentPath::root() == ComponentPath{std::string{'/'}});
+}
+
+TEST_CASE("ComponentPath::empty returns true for default-constructed path")
+{
+    REQUIRE(ComponentPath{}.empty());
+}
+
+TEST_CASE("ComponentPath::empty returns false for populated path")
+{
+    REQUIRE(ComponentPath{"some/path"}.empty() == false);
+}
+
+TEST_CASE("ComponentPath::clear clears the content of the path")
+{
+    ComponentPath cp{"some/path"};
+    REQUIRE(cp != ComponentPath{});
+    cp.clear();
+    REQUIRE(cp == ComponentPath{});
+}
+
+TEST_CASE("std::hash<ComponentPath> returns equivalent results to hashing the underlying string")
+{
+    REQUIRE(std::hash<ComponentPath>{}(OpenSim::ComponentPath{"some/path"}) == std::hash<std::string>{}("some/path"));
+
+    // ... but beware of normalization...
+    REQUIRE(std::hash<ComponentPath>{}(OpenSim::ComponentPath{"normalizable/././path"}) != std::hash<std::string>{}("normalizable/././path"));
+}


### PR DESCRIPTION
The motivation for this change is to make downstream code more in-line with how it would be written when using a `std::string`, and to enable patterns like `std::unordered_map<ComponentPath, OpenSim::Joint const*> jointLookup` etc.

### Brief summary of changes

- Added `ComponentPath::root()`, which returns a `ComponentPath` equivalent to "/"
- `ComponentPath` is now less-than (`<`) comparable, making it usable in (e.g.) `std::map`
- `ComponentPath` now has a `std::hash<T>` implementation, making it usable in (e.g.) `std::unordered_map`
- Added `.clear()` and `.empty()` to `ComponentPath` for more parity with `std::string`'s semantics

### Testing I've completed

- Unit tests added for each new behavior

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3674)
<!-- Reviewable:end -->
