### PR TITLE
Fix rFindIndex returns invalid index (#3743)

### DIFF
--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -483,7 +483,13 @@ public:
     int rfindIndex(const T& aValue) const
     {
         const auto it = std::find(_storage.rbegin(), _storage.rend(), aValue);
-        return it != _storage.rend() ? static_cast<int>(std::distance(_storage.begin(), it.base())) : -1;
+        if (it != _storage.rend()) {
+            auto idx = std::distance(_storage.begin(), it.base()) - 1;
+            return static_cast<int>(idx);
+        }
+        else {
+            return -1;
+        }
     }
 
     /**

--- a/OpenSim/Common/Test/testArray.cpp
+++ b/OpenSim/Common/Test/testArray.cpp
@@ -101,3 +101,20 @@ TEST_CASE("Array searchBinary Behaves Similarly to Legacy Implementation")
         REQUIRE(legacyOutput == newOutput);
     }
 }
+
+TEST_CASE("Array rFindIndex returns expected results")
+{
+    Array<int> vals;
+    vals.append(0);
+    vals.append(1);
+    vals.append(2);
+    vals.append(2);
+    vals.append(3);
+
+    REQUIRE(vals.rfindIndex(3) == 4);
+    REQUIRE(vals.rfindIndex(2) == 3);
+    REQUIRE(vals.findIndex(2) == 2);  // sanity check for duplicate case
+    REQUIRE(vals.rfindIndex(1) == 1);
+    REQUIRE(vals.rfindIndex(0) == 0);
+    REQUIRE(vals.rfindIndex(1337) == -1);
+}


### PR DESCRIPTION
Fixes issue #3743

### Brief summary of changes

- Fixes bad `reverse_iterator.base()` logic in the reverse search (should subtract 1 from result)

### Testing I've completed

- Added test that fails due to bad implementation
- It failed
- Changed implementation with guidance from (e.g.) https://stackoverflow.com/questions/24997910/get-index-in-vector-from-reverse-iterator
- It passed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal bugfix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3748)
<!-- Reviewable:end -->
