### PR TITLE
Adding automated performance testing to CI workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -392,10 +392,11 @@ jobs:
     outputs:
       version: ${{ steps.configure.outputs.version }}
 
-    env:
-      commitmsg: ${{ github.event.head_commit.message }}
-
     steps:
+    - name: Debug Commit Message
+      run: |
+       echo "Commit Message: ${{ github.event.head_commit.message }}"
+      
     - uses: actions/checkout@v3
     
     - uses: actions/setup-python@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -404,10 +404,10 @@ jobs:
 
     - name: Testing commit message
       run: |
-        echo github.event.head_commit.message
-        echo contains($commitmsg, '[perf]')
+        # echo github.event.head_commit.message
+        # echo contains($commitmsg, '[perf]')
         echo $commitmsg
-        echo ${{ contains($commitmsg, '[perf]') }}
+        # echo ${{ contains($commitmsg, '[perf]') }}
         
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -573,7 +573,7 @@ jobs:
     - name: Post Results to PR Comment
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/issues/${PR_NUMBER} | jq -r '.body')
+        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance Analysis Results"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
@@ -596,15 +596,16 @@ jobs:
         "
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
-        COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-        echo ${COMMENT_ID}
+        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+        # echo ${COMMENT_ID}
 
-        # Update the existing top-level comment
+        # Update the existing description
         gh api \
           --method PATCH \
           -H "Content-Type: application/json" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments/${COMMENT_ID} \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "/repos/opensim-org/opensim-core/pulls/${PR_NUMBER}" \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -176,7 +176,7 @@ jobs:
       run: python3 -m pip install numpy==1.20.2
 
     - name: Install SWIG
-      run: |
+      run: | 
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 
@@ -258,7 +258,7 @@ jobs:
   mac_target:
     name: Mac [target]
 
-    runs-on: macos-14
+    runs-on: macos-12
 
     if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
@@ -385,7 +385,7 @@ jobs:
 
   mac_source:
 
-    runs-on: macos-14
+    runs-on: macos-12
     
     name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -256,7 +256,6 @@ jobs:
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   mac_target:
-    if: github.event_name == 'pull_request'
     name: Mac-target
 
     runs-on: macos-12
@@ -510,18 +509,10 @@ jobs:
         path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
 
   compare-macs:
-    if: github.event_name == 'pull_request'
     needs:
       - mac_target
       - mac_source
     runs-on: macos-12
-    on:
-      pull_request:
-        branches:
-          - '*'
-      issue_comment:
-        types:
-          - created
 
     steps:
     - uses: actions/setup-python@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -387,11 +387,8 @@ jobs:
   mac_source:
 
     runs-on: macos-12
-
-    env:
-      JOB_NAME: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac (source)' || 'Mac' }}
     
-    name: ${{ env.JOB_NAME }}
+    name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac (source)' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -544,7 +544,7 @@ jobs:
         repo: opensim-perf
         owner: opensim-org
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
-        run_timeout_seconds: 1500 
+        run_timeout_seconds: 600
 
     - name: Download performance analysis results
       id: download-artifact

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -534,8 +534,8 @@ jobs:
     - name: Unzip source branch artifact
       run: |
         mkdir unzipped
-        unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
-        cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
+        unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/
+        cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
         ls
 
     - name: Download target branch artifact
@@ -546,9 +546,8 @@ jobs:
 
     - name: Unzip target branch artifact
       run: |
-        mkdir unzipped
-        unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
-        cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
+        unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/
+        cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
         ls
 
     - name: Run Examples and Compare Performance

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -574,34 +574,35 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/issues/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance Check Results"
-        echo "DEBUG1"
-
-        # Check if the custom header exists in the existing comment body
-        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-          # Extract the content after the custom header
-          EXISTING_TABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/{flag=1; next} flag")
-
-          # Replace the existing table content with new content
-          NEW_TABLE_CONTENT=$(cat performance_results.md)
-          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${EXISTING_TABLE_CONTENT}"/${NEW_TABLE_CONTENT}}"
-        else
-          # If the custom header doesn't exist, just append the new content with the header
-          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT}
-
-          ${CUSTOM_HEADER}
-
-          $(cat performance_results.md)"
+        CUSTOM_HEADER="### Performance Analysis Results"
+        
+        REVIEWABLE_TAG="<!-- Reviewable:start -->"
+        REVIEWABLE_BLOCK=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
 
-        echo "DEBUG2"
-        echo ${PR_NUMBER}
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        else
+          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+        fi
 
-        gh api \
-          --method POST \
+        NEW_CONTENT="${CUSTOM_HEADER}
+
+        $(cat performance_results.md)
+
+        ${REVIEWABLE_BLOCK}
+        "
+        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+
+        COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+
+        # Update the existing top-level comment
+        gh api repos/opensim-org/opensim-core/issues/comments/${COMMENT_ID} \
+          --method PATCH \
           -H "Content-Type: application/json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -524,6 +524,7 @@ jobs:
       with:
         repository: adamkewley/osimperf
         ref: master
+        path: osimperf
 
     - name: Download source branch artifact
       uses: actions/download-artifact@v2

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -533,7 +533,7 @@ jobs:
 
     - name: Unzip source branch artifact
       run: |
-        ls
+        mkdir unzipped
         unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
         cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
         ls
@@ -546,7 +546,7 @@ jobs:
 
     - name: Unzip target branch artifact
       run: |
-        ls
+        mkdir unzipped
         unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
         cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
         ls

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -524,12 +524,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"run_id": "${{ github.run_id }}",
-              "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac",
-              "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac",
-              "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip",
-              "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip",
-            }'
+        workflow_inputs: '{"run_id": "${{ github.run_id }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -575,7 +575,7 @@ jobs:
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/issues/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance Analysis Results"
-        
+
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
         REVIEWABLE_BLOCK=""
         if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
@@ -599,10 +599,11 @@ jobs:
         COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
 
         # Update the existing top-level comment
-        gh api repos/opensim-org/opensim-core/issues/comments/${COMMENT_ID} \
+        gh api \
           --method PATCH \
           -H "Content-Type: application/json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments/${COMMENT_ID} \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -555,9 +555,9 @@ jobs:
 
     - name: Run Examples and Compare Performance
       run: |
-        ls
-        echo $GITHUB_WORKSPACE
-        python osimperf/osimperf --help
+        lhs=unzipped/opensim-core-${{ github.event.pull_request.base.ref }}/bin/opensim-cmd
+        rhs=unzipped/opensim-core-${{ needs.mac_source.outputs.version }}/bin/opensim-cmd
+        python osimperf/osimperf compare-all --repeats 16 ${lhs} ${rhs}
 
     - name: Extract Performance Results
       run: |
@@ -576,7 +576,7 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance Analysis Results"
+        CUSTOM_HEADER="### Performance analysis"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
         REVIEWABLE_BLOCK=""

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -389,7 +389,7 @@ jobs:
     runs-on: macos-12
 
     env:
-      JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, 'your_specific_string') ? ' (source)' : '' }}
+      JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, '[perf]') && ' (source)' || '' }}
     
     name: Mac${{ env.JOB_NAME_SUFFIX }}
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -517,7 +517,7 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-  perf_test:
+  performance_analysis:
     name: Performance Analysis
 
     needs:
@@ -525,6 +525,9 @@ jobs:
       - mac_source
 
     runs-on: macos-12
+
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     # TODO
     # if: contains(github.event.head_commit.message, '[perf]')
@@ -556,6 +559,7 @@ jobs:
       with:
         github_token: ${{ secrets.PERF_DISPATCH_PAT }}
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
+        workflow: performance_analysis.yml
         name: performance-results
         path: results
         repo: opensim-org/opensim-perf

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,245 +15,245 @@ on:
       - '*'
 
 jobs:
-  windows:
-    name: Windows
+  # windows:
+  #   name: Windows
 
-    runs-on: windows-2019
+  #   runs-on: windows-2019
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Install Doxygen
-      # choco install doxygen.portable # <-- too unreliable.
-      run: |
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
-        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
+  #   - name: Install Doxygen
+  #     # choco install doxygen.portable # <-- too unreliable.
+  #     run: |
+  #       (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
+  #       7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
+  #       echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
-    - name: Install Python packages
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
+  #   - name: Install Python packages
+  #     uses: actions/setup-python@v4
+  #     with:
+  #       python-version: '3.8'
         
-    - name: Install numpy
-      #Need numpy to use SWIG numpy typemaps.
-      run: python3 -m pip install numpy==1.20.2
+  #   - name: Install numpy
+  #     #Need numpy to use SWIG numpy typemaps.
+  #     run: python3 -m pip install numpy==1.20.2
 
-    - name: Install SWIG
-      run: |
-        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
-        swig -swiglib
+  #   - name: Install SWIG
+  #     run: |
+  #       choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+  #       swig -swiglib
 
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+  #   - name: Cache dependencies
+  #     id: cache-dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/opensim_dependencies_install
+  #       # Every time a cache is created, it's stored with this key.
+  #       # In subsequent runs, if the key matches the key of an existing cache,
+  #       # then the cache is used. We chose for this key to depend on the
+  #       # operating system and a hash of the hashes of all files in the
+  #       # dependencies directory (non-recursive).
+  #       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-    - name: Build dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        echo $env:GITHUB_WORKSPACE\\build_deps
-        mkdir $env:GITHUB_WORKSPACE\\build_deps
-        chdir $env:GITHUB_WORKSPACE\\build_deps
-        # /W0 disables warnings.
-        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-        # TODO: CMake provides /W3, which overrides our /W0
-        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
-        cmake --build . --config Release -- /maxcpucount:4
+  #   - name: Build dependencies
+  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+  #     run: |
+  #       echo $env:GITHUB_WORKSPACE\\build_deps
+  #       mkdir $env:GITHUB_WORKSPACE\\build_deps
+  #       chdir $env:GITHUB_WORKSPACE\\build_deps
+  #       # /W0 disables warnings.
+  #       # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+  #       # TODO: CMake provides /W3, which overrides our /W0
+  #       cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
+  #       cmake --build . --config Release -- /maxcpucount:4
 
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE\\build
-        # TODO: Can remove /WX when we use that in CMakeLists.txt.
-        # Set the CXXFLAGS environment variable to turn warnings into errors.
-        # Skip timing test section included by default.
-        cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64 
-        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
-        $version = $env:match.split('=')[1]
-        echo $version
-        echo "VERSION=$version" >> $GITHUB_ENV
-        echo "version=$version" >> $env:GITHUB_OUTPUT
+  #   - name: Configure opensim-core
+  #     id: configure
+  #     run: |
+  #       mkdir $env:GITHUB_WORKSPACE\\build
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       # TODO: Can remove /WX when we use that in CMakeLists.txt.
+  #       # Set the CXXFLAGS environment variable to turn warnings into errors.
+  #       # Skip timing test section included by default.
+  #       cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64 
+  #       $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+  #       $version = $env:match.split('=')[1]
+  #       echo $version
+  #       echo "VERSION=$version" >> $GITHUB_ENV
+  #       echo "version=$version" >> $env:GITHUB_OUTPUT
 
-    - name: Build opensim-core
-      # Install now to avoid building bindings twice (issue when using Visual Studio 2019).
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        cmake --build . --config Release --target doxygen -- /maxcpucount:4
-        cmake --build . --config Release --target install -- /maxcpucount:4
+  #   - name: Build opensim-core
+  #     # Install now to avoid building bindings twice (issue when using Visual Studio 2019).
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       cmake --build . --config Release --target doxygen -- /maxcpucount:4
+  #       cmake --build . --config Release --target install -- /maxcpucount:4
 
-    - name: Test opensim-core
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        ctest --parallel 4 --output-on-failure --build-config Release -E python*
+  #   - name: Test opensim-core
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       ctest --parallel 4 --output-on-failure --build-config Release -E python*
 
-    - name: Install opensim-core
-      # TODO: This is where we wish to do the installing, but it's done above for now.
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE
-        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
-        7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
+  #   - name: Install opensim-core
+  #     # TODO: This is where we wish to do the installing, but it's done above for now.
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       chdir $env:GITHUB_WORKSPACE
+  #       Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
+  #       7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
 
