### PR TITLE
Fix muscle mass documentation error in Umberger2010MuscleMetabolicsProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ v4.6
   orientation from `Station`s in the model
 - Models with `PrescribedController`s are now supported by Moco (#3701). Controls for actuators controlled by 
   `PrescribedController`s are now excluded from the optimization problem.
+- Fixed documentation error in `Umberger2010MuscleMetabolicsProbe` where muscle mass was incorrectly omitted for the
+  activation maintenance rate.
 
 v4.5
 ====

--- a/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
+++ b/OpenSim/Simulation/Model/Umberger2010MuscleMetabolicsProbe.h
@@ -111,8 +111,8 @@ class Umberger2010MuscleMetabolicsProbe_MetabolicMuscleParameterSet;
  *
  * <H2><B> ACTIVATION & MAINTENANCE HEAT RATE (W) </B></H2>
  * If <I>activation_maintenance_rate_on</I> is set to true, then Adot+Mdot is calculated as follows:\n
- * <B>Adot+Mdot = [128*(1-r) + 25] * A^0.6 * S                                         </B>,  <I> l_CE <= l_CE_opt </I>\n 
- * <B>Adot+Mdot = (0.4*[128*(1-r) + 25] + 0.6*[128*(1-r) + 25]*F_CE_iso) * A^0.6 * S   </B>,  <I> l_CE >  l_CE_opt </I>
+ * <B>Adot+Mdot = m * [128*(1-r) + 25] * A^0.6 * S                                         </B>,  <I> l_CE <= l_CE_opt </I>\n 
+ * <B>Adot+Mdot = m * (0.4*[128*(1-r) + 25] + 0.6*[128*(1-r) + 25]*F_CE_iso) * A^0.6 * S   </B>,  <I> l_CE >  l_CE_opt </I>
  *     - <B>A = u          </B>,    u >  a
  *     - <B>A = (u+a)/2    </B>,    u <= a
  *


### PR DESCRIPTION
### Brief summary of changes
The activation and heat maintenance rate (line 317 cpp file) is multiplied by muscle mass when the total energy consumption is calculated (line 459), which was not reflected in the documentation. The documentation now correctly shows muscle mass multiplication for the activation maintenance and the shortening rate. Note that the mechanical work rate is correctly displayed without muscle mass multiplication, as this factor was divided by muscle mass upon its calculation (line 406).

### Testing I've completed
Documentation change, no testing required.

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3738)
<!-- Reviewable:end -->
