### PR TITLE
Refactor testComponents.cpp to use Catch and logging interface

### DIFF
--- a/OpenSim/Tests/Components/CMakeLists.txt
+++ b/OpenSim/Tests/Components/CMakeLists.txt
@@ -1,7 +1,9 @@
+find_package(Catch2 REQUIRED HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
+
 file(GLOB TEST_PROGS "test*.cpp")
 OpenSimCopySharedTestFiles(gait10dof18musc_subject01.osim)
 
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_PROGS}
-    LINKLIBS osimTools
+    LINKLIBS osimTools Catch2::Catch2WithMain
     )

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -154,11 +154,11 @@ void testComponentEquivalence(
 
     int nin_a = a.getNumInputs();
     int nin_b = b.getNumInputs();
-    log_info("{} getNumInputs: {}: a == {}, b == {}", className, nin_a, nin_b);
+    log_info("{} getNumInputs: a == {}, b == {}", className, nin_a, nin_b);
 
     int nout_a = a.getNumOutputs();
     int nout_b = b.getNumOutputs();
-    log_info("{} getNumOutputs: {}: a == {}, b == {}", className, nout_a, nout_b);
+    log_info("{} getNumOutputs: a == {}, b == {}", className, nout_a, nout_b);
 
     CHECK((a == b && "components must have same properties"));
     CHECK((ns_a == ns_b && "components must have same number of sockets"));
@@ -250,9 +250,11 @@ void testComponentInAggregate(std::unique_ptr<Component> p)
 
     // ensure Sockets are satisfied
     Component* sub = &instance;
-    auto comps = instance.updComponentList<Component>();
-    auto itc = comps.begin();
+    auto components = instance.updComponentList<Component>();
+    auto componentsCur = components.begin();
+    auto componentsEnd = components.end();
     while (sub) {
+        log_info("Traversing to {}", sub->getConcreteClassName());
         for (const auto& socketName : sub->getSocketNames()) {
             AbstractSocket& socket = sub->updSocket(socketName);
             std::string dependencyTypeName = socket.getConnecteeTypeName();
@@ -303,10 +305,16 @@ void testComponentInAggregate(std::unique_ptr<Component> p)
             }
         }
 
-        Component& next = *itc;
-        //Now keep checking the subcomponents
-        sub = &next;
-        itc++;
+        log_info("Traversed {}", sub->getConcreteClassName());
+
+        // keep checking the remaining subcomponents
+        if (componentsCur != componentsEnd) {
+            Component& next = *componentsCur;
+            sub = &next;
+            ++componentsCur;
+        } else {
+            sub = nullptr;
+        }
     }
 
     // Now make sure Inputs are satisfied.

--- a/OpenSim/Tests/Components/testComponents.cpp
+++ b/OpenSim/Tests/Components/testComponents.cpp
@@ -21,195 +21,241 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <stdint.h>
+
 #include <OpenSim/OpenSim.h>
+#include <OpenSim/Common/Logger.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Auxiliary/getRSS.h>
 
+#include <catch2/catch_all.hpp>
+
+#include <cstdint>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
 using namespace OpenSim;
-using namespace std;
 