-    - name: Test Python bindings
-      run: |
-        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
-        # Move to the installed location of the python package.
-        cd ~/opensim-core-install/sdk/python
-        # Run python tests.
-        python -m unittest discover --start-directory opensim/tests --verbose
+  #   - name: Test Python bindings
+  #     run: |
+  #       echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+  #       # Move to the installed location of the python package.
+  #       cd ~/opensim-core-install/sdk/python
+  #       # Run python tests.
+  #       python -m unittest discover --start-directory opensim/tests --verbose
 
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
-      with:
-        name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
-        path: opensim-core-${{ steps.configure.outputs.version }}.zip
+  #   - name: Upload opensim-core
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
+  #       path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-    # TODO: Must be relative to the workspace?
-    # - name: Upload opensim-moco dependencies
-    #   uses: actions/upload-artifact@v1.0.0
-    #   with:
-    #     name: opensim-core-dependencies
-    #     path: opensim_dependencies_install.zip
+  #   # TODO: Must be relative to the workspace?
+  #   # - name: Upload opensim-moco dependencies
+  #   #   uses: actions/upload-artifact@v1.0.0
+  #   #   with:
+  #   #     name: opensim-core-dependencies
+  #   #     path: opensim_dependencies_install.zip
 
-    # - name: Create release
-    #   id: create-release
-    #   uses: actions/create-release@v1.0.0
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     tag_name: ${{ github.ref }}
-    #     release_name: OpenSim Core ${{ github.ref }}
-    #     draft: true
-    #     prerelease: false
+  #   # - name: Create release
+  #   #   id: create-release
+  #   #   uses: actions/create-release@v1.0.0
+  #   #   env:
+  #   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   #   with:
+  #   #     tag_name: ${{ github.ref }}
+  #   #     release_name: OpenSim Core ${{ github.ref }}
+  #   #     draft: true
+  #   #     prerelease: false
 
-    # - name: Zip opensim-core
-    #   run: |
-    #     7z a opensim-core-$VERSION.zip opensim-core-${VERSION}
+  #   # - name: Zip opensim-core
+  #   #   run: |
+  #   #     7z a opensim-core-$VERSION.zip opensim-core-${VERSION}
 
-    # - name: Upload release asset
-    #   id: upload-release-asset
-    #   uses: actions/upload-release-asset@v1.0.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create-release.outputs.upload_url }}
-    #     asset_path: ./opensim-core-${{ github.ref }}.zip
-    #     asset_name: opensim-core-${{ github.ref }}.zip
-    #     asset_content_type: application/zip
+  #   # - name: Upload release asset
+  #   #   id: upload-release-asset
+  #   #   uses: actions/upload-release-asset@v1.0.1
+  #   #   env:
+  #   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   #   with:
+  #   #     upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #   #     asset_path: ./opensim-core-${{ github.ref }}.zip
+  #   #     asset_name: opensim-core-${{ github.ref }}.zip
+  #   #     asset_content_type: application/zip
 
-  windows2022:
-    name: Windows2022
+  # windows2022:
+  #   name: Windows2022
 
-    runs-on: windows-2022
+  #   runs-on: windows-2022
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Install Doxygen
-      # choco install doxygen.portable # <-- too unreliable.
-      run: |
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
-        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
+  #   - name: Install Doxygen
+  #     # choco install doxygen.portable # <-- too unreliable.
+  #     run: |
+  #       (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
+  #       7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
+  #       echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
-    - name: Install Python packages
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
+  #   - name: Install Python packages
+  #     uses: actions/setup-python@v4
+  #     with:
+  #       python-version: '3.8'
         
-    - name: Install numpy
-      #Need numpy to use SWIG numpy typemaps.
-      run: python3 -m pip install numpy==1.20.2
+  #   - name: Install numpy
+  #     #Need numpy to use SWIG numpy typemaps.
+  #     run: python3 -m pip install numpy==1.20.2
 
-    - name: Install SWIG
-      run: | 
-        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
-        swig -swiglib
+  #   - name: Install SWIG
+  #     run: | 
+  #       choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+  #       swig -swiglib
 
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+  #   - name: Cache dependencies
+  #     id: cache-dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/opensim_dependencies_install
+  #       # Every time a cache is created, it's stored with this key.
+  #       # In subsequent runs, if the key matches the key of an existing cache,
+  #       # then the cache is used. We chose for this key to depend on the
+  #       # operating system and a hash of the hashes of all files in the
+  #       # dependencies directory (non-recursive).
+  #       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-    - name: Build dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        echo $env:GITHUB_WORKSPACE\\build_deps
-        mkdir $env:GITHUB_WORKSPACE\\build_deps
-        chdir $env:GITHUB_WORKSPACE\\build_deps
-        # /W0 disables warnings.
-        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-        # TODO: CMake provides /W3, which overrides our /W0
-        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
-        cmake --build . --config Release -- /maxcpucount:4
+  #   - name: Build dependencies
+  #     if: steps.cache-dependencies.outputs.cache-hit != 'true'
+  #     run: |
+  #       echo $env:GITHUB_WORKSPACE\\build_deps
+  #       mkdir $env:GITHUB_WORKSPACE\\build_deps
+  #       chdir $env:GITHUB_WORKSPACE\\build_deps
+  #       # /W0 disables warnings.
+  #       # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+  #       # TODO: CMake provides /W3, which overrides our /W0
+  #       cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
+  #       cmake --build . --config Release -- /maxcpucount:4
 
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE\\build
-        # TODO: Can remove /WX when we use that in CMakeLists.txt.
-        # Set the CXXFLAGS environment variable to turn warnings into errors.
-        # Skip timing test section included by default.
-        cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64
-        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
-        $version = $env:match.split('=')[1]
-        echo $version
-        echo "VERSION=$version" >> $GITHUB_ENV
-        echo "version=$version" >> $env:GITHUB_OUTPUT
+  #   - name: Configure opensim-core
+  #     id: configure
+  #     run: |
+  #       mkdir $env:GITHUB_WORKSPACE\\build
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       # TODO: Can remove /WX when we use that in CMakeLists.txt.
+  #       # Set the CXXFLAGS environment variable to turn warnings into errors.
+  #       # Skip timing test section included by default.
+  #       cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64
+  #       $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+  #       $version = $env:match.split('=')[1]
+  #       echo $version
+  #       echo "VERSION=$version" >> $GITHUB_ENV
+  #       echo "version=$version" >> $env:GITHUB_OUTPUT
 
 
-    - name: Build opensim-core
-      # Install now to avoid building bindings twice (TODO: issue when using Visual Studio 2019, is this an issue too in Visual Studio 2022?).
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        cmake --build . --config Release --target doxygen -- /maxcpucount:4
-        cmake --build . --config Release --target install -- /maxcpucount:4
+  #   - name: Build opensim-core
+  #     # Install now to avoid building bindings twice (TODO: issue when using Visual Studio 2019, is this an issue too in Visual Studio 2022?).
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       cmake --build . --config Release --target doxygen -- /maxcpucount:4
+  #       cmake --build . --config Release --target install -- /maxcpucount:4
 
-    - name: Test opensim-core
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        ctest --parallel 4 --output-on-failure --build-config Release -E python*
+  #   - name: Test opensim-core
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       ctest --parallel 4 --output-on-failure --build-config Release -E python*
 
-    - name: Install opensim-core
-      # TODO: This is where we wish to do the installing, but it's done above for now.
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE
-        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
-        7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
+  #   - name: Install opensim-core
+  #     # TODO: This is where we wish to do the installing, but it's done above for now.
+  #     run: |
+  #       chdir $env:GITHUB_WORKSPACE\\build
+  #       chdir $env:GITHUB_WORKSPACE
+  #       Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
+  #       7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
 
-    - name: Test Python bindings
-      run: |
-        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
-        # Move to the installed location of the python package.
-        cd ~/opensim-core-install/sdk/python
-        # Run python tests.
-        python -m unittest discover --start-directory opensim/tests --verbose
+  #   - name: Test Python bindings
+  #     run: |
+  #       echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+  #       # Move to the installed location of the python package.
+  #       cd ~/opensim-core-install/sdk/python
+  #       # Run python tests.
+  #       python -m unittest discover --start-directory opensim/tests --verbose
 
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
-      with:
-        name: opensim-core-${{ steps.configure.outputs.version }}-win
-        path: opensim-core-${{ steps.configure.outputs.version }}.zip
+  #   - name: Upload opensim-core
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: opensim-core-${{ steps.configure.outputs.version }}-win
+  #       path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   mac_target:
     name: Mac (target)
@@ -377,7 +377,7 @@ jobs:
         python3 -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
@@ -400,10 +400,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Print Commit SHA
-      run: |
-        echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
     
     - uses: actions/setup-python@v4
       with:
@@ -514,7 +510,7 @@ jobs:
         python3 -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
@@ -678,228 +674,228 @@ jobs:
     #     echo "4 | 44 | D" >> performance_results.md
  
 
-  ubuntu20:
-    name: Ubuntu2004
+  # ubuntu20:
+  #   name: Ubuntu2004
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Install packages
-      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
+  #   - name: Install packages
+  #     run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
 
-    - name: Install SWIG
-      # if: steps.cache-swig.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-        make && make -j4 install
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+  #   - name: Install SWIG
+  #     # if: steps.cache-swig.outputs.cache-hit != 'true'
+  #     run: |
+  #       mkdir ~/swig-source && cd ~/swig-source
+  #       wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+  #       tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+  #       sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+  #       make && make -j4 install
+  #   - name: Cache dependencies
+  #     id: cache-dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/opensim_dependencies_install
+  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-    - name: Build dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
+  #   - name: Build dependencies
+  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+  #     run: |
+  #       mkdir $GITHUB_WORKSPACE/../build_deps
+  #       cd $GITHUB_WORKSPACE/../build_deps
+  #       DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+  #       DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+  #       DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+  #       DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
+  #       printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+  #       cmake "${DEP_CMAKE_ARGS[@]}"
+  #       make --jobs 4
 
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+  #   - name: Configure opensim-core
+  #     id: configure
+  #     run: |
+  #       mkdir $GITHUB_WORKSPACE/../build
+  #       cd $GITHUB_WORKSPACE/../build
+  #       OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+  #       OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+  #       OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+  #       OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+  #       # TODO: Update to simbody.github.io/latest
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+  #       printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+  #       cmake "${OSIM_CMAKE_ARGS[@]}"
+  #       VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+  #       echo $VERSION
+  #       echo "VERSION=$VERSION" >> $GITHUB_ENV
+  #       echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Build opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
+  #   - name: Build opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       make --jobs 4
 
-    - name: Test opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        # TODO: Temporary for python to find Simbody libraries.
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-        ctest --parallel 4 --output-on-failure
+  #   - name: Test opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       # TODO: Temporary for python to find Simbody libraries.
+  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+  #       ctest --parallel 4 --output-on-failure
 
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make --jobs 4 install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
-        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+  #   - name: Install opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       make doxygen
+  #       make --jobs 4 install
+  #       cd $GITHUB_WORKSPACE
+  #       mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+  #       zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
+  #       mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
-    # - name: Test Python bindings
-    #   run: |
-    #     echo "TODO: Skipping Python tests."
-    #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-    #     # Run the python tests, verbosely.
-    #     # python3 -m unittest discover --start-directory opensim/tests --verbose
+  #   # - name: Test Python bindings
+  #   #   run: |
+  #   #     echo "TODO: Skipping Python tests."
+  #   #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+  #   #     # Run the python tests, verbosely.
+  #   #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
-      with:
-        # The upload-artifact zipping does not preserve symlinks or executable
-        # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-linux
-        path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
+  #   - name: Upload opensim-core
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       # The upload-artifact zipping does not preserve symlinks or executable
+  #       # bits. So we zip ourselves, even though this causes a double-zip.
+  #       name: opensim-core-${{ steps.configure.outputs.version }}-ub20-linux
+  #       path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
 
-  ubuntu20-nomoco:
-    name: Ubuntu2004-nomoco
+  # ubuntu20-nomoco:
+  #   name: Ubuntu2004-nomoco
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Install packages
-      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
+  #   - name: Install packages
+  #     run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
 
