### PR TITLE
Fix getConnectee throwing if called during finalizeConnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ new `getConnectee` overloads that take an index to a desired object in the list 
   querying a component's outputs by name (#3673)
 - The XMLDocument that is held within OpenSim::Object is now reference-counted, to help ensure
   it is freed (e.g. when an exception is thrown)
+- Calling `getConnectee` no longer strongly requires that `finalizeConnection` has been called on the socket. The
+  implementation will now fall back to the (slower) method of following the socket's connectee path property. This
+  is useful if (e.g.) following sockets *during* a call to `Component::finalizeConnections`
 
 v4.5
 ====

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -3486,6 +3486,24 @@ const C& Socket<C>::getConnectee(int index) const {
 }
 
 template<class C>
+const C& Socket<C>::getConnecteeInternal(int index) const {
+    if (0 <= index && index < static_cast<int>(_connectees.size()) && _connectees[index]) {
+        // fast case: use the cached connectee pointer
+        //
+        // it's usually cached via a direct call to `connect`, or through
+        // a call to `finalizeConnection`
+        return *_connectees[index];
+    }
+
+    // else: slow case: use the connectee path property to perform the lookup
+    //
+    // this is slower, but runtime-validated. It's necessary when (e.g.) a
+    // component wants to use sockets during an `extendFinalizeConnections`
+    // override (i.e. midway through recursively caching `_connectees`)
+    return getOwner().template getComponent<C>(getConnecteePath(index));
+}
+
+template<class C>
 void Socket<C>::findAndConnect(const ComponentPath& connectee) {
     const auto* comp =
             getOwner().getRoot().template findComponent<C>(connectee);

--- a/OpenSim/Common/ComponentSocket.h
+++ b/OpenSim/Common/ComponentSocket.h
@@ -480,22 +480,7 @@ private:
         return _connectees[index].getRef();
     }
 
-    const T& getConnecteeInternal(int index) const {
-        if (0 <= index && index < _connectees.size() && _connectees[index]) {
-            // fast case: use the cached connectee pointer
-            //
-            // it's usually cached via a direct call to `connect`, or through
-            // a call to `finalizeConnection`
-            return *_connectees[index];
-        }
-
-        // else: slow case: use the connectee path property to perform the lookup
-        //
-        // this is slower, but runtime-validated. It's necessary when (e.g.) a
-        // component wants to use sockets during an `extendFinalizeConnections`
-        // override (i.e. midway through recursively calling `finalizeConnection`)
-        return getOwner().getComponent<T>(getConnecteePath(index));
-    }
+    const T& getConnecteeInternal(int index) const;
 
     void connectInternal(const T& objT) {
         if (!isListSocket()) {

--- a/OpenSim/Common/Test/testComponentInterface.cpp
+++ b/OpenSim/Common/Test/testComponentInterface.cpp
@@ -686,11 +686,17 @@ TEST_CASE("Component Interface Misc.")
     TheWorld *world2 = new TheWorld(modelFile, true);
 
     world2->updComponent("Bar").getSocket<Foo>("childFoo");
-    // We haven't called connect yet, so this connection isn't made yet.
-    SimTK_TEST_MUST_THROW_EXC(
-            world2->updComponent("Bar").getConnectee<Foo>("childFoo"),
-            OpenSim::Exception
-             );
+
+    // in older versions of OpenSim, calling `getConnectee` on a socket
+    // that hasn't been `connect`ed or `finalizeConnection`ed yet was
+    // an exception.
+    //
+    // newer versions fall back to a (slower) runtime lookup of the connectee
+    // using the connectee's component path
+    // SimTK_TEST_MUST_THROW_EXC(
+    //     world2->updComponent("Bar").getConnectee<Foo>("childFoo"),
+    //     OpenSim::Exception
+    // );
 
     ASSERT(theWorld == *world2, __FILE__, __LINE__,
         "Model serialization->deserialization FAILED");


### PR DESCRIPTION
Fixes an issue I'm having with `SocketDefinedFrame`s implementation (upcoming PR).

Effectively, the bug is that:

- After adding something to a model programmatically, you _must_ call `finalizeConnections` in order to ensure that the socket pointers are baked into the socket's `componentPath` property
- Several use-cases in [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator) (e.g. undo/redo) call for copying the model, which wipes those pointers
- This is *usually* fine, because I typically re-call `finalizeConnections` on those copies
- However, `finalizeConnections` has very specific semantics that don't work once you have components in the model graph (e.g. custom frames) that depend on components that aren't in the model graph (e.g. `Station`s):
  - It finalizes the `Model`'s socket connections (non-recursive)
  - Then it creates+traverses a multi-body graph
  - For each frame in the graph, it calls `frame.finalizeConnections(model)`
  - Which finalizes the frame's sockets, and the frame's children's sockets
  - However, it doesn't finalize the sockets of anything the frame is connected to (i.e. the socket finalization performed during multibody graph building only satisfies the data _hierarchy_, not the socket graph)

So, in the edge-case that you:

- Have a custom component that will participate in the model graph (e.g. `StationDefinedFrame`)
- And that component depends on stuff via `SOCKET`s (e.g. `Station`s somewhere else in the hierarchy)
- And calling `finalizeConnections` on the component requires pulling information from those dependencies via those sockets (e.g. calling `finalizeConnections` on a `StationDefinedFrame` may want to query the `Station`s for body-fixed positions, base frame, etc.)
- Then it'll fail

The solution is PRed, and it effectively relaxes sockets such that they work fine even if you don't call `finalizeConnection` on them. This effectively downgrades `finalizeConnection` from "hard requirement for using a socket" to "performance-enhancing requirement".

### Brief summary of changes

- Make `Socket::getConnectee` work, even if `finalizeConnection` hasn't been called on it yet

### Testing I've completed

- The OpenSim test suite
- Which had a failure because one test expects sockets to fail if used before `finalizeConnection`. This test was commented out because that isn't a strictly required behavior (it's a desirable one, for perf reasons, but it isn't a hard requirement)

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3687)
<!-- Reviewable:end -->
