### PR TITLE
Add back CopyConstructors for instantiated array templates

### DIFF
--- a/Bindings/Java/swig/java_common.i
+++ b/Bindings/Java/swig/java_common.i
@@ -176,14 +176,6 @@ using namespace SimTK;
   }
 };
 
-%copyctor OpenSim::Array<ArrayXYPoint>;
-%copyctor OpenSim::Array<bool>;
-%copyctor OpenSim::Array<double>;
-%copyctor OpenSim::Array<int>;
-%copyctor OpenSim::Array<std::string>;
-%copyctor OpenSim::Array<Vec3>;
-%copyctor OpenSim::Array<OpenSim::Object*>;
-%copyctor OpenSim::Array<const OpenSim::Object*>;
 
 %extend OpenSim::Object {
 	static OpenSim::Array<std::string> getFunctionClassNames() {

--- a/Bindings/Java/swig/java_common.i
+++ b/Bindings/Java/swig/java_common.i
@@ -176,6 +176,15 @@ using namespace SimTK;
   }
 };
 
+%copyctor OpenSim::Array<ArrayXYPoint>;
+%copyctor OpenSim::Array<bool>;
+%copyctor OpenSim::Array<double>;
+%copyctor OpenSim::Array<int>;
+%copyctor OpenSim::Array<std::string>;
+%copyctor OpenSim::Array<Vec3>;
+%copyctor OpenSim::Array<OpenSim::Object*>;
+%copyctor OpenSim::Array<const OpenSim::Object*>;
+
 %extend OpenSim::Object {
 	static OpenSim::Array<std::string> getFunctionClassNames() {
 		  OpenSim::Array<std::string> availableClassNames;

--- a/Bindings/Java/tests/CMakeLists.txt
+++ b/Bindings/Java/tests/CMakeLists.txt
@@ -135,6 +135,7 @@ set_target_properties(RunJavaTests PROPERTIES
 # Test name must be the name of a java file in this directory.
 # Leave out the ".java" extension.
 OpenSimAddJavaTest(TestVectors)
+OpenSimAddJavaTest(TestArrays)
 OpenSimAddJavaTest(TestBasics)
 OpenSimAddJavaTest(TestIterators)
 OpenSimAddJavaTest(TestVisualization)

--- a/Bindings/Java/tests/TestArrays.java
+++ b/Bindings/Java/tests/TestArrays.java
@@ -1,0 +1,38 @@
+import org.opensim.modeling.*;
+
+class TestArrays {
+    public static void TestArrays() {
+        ArrayDouble arrayDouble = new ArrayDouble();
+
+        // add, remove, getSize, index, make a copy
+        double doubleVal = 123.4;
+        arrayDouble.append(doubleVal);
+        assert arrayDouble.get(0) == doubleVal;
+        assert arrayDouble.size() == 1;
+        // make a copy
+        ArrayDouble arrayCopy = new ArrayDouble(arrayDouble);
+        assert arrayCopy.get(0) == doubleVal;
+        arrayDouble.remove(0);
+        assert arrayCopy.getSize() == 1;
+        assert arrayDouble.size() == 0;
+
+        ArrayStr arrayStrings = new ArrayStr();
+        String strVal = "AString";
+        arrayStrings.append(strVal);
+        assert arrayStrings.get(0).equals(strVal);
+        assert arrayStrings.size() == 1;
+        // make a copy
+        ArrayStr arrayStrCopy = new ArrayStr(arrayStrings);
+        assert arrayStrCopy.get(0).equals(strVal);
+        arrayStrings.remove(0);
+        assert arrayStrCopy.getSize() == 1;
+        assert arrayStrings.size() == 0;
+
+    }
+  public static void main(String[] args) {
+      TestArrays();
+      
+      System.out.println("Test finished!");
+      // TODO to cause test to fail: System.exit(-1);
+  }
+}

--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -52,7 +52,14 @@ namespace OpenSim {
  */
 template<class T>
 class Array {
+
 public:
+    Array(Array const&) = default;;
+    Array(Array&&) noexcept = default;
+    Array& operator=(Array const&) = default;
+    Array& operator=(Array&&) noexcept = default;
+    ~Array() noexcept = default;
+
     explicit Array(T aDefaultValue = T(), int aSize = 0, int aCapacity = 1) :
         _defaultValue{std::move(aDefaultValue)}
     {


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Updating the Array class resulted in missing Copy constructors for all Array<> classes in Java/Matlab. This PR adds them back so that GUI code and possible user code that depends on them continue to work.
### Testing I've completed
Building, checking resulting Java files
### Looking for feedback on...
1. Should we try to do this for Python as well? Not sure how this is handled now.
2. If 1 is affirmative, should we make this change in Array directly or keep it off as a SWIG limitation

### CHANGELOG.md (choose one)

- no need to update because fixing unintended change not user facing yet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3709)
<!-- Reviewable:end -->