-    - name: Install SWIG
-      # if: steps.cache-swig.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-        make && make -j4 install
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+  #   - name: Install SWIG
+  #     # if: steps.cache-swig.outputs.cache-hit != 'true'
+  #     run: |
+  #       mkdir ~/swig-source && cd ~/swig-source
+  #       wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+  #       tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+  #       sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+  #       make && make -j4 install
+  #   - name: Cache dependencies
+  #     id: cache-dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/opensim_dependencies_install
+  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-    - name: Build dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
+  #   - name: Build dependencies
+  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+  #     run: |
+  #       mkdir $GITHUB_WORKSPACE/../build_deps
+  #       cd $GITHUB_WORKSPACE/../build_deps
+  #       DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+  #       DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+  #       DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+  #       DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
+  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
+  #       printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+  #       cmake "${DEP_CMAKE_ARGS[@]}"
+  #       make --jobs 4
 
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=off)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=off)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+  #   - name: Configure opensim-core
+  #     id: configure
+  #     run: |
+  #       mkdir $GITHUB_WORKSPACE/../build
+  #       cd $GITHUB_WORKSPACE/../build
+  #       OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+  #       OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+  #       OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+  #       OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=off)
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=off)
+  #       # TODO: Update to simbody.github.io/latest
+  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+  #       OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+  #       printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+  #       cmake "${OSIM_CMAKE_ARGS[@]}"
+  #       VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+  #       echo $VERSION
+  #       echo "VERSION=$VERSION" >> $GITHUB_ENV
+  #       echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Build opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
+  #   - name: Build opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       make --jobs 4
 
-    - name: Test opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        # TODO: Temporary for python to find Simbody libraries.
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-        # ctest --parallel 4 --output-on-failure
+  #   - name: Test opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       # TODO: Temporary for python to find Simbody libraries.
+  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+  #       # ctest --parallel 4 --output-on-failure
 
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make --jobs 4 install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
-        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+  #   - name: Install opensim-core
+  #     run: |
+  #       cd $GITHUB_WORKSPACE/../build
+  #       make doxygen
+  #       make --jobs 4 install
+  #       cd $GITHUB_WORKSPACE
+  #       mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+  #       zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
+  #       mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
-    # - name: Test Python bindings
-    #   run: |
-    #     echo "TODO: Skipping Python tests."
-    #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-    #     # Run the python tests, verbosely.
-    #     # python3 -m unittest discover --start-directory opensim/tests --verbose
+  #   # - name: Test Python bindings
+  #   #   run: |
+  #   #     echo "TODO: Skipping Python tests."
+  #   #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+  #   #     # Run the python tests, verbosely.
+  #   #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
-      with:
-        # The upload-artifact zipping does not preserve symlinks or executable
-        # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco-linux
-        path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
+  #   - name: Upload opensim-core
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       # The upload-artifact zipping does not preserve symlinks or executable
+  #       # bits. So we zip ourselves, even though this causes a double-zip.
+  #       name: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco-linux
+  #       path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
 
-  style:
-    name: Style
+  # style:
+  #   name: Style
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - name: Check for tabs
-      # Ensure that there are no tabs in source code.
-      # GREP returns 0 (true) if there are any matches, and
-      # we don't want any matches. If there are matches,
-      # print a helpful message, and make the test fail by using "false".
-      # The GREP command here checks for any tab characters in the the files
-      # that match the specified pattern. GREP does not pick up explicit tabs
-      # (e.g., literally a \t in a source file).
-      run: if grep --line-num --recursive --exclude-dir="*dependencies*" --exclude-dir="*snopt*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
+  #   - name: Check for tabs
+  #     # Ensure that there are no tabs in source code.
+  #     # GREP returns 0 (true) if there are any matches, and
+  #     # we don't want any matches. If there are matches,
+  #     # print a helpful message, and make the test fail by using "false".
+  #     # The GREP command here checks for any tab characters in the the files
+  #     # that match the specified pattern. GREP does not pick up explicit tabs
+  #     # (e.g., literally a \t in a source file).
+  #     run: if grep --line-num --recursive --exclude-dir="*dependencies*" --exclude-dir="*snopt*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,10 +260,13 @@ jobs:
 
     runs-on: macos-12
 
-    # TODO
     if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
+    - name: Testing commit message
+      run: |
+        echo github.event.head_commit.message
+
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.base.ref }} 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -572,6 +572,7 @@ jobs:
 
     - name: Post Results to PR Comment
       run: |
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api repos/:owner/:repo/issues/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance Check Results"
 
@@ -591,14 +592,16 @@ jobs:
 
           $(cat performance_results.md)"
         fi
