### PR TITLE
Fix set Array element at last slot and beef test case accordingly build-gui

### DIFF
--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -339,8 +339,8 @@ public:
             return;
         }
 
-        if (aIndex+2 >= static_cast<int>(_storage.capacity())) {
-            setSize(aIndex+2);
+        if (aIndex+1 >= static_cast<int>(_storage.capacity())) {
+            setSize(aIndex+1);
         }
 
         _storage[aIndex] = aValue;

--- a/OpenSim/Common/Test/testArray.cpp
+++ b/OpenSim/Common/Test/testArray.cpp
@@ -118,3 +118,14 @@ TEST_CASE("Array rFindIndex returns expected results")
     REQUIRE(vals.rfindIndex(0) == 0);
     REQUIRE(vals.rfindIndex(1337) == -1);
 }
+
+TEST_CASE("Array set keeps size")
+{
+    Array<int> vals;
+    vals.append(0);
+
+    REQUIRE(vals.size() == 1);
+    vals.set(0, 4);
+    REQUIRE(vals.size() == 1);
+    REQUIRE(vals.get(0) == 4);  
+}

--- a/OpenSim/Common/Test/testArray.cpp
+++ b/OpenSim/Common/Test/testArray.cpp
@@ -119,7 +119,7 @@ TEST_CASE("Array rFindIndex returns expected results")
     REQUIRE(vals.rfindIndex(1337) == -1);
 }
 
-TEST_CASE("Array set keeps size")
+TEST_CASE("Array set keeps size if within bounds")
 {
     Array<int> vals;
     vals.append(0);


### PR DESCRIPTION
Fixes issue #0 build-gui [build-gui]

### Brief summary of changes
Setting 0th entry for an Array of size 1 resulted in a change of size to 2 and basically acted as insert.
### Testing I've completed
Beefed test case for Array that was failing before the code change and now passes. GUI build with the fix doesn't exhibit the problem anymore.
### Looking for feedback on...

### CHANGELOG.md (choose one)

- May not need because the bug was not included in any public release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3753)
<!-- Reviewable:end -->
