### PR TITLE
Fix warnings produced by g++11

### DIFF
--- a/OpenSim/Common/Signal.cpp
+++ b/OpenSim/Common/Signal.cpp
@@ -37,6 +37,8 @@
 #include "simmath/internal/Spline.h"
 #include "simmath/internal/SplineFitter.h"
 
+#include <vector>
+
 using namespace OpenSim;
 using namespace std;
 
@@ -343,7 +345,7 @@ size_t size;
 int i,j;
 int n,k;
 double w1,w2,x1,x2;
-double *s;
+std::vector<double> s;
 
 
     // CHECK THAT M IS NOT TOO LARGE RELATIVE TO N
@@ -356,12 +358,7 @@ double *s;
 
     // ALLOCATE MEMORY FOR s
     size = N + M + M;
-    s = (double *) calloc(size,sizeof(double));
-    if (s == NULL) {
-        log_error(
-                "lowpass() -> Not enough memory to process your sampled data.");
-        return(-1);
-    }
+    s.resize(size);
 
     // CALCULATE THE ANGULAR CUTOFF FREQUENCY
     w1 = 2*SimTK_PI*f1;
@@ -387,9 +384,6 @@ double *s;
         }
         sigf[n] = sigf[n] / sum_coef; // normalize for unity gain at DC
     }
-
-    // CLEANUP
-    if(s!=NULL) delete s;
 
   return(0);
 }

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -337,7 +337,7 @@ public:
      \param time Value to search for.
      */
     size_t getRowIndexBeforeTime(const double& time) const {
-        size_t candidate = getNearestRowIndexForTime(time, false);
+        ptrdiff_t candidate = getNearestRowIndexForTime(time, false);
         using DT = DataTable_<double, ETY>;
         const auto& timeCol = DT::getIndependentColumn();
         const SimTK::Real eps = SimTK::SignificantReal;


### PR DESCRIPTION
These minor changes are to fix warnings that are produced by g++11.

The specific warnings relate to:

- `free` being used to free memory allocated by `calloc` (reported as a mismatched allocation)
- A comparison of `v < 0` being logically invalid. The code was probably incorrectly changed to `size_t` at some point and doesn't account for the fact that the following code could potentially underflow `0`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3682)
<!-- Reviewable:end -->