-        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
-        curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments" \
-          -d "{\"body\": \"${NEW_COMMENT_BODY}\"}"
+        echo "DEBUG"
 
+        gh api \
+          --method POST \
+          -H "Content-Type: application/json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/OWNER/REPO/issues/PR_NUMBER/comments \
+          -f "body=${NEW_COMMENT_BODY}"
+ 
 
   ubuntu20:
     name: Ubuntu2004

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -395,8 +395,12 @@ jobs:
     steps:
     - name: Debug Commit Message
       run: |
-       echo "Commit Message: ${{ github.event.commits[0].message }}"
-      
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          echo "Commit Message: ${{ github.event.commits[0].message }}"
+        else
+          echo "Not a push event; commit information not available."
+        fi
+
     - uses: actions/checkout@v3
     
     - uses: actions/setup-python@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,7 +260,7 @@ jobs:
 
     runs-on: macos-12
 
-    if: ${{ contains(github.event.pull_request.title, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -387,7 +387,7 @@ jobs:
 
     runs-on: macos-12
     
-    name: ${{ contains(github.event.pull_request.title, '[perf]') && 'Mac [source]' || 'Mac' }}
+    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -523,7 +523,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
 
-    if: ${{ contains(github.event.pull_request.title, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
     steps:
     - name: Trigger opensim-perf workflow
@@ -594,83 +594,7 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
           -f "body=${NEW_COMMENT_BODY}"
-
-
-    # - name: Trigger opensim-perf workflow
-    #   uses: actions/github-script@v6
-    #   with:
-    #     github-token: ${{ secrets.PERF_DISPATCH_PAT }}
-    #     script: |
-    #       const result = await github.rest.actions.createWorkflowDispatch({
-    #         owner: 'opensim-org',
-    #         repo: 'opensim-perf',
-    #         workflow_id: 'performance_analysis.yml',
-    #         ref: 'main',
-    #         inputs: {
-    #           run_id: '${{ github.run_id }}',
-    #           target_artifact_name: 'opensim-core-${{ github.event.pull_request.base.ref }}-mac',
-    #           source_artifact_name: 'opensim-core-${{ steps.configure.outputs.version }}-mac',
-    #           target_artifact_zip: 'opensim-core-${{ github.event.pull_request.base.ref }}.zip',
-    #           source_artifact_zip: 'opensim-core-${{ steps.configure.outputs.version }}.zip',
-    #         }
-    #       })
-    #       console.log(result)
-    # - uses: actions/setup-python@v4
-    #   with:
-    #     python-version: '3.8'
-
-    # - name: Checkout osimperf
-    #   uses: actions/checkout@v3
-    #   with:
-    #     repository: adamkewley/osimperf
-    #     ref: master
-    #     path: osimperf
-
-    # - name: Download source branch artifact
-    #   uses: actions/download-artifact@v2
-    #   with:
-    #     name: opensim-core-${{ needs.mac_source.outputs.version }}-mac
-    #     path: artifacts
-
-    # - name: Unzip source branch artifact
-    #   run: |
-    #     mkdir unzipped
-    #     unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}.zip -d unzipped/
-    #     # cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
-    #     ls
-
-    # - name: Download target branch artifact
-    #   uses: actions/download-artifact@v2
-    #   with:
-    #     name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
-    #     path: artifacts
-
-    # - name: Unzip target branch artifact
-    #   run: |
-    #     unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}.zip -d unzipped/
-    #     # cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
-    #     ls
-
-    # - name: Run Examples and Compare Performance
-    #   run: |
-    #     lhs=unzipped/opensim-core-${{ github.event.pull_request.base.ref }}/bin/opensim-cmd
-    #     rhs=unzipped/opensim-core-${{ needs.mac_source.outputs.version }}/bin/opensim-cmd
-    #     python osimperf/osimperf compare-all --repeats 16 ${lhs} ${rhs}
-
-    # - name: Extract Performance Results
-    #   run: |
-    #     # Replace this with your command to generate the markdown table
-    #     echo "Generating markdown table..."
-    #     # Your command to generate the markdown table here
-    #     # Store the markdown table in a file, e.g., performance_results.md
-    #     echo "Sample | Performance | Table" > performance_results.md
-    #     echo "--- | --- | ---" >> performance_results.md
-    #     echo "1 | 100 | A" >> performance_results.md
-    #     echo "2 | 90 | B" >> performance_results.md
-    #     echo "3 | 76 | C" >> performance_results.md
-    #     echo "4 | 44 | D" >> performance_results.md
  
-
   ubuntu20:
     name: Ubuntu2004
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -569,6 +569,8 @@ jobs:
         echo "--- | --- | ---" >> performance_results.md
         echo "1 | 100 | A" >> performance_results.md
         echo "2 | 90 | B" >> performance_results.md
+        echo "3 | 76 | C" >> performance_results.md
+        echo "4 | 44 | D" >> performance_results.md
 
     - name: Post Results to PR Comment
       run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -555,8 +555,7 @@ jobs:
       run: |
         ls
         echo $GITHUB_WORKSPACE
-        cd $GITHUB_WORKSPACE/osimperf
-        osimperf --help
+        python osimperf/osimperf --help
 
     - name: Extract Performance Results
       run: |
@@ -571,14 +570,32 @@ jobs:
 
     - name: Post Results to PR Comment
       run: |
-        COMMENT_BODY=$(cat performance_results.md)
+        EXISTING_COMMENT_CONTENT=$(gh api repos/:owner/:repo/issues/${PR_NUMBER} | jq -r '.body')
+        CUSTOM_HEADER="### Performance Check Results"
+
+        # Check if the custom header exists in the existing comment body
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          # Extract the content after the custom header
+          EXISTING_TABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/{flag=1; next} flag")
+
+          # Replace the existing table content with new content
+          NEW_TABLE_CONTENT=$(cat new_performance_results.md)
+          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${EXISTING_TABLE_CONTENT}"/${NEW_TABLE_CONTENT}}"
+        else
+          # If the custom header doesn't exist, just append the new content with the header
+          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT}
+
+          ${CUSTOM_HEADER}
+
+          $(cat new_performance_results.md)"
+        fi
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 
         curl -X POST \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           "https://api.github.com/repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments" \
-          -d "{\"body\": \"${COMMENT_BODY}\"}"
+          -d "{\"body\": \"${NEW_COMMENT_BODY}\"}"
 
 
   ubuntu20:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -544,7 +544,7 @@ jobs:
         repo: opensim-perf
         owner: opensim-org
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
-        run_timeout_seconds: 300 
+        run_timeout_seconds: 1500 
 
     - name: Download performance analysis results
       id: download-artifact

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -386,6 +386,9 @@ jobs:
   mac_source:
 
     runs-on: macos-12
+
+    env:
+      commitmsg: ${{ github.event.head_commit.message }}
     
     name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
 
@@ -402,9 +405,9 @@ jobs:
     - name: Testing commit message
       run: |
         echo github.event.head_commit.message
-        echo contains(github.event.head_commit.message, '[perf]')
-        echo ${{ github.event.head_commit.message }}
-        echo ${{ contains(github.event.head_commit.message, '[perf]') }}
+        echo contains($commitmsg, '[perf]')
+        echo $commitmsg
+        echo ${{ contains($commitmsg, '[perf]') }}
         
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -554,7 +554,8 @@ jobs:
     - name: Run Examples and Compare Performance
       run: |
         ls
-        cd osimperf
+        echo $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE/osimperf
         osimperf --help
 
     - name: Extract Performance Results

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -570,6 +570,45 @@ jobs:
           path: results
           repo: opensim-org/opensim-perf
 
+      - name: Post Results to PR Comment
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
+          CUSTOM_HEADER="### Performance analysis"
+
+          REVIEWABLE_TAG="<!-- Reviewable:start -->"
+          REVIEWABLE_BLOCK=""
+          if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+            REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+          fi
+
+          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+          else
+            CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+          fi
+
+          NEW_CONTENT="${CUSTOM_HEADER}
+
+          $(cat results/performance_results.md)
+
+          ${REVIEWABLE_BLOCK}
+          "
+          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+
+          # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+          # echo ${COMMENT_ID}
+
+          # Update the existing description
+          gh api \
+            --method PATCH \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+            -f "body=${NEW_COMMENT_BODY}"
+
+
     # - uses: actions/setup-python@v4
     #   with:
     #     python-version: '3.8'
@@ -624,44 +663,6 @@ jobs:
     #     echo "2 | 90 | B" >> performance_results.md
     #     echo "3 | 76 | C" >> performance_results.md
     #     echo "4 | 44 | D" >> performance_results.md
-
-    - name: Post Results to PR Comment
-      run: |
-        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis"
-
-        REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        REVIEWABLE_BLOCK=""
-        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-        fi
-
-        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-        else
-          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
-        fi
-
-        NEW_CONTENT="${CUSTOM_HEADER}
-
-        $(cat results/performance_results.md)
-
-        ${REVIEWABLE_BLOCK}
-        "
-        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
-
-        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-        # echo ${COMMENT_ID}
-
-        # Update the existing description
-        gh api \
-          --method PATCH \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
-          -f "body=${NEW_COMMENT_BODY}"
  
 
   ubuntu20:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,245 +15,245 @@ on:
       - '*'
 
 jobs:
-  # windows:
-  #   name: Windows
+  windows:
+    name: Windows
 
-  #   runs-on: windows-2019
+    runs-on: windows-2019
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Install Doxygen
-  #     # choco install doxygen.portable # <-- too unreliable.
-  #     run: |
-  #       (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
-  #       7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-  #       echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
+    - name: Install Doxygen
+      # choco install doxygen.portable # <-- too unreliable.
+      run: |
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
+        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
+        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
-  #   - name: Install Python packages
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: '3.8'
+    - name: Install Python packages
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
         
-  #   - name: Install numpy
-  #     #Need numpy to use SWIG numpy typemaps.
-  #     run: python3 -m pip install numpy==1.20.2
+    - name: Install numpy
+      #Need numpy to use SWIG numpy typemaps.
+      run: python3 -m pip install numpy==1.20.2
 
-  #   - name: Install SWIG
-  #     run: |
-  #       choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
-  #       swig -swiglib
+    - name: Install SWIG
+      run: |
+        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+        swig -swiglib
 
-  #   - name: Cache dependencies
-  #     id: cache-dependencies
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/opensim_dependencies_install
-  #       # Every time a cache is created, it's stored with this key.
-  #       # In subsequent runs, if the key matches the key of an existing cache,
-  #       # then the cache is used. We chose for this key to depend on the
-  #       # operating system and a hash of the hashes of all files in the
-  #       # dependencies directory (non-recursive).
-  #       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # Every time a cache is created, it's stored with this key.
+        # In subsequent runs, if the key matches the key of an existing cache,
+        # then the cache is used. We chose for this key to depend on the
+        # operating system and a hash of the hashes of all files in the
+        # dependencies directory (non-recursive).
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-  #   - name: Build dependencies
-  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-  #     run: |
-  #       echo $env:GITHUB_WORKSPACE\\build_deps
-  #       mkdir $env:GITHUB_WORKSPACE\\build_deps
-  #       chdir $env:GITHUB_WORKSPACE\\build_deps
-  #       # /W0 disables warnings.
-  #       # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-  #       # TODO: CMake provides /W3, which overrides our /W0
-  #       cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
-  #       cmake --build . --config Release -- /maxcpucount:4
+    - name: Build dependencies
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        echo $env:GITHUB_WORKSPACE\\build_deps
+        mkdir $env:GITHUB_WORKSPACE\\build_deps
+        chdir $env:GITHUB_WORKSPACE\\build_deps
+        # /W0 disables warnings.
+        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+        # TODO: CMake provides /W3, which overrides our /W0
+        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
+        cmake --build . --config Release -- /maxcpucount:4
 
-  #   - name: Configure opensim-core
-  #     id: configure
-  #     run: |
-  #       mkdir $env:GITHUB_WORKSPACE\\build
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       # TODO: Can remove /WX when we use that in CMakeLists.txt.
-  #       # Set the CXXFLAGS environment variable to turn warnings into errors.
-  #       # Skip timing test section included by default.
-  #       cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64 
-  #       $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
-  #       $version = $env:match.split('=')[1]
-  #       echo $version
-  #       echo "VERSION=$version" >> $GITHUB_ENV
-  #       echo "version=$version" >> $env:GITHUB_OUTPUT
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE\\build
+        # TODO: Can remove /WX when we use that in CMakeLists.txt.
+        # Set the CXXFLAGS environment variable to turn warnings into errors.
+        # Skip timing test section included by default.
+        cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64 
+        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+        $version = $env:match.split('=')[1]
+        echo $version
+        echo "VERSION=$version" >> $GITHUB_ENV
+        echo "version=$version" >> $env:GITHUB_OUTPUT
 
-  #   - name: Build opensim-core
-  #     # Install now to avoid building bindings twice (issue when using Visual Studio 2019).
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       cmake --build . --config Release --target doxygen -- /maxcpucount:4
-  #       cmake --build . --config Release --target install -- /maxcpucount:4
+    - name: Build opensim-core
+      # Install now to avoid building bindings twice (issue when using Visual Studio 2019).
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        cmake --build . --config Release --target doxygen -- /maxcpucount:4
+        cmake --build . --config Release --target install -- /maxcpucount:4
 
-  #   - name: Test opensim-core
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       ctest --parallel 4 --output-on-failure --build-config Release -E python*
+    - name: Test opensim-core
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        ctest --parallel 4 --output-on-failure --build-config Release -E python*
 
-  #   - name: Install opensim-core
-  #     # TODO: This is where we wish to do the installing, but it's done above for now.
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       chdir $env:GITHUB_WORKSPACE
-  #       Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
-  #       7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
+    - name: Install opensim-core
+      # TODO: This is where we wish to do the installing, but it's done above for now.
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE
+        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
+        7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
 
-  #   - name: Test Python bindings
-  #     run: |
-  #       echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
-  #       # Move to the installed location of the python package.
-  #       cd ~/opensim-core-install/sdk/python
-  #       # Run python tests.
-  #       python -m unittest discover --start-directory opensim/tests --verbose
+    - name: Test Python bindings
+      run: |
+        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+        # Move to the installed location of the python package.
+        cd ~/opensim-core-install/sdk/python
+        # Run python tests.
+        python -m unittest discover --start-directory opensim/tests --verbose
 
-  #   - name: Upload opensim-core
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
-  #       path: opensim-core-${{ steps.configure.outputs.version }}.zip
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v3
+      with:
+        name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
+        path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-  #   # TODO: Must be relative to the workspace?
-  #   # - name: Upload opensim-moco dependencies
-  #   #   uses: actions/upload-artifact@v1.0.0
-  #   #   with:
-  #   #     name: opensim-core-dependencies
-  #   #     path: opensim_dependencies_install.zip
+    # TODO: Must be relative to the workspace?
+    # - name: Upload opensim-moco dependencies
+    #   uses: actions/upload-artifact@v1.0.0
+    #   with:
+    #     name: opensim-core-dependencies
+    #     path: opensim_dependencies_install.zip
 
-  #   # - name: Create release
-  #   #   id: create-release
-  #   #   uses: actions/create-release@v1.0.0
-  #   #   env:
-  #   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   #   with:
-  #   #     tag_name: ${{ github.ref }}
-  #   #     release_name: OpenSim Core ${{ github.ref }}
-  #   #     draft: true
-  #   #     prerelease: false
+    # - name: Create release
+    #   id: create-release
+    #   uses: actions/create-release@v1.0.0
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     tag_name: ${{ github.ref }}
+    #     release_name: OpenSim Core ${{ github.ref }}
+    #     draft: true
+    #     prerelease: false
 
-  #   # - name: Zip opensim-core
-  #   #   run: |
-  #   #     7z a opensim-core-$VERSION.zip opensim-core-${VERSION}
+    # - name: Zip opensim-core
+    #   run: |
+    #     7z a opensim-core-$VERSION.zip opensim-core-${VERSION}
 
-  #   # - name: Upload release asset
-  #   #   id: upload-release-asset
-  #   #   uses: actions/upload-release-asset@v1.0.1
-  #   #   env:
-  #   #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   #   with:
-  #   #     upload_url: ${{ steps.create-release.outputs.upload_url }}
-  #   #     asset_path: ./opensim-core-${{ github.ref }}.zip
-  #   #     asset_name: opensim-core-${{ github.ref }}.zip
-  #   #     asset_content_type: application/zip
+    # - name: Upload release asset
+    #   id: upload-release-asset
+    #   uses: actions/upload-release-asset@v1.0.1
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   with:
+    #     upload_url: ${{ steps.create-release.outputs.upload_url }}
+    #     asset_path: ./opensim-core-${{ github.ref }}.zip
+    #     asset_name: opensim-core-${{ github.ref }}.zip
+    #     asset_content_type: application/zip
 
-  # windows2022:
-  #   name: Windows2022
+  windows2022:
+    name: Windows2022
 
-  #   runs-on: windows-2022
+    runs-on: windows-2022
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Install Doxygen
-  #     # choco install doxygen.portable # <-- too unreliable.
-  #     run: |
-  #       (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
-  #       7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-  #       echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
+    - name: Install Doxygen
+      # choco install doxygen.portable # <-- too unreliable.
+      run: |
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
+        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
+        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
 
-  #   - name: Install Python packages
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: '3.8'
+    - name: Install Python packages
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
         
-  #   - name: Install numpy
-  #     #Need numpy to use SWIG numpy typemaps.
-  #     run: python3 -m pip install numpy==1.20.2
+    - name: Install numpy
+      #Need numpy to use SWIG numpy typemaps.
+      run: python3 -m pip install numpy==1.20.2
 
-  #   - name: Install SWIG
-  #     run: | 
-  #       choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
-  #       swig -swiglib
+    - name: Install SWIG
+      run: | 
+        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+        swig -swiglib
 
-  #   - name: Cache dependencies
-  #     id: cache-dependencies
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/opensim_dependencies_install
-  #       # Every time a cache is created, it's stored with this key.
-  #       # In subsequent runs, if the key matches the key of an existing cache,
-  #       # then the cache is used. We chose for this key to depend on the
-  #       # operating system and a hash of the hashes of all files in the
-  #       # dependencies directory (non-recursive).
-  #       # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # Every time a cache is created, it's stored with this key.
+        # In subsequent runs, if the key matches the key of an existing cache,
+        # then the cache is used. We chose for this key to depend on the
+        # operating system and a hash of the hashes of all files in the
+        # dependencies directory (non-recursive).
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-  #   - name: Build dependencies
-  #     if: steps.cache-dependencies.outputs.cache-hit != 'true'
-  #     run: |
-  #       echo $env:GITHUB_WORKSPACE\\build_deps
-  #       mkdir $env:GITHUB_WORKSPACE\\build_deps
-  #       chdir $env:GITHUB_WORKSPACE\\build_deps
-  #       # /W0 disables warnings.
-  #       # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-  #       # TODO: CMake provides /W3, which overrides our /W0
-  #       cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
-  #       cmake --build . --config Release -- /maxcpucount:4
+    - name: Build dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        echo $env:GITHUB_WORKSPACE\\build_deps
+        mkdir $env:GITHUB_WORKSPACE\\build_deps
+        chdir $env:GITHUB_WORKSPACE\\build_deps
+        # /W0 disables warnings.
+        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+        # TODO: CMake provides /W3, which overrides our /W0
+        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
+        cmake --build . --config Release -- /maxcpucount:4
 
-  #   - name: Configure opensim-core
-  #     id: configure
-  #     run: |
-  #       mkdir $env:GITHUB_WORKSPACE\\build
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       # TODO: Can remove /WX when we use that in CMakeLists.txt.
-  #       # Set the CXXFLAGS environment variable to turn warnings into errors.
-  #       # Skip timing test section included by default.
-  #       cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64
-  #       $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
-  #       $version = $env:match.split('=')[1]
-  #       echo $version
-  #       echo "VERSION=$version" >> $GITHUB_ENV
-  #       echo "version=$version" >> $env:GITHUB_OUTPUT
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE\\build
+        # TODO: Can remove /WX when we use that in CMakeLists.txt.
+        # Set the CXXFLAGS environment variable to turn warnings into errors.
+        # Skip timing test section included by default.
+        cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64
+        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+        $version = $env:match.split('=')[1]
+        echo $version
+        echo "VERSION=$version" >> $GITHUB_ENV
+        echo "version=$version" >> $env:GITHUB_OUTPUT
 
 
-  #   - name: Build opensim-core
-  #     # Install now to avoid building bindings twice (TODO: issue when using Visual Studio 2019, is this an issue too in Visual Studio 2022?).
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       cmake --build . --config Release --target doxygen -- /maxcpucount:4
-  #       cmake --build . --config Release --target install -- /maxcpucount:4
+    - name: Build opensim-core
+      # Install now to avoid building bindings twice (TODO: issue when using Visual Studio 2019, is this an issue too in Visual Studio 2022?).
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        cmake --build . --config Release --target doxygen -- /maxcpucount:4
+        cmake --build . --config Release --target install -- /maxcpucount:4
 
-  #   - name: Test opensim-core
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       ctest --parallel 4 --output-on-failure --build-config Release -E python*
+    - name: Test opensim-core
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        ctest --parallel 4 --output-on-failure --build-config Release -E python*
 
-  #   - name: Install opensim-core
-  #     # TODO: This is where we wish to do the installing, but it's done above for now.
-  #     run: |
-  #       chdir $env:GITHUB_WORKSPACE\\build
-  #       chdir $env:GITHUB_WORKSPACE
-  #       Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
-  #       7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
+    - name: Install opensim-core
+      # TODO: This is where we wish to do the installing, but it's done above for now.
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE
+        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
+        7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
 
-  #   - name: Test Python bindings
-  #     run: |
-  #       echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
-  #       # Move to the installed location of the python package.
-  #       cd ~/opensim-core-install/sdk/python
-  #       # Run python tests.
-  #       python -m unittest discover --start-directory opensim/tests --verbose
+    - name: Test Python bindings
+      run: |
+        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+        # Move to the installed location of the python package.
+        cd ~/opensim-core-install/sdk/python
+        # Run python tests.
+        python -m unittest discover --start-directory opensim/tests --verbose
 
-  #   - name: Upload opensim-core
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: opensim-core-${{ steps.configure.outputs.version }}-win
-  #       path: opensim-core-${{ steps.configure.outputs.version }}.zip
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v3
+      with:
+        name: opensim-core-${{ steps.configure.outputs.version }}-win
+        path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   mac_target:
     name: Mac (target)
@@ -261,7 +261,7 @@ jobs:
     runs-on: macos-12
 
     # TODO
-    # if: contains(github.event.head_commit.message, '[perf]')
+    if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
     - uses: actions/checkout@v3
@@ -388,12 +388,10 @@ jobs:
 
     runs-on: macos-12
 
-    # TODO
-    # env:
-    #   JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, 'your_specific_string') ? ' (source)' : '' }}
-    # name: Mac${{ env.JOB_NAME_SUFFIX }}
-
-    name: Mac (source)
+    env:
+      JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, 'your_specific_string') ? ' (source)' : '' }}
+    
+    name: Mac${{ env.JOB_NAME_SUFFIX }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -529,8 +527,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
 
-    # TODO
-    # if: contains(github.event.head_commit.message, '[perf]')
+    if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
     - name: Trigger opensim-perf workflow
@@ -678,228 +675,228 @@ jobs:
     #     echo "4 | 44 | D" >> performance_results.md
  
 
-  # ubuntu20:
-  #   name: Ubuntu2004
+  ubuntu20:
+    name: Ubuntu2004
 
-  #   runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Install packages
-  #     run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
 
-  #   - name: Install SWIG
-  #     # if: steps.cache-swig.outputs.cache-hit != 'true'
-  #     run: |
-  #       mkdir ~/swig-source && cd ~/swig-source
-  #       wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-  #       tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-  #       sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-  #       make && make -j4 install
-  #   - name: Cache dependencies
-  #     id: cache-dependencies
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/opensim_dependencies_install
-  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-  #   - name: Build dependencies
-  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-  #     run: |
-  #       mkdir $GITHUB_WORKSPACE/../build_deps
-  #       cd $GITHUB_WORKSPACE/../build_deps
-  #       DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-  #       DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-  #       DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-  #       DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
-  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-  #       printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-  #       cmake "${DEP_CMAKE_ARGS[@]}"
-  #       make --jobs 4
+    - name: Build dependencies
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
 
-  #   - name: Configure opensim-core
-  #     id: configure
-  #     run: |
-  #       mkdir $GITHUB_WORKSPACE/../build
-  #       cd $GITHUB_WORKSPACE/../build
-  #       OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-  #       OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-  #       OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-  #       OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-  #       # TODO: Update to simbody.github.io/latest
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-  #       printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-  #       cmake "${OSIM_CMAKE_ARGS[@]}"
-  #       VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-  #       echo $VERSION
-  #       echo "VERSION=$VERSION" >> $GITHUB_ENV
-  #       echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-  #   - name: Build opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       make --jobs 4
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
 
-  #   - name: Test opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       # TODO: Temporary for python to find Simbody libraries.
-  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-  #       ctest --parallel 4 --output-on-failure
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        # TODO: Temporary for python to find Simbody libraries.
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+        ctest --parallel 4 --output-on-failure
 
-  #   - name: Install opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       make doxygen
-  #       make --jobs 4 install
-  #       cd $GITHUB_WORKSPACE
-  #       mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-  #       zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
-  #       mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make --jobs 4 install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
+        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
-  #   # - name: Test Python bindings
-  #   #   run: |
-  #   #     echo "TODO: Skipping Python tests."
-  #   #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-  #   #     # Run the python tests, verbosely.
-  #   #     # python3 -m unittest discover --start-directory opensim/tests --verbose
+    # - name: Test Python bindings
+    #   run: |
+    #     echo "TODO: Skipping Python tests."
+    #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+    #     # Run the python tests, verbosely.
+    #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
-  #   - name: Upload opensim-core
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       # The upload-artifact zipping does not preserve symlinks or executable
-  #       # bits. So we zip ourselves, even though this causes a double-zip.
-  #       name: opensim-core-${{ steps.configure.outputs.version }}-ub20-linux
-  #       path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v3
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
 
-  # ubuntu20-nomoco:
-  #   name: Ubuntu2004-nomoco
+  ubuntu20-nomoco:
+    name: Ubuntu2004-nomoco
 
-  #   runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Install packages
-  #     run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools patchelf
 
-  #   - name: Install SWIG
-  #     # if: steps.cache-swig.outputs.cache-hit != 'true'
-  #     run: |
-  #       mkdir ~/swig-source && cd ~/swig-source
-  #       wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-  #       tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-  #       sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-  #       make && make -j4 install
-  #   - name: Cache dependencies
-  #     id: cache-dependencies
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ~/opensim_dependencies_install
-  #       key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
 
-  #   - name: Build dependencies
-  #     # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-  #     run: |
-  #       mkdir $GITHUB_WORKSPACE/../build_deps
-  #       cd $GITHUB_WORKSPACE/../build_deps
-  #       DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-  #       DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-  #       DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-  #       DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
-  #       DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
-  #       printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-  #       cmake "${DEP_CMAKE_ARGS[@]}"
-  #       make --jobs 4
+    - name: Build dependencies
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=OFF)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=OFF)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
 
-  #   - name: Configure opensim-core
-  #     id: configure
-  #     run: |
-  #       mkdir $GITHUB_WORKSPACE/../build
-  #       cd $GITHUB_WORKSPACE/../build
-  #       OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-  #       OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-  #       OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-  #       OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=off)
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=off)
-  #       # TODO: Update to simbody.github.io/latest
-  #       OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-  #       OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-  #       printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-  #       cmake "${OSIM_CMAKE_ARGS[@]}"
-  #       VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-  #       echo $VERSION
-  #       echo "VERSION=$VERSION" >> $GITHUB_ENV
-  #       echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=off)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-  #   - name: Build opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       make --jobs 4
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
 
-  #   - name: Test opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       # TODO: Temporary for python to find Simbody libraries.
-  #       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-  #       # ctest --parallel 4 --output-on-failure
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        # TODO: Temporary for python to find Simbody libraries.
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+        # ctest --parallel 4 --output-on-failure
 
-  #   - name: Install opensim-core
-  #     run: |
-  #       cd $GITHUB_WORKSPACE/../build
-  #       make doxygen
-  #       make --jobs 4 install
-  #       cd $GITHUB_WORKSPACE
-  #       mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-  #       zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
-  #       mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make --jobs 4 install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ub20.zip opensim-core-${{ steps.configure.outputs.version }}
+        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
-  #   # - name: Test Python bindings
-  #   #   run: |
-  #   #     echo "TODO: Skipping Python tests."
-  #   #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-  #   #     # Run the python tests, verbosely.
-  #   #     # python3 -m unittest discover --start-directory opensim/tests --verbose
+    # - name: Test Python bindings
+    #   run: |
+    #     echo "TODO: Skipping Python tests."
+    #     # cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+    #     # Run the python tests, verbosely.
+    #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
-  #   - name: Upload opensim-core
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       # The upload-artifact zipping does not preserve symlinks or executable
-  #       # bits. So we zip ourselves, even though this causes a double-zip.
-  #       name: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco-linux
-  #       path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v3
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ steps.configure.outputs.version }}-ub20-nomoco-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ub20.zip
 