-static Model dummyModel;
-const double acceptableMemoryLeakPercent = 1.0;
-const bool reportAllMemoryLeaks = true;
+namespace {
 
-void testComponent(const Component& instanceToTest);
-void testCloning(Component* instance);
-void testSerialization(Component* instance);
+    // helper: adds `instance` to the model in the appropriate collection (`Body` goes
+    // into `BodySet`, etc.)
+    void addObjectAsComponentToModel(
+        std::unique_ptr<Object> instance,
+        Model& model)
+    {
+        const std::string& className = instance->getConcreteClassName();
+        log_info("Adding {} to the model.", className);
 
-void addObjectAsComponentToModel(Object* instance, Model& model);
-
-// This component, used solely for testing, is used to satisfy the Inputs of
-// the components we test.
-class OutputGenerator : public Component {
-OpenSim_DECLARE_CONCRETE_OBJECT(OutputGenerator, Component);
-public:
-    OpenSim_DECLARE_OUTPUT(outdouble, double, calcDouble, SimTK::Stage::Model);
-    OpenSim_DECLARE_OUTPUT(outvec3, SimTK::Vec3, calcVec3, SimTK::Stage::Model);
-    OpenSim_DECLARE_OUTPUT(outxform, SimTK::Transform, calcXform, SimTK::Stage::Model);
-    double calcDouble(const SimTK::State&) const {return 0.0;}
-    SimTK::Vec3 calcVec3(const SimTK::State&) const {return SimTK::Vec3(0);}
-    SimTK::Transform calcXform(const SimTK::State&) const
-    {return SimTK::Transform(SimTK::Vec3(0));}
-};
-
-int main()
-{
-    Object::registerType(OutputGenerator());
-
-    SimTK::Array_<std::string> failures;
-
-    // get all registered Components
-    SimTK::Array_<Component*> availableComponents;
-
-    // starting with type Frame
-    ArrayPtrs<Frame> availableFrames;
-    Object::getRegisteredObjectsOfGivenType(availableFrames);
-    for (int i = 0; i < availableFrames.size(); ++i) {
-        availableComponents.push_back(availableFrames[i]);
-    }
-
-    // next with type Geometry
-    ArrayPtrs<Geometry> availableGeometry;
-    Object::getRegisteredObjectsOfGivenType(availableGeometry);
-    for (int i = 0; i < availableGeometry.size(); ++i) {
-        availableComponents.push_back(availableGeometry[i]);
-    }
-
-    // next with type Point
-    ArrayPtrs<Point> availablePoints;
-    Object::getRegisteredObjectsOfGivenType(availablePoints);
-    for (int i = 0; i < availablePoints.size(); ++i) {
-        availableComponents.push_back(availablePoints[i]);
-    }
-
-    // then type Joint
-    ArrayPtrs<Joint> availableJoints;
-    Object::getRegisteredObjectsOfGivenType(availableJoints);
-    for (int i = 0; i < availableJoints.size(); ++i) {
-        availableComponents.push_back(availableJoints[i]);
-    }
-
-    // then type TwoFrameLinker<Constraint>
-    ArrayPtrs<TwoFrameLinker<Constraint, PhysicalFrame> > availableLink2Constraints;
-    Object::getRegisteredObjectsOfGivenType(availableLink2Constraints);
-    for (int i = 0; i < availableLink2Constraints.size(); ++i) {
-        availableComponents.push_back(availableLink2Constraints[i]);
-    }
-
-    // then type TwoFrameLinker<Force> which are all the BushingForces
-    ArrayPtrs<TwoFrameLinker<Force, PhysicalFrame> > availableBushingForces;
-    Object::getRegisteredObjectsOfGivenType(availableBushingForces);
-    for (int i = 0; i < availableBushingForces.size(); ++i) {
-        availableComponents.push_back(availableBushingForces[i]);
-    }
-
-    // Test PrescribedForce
-    std::unique_ptr<PrescribedForce> f(new PrescribedForce());
-    availableComponents.push_back(f.get());
-
-    // continue with other Constraints, Forces, Actuators, ...
-    //Examples of updated forces that pass
-    ArrayPtrs<PointToPointSpring> availablePointToPointSpring;
-    Object::getRegisteredObjectsOfGivenType(availablePointToPointSpring);
-    availableComponents.push_back(availablePointToPointSpring[0]);
-
-    /** //Uncomment when dependencies of CoordinateCouplerConstraints are 
-    // specified as Sockets 
-    ArrayPtrs<Constraint> availableConstraints;
-    Object::getRegisteredObjectsOfGivenType(availableConstraints);
-    for (int i = 0; i < availableConstraints.size(); ++i) {
-        availableComponents.push_back(availableConstraints[i]);
-    }
-    */
-
-    availableComponents.push_back(new SignalGenerator());
-
-    for (unsigned int i = 0; i < availableComponents.size(); i++) {
-        try {
-            testComponent(*availableComponents[i]);
-        }
-        catch (const std::exception& e) {
-            cout << "*******************************************************\n";
-            cout<< "FAILURE: " << availableComponents[i]->getConcreteClassName() << endl;
-            cout<< e.what() << endl;
-            failures.push_back(availableComponents[i]->getConcreteClassName());
+        if (Object::isObjectTypeDerivedFrom<Analysis>(className)) {
+            OPENSIM_THROW(Exception, "Analysis is not a Component.");
+        } else if (Object::isObjectTypeDerivedFrom<Body>(className)) {
+            model.addBody(dynamic_cast<Body*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Constraint>(className)) {
+            model.addConstraint(dynamic_cast<Constraint*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<ContactGeometry>(className)) {
+            model.addContactGeometry(dynamic_cast<ContactGeometry*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Controller>(className)) {
+            model.addController(dynamic_cast<Controller*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Force>(className)) {
+            model.addForce(dynamic_cast<Force*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Probe>(className)) {
+            model.addProbe(dynamic_cast<Probe*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Joint>(className)) {
+            model.addJoint(dynamic_cast<Joint*>(instance.release()));
+        } else if (Object::isObjectTypeDerivedFrom<Component>(className)) {
+            model.addComponent(dynamic_cast<Component*>(instance.release()));
+        } else {
+            OPENSIM_THROW(Exception, className + " is not a Component.");
         }
     }
-    
-    if (!failures.empty()) {
-        cout << "*******************************************************\n";
-        cout << "Done, with failure(s): " << failures << endl;
-        cout << failures.size() << "/" << availableComponents.size() 
-            << " components failed test." << endl;
-        cout << 100 * (availableComponents.size() - failures.size()) / availableComponents.size()
-            << "% components passed." << endl;
-        cout << "*******************************************************\n" << endl;
-        return 1;
+
+    // helper class: used to satisfy the Inputs of the tested components
+    class OutputGenerator : public Component {
+        OpenSim_DECLARE_CONCRETE_OBJECT(OutputGenerator, Component);
+    public:
+        OpenSim_DECLARE_OUTPUT(outdouble, double, calcDouble, SimTK::Stage::Model);
+        OpenSim_DECLARE_OUTPUT(outvec3, SimTK::Vec3, calcVec3, SimTK::Stage::Model);
+        OpenSim_DECLARE_OUTPUT(outxform, SimTK::Transform, calcXform, SimTK::Stage::Model);
+
+        double calcDouble(const SimTK::State&) const { return 0.0; }
+        SimTK::Vec3 calcVec3(const SimTK::State&) const { return SimTK::Vec3(0); }
+        SimTK::Transform calcXform(const SimTK::State&) const
+        {
+            return SimTK::Transform(SimTK::Vec3(0));
+        }
+    };
+
+    // helper: appends compnents of type `T` in the global registry to `appendOut`
+    template<typename T>
+    void appendComponentsOfType(std::vector<Component*>& appendOut)
+    {
+        ArrayPtrs<T> ptrs;
+        Object::getRegisteredObjectsOfGivenType(ptrs);
+        for (int i = 0; i < ptrs.size(); ++i) {
+            appendOut.push_back(ptrs[i]);
+        }
     }
-    cout << "\ntestComponents PASSED. " << availableComponents.size() 
-        << " components were tested." << endl;
+
+    // helper: gets all of the components that this test suite should test
+    std::vector<Component*> getRegisteredComponents()
+    {
+        std::vector<Component*> rv;
+        appendComponentsOfType<Frame>(rv);
+        appendComponentsOfType<Geometry>(rv);
+        appendComponentsOfType<Point>(rv);
+        appendComponentsOfType<Joint>(rv);
+        appendComponentsOfType<TwoFrameLinker<Constraint, PhysicalFrame>>(rv);
+        appendComponentsOfType<TwoFrameLinker<Force, PhysicalFrame>>(rv);  // (all the BushingForces)
+        appendComponentsOfType<PointToPointSpring>(rv);
+
+        // uncomment this when dependencies of `CoordinateCouplerConstraints` are
+        // specified as Sockets:
+        //
+        // appendComponentsOfType<Constraint>;
+        return rv;
+    }
+
+    // constructs a range of components that this file tests for consistency
+    class ComponentTestCases final {
+    public:
+        ComponentTestCases()
+        {
+            _components = getRegisteredComponents();
+            _components.push_back(&_prescribedForce);
+            _components.push_back(&_signalGenerator);
+        }
+
+        auto begin() { return _components.begin(); }
+        auto end() { return _components.end(); }
+    private:
+        // non-registered components that should be tested
+        PrescribedForce _prescribedForce;
+        SignalGenerator _signalGenerator;
+
+        std::vector<Component*> _components;
+    };
 }
 
-
-//template <typename T>
-void testComponent(const Component& instanceToTest)
+void testComponentEquivalence(
+    const Component& a,
+    const Component& b,
+    bool recurse = true)
 {
-    // Empty model used to serve as the aggregate Component
+    const std::string& className = a.getConcreteClassName();
+
+    int ns_a = a.getNumSockets();
+    int ns_b = b.getNumSockets();
+    log_info("{} getNumSockets: a == {}, b == {}", className, ns_a, ns_b);
+
+    int nin_a = a.getNumInputs();
+    int nin_b = b.getNumInputs();
+    log_info("{} getNumInputs: {}: a == {}, b == {}", className, nin_a, nin_b);
+
+    int nout_a = a.getNumOutputs();
+    int nout_b = b.getNumOutputs();
+    log_info("{} getNumOutputs: {}: a == {}, b == {}", className, nout_a, nout_b);
+
+    CHECK((a == b && "components must have same properties"));
+    CHECK((ns_a == ns_b && "components must have same number of sockets"));
+    CHECK((nin_a == nin_b && "components must have same number of inputs"));
+    CHECK((nout_a == nout_b && "components must have same number of outputs"));
+
+    if (recurse) {
+        try {
+            auto aSubsList = a.getComponentList<Component>();
+            auto bSubsList = b.getComponentList<Component>();
+            auto iter_a = aSubsList.begin();
+            auto iter_b = bSubsList.begin();
+
+            //Subcomponents must be equivalent too!
+            while (iter_a != aSubsList.end() && iter_b != aSubsList.end()) {
+                testComponentEquivalence(*iter_a, *iter_b, false);
+                ++iter_a;
+                ++iter_b;
+            }
+        }
+        catch (const ComponentIsRootWithNoSubcomponents& ex) {
+            // only trap the `ComponentIsRootWithNoSubcomponents`:
+            //
+            // just print the exception message but allow the test to
+            // continue, because the test is blind to whether Components
+            // should have any subcomponents as part of its generic
+            // processing.
+            log_warn("(ignored exception): {}", ex.what());
+        }
+    }
+}
+
+void testCloning(Component& instance)
+{
+    log_info("Cloning the component.");
+
+    std::unique_ptr<Component> copyInstance{instance.clone()};
+    if (!(*copyInstance == instance))
+    {
+        log_info("XML serialization for the first instance:");
+        log_info("{}", instance.dump());
+        log_info("XML serialization for the clone:");
+        log_info("{}", copyInstance->dump());
+
+        const std::string& className = instance.getConcreteClassName();
+        OPENSIM_THROW(Exception, "testComponents: for " + className + ", clone() did not produce an identical object.");
+    }
+
+    instance.finalizeFromProperties();
+    copyInstance->finalizeFromProperties();
+
+    testComponentEquivalence(instance, *copyInstance);
+}
+
+void testSerialization(Component& instance)
+{
+    const std::string& className = instance.getConcreteClassName();
+    std::string serializationFilename = "testing_serialization_" + className + ".xml";
+    instance.print(serializationFilename);
+
+    std::unique_ptr<Object> deserializedInstance{Object::makeObjectFromFile(serializationFilename)};
+
+    if (!(*deserializedInstance == instance))
+    {
+        log_info("XML for serialized instance:");
+        log_info("{}", instance.dump());
+        log_info("XML for serialization of deserialized instance:");
+        log_info("{}", deserializedInstance->dump());
+        OPENSIM_THROW(Exception, "testComponents: for " + className + ", deserialization did not produce an identical object.");
+    }
+
+    Component& deserializedComp = dynamic_cast<Component&>(*deserializedInstance);
+
+    instance.finalizeFromProperties();
+    deserializedComp.finalizeFromProperties();
+
+    testComponentEquivalence(instance, deserializedComp);
+}
+
+void testComponentInAggregate(std::unique_ptr<Component> p)
+{
+    log_info("Test if {} works in a higher-level aggregate Model", p->getConcreteClassName());
+
     Model model;
     model.setName("TheModel");
 
-    // Make a copy so that we can modify the instance.
-    Component* instance = instanceToTest.clone();
-    const string& className = instance->getConcreteClassName();
+    // add it to the model
+    Component* instance = p.get();
+    addObjectAsComponentToModel(std::move(p), model);
 
-    cout << "\n**********************************************************\n";
-    cout << "* Testing " << className << endl;
-    cout << "**********************************************************" << endl;
-
-    // 1. Set properties to random values.
-    // -----------------------------------
-    cout << "Randomizing the component's properties." << endl;
-    randomize(instance);
-
-    // 2. Ensure that cloning produces an exact copy.
-    // ----------------------------------------------
-    // This will find missing calls to copyProperty_<name>().
-    testCloning(instance);
-
-    // 3. Serialize and de-serialize.
-    // ------------------------------
-    // This will find issues with de/serialization.
-    cout << "Serializing and deserializing component." << endl;
-    // Give Component opportunity to validate properties that could 
-    // be junk from randomizer
-    instance->finalizeFromProperties();
-    testSerialization(instance);
-
-    const size_t instanceSize = getCurrentRSS();
-
-    // 4. Verify Components structural attributes
-
-    // -------------------------------------------------------------------
-    cout << "Set up aggregate component." << endl;
-    // 5. Add this component to an aggregate component.
-    // ------------------------------------------------
-    addObjectAsComponentToModel(instance, model);
-
-
-    // 6. Connect up the aggregate; check that connections are correct.
-    // ----------------------------------------------------------------
-
-    // First make sure Sockets are satisfied.
+    // ensure Sockets are satisfied
     Component* sub = instance;
     auto comps = instance->updComponentList<Component>();
-    ComponentList<Component>::iterator itc = comps.begin();
+    auto itc = comps.begin();
     while (sub) {
         for (const auto& socketName : sub->getSocketNames()) {
             AbstractSocket& socket = sub->updSocket(socketName);
-            string dependencyTypeName = socket.getConnecteeTypeName();
-            cout << "Socket '" << socket.getName() <<
-                "' has dependency on: " << dependencyTypeName << endl;
+            std::string dependencyTypeName = socket.getConnecteeTypeName();
+
+            log_info("Socket '{}' has dependency on: {}", socket.getName(), dependencyTypeName);
 
             // Dependency on a Coordinate needs special treatment.
             // A Coordinate is defined by a Joint and cannot stand on its own.
@@ -247,7 +293,7 @@ void testComponent(const Component& instanceToTest)
 
                 // add the dependency 
                 const Object* depRawPtr = dependency.get();
-                addObjectAsComponentToModel(dependency.release(), model);
+                addObjectAsComponentToModel(std::move(dependency), model);
 
                 // Connect the socket. This should come after adding the
                 // dependency to the model, otherwise the connectee path may
@@ -255,13 +301,13 @@ void testComponent(const Component& instanceToTest)
                 socket.connect(*depRawPtr);
             }
         }
-        
+
         Component& next = *itc;
         //Now keep checking the subcomponents
         sub = &next;
         itc++;
     }
-    
+
     // Now make sure Inputs are satisfied.
     // We'll use the custom OutputGenerator class to satisfy the inputs.
     OutputGenerator* outputGen = new OutputGenerator();
@@ -270,18 +316,17 @@ void testComponent(const Component& instanceToTest)
     for (auto& sub : model.updComponentList()) {
         for (const auto& inputName : sub.getInputNames()) {
             AbstractInput& input = sub.updInput(inputName);
-            
+
             // Special case: Geometry cannot have both its input and socket
             // connected.
             if (dynamic_cast<Geometry*>(&sub) && inputName == "transform") {
                 input.setConnecteePath("");
                 continue;
             }
-            
-            string dependencyTypeName = input.getConnecteeTypeName();
-            cout << "Input '" << input.getName() << "' has dependency on: " <<
-                "Output<" << dependencyTypeName << ">" << endl;
-            
+
+            std::string dependencyTypeName = input.getConnecteeTypeName();
+            log_info("Input '{}' has dependency on: Output<{}>", input.getName(), dependencyTypeName);
+
             // Find an output of the correct type.
             bool foundAnOutput = false;
             for (const auto& ito : outputGen->getOutputs()) {
@@ -292,23 +337,20 @@ void testComponent(const Component& instanceToTest)
                 }
             }
             if (!foundAnOutput) {
-                throw Exception("OutputGenerator does not provide an output "
-                                "of type " + dependencyTypeName + ".");
+                OPENSIM_THROW(Exception, "OutputGenerator does not provide an output of type " + dependencyTypeName + ".");
             }
         }
     }
-    
+
     // This method calls connect().
-    cout << "Calling Model::setup()." << endl;
+    log_info("Calling Model::setup().");
     try{
         model.setup();
     }
-    catch (const std::exception &x) {
-        cout << "testComponents::" << className << " unable to connect to model:" << endl;
-        cout << " '" << x.what() << "'" <<endl;
-        cout << "Error is likely due to " << className;
-        cout << " having structural dependencies that are not specified as Sockets.";
-        cout << endl;
+    catch (const std::exception& x) {
+        log_info("testComponents::{} unable to connect to model:", instance->getConcreteClassName());
+        log_info(" '{}'", x.what());
+        log_info("Error is likely due to {} having structural dependencies that are not specified as Sockets.", instance->getConcreteClassName());
     }
 
     // 7. Build the system.
@@ -318,26 +360,24 @@ void testComponent(const Component& instanceToTest)
         initState = model.initSystem();
     }
     catch (const std::exception &x) {
-        cout << "testComponents::" << className << " unable to initialize the system:" << endl;
-        cout << " '" << x.what() << "'" << endl;
-        cout << "Skipping ... " << endl;
+        log_info("testComponents::{} unable to initialize the system:", instance->getConcreteClassName());
+        log_info(" '{}'", x.what());
+        log_info("Skipping ... ");
     }
 
     // Verify that the Model (and its System) remains up-to-date with its
     // properties after initSystem (or attempt). Throw if not.
     OPENSIM_THROW_IF(!model.isObjectUpToDateWithProperties(), Exception,
-        "testComponents:: model.initSystem() caused Model to no longer be "
-        "up-to-date with its properties.");
+        "testComponents:: model.initSystem() caused Model to no longer be up-to-date with its properties.");
 
     // Outputs.
     // --------
-    cout << "Invoking Output's." << endl;
+    log_info("Invoking Output's.");
     for (const auto& entry : instance->getOutputs()) {
         const std::string thisName = entry.first;
         const AbstractOutput* thisOutput = entry.second.get();
 
-        cout << "Testing Output " << thisName << ", dependent on " <<
-            thisOutput->getDependsOnStage().getName() << endl;
+        log_info("Testing Output {}, dependent on {}", thisName, thisOutput->getDependsOnStage().getName());
 
         // Start fresh.
         SimTK::State state(initState);
@@ -348,9 +388,9 @@ void testComponent(const Component& instanceToTest)
         if (thisOutput->getDependsOnStage() > SimTK::Stage::Model)
         {
             model.getSystem().realize(state,
-                    thisOutput->getDependsOnStage().prev());
+                thisOutput->getDependsOnStage().prev());
             ASSERT_THROW(SimTK::Exception::StageTooLow,
-                    thisOutput->getValueAsString(state);
+                thisOutput->getValueAsString(state);
             );
         }
 
@@ -358,143 +398,48 @@ void testComponent(const Component& instanceToTest)
         // Doesn't matter what the value is; just want to make sure the output
         // is wired.
         model.getSystem().realize(state, thisOutput->getDependsOnStage());
-        cout << "Component " << className <<", output " <<thisName << ": " <<
-            thisOutput->getValueAsString(state) << endl;
+        log_info("Component {}, output {}: {}", instance->getConcreteClassName(), thisName, thisOutput->getValueAsString(state));
     }
 }
 
-void testComponentEquivalence(const Component* a, const Component* b, bool recurse = true)
+void testComponent(const Component& instanceToTest)
 {
-    const string& className = a->getConcreteClassName();
+    log_info("");
+    log_info("**********************************************************");
+    log_info("* Testing {}", instanceToTest.getConcreteClassName());
+    log_info("**********************************************************");
 
-    bool same = *a == *b;
-    ASSERT(same, __FILE__, __LINE__,
-        className + " components are not equivalent in properties.");
+    // Make a copy so that we can modify the instance.
+    std::unique_ptr<Component> instance{instanceToTest.clone()};
 
-    int ns_a = a->getNumSockets();
-    int ns_b = b->getNumSockets();
-    cout << className << " getNumSockets: " << ns_a << endl;
-    ASSERT(ns_a == ns_b, __FILE__, __LINE__,
-        className + "components differ in number of sockets.");
+    // 1. Set properties to random values.
+    // -----------------------------------
+    log_info("Randomizing the component's properties.");
+    randomize(instance.get());
 
-    int nin_a = a->getNumInputs();
-    int nin_b = b->getNumInputs();
-    cout << className << " getNumInputs: " << nin_a << endl;
-    ASSERT(nin_a == nin_b, __FILE__, __LINE__,
-        className + " components differ in number of inputs.");
+    // 2. Ensure that cloning produces an exact copy.
+    // ----------------------------------------------
+    // This will find missing calls to copyProperty_<name>().
+    testCloning(*instance);
 
-    int nout_a = a->getNumOutputs();
-    int nout_b = b->getNumOutputs();
-    cout << className << " getNumOutputs: " << nout_a << endl;
-    ASSERT(nout_a == nout_b, __FILE__, __LINE__,
-        className + " components differ in number of outputs.");
-
-    if (recurse) {
-        try {
-            auto aSubsList = a->getComponentList<Component>();
-            auto bSubsList = b->getComponentList<Component>();
-            auto iter_a = aSubsList.begin();
-            auto iter_b = bSubsList.begin();
-
-            //Subcomponents must be equivalent too!
-            while (iter_a != aSubsList.end() && iter_b != aSubsList.end()) {
-                const Component& asub = *iter_a;
-                const Component& bsub = *iter_b;
-                testComponentEquivalence(&asub, &bsub, false);
-                ++iter_a;
-                ++iter_b;
-            }
-        }
-        // only trap the ComponentIsRootWithNoSubcomponents
-        catch (const ComponentIsRootWithNoSubcomponents& ex) {
-            // Just print the exception message but allow the test to continue.
-            // The test is blind to whether Components should have any 
-            // subcomponents as part of its generic processing.
-            cout << ex.what() << endl;
-        }
-    }
-}
-
-void testCloning(Component* instance)
-{
-    cout << "Cloning the component." << endl;
-    Component* copyInstance = instance->clone();
-    if (!(*copyInstance == *instance))
-    {
-        cout << "XML serialization for the first instance:" << endl;
-        cout << instance->dump() << endl;
-        cout << "XML serialization for the clone:" << endl;
-        cout << copyInstance->dump() << endl;
-        const string& className = instance->getConcreteClassName();
-        throw Exception(
-            "testComponents: for " + className +
-            ", clone() did not produce an identical object.",
-            __FILE__, __LINE__);
-    }
-
+    // 3. Serialize and de-serialize.
+    // ------------------------------
+    // This will find issues with de/serialization, after giving the
+    // component opportunity to validate the properties via finalizeFromProperties
+    log_info("Serializing and deserializing component.");
     instance->finalizeFromProperties();
-    copyInstance->finalizeFromProperties();
+    testSerialization(*instance);
 
-    testComponentEquivalence(instance, copyInstance);
-    delete copyInstance;
+    // 4. Test the component in a `Model` aggregate
+    testComponentInAggregate(std::move(instance));
 }
 
-void testSerialization(Component* instance)
+TEST_CASE("testComponents")
 {
-    const string& className = instance->getConcreteClassName();
-    string serializationFilename =
-        "testing_serialization_" + className + ".xml";
-    instance->print(serializationFilename);
-
-    Object* deserializedInstance =
-        static_cast<Object*>(Object::makeObjectFromFile(serializationFilename));
-
-    if (!(*deserializedInstance == *instance))
-    {
-        cout << "XML for serialized instance:" << endl;
-        cout << instance->dump() << endl;
-        cout << "XML for serialization of deserialized instance:" << endl;
-        cout << deserializedInstance->dump() << endl;
-        throw Exception(
-            "testComponents: for " + className +
-            ", deserialization did not produce an identical object.",
-            __FILE__, __LINE__);
-    }
-
-    Component* deserializedComp = dynamic_cast<Component *>(deserializedInstance);
-
-    instance->finalizeFromProperties();
-    deserializedComp->finalizeFromProperties();
-
-    testComponentEquivalence(instance, deserializedComp);
-    delete deserializedInstance;
-}
-
-void addObjectAsComponentToModel(Object* instance, Model& model)
-{
-    const string& className = instance->getConcreteClassName();
-    cout << "Adding " << className << " to the model." << endl;
-
-    if (Object::isObjectTypeDerivedFrom< Analysis >(className))
-        throw Exception("Analysis is not a Component.", __FILE__, __LINE__);
-    else if (Object::isObjectTypeDerivedFrom< Body >(className))
-        model.addBody(dynamic_cast<Body*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Constraint >(className))
-        model.addConstraint(dynamic_cast<Constraint*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< ContactGeometry >(className))
-        model.addContactGeometry(dynamic_cast<ContactGeometry*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Controller >(className))
-        model.addController(dynamic_cast<Controller*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Force >(className))
-        model.addForce(dynamic_cast<Force*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Probe >(className))
-        model.addProbe(dynamic_cast<Probe*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Joint >(className))
-        model.addJoint(dynamic_cast<Joint*>(instance));
-    else if (Object::isObjectTypeDerivedFrom< Component >(className))
-        model.addComponent(dynamic_cast<Component*>(instance));
-    else {
-        throw Exception(className + " is not a Component.",
-            __FILE__, __LINE__);
+    for (Component* c : ComponentTestCases{}) {
+        DYNAMIC_SECTION("test " << c->getConcreteClassName())
+        {
+            REQUIRE_NOTHROW(testComponent(*c));
+        }
     }
 }


### PR DESCRIPTION
Heavily refactors `OpenSim/Tests/Components/testComponents.cpp` to:

### Brief summary of changes

- Use `Catch2` with `DYNAMIC_SECTION`, so that particular component failures are clearly labelled in the test log
- Use `OpenSim::log_info` and `OpenSim::log_warn`, rather than `std::cout` for logging, so that the messages are easier to read
- Refactor the individual component test cases into `ComponentTestCases`, so there's one central place for controlling component lifetime, which components are tested, etc. (#3694 essentially needs this if I can't rewrite the tests to correctly build transient socket dependencies)
- Change most helper functions to take `Component&` rather than `Component*` (the pointer was never rewritten or nullchecked, so a reference is preferable)
- Replace raw `new`s to `std::unique_ptr`, where it makes sense

### Testing I've completed

- It's a test
- And the output seems largely the same (i.e. checks don't appear to have been removed, etc.)

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because boring

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3695)
<!-- Reviewable:end -->
