### PR TITLE
Fix SWIG binding generation fails if cmake is ran from opensim-core

### DIFF
--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -656,6 +656,7 @@ macro(OpenSimFindSwigFileDependencies OSIMSWIGDEP_RETURNVAL
             ${OSIMSWIGDEP_INVOCATION}
         OUTPUT_VARIABLE _dependencies_makefile
         RESULT_VARIABLE _successfully_got_dependencies
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
     # On Windows, _dependencies_makefile now contains something like this:
     # C:\opensim-core\Bindings\Python\swig\python_simbody_wrap.cxx: \


### PR DESCRIPTION
Encountered when building `opensim-core` from within its source dir. Error:

```text
gmake[2]: *** No rule to make target 'Bindings/Python/Bindings/preliminaries.i', needed by 'Bindings/Python/simbody.py'.  Stop.
gmake[1]: *** [CMakeFiles/Makefile2:6844: Bindings/Python/CMakeFiles/_simbody.dir/all] Error 2
```

Invocation Example:

```bash
cmake -S . -LAH -B ../opensim-build -DOPENSIM_DEPENDENCIES_DIR=${PWD}/../deps-install -DOPENSIM_WITH_CASADI=OFF -DOPENSIM_WITH_TROPTER=OFF -DBUILD_JAVA_WRAPPING=ON -DBUILD_PYTHON_WRAPPING=ON -DSWIG_DIR=~/swig/share/swig -DSWIG_EXECUTABLE=~/swig/bin/swig -DCMAKE_BUILD_TYPE=Release -DOPENSIM_DOXYGEN_USE_MATHJAX=OFF
```

The failure is because `execute_process`'s working directory is wherever `cmake` is ran, and this can cause extra entries to be added to the swig invocation

### Brief summary of changes

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because minor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3704)
<!-- Reviewable:end -->