-  # style:
-  #   name: Style
+  style:
+    name: Style
 
-  #   runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - name: Check for tabs
-  #     # Ensure that there are no tabs in source code.
-  #     # GREP returns 0 (true) if there are any matches, and
-  #     # we don't want any matches. If there are matches,
-  #     # print a helpful message, and make the test fail by using "false".
-  #     # The GREP command here checks for any tab characters in the the files
-  #     # that match the specified pattern. GREP does not pick up explicit tabs
-  #     # (e.g., literally a \t in a source file).
-  #     run: if grep --line-num --recursive --exclude-dir="*dependencies*" --exclude-dir="*snopt*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi
+    - name: Check for tabs
+      # Ensure that there are no tabs in source code.
+      # GREP returns 0 (true) if there are any matches, and
+      # we don't want any matches. If there are matches,
+      # print a helpful message, and make the test fail by using "false".
+      # The GREP command here checks for any tab characters in the the files
+      # that match the specified pattern. GREP does not pick up explicit tabs
+      # (e.g., literally a \t in a source file).
+      run: if grep --line-num --recursive --exclude-dir="*dependencies*" --exclude-dir="*snopt*" --include={CMakeLists.txt,*.cpp,*.c,*.h} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -256,7 +256,7 @@ jobs:
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   mac_target:
-    name: Mac (target)
+    name: Mac [target]
 
     runs-on: macos-12
 
@@ -388,7 +388,7 @@ jobs:
 
     runs-on: macos-12
     
-    name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac (source)' || 'Mac' }}
+    name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -522,6 +522,7 @@ jobs:
         token: ${{ secrets.PERF_DISPATCH_PAT }}
         repo: opensim-perf
         owner: opensim-org
+        ref: main
         workflow: performance_analysis.yml
         workflow_inputs: '{"run_id": "${{ github.run_id }}",
               "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac",

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -256,7 +256,7 @@ jobs:
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   mac_target:
-    name: Mac-target
+    name: Mac (target)
 
     runs-on: macos-12
 
@@ -382,7 +382,7 @@ jobs:
         path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
 
   mac_source:
-    name: Mac-source
+    name: Mac (source)
 
     runs-on: macos-12
 
@@ -524,7 +524,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"run_id": "${{ github.run_id }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip"}'
+        workflow_inputs: '{"run_id": "${{ github.run_id }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0
@@ -533,8 +533,7 @@ jobs:
         repo: opensim-perf
         owner: opensim-org
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
-        run_timeout_seconds: 300 # Optional
-        poll_interval_ms: 5000 # Optional
+        run_timeout_seconds: 300 
 
     - name: Download performance analysis results
       id: download-artifact

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -408,7 +408,8 @@ jobs:
         if [[ "${{ github.event_name }}" == "push" ]]; then
           echo "Commit Message: ${{ github.event.commits[0].message }}"
         else
-          echo "Commit Message: ${{ github.event.pull_request.head_commit.message }}"
+          echo "Title: ${{ github.event.pull_request.title }}"
+          echo "Commit Message: ${{ github.event.pull_request.commits[0].message }}"
         fi
     
     - uses: actions/setup-python@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -402,6 +402,14 @@ jobs:
         fi
 
     - uses: actions/checkout@v3
+
+    - name: Debug Commit Message after checkout
+      run: |
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          echo "Commit Message: ${{ github.event.commits[0].message }}"
+        else
+          echo "Commit Message: ${{ github.event.pull_request.head_commit.message }}"
+        fi
     
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,7 +260,7 @@ jobs:
 
     runs-on: macos-12
 
-    if: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf]') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -387,30 +387,13 @@ jobs:
 
     runs-on: macos-12
     
