### PR TITLE
OpenSim updated to use Simbody#779

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -24,14 +24,14 @@ function(SetDefaultCMakeInstallPrefix)
     get_filename_component(BASE_DIR ${BASE_DIR} DIRECTORY)
     # Default install prefix for OpenSim dependencies. If user changes
     # CMAKE_INSTALL_PREFIX, this directory will be removed.
-    set(DEFAULT_CMAKE_INSTALL_PREFIX 
+    set(DEFAULT_CMAKE_INSTALL_PREFIX
         ${BASE_DIR}/opensim_dependencies_install
         CACHE
         INTERNAL
         "Default CMAKE_INSTALL_PREFIX for OpenSim dependencies.")
 
     if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-        set(CMAKE_INSTALL_PREFIX 
+        set(CMAKE_INSTALL_PREFIX
             ${DEFAULT_CMAKE_INSTALL_PREFIX}
             CACHE
             PATH
@@ -40,7 +40,7 @@ function(SetDefaultCMakeInstallPrefix)
     endif()
 endfunction()
 
-# CMake doesn't clear prefix directories when user changes it. 
+# CMake doesn't clear prefix directories when user changes it.
 # Remove it to avoid confusion.
 function(RemoveDefaultInstallDirIfEmpty DIR)
     file(GLOB CONTENTS ${DIR}/*)
@@ -73,7 +73,7 @@ endfunction()
 #   GIT_URL    -- (Required) git repository to download the sources from.
 #   GIT_TAG    -- (Required) git tag to checkout before commencing build.
 #   DEPENDS    -- (Optional) Other projects this project depends on.
-#   CMAKE_ARGS -- (Optional) A CMake list of arguments to be passed to CMake 
+#   CMAKE_ARGS -- (Optional) A CMake list of arguments to be passed to CMake
 #                 while building the project.
 # You must provide either URL or GIT_URL and GIT_TAG, but not all 3.
 function(AddDependency)
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    589e931f4a127830a5876ee4dd8f327b47361504
+              GIT_TAG    2b4aefbb43d8b55f3edc3bdfafa9636fb988ed3c
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})
@@ -265,7 +265,7 @@ if (WIN32)
 
 
     if(SUPERBUILD_ipopt)
-    
+
         # Ipopt: Download pre-built binaries built by chrisdembia.
         # This binary distribution comes with MUMPS and OpenBLAS.
         # Compiled with clang-cl 5.0 and flang, using conda.


### PR DESCRIPTION
### Brief summary of changes
This commit updates the dependency GIT_TAG for Simbody (see https://github.com/opensim-org/opensim-core/blob/main/dependencies/CMakeLists.txt#L183) to use https://github.com/simbody/simbody/commit/2b4aefbb43d8b55f3edc3bdfafa9636fb988ed3c.

https://github.com/simbody/simbody/commit/2b4aefbb43d8b55f3edc3bdfafa9636fb988ed3c adds three templatized methods (see below) that allow numerical types to be written to XML documents with a specified number of significant figures (i.e., precision):
```
String::String(const T& t, int precision)
Xml::Element(const String& tagWord, const T& value, int precision)
Xml::setValueAs(const T& value, int precision)
```
It also restores the default precision to what it was prior to https://github.com/simbody/simbody/pull/762 (i.e., to 6 sig figs, which has been the standard in .osim files for some time.)

https://github.com/simbody/simbody/pull/779 implements a bug fix to https://github.com/simbody/simbody/pull/776, which was the first PR to introduce variable output precision to the above templatized methods.

This update requires no changes to existing OpenSim code.

### Testing I've completed
- I added a new subunit test (https://github.com/simbody/simbody/blob/master/SimTKcommon/tests/TestXml.cpp#L537 ) that verifies proper execution of the above methods.
- simbody unit tests pass.
- opensim-core unit tests pass (i.e., the update doesn't appear to break anything).

### CHANGELOG.md
- No need to update the change log because, at present, no code in [OpenSim main](https://github.com/opensim-org/opensim-core/tree/main) use the above methods. There are, however, classes in development that do take advantage of the variable output precision (e.g., [OpenSim::StatesDocument](https://github.com/fcanderson/opensim-core/blob/ostates/OpenSim/Simulation/StatesDocument.h)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3728)
<!-- Reviewable:end -->
