### PR TITLE
OpenSim updated to use Simbody#781

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -183,7 +183,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    2b4aefbb43d8b55f3edc3bdfafa9636fb988ed3c
+              GIT_TAG    6e7913c3851105f3d24b3fad2fdc4a42a7d86f50
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
### Brief summary of changes
This commit updates the dependency GIT_TAG for Simbody (see https://github.com/opensim-org/opensim-core/blob/main/dependencies/CMakeLists.txt#L186) to use https://github.com/simbody/simbody/commit/6e7913c3851105f3d24b3fad2fdc4a42a7d86f50.

https://github.com/simbody/simbody/commit/6e7913c3851105f3d24b3fad2fdc4a42a7d86f50 addresses inconsistent behavior in std::ostream::setprecision(int p) when p < 0 across operating systems (e.g., Windows 11 vs. Windows 10) and build types (e.g., Release vs Debug). See https://github.com/simbody/simbody/pull/781.

This update requires no changes to existing OpenSim code.

### Testing I've completed
- I updated subunit test (https://github.com/simbody/simbody/blob/master/SimTKcommon/tests/TestXml.cpp#L537 ).
- simbody unit tests pass.
- opensim-core unit tests pass.

### CHANGELOG.md (choose one)
- No need to update the change log because, with the exception of see https://github.com/opensim-org/opensim-core/blob/main/dependencies/CMakeLists.txt#L186, no changes were made to [OpenSim main](https://github.com/opensim-org/opensim-core/tree/main).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3733)
<!-- Reviewable:end -->