-    name: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
+    name: ${{ contains(github.event.pull_request.title, '[perf]') && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
 
     steps:
-    - name: Debug Commit Message
-      run: |
-        if [[ "${{ github.event_name }}" == "push" ]]; then
-          echo "Commit Message: ${{ github.event.commits[0].message }}"
-        else
-          echo "Commit Message: ${{ github.event.pull_request.head_commit.message }}"
-        fi
-
     - uses: actions/checkout@v3
-
-    - name: Debug Commit Message after checkout
-      run: |
-        if [[ "${{ github.event_name }}" == "push" ]]; then
-          echo "Commit Message: ${{ github.event.commits[0].message }}"
-        else
-          echo "Title: ${{ github.event.pull_request.title }}"
-          echo "Commit Message: ${{ github.event.pull_request.commits[0].message }}"
-        fi
     
     - uses: actions/setup-python@v4
       with:
@@ -540,7 +523,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
 
-    if: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf]') }}
 
     steps:
     - name: Trigger opensim-perf workflow

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,6 +260,9 @@ jobs:
 
     runs-on: macos-12
 
+    # TODO
+    # if: contains(github.event.head_commit.message, '[perf]')
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -382,9 +385,15 @@ jobs:
         path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
 
   mac_source:
-    name: Mac (source)
 
     runs-on: macos-12
+
+    # TODO
+    # env:
+    #   JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, 'your_specific_string') ? ' (source)' : '' }}
+    # name: Mac${{ env.JOB_NAME_SUFFIX }}
+
+    name: Mac (source)
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -509,10 +518,16 @@ jobs:
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   perf_test:
+    name: Performance Analysis
+
     needs:
       - mac_target
       - mac_source
+
     runs-on: macos-12
+
+    # TODO
+    # if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
     - name: Trigger opensim-perf workflow
@@ -524,7 +539,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"run_id": "${{ github.run_id }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -538,8 +538,8 @@ jobs:
         echo $GITHUB_WORKSPACE
         cd $GITHUB_WORKSPACE
         ls
-        unzip $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11 -d $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11
-        cd $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11
+        unzip opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d opensim-core-${{ needs.mac_source.outputs.version }}-11
+        cd opensim-core-${{ needs.mac_source.outputs.version }}-11
         ls
 
     - name: Download target branch artifact
@@ -555,8 +555,8 @@ jobs:
         echo $GITHUB_WORKSPACE
         cd $GITHUB_WORKSPACE
         ls
-        unzip $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11 -d $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11
-        cd $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11
+        unzip opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d opensim-core-${{ github.event.pull_request.base.ref }}-11
+        cd opensim-core-${{ github.event.pull_request.base.ref }}-11
         ls
 
     - name: Run Examples and Compare Performance

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -391,7 +391,7 @@ jobs:
     env:
       JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, '[perf]') && ' (source)' || '' }}
     
-    name: Mac${{ env.JOB_NAME_SUFFIX }}
+    name: Mac$JOB_NAME_SUFFIX
 
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -573,7 +573,7 @@ jobs:
     - name: Post Results to PR Comment
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        EXISTING_COMMENT_CONTENT=$(gh api repos/:owner/:repo/issues/${PR_NUMBER} | jq -r '.body')
+        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/issues/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance Check Results"
         echo "DEBUG1"
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -264,6 +264,9 @@ jobs:
     # if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
+    - name: Print Commit SHA
+      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
+      
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.base.ref }} 
@@ -539,7 +542,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"commit_sha": "${{ github.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -404,7 +404,7 @@ jobs:
 
     - name: Testing commit message
       run: |
-        echo $commitmsg
+        echo ${{ github.event.commits[0].message }}
 
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -535,7 +535,7 @@ jobs:
       run: |
         mkdir unzipped
         unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/
-        cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
+        # cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
         ls
 
     - name: Download target branch artifact
@@ -547,12 +547,13 @@ jobs:
     - name: Unzip target branch artifact
       run: |
         unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/
-        cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
+        # cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
         ls
 
     - name: Run Examples and Compare Performance
       run: |
-        cd $GITHUB_WORKSPACE/osimperf
+        ls
+        cd osimperf
         osimperf --help
 
     - name: Extract Performance Results

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -403,7 +403,8 @@ jobs:
       run: |
         echo github.event.head_commit.message
         echo contains(github.event.head_commit.message, '[perf]')
-        echo $${{ contains(github.event.head_commit.message, '[perf]') }}
+        echo ${{ github.event.head_commit.message }}
+        echo ${{ contains(github.event.head_commit.message, '[perf]') }}
         
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -264,12 +264,12 @@ jobs:
     # if: contains(github.event.head_commit.message, '[perf]')
 
     steps:
-    - name: Print Commit SHA
-      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
-      
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.base.ref }} 
+
+    - name: Print Commit SHA
+      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
       
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -513,6 +513,8 @@ jobs:
       - mac_target
       - mac_source
     runs-on: macos-12
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
     - uses: actions/setup-python@v4
@@ -579,7 +581,7 @@ jobs:
           EXISTING_TABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/{flag=1; next} flag")
 
           # Replace the existing table content with new content
-          NEW_TABLE_CONTENT=$(cat new_performance_results.md)
+          NEW_TABLE_CONTENT=$(cat performance_results.md)
           NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${EXISTING_TABLE_CONTENT}"/${NEW_TABLE_CONTENT}}"
         else
           # If the custom header doesn't exist, just append the new content with the header
@@ -587,7 +589,7 @@ jobs:
 
           ${CUSTOM_HEADER}
 
-          $(cat new_performance_results.md)"
+          $(cat performance_results.md)"
         fi
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -398,6 +398,12 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
+
+    - name: Testing commit message
+      run: |
+        echo github.event.head_commit.message
+        echo contains(github.event.head_commit.message, '[perf]')
+        echo $${{ contains(github.event.head_commit.message, '[perf]') }}
         
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -545,7 +545,12 @@ jobs:
 
     - name: Unzip target branch artifact
       run: |
-        unzip $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11
+        ls
+        echo "GITHUB_WORKSPACE: "
+        echo $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        ls
+        unzip $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11 -d $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11
         cd $GITHUB_WORKSPACE/opensim-core-${{ github.event.pull_request.base.ref }}-11
         ls
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,7 +260,7 @@ jobs:
 
     runs-on: macos-12
 
-    if: ${{ contains(github.event.head_commit.message, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -387,7 +387,7 @@ jobs:
 
     runs-on: macos-12
     
-    name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
+    name: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -398,7 +398,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "push" ]]; then
           echo "Commit Message: ${{ github.event.commits[0].message }}"
         else
-          echo "Not a push event; commit information not available."
+          echo "Commit Message: ${{ github.event.pull_request.head_commit.message }}"
         fi
 
     - uses: actions/checkout@v3
@@ -406,10 +406,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
-
-    - name: Testing commit message
-      run: |
-        echo ${{ github.event.commits[0].message }}
 
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
@@ -535,7 +531,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
 
-    if: ${{ contains(github.event.head_commit.message, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.head_commit.message, '[perf]') }}
 
     steps:
     - name: Trigger opensim-perf workflow

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -402,7 +402,8 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Print Commit SHA
-      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
+      run: |
+        echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
     
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -113,7 +113,7 @@ jobs:
         python -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: opensim-core-${{ steps.configure.outputs.version }}-win-2019
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
@@ -250,7 +250,7 @@ jobs:
         python -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: opensim-core-${{ steps.configure.outputs.version }}-win
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
@@ -688,7 +688,7 @@ jobs:
     #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
@@ -793,7 +793,7 @@ jobs:
     #     # python3 -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Upload opensim-core
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -176,7 +176,7 @@ jobs:
       run: python3 -m pip install numpy==1.20.2
 
     - name: Install SWIG
-      run: | 
+      run: |
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 
@@ -258,7 +258,7 @@ jobs:
   mac_target:
     name: Mac [target]
 
-    runs-on: macos-12
+    runs-on: macos-14
 
     if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
@@ -385,7 +385,7 @@ jobs:
 
   mac_source:
 
-    runs-on: macos-12
+    runs-on: macos-14
     
     name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
 
@@ -557,7 +557,7 @@ jobs:
         path: results
         repo: opensim-org/opensim-perf
 
-    - name: Post Results to PR Comment
+    - name: Post results to pull request description
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
@@ -582,9 +582,6 @@ jobs:
         ${REVIEWABLE_BLOCK}
         "
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
-
-        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-        # echo ${COMMENT_ID}
 
         # Update the existing description
         gh api \

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -529,34 +529,26 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: opensim-core-${{ needs.mac_source.outputs.version }}-mac-11
-        path: opensim-core-${{ needs.mac_source.outputs.version }}-11.zip
+        path: artifacts
 
     - name: Unzip source branch artifact
       run: |
         ls
-        echo "GITHUB_WORKSPACE: "
-        echo $GITHUB_WORKSPACE
-        cd $GITHUB_WORKSPACE
-        ls
-        unzip opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d opensim-core-${{ needs.mac_source.outputs.version }}-11
-        cd opensim-core-${{ needs.mac_source.outputs.version }}-11
+        unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
+        cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}-11
         ls
 
     - name: Download target branch artifact
       uses: actions/download-artifact@v2
       with:
         name: opensim-core-${{ github.event.pull_request.base.ref }}-mac-11
-        path: opensim-core-${{ github.event.pull_request.base.ref }}-11.zip
+        path: artifacts
 
     - name: Unzip target branch artifact
       run: |
         ls
-        echo "GITHUB_WORKSPACE: "
-        echo $GITHUB_WORKSPACE
-        cd $GITHUB_WORKSPACE
-        ls
-        unzip opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d opensim-core-${{ github.event.pull_request.base.ref }}-11
-        cd opensim-core-${{ github.event.pull_request.base.ref }}-11
+        unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
+        cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}-11
         ls
 
     - name: Run Examples and Compare Performance

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -536,7 +536,7 @@ jobs:
       #       console.log(result)
 
       - name: Trigger opensim-perf workflow
-        uses: codex-/return-dispatch@v1
+        uses: Codex-/return-dispatch@v1.12.0
         id: return_dispatch
         with:
           token: ${{ secrets.PERF_DISPATCH_PAT }}
@@ -551,7 +551,7 @@ jobs:
               }'
 
       - name: Await opensim-perf workflow
-        uses: Codex-/await-remote-run@v1.0.0
+        uses: Codex-/await-remote-run@v1.11.0
         with:
           token: ${{ secrets.PERF_DISPATCH_PAT }}
           repo: opensim-perf
@@ -562,7 +562,7 @@ jobs:
 
       - name: Download performance analysis results
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v3.0.0
         with:
           github_token: ${{ secrets.PERF_DISPATCH_PAT }}
           run_id: ${{ steps.return_dispatch.outputs.run_id }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -260,13 +260,9 @@ jobs:
 
     runs-on: macos-12
 
-    if: contains(github.event.head_commit.message, '[perf]')
+    if: ${{ contains(github.event.head_commit.message, '[perf]') }}
 
     steps:
-    - name: Testing commit message
-      run: |
-        echo github.event.head_commit.message
-
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.base.ref }} 
@@ -527,7 +523,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
 
-    if: contains(github.event.head_commit.message, '[perf]')
+    if: ${{ contains(github.event.head_commit.message, '[perf]') }}
 
     steps:
     - name: Trigger opensim-perf workflow

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -575,6 +575,7 @@ jobs:
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api repos/:owner/:repo/issues/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance Check Results"
+        echo "DEBUG1"
 
         # Check if the custom header exists in the existing comment body
         if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
@@ -593,13 +594,14 @@ jobs:
           $(cat performance_results.md)"
         fi
 
-        echo "DEBUG"
+        echo "DEBUG2"
+        echo ${PR_NUMBER}
 
         gh api \
           --method POST \
           -H "Content-Type: application/json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/OWNER/REPO/issues/PR_NUMBER/comments \
+          /repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -395,7 +395,7 @@ jobs:
     steps:
     - name: Debug Commit Message
       run: |
-       echo "Commit Message: ${{ github.event.head_commit.message }}"
+       echo "Commit Message: ${{ github.event.commits[0].message }}"
       
     - uses: actions/checkout@v3
     

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -386,14 +386,14 @@ jobs:
   mac_source:
 
     runs-on: macos-12
-
-    env:
-      commitmsg: ${{ github.event.head_commit.message }}
     
     name: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
+
+    env:
+      commitmsg: ${{ github.event.head_commit.message }}
 
     steps:
     - uses: actions/checkout@v3
@@ -404,11 +404,8 @@ jobs:
 
     - name: Testing commit message
       run: |
-        # echo github.event.head_commit.message
-        # echo contains($commitmsg, '[perf]')
         echo $commitmsg
-        # echo ${{ contains($commitmsg, '[perf]') }}
-        
+
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -508,7 +508,7 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac-11
         path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
 
-  compare-macs:
+  perf_test:
     needs:
       - mac_target
       - mac_source
@@ -517,98 +517,111 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
+      - name: Trigger opensim-perf workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PERF_DISPATCH_PAT }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: 'opensim-org',
+              repo: 'opensim-perf',
+              workflow_id: 'performance_analysis.yml',
+              ref: 'main'
+            })
+            console.log(result)
 
-    - name: Checkout osimperf
-      uses: actions/checkout@v3
-      with:
-        repository: adamkewley/osimperf
-        ref: master
-        path: osimperf
+    # - uses: actions/setup-python@v4
+    #   with:
+    #     python-version: '3.8'
 
-    - name: Download source branch artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: opensim-core-${{ needs.mac_source.outputs.version }}-mac-11
-        path: artifacts
+    # - name: Checkout osimperf
+    #   uses: actions/checkout@v3
+    #   with:
+    #     repository: adamkewley/osimperf
+    #     ref: master
+    #     path: osimperf
 
-    - name: Unzip source branch artifact
-      run: |
-        mkdir unzipped
-        unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/
-        # cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
-        ls
+    # - name: Download source branch artifact
+    #   uses: actions/download-artifact@v2
+    #   with:
+    #     name: opensim-core-${{ needs.mac_source.outputs.version }}-mac-11
+    #     path: artifacts
 
-    - name: Download target branch artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: opensim-core-${{ github.event.pull_request.base.ref }}-mac-11
-        path: artifacts
+    # - name: Unzip source branch artifact
+    #   run: |
+    #     mkdir unzipped
+    #     unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/
+    #     # cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
+    #     ls
 
-    - name: Unzip target branch artifact
-      run: |
-        unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/
-        # cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
-        ls
+    # - name: Download target branch artifact
+    #   uses: actions/download-artifact@v2
+    #   with:
+    #     name: opensim-core-${{ github.event.pull_request.base.ref }}-mac-11
+    #     path: artifacts
 
-    - name: Run Examples and Compare Performance
-      run: |
-        lhs=unzipped/opensim-core-${{ github.event.pull_request.base.ref }}/bin/opensim-cmd
-        rhs=unzipped/opensim-core-${{ needs.mac_source.outputs.version }}/bin/opensim-cmd
-        python osimperf/osimperf compare-all --repeats 16 ${lhs} ${rhs}
+    # - name: Unzip target branch artifact
+    #   run: |
+    #     unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/
+    #     # cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
+    #     ls
 
-    - name: Extract Performance Results
-      run: |
-        # Replace this with your command to generate the markdown table
-        echo "Generating markdown table..."
-        # Your command to generate the markdown table here
-        # Store the markdown table in a file, e.g., performance_results.md
-        echo "Sample | Performance | Table" > performance_results.md
-        echo "--- | --- | ---" >> performance_results.md
-        echo "1 | 100 | A" >> performance_results.md
-        echo "2 | 90 | B" >> performance_results.md
-        echo "3 | 76 | C" >> performance_results.md
-        echo "4 | 44 | D" >> performance_results.md
+    # - name: Run Examples and Compare Performance
+    #   run: |
+    #     lhs=unzipped/opensim-core-${{ github.event.pull_request.base.ref }}/bin/opensim-cmd
+    #     rhs=unzipped/opensim-core-${{ needs.mac_source.outputs.version }}/bin/opensim-cmd
+    #     python osimperf/osimperf compare-all --repeats 16 ${lhs} ${rhs}
 
-    - name: Post Results to PR Comment
-      run: |
-        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis"
+    # - name: Extract Performance Results
+    #   run: |
+    #     # Replace this with your command to generate the markdown table
+    #     echo "Generating markdown table..."
+    #     # Your command to generate the markdown table here
+    #     # Store the markdown table in a file, e.g., performance_results.md
+    #     echo "Sample | Performance | Table" > performance_results.md
+    #     echo "--- | --- | ---" >> performance_results.md
+    #     echo "1 | 100 | A" >> performance_results.md
+    #     echo "2 | 90 | B" >> performance_results.md
+    #     echo "3 | 76 | C" >> performance_results.md
+    #     echo "4 | 44 | D" >> performance_results.md
 
-        REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        REVIEWABLE_BLOCK=""
-        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-        fi
+    # - name: Post Results to PR Comment
+    #   run: |
+    #     PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+    #     EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
+    #     CUSTOM_HEADER="### Performance analysis"
 
-        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-        else
-          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
-        fi
+    #     REVIEWABLE_TAG="<!-- Reviewable:start -->"
+    #     REVIEWABLE_BLOCK=""
+    #     if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+    #       REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+    #     fi
 
-        NEW_CONTENT="${CUSTOM_HEADER}
+    #     if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+    #       CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+    #     else
+    #       CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+    #     fi
 
-        $(cat performance_results.md)
+    #     NEW_CONTENT="${CUSTOM_HEADER}
 
-        ${REVIEWABLE_BLOCK}
-        "
-        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+    #     $(cat performance_results.md)
 
-        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-        # echo ${COMMENT_ID}
+    #     ${REVIEWABLE_BLOCK}
+    #     "
+    #     NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
-        # Update the existing description
-        gh api \
-          --method PATCH \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
-          -f "body=${NEW_COMMENT_BODY}"
+    #     # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+    #     # echo ${COMMENT_ID}
+
+    #     # Update the existing description
+    #     gh api \
+    #       --method PATCH \
+    #       -H "Content-Type: application/json" \
+    #       -H "Accept: application/vnd.github.v3+json" \
+    #       -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+    #       repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+    #       -f "body=${NEW_COMMENT_BODY}"
  
 
   ubuntu20:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -389,9 +389,9 @@ jobs:
     runs-on: macos-12
 
     env:
-      JOB_NAME_SUFFIX: ${{ contains(github.event.head_commit.message, '[perf]') && ' (source)' || '' }}
+      JOB_NAME: ${{ contains(github.event.head_commit.message, '[perf]') && 'Mac (source)' || 'Mac' }}
     
-    name: Mac$JOB_NAME_SUFFIX
+    name: ${{ env.JOB_NAME }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -515,100 +515,99 @@ jobs:
     runs-on: macos-12
 
     steps:
-      # - name: Trigger opensim-perf workflow
-      #   uses: actions/github-script@v6
-      #   with:
-      #     github-token: ${{ secrets.PERF_DISPATCH_PAT }}
-      #     script: |
-      #       const result = await github.rest.actions.createWorkflowDispatch({
-      #         owner: 'opensim-org',
-      #         repo: 'opensim-perf',
-      #         workflow_id: 'performance_analysis.yml',
-      #         ref: 'main',
-      #         inputs: {
-      #           run_id: '${{ github.run_id }}',
-      #           target_artifact_name: 'opensim-core-${{ github.event.pull_request.base.ref }}-mac',
-      #           source_artifact_name: 'opensim-core-${{ steps.configure.outputs.version }}-mac',
-      #           target_artifact_zip: 'opensim-core-${{ github.event.pull_request.base.ref }}.zip',
-      #           source_artifact_zip: 'opensim-core-${{ steps.configure.outputs.version }}.zip',
-      #         }
-      #       })
-      #       console.log(result)
+    - name: Trigger opensim-perf workflow
+      uses: Codex-/return-dispatch@v1.12.0
+      id: return_dispatch
+      with:
+        token: ${{ secrets.PERF_DISPATCH_PAT }}
+        repo: opensim-perf
+        owner: opensim-org
+        workflow: performance_analysis.yml
+        workflow_inputs: '{"run_id": "${{ github.run_id }}",
+              "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac",
+              "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac",
+              "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip",
+              "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip",
+            }'
 
-      - name: Trigger opensim-perf workflow
-        uses: Codex-/return-dispatch@v1.12.0
-        id: return_dispatch
-        with:
-          token: ${{ secrets.PERF_DISPATCH_PAT }}
-          repo: opensim-perf
-          owner: opensim-org
-          workflow: performance_analysis.yml
-          workflow_inputs: '{"run_id": "${{ github.run_id }}",
-                "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac",
-                "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac",
-                "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip",
-                "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip",
-              }'
+    - name: Await opensim-perf workflow
+      uses: Codex-/await-remote-run@v1.11.0
+      with:
+        token: ${{ secrets.PERF_DISPATCH_PAT }}
+        repo: opensim-perf
+        owner: opensim-org
+        run_id: ${{ steps.return_dispatch.outputs.run_id }}
+        run_timeout_seconds: 300 # Optional
+        poll_interval_ms: 5000 # Optional
 
-      - name: Await opensim-perf workflow
-        uses: Codex-/await-remote-run@v1.11.0
-        with:
-          token: ${{ secrets.PERF_DISPATCH_PAT }}
-          repo: opensim-perf
-          owner: opensim-org
-          run_id: ${{ steps.return_dispatch.outputs.run_id }}
-          run_timeout_seconds: 300 # Optional
-          poll_interval_ms: 5000 # Optional
+    - name: Download performance analysis results
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v3.0.0
+      with:
+        github_token: ${{ secrets.PERF_DISPATCH_PAT }}
+        run_id: ${{ steps.return_dispatch.outputs.run_id }}
+        name: performance-results
+        path: results
+        repo: opensim-org/opensim-perf
 
-      - name: Download performance analysis results
-        id: download-artifact
-        uses: dawidd6/action-download-artifact@v3.0.0
-        with:
-          github_token: ${{ secrets.PERF_DISPATCH_PAT }}
-          run_id: ${{ steps.return_dispatch.outputs.run_id }}
-          name: performance-results
-          path: results
-          repo: opensim-org/opensim-perf
+    - name: Post Results to PR Comment
+      run: |
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
+        CUSTOM_HEADER="### Performance analysis"
 
-      - name: Post Results to PR Comment
-        run: |
-          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-          CUSTOM_HEADER="### Performance analysis"
+        REVIEWABLE_TAG="<!-- Reviewable:start -->"
+        REVIEWABLE_BLOCK=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+        fi
 
-          REVIEWABLE_TAG="<!-- Reviewable:start -->"
-          REVIEWABLE_BLOCK=""
-          if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-            REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-          fi
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        else
+          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+        fi
 
-          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-          else
-            CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
-          fi
+        NEW_CONTENT="${CUSTOM_HEADER}
 
-          NEW_CONTENT="${CUSTOM_HEADER}
+        $(cat results/performance_results.md)
 
-          $(cat results/performance_results.md)
+        ${REVIEWABLE_BLOCK}
+        "
+        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
-          ${REVIEWABLE_BLOCK}
-          "
-          NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+        # echo ${COMMENT_ID}
 
-          # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-          # echo ${COMMENT_ID}
-
-          # Update the existing description
-          gh api \
-            --method PATCH \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
-            -f "body=${NEW_COMMENT_BODY}"
+        # Update the existing description
+        gh api \
+          --method PATCH \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+          -f "body=${NEW_COMMENT_BODY}"
 
 
+    # - name: Trigger opensim-perf workflow
+    #   uses: actions/github-script@v6
+    #   with:
+    #     github-token: ${{ secrets.PERF_DISPATCH_PAT }}
+    #     script: |
+    #       const result = await github.rest.actions.createWorkflowDispatch({
+    #         owner: 'opensim-org',
+    #         repo: 'opensim-perf',
+    #         workflow_id: 'performance_analysis.yml',
+    #         ref: 'main',
+    #         inputs: {
+    #           run_id: '${{ github.run_id }}',
+    #           target_artifact_name: 'opensim-core-${{ github.event.pull_request.base.ref }}-mac',
+    #           source_artifact_name: 'opensim-core-${{ steps.configure.outputs.version }}-mac',
+    #           target_artifact_zip: 'opensim-core-${{ github.event.pull_request.base.ref }}.zip',
+    #           source_artifact_zip: 'opensim-core-${{ steps.configure.outputs.version }}.zip',
+    #         }
+    #       })
+    #       console.log(result)
     # - uses: actions/setup-python@v4
     #   with:
     #     python-version: '3.8'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -533,7 +533,12 @@ jobs:
 
     - name: Unzip source branch artifact
       run: |
-        unzip $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11
+        ls
+        echo "GITHUB_WORKSPACE: "
+        echo $GITHUB_WORKSPACE
+        cd $GITHUB_WORKSPACE
+        ls
+        unzip $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11 -d $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11
         cd $GITHUB_WORKSPACE/opensim-core-${{ needs.mac_source.outputs.version }}-11
         ls
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -605,7 +605,7 @@ jobs:
           -H "Content-Type: application/json" \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "/repos/opensim-org/opensim-core/pulls/${PR_NUMBER}" \
+          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -364,7 +364,7 @@ jobs:
         make install
         cd $GITHUB_WORKSPACE
         mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ github.event.pull_request.base.ref }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}-11.zip opensim-core-${{ github.event.pull_request.base.ref }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}.zip opensim-core-${{ github.event.pull_request.base.ref }}
         mv opensim-core-${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE/../opensim-core-install
 
     - name: Test Python bindings
@@ -378,8 +378,8 @@ jobs:
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ github.event.pull_request.base.ref }}-mac-11
-        path: opensim-core-${{ github.event.pull_request.base.ref }}-11.zip
+        name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
+        path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
 
   mac_source:
     name: Mac-source
@@ -491,7 +491,7 @@ jobs:
         make install
         cd $GITHUB_WORKSPACE
         mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-11.zip opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}.zip opensim-core-${{ steps.configure.outputs.version }}
         mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
     - name: Test Python bindings
@@ -505,30 +505,70 @@ jobs:
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-mac-11
-        path: opensim-core-${{ steps.configure.outputs.version }}-11.zip
+        name: opensim-core-${{ steps.configure.outputs.version }}-mac
+        path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
   perf_test:
     needs:
       - mac_target
       - mac_source
     runs-on: macos-12
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      # - name: Trigger opensim-perf workflow
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ secrets.PERF_DISPATCH_PAT }}
+      #     script: |
+      #       const result = await github.rest.actions.createWorkflowDispatch({
+      #         owner: 'opensim-org',
+      #         repo: 'opensim-perf',
+      #         workflow_id: 'performance_analysis.yml',
+      #         ref: 'main',
+      #         inputs: {
+      #           run_id: '${{ github.run_id }}',
+      #           target_artifact_name: 'opensim-core-${{ github.event.pull_request.base.ref }}-mac',
+      #           source_artifact_name: 'opensim-core-${{ steps.configure.outputs.version }}-mac',
+      #           target_artifact_zip: 'opensim-core-${{ github.event.pull_request.base.ref }}.zip',
+      #           source_artifact_zip: 'opensim-core-${{ steps.configure.outputs.version }}.zip',
+      #         }
+      #       })
+      #       console.log(result)
+
       - name: Trigger opensim-perf workflow
-        uses: actions/github-script@v6
+        uses: codex-/return-dispatch@v1
+        id: return_dispatch
         with:
-          github-token: ${{ secrets.PERF_DISPATCH_PAT }}
-          script: |
-            const result = await github.rest.actions.createWorkflowDispatch({
-              owner: 'opensim-org',
-              repo: 'opensim-perf',
-              workflow_id: 'performance_analysis.yml',
-              ref: 'main'
-            })
-            console.log(result)
+          token: ${{ secrets.PERF_DISPATCH_PAT }}
+          repo: opensim-perf
+          owner: opensim-org
+          workflow: performance_analysis.yml
+          workflow_inputs: '{"run_id": "${{ github.run_id }}",
+                "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac",
+                "source_artifact_name": "opensim-core-${{ steps.configure.outputs.version }}-mac",
+                "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip",
+                "source_artifact_zip": "opensim-core-${{ steps.configure.outputs.version }}.zip",
+              }'
+
+      - name: Await opensim-perf workflow
+        uses: Codex-/await-remote-run@v1.0.0
+        with:
+          token: ${{ secrets.PERF_DISPATCH_PAT }}
+          repo: opensim-perf
+          owner: opensim-org
+          run_id: ${{ steps.return_dispatch.outputs.run_id }}
+          run_timeout_seconds: 300 # Optional
+          poll_interval_ms: 5000 # Optional
+
+      - name: Download performance analysis results
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          github_token: ${{ secrets.PERF_DISPATCH_PAT }}
+          run_id: ${{ steps.return_dispatch.outputs.run_id }}
+          name: performance-results
+          path: results
+          repo: opensim-org/opensim-perf
 
     # - uses: actions/setup-python@v4
     #   with:
@@ -544,25 +584,25 @@ jobs:
     # - name: Download source branch artifact
     #   uses: actions/download-artifact@v2
     #   with:
-    #     name: opensim-core-${{ needs.mac_source.outputs.version }}-mac-11
+    #     name: opensim-core-${{ needs.mac_source.outputs.version }}-mac
     #     path: artifacts
 
     # - name: Unzip source branch artifact
     #   run: |
     #     mkdir unzipped
-    #     unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}-11.zip -d unzipped/
+    #     unzip artifacts/opensim-core-${{ needs.mac_source.outputs.version }}.zip -d unzipped/
     #     # cd unzipped/opensim-core-${{ needs.mac_source.outputs.version }}
     #     ls
 
     # - name: Download target branch artifact
     #   uses: actions/download-artifact@v2
     #   with:
-    #     name: opensim-core-${{ github.event.pull_request.base.ref }}-mac-11
+    #     name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
     #     path: artifacts
 
     # - name: Unzip target branch artifact
     #   run: |
-    #     unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}-11.zip -d unzipped/
+    #     unzip artifacts/opensim-core-${{ github.event.pull_request.base.ref }}.zip -d unzipped/
     #     # cd unzipped/opensim-core-${{ github.event.pull_request.base.ref }}
     #     ls
 
@@ -585,43 +625,43 @@ jobs:
     #     echo "3 | 76 | C" >> performance_results.md
     #     echo "4 | 44 | D" >> performance_results.md
 
-    # - name: Post Results to PR Comment
-    #   run: |
-    #     PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-    #     EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-    #     CUSTOM_HEADER="### Performance analysis"
+    - name: Post Results to PR Comment
+      run: |
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
+        CUSTOM_HEADER="### Performance analysis"
 
-    #     REVIEWABLE_TAG="<!-- Reviewable:start -->"
-    #     REVIEWABLE_BLOCK=""
-    #     if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-    #       REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-    #     fi
+        REVIEWABLE_TAG="<!-- Reviewable:start -->"
+        REVIEWABLE_BLOCK=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+        fi
 
-    #     if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-    #       CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-    #     else
-    #       CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
-    #     fi
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        else
+          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+        fi
 
-    #     NEW_CONTENT="${CUSTOM_HEADER}
+        NEW_CONTENT="${CUSTOM_HEADER}
 
-    #     $(cat performance_results.md)
+        $(cat results/performance_results.md)
 
-    #     ${REVIEWABLE_BLOCK}
-    #     "
-    #     NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+        ${REVIEWABLE_BLOCK}
+        "
+        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
-    #     # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
-    #     # echo ${COMMENT_ID}
+        # COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+        # echo ${COMMENT_ID}
 
-    #     # Update the existing description
-    #     gh api \
-    #       --method PATCH \
-    #       -H "Content-Type: application/json" \
-    #       -H "Accept: application/vnd.github.v3+json" \
-    #       -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-    #       repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
-    #       -f "body=${NEW_COMMENT_BODY}"
+        # Update the existing description
+        gh api \
+          --method PATCH \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+          -f "body=${NEW_COMMENT_BODY}"
  
 
   ubuntu20:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -597,13 +597,14 @@ jobs:
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
         COMMENT_ID=$(gh api repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments | jq -r '.[0].id')
+        echo ${COMMENT_ID}
 
         # Update the existing top-level comment
         gh api \
           --method PATCH \
           -H "Content-Type: application/json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments/${COMMENT_ID} \
+          repos/opensim-org/opensim-core/issues/${PR_NUMBER}/comments/${COMMENT_ID} \
           -f "body=${NEW_COMMENT_BODY}"
  
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -268,9 +268,6 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.base.ref }} 
 
-    - name: Print Commit SHA
-      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
-      
     - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
@@ -403,6 +400,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Print Commit SHA
+      run: echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
     
     - uses: actions/setup-python@v4
       with:

--- a/Bindings/Python/tests/test_DataAdapter.py
+++ b/Bindings/Python/tests/test_DataAdapter.py
@@ -107,6 +107,3 @@ class TestDataAdapter(unittest.TestCase):
         # Clean up.
         os.remove(markersFilename)
         os.remove(forcesFilename)
-
-    def test_ThisTestExists(self):
-        print("I test, therefore I am.")


### PR DESCRIPTION
### Summary of changes

This change adds automated performance testing for pull requests to our GitHub Actions CI workflow. The performance testing compares the target branch (usually `main`) to the PR source branch and posts a markdown table containing a summary of the performance testing results to the PR description body (see below for example). The performance testing can be triggered by including the string '[perf]' anywhere in the PR title or description body  (**not** the commit message, the testing will be triggered for all commits pushed to the PR branch).

The automated testing relies on the new private repository with in [opensim-org/opensim-perf](https://github.com/opensim-org/opensim-perf), which is essentially a fork of the excellent [adamkewley/osimperf](https://github.com/adamkewley/osimperf). This new private repo allows to use self-hosted runners securely, since forks of public repos can modify workflow scripts to do very malicious things on our local machines (e.g., cryptomine Dogecoin).

Workflows in this repo will trigger a workflow called `performance_analysis.yml` in opensim-perf via the GitHub action [Codex-/return-dispatch@v1.12.0](https://github.com/marketplace/actions/return-dispatch). The sister action [Codex-/await-remote-run@v1.11.0](https://github.com/marketplace/actions/await-remote-run) lets us wait for the workflow on opensim-perf to finish before continuing.  The third new action [dawidd6/action-download-artifact@v3.0.0](https://github.com/marketplace/actions/download-workflow-artifact) allows us to download artifacts across repositories; these "handoffs" require the new personal access token `PERF_DISPATCH_PAT` which I've created and added as a secret variable to opensim-org. 

I've also upgraded `actions/upload-artifact` to version 4 (i.e., `actions/upload-artifact@v4`), which now will upload artifacts for individual jobs immediately when they are available. We no longer have to wait for the full CI workflow to finish before the uploads occurs, which means that artifacts for jobs that passed will now be available even if other jobs fail. 

One minor downside of this change is for PRs where performance testing is skipped, the new job `Mac [target]` will still show up as "skipped". This is a limitation of the GitHub Actions UI for now.

The end-to-end workflow looks something like this:
1. A pull request (with [perf] somewhere in the title or body) triggers `continuous_integration.yml`.
2. The CI builds both `Mac [target]` and `Mac [source]` and uploads the artifacts.
3. The new job `performance_analysis`, which depends on the two Mac builds, triggers the workflow `performance_analysis.yml` on opensim-perf. It passes the commit hash and artifact names so the opensim-perf workflow knows where and what to download.
4. The job `performance_analysis` now waits for opensim-perf to finish its workflow.
5. opensim-perf downloads the two artifacts, unzips them, runs the performance testing suite, and uploads an artifact containing the results in the markdown table `performance_results.md`.
6. The opensim-core workflow resumes, downloads the table, and posts it to the PR description body (or overwrites the current table if it exists).

### Testing I've completed

All of it.

### Looking for feedback on...

1. Any security vulnerabilities I might have missed?
2. Stability concerns about the custom actions from the GitHub Actions marketplace? They seem pretty stable, well-used, and well-documented, but the workflow wholly depends on them currently. 

### CHANGELOG.md (choose one)

- no need to update because...I'll update CONTRIBUTING.md instead.

### Performance analysis

|                  Test Name | lhs [secs] | σ [secs] | rhs [secs] | σ [secs] | Speedup |
| -------------------------- | ---------- | -------- | ---------- | -------- | ------- |
|                      Arm26 |       0.33 |     0.00 |       0.34 |     0.00 |    0.97 |
| passive_dynamic_noanalysis |       3.42 |     0.10 |       3.31 |     0.15 |    1.03 |
|             ToyDropLanding |       0.13 |     0.00 |       0.13 |     0.00 |    0.99 |
|                   Gait2354 |       0.34 |     0.00 |       0.34 |     0.00 |    1.00 |
|            passive_dynamic |       4.13 |     0.00 |       4.14 |     0.01 |    1.00 |
|   ToyDropLanding_nomuscles |       0.12 |     0.00 |       0.12 |     0.00 |    1.00 |
|             RajagopalModel |       6.26 |     0.00 |       6.34 |     0.01 |    0.99 |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3686)
<!-- Reviewable:end -->
