### PR TITLE
Add CI `windows2022` jobs for performance analysis

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -678,9 +678,11 @@ jobs:
         if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
           BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
+        echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 
 
         MAC_HEADER="### Performance analysis (Mac)"
         if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
+          echo "MAC_HEADER found"
           BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
         fi 
         echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -674,17 +674,17 @@ jobs:
         CUSTOM_HEADER="### Performance analysis (Windows)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        BOTTOM_CONTENT=""
-        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-        fi
-        echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 
-
         MAC_HEADER="### Performance analysis (Mac)"
+        BOTTOM_CONTENT=""
         if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
           echo "MAC_HEADER found"
           BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
+        else
+          if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+            BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+          fi
         fi 
+        
         echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 
     
         if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -154,7 +154,7 @@ jobs:
   windows2022_target:
     name: Windows2022 [target]
 
-    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]') }}
 
     runs-on: windows-2022
 
@@ -261,7 +261,7 @@ jobs:
     
     runs-on: windows-2022
     
-    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
+    name: ${{ (contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]')) && 'Windows2022 [source]' || 'Windows2022' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -370,8 +370,7 @@ jobs:
 
     runs-on: macos-12
 
-    # if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
-    if: false
+    if: ${{ contains(github.event.pull_request.title, '[perf-mac]') || contains(github.event.pull_request.body, '[perf-mac]') }}
 
     steps:
     - uses: actions/checkout@v3
@@ -498,8 +497,7 @@ jobs:
 
     runs-on: macos-12
     
-    name: Mac
-    # name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
+    name: ${{ (contains(github.event.pull_request.title, '[perf-mac]') || contains(github.event.pull_request.body, '[perf-mac]')) && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -623,8 +621,11 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-mac
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-  performance_analysis:
-    name: Performance Analysis
+  performance_analysis_win:
+    name: Performance Analysis (Windows)
+
+    env:
+      GH_TOKEN: ${{ github.token }}
 
     needs:
       - windows2022_target
@@ -632,10 +633,7 @@ jobs:
 
     runs-on: macos-12
 
-    env:
-      GH_TOKEN: ${{ github.token }}
-
-    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    if: ${{ contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]') }}
 
     steps:
     - name: Trigger opensim-perf workflow
@@ -647,7 +645,12 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis_win.yml
-        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
+        workflow_inputs: |
+          '{"commit_sha": "${{ github.event.pull_request.head.sha }}", 
+            "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", 
+            "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", 
+            "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", 
+            "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0
@@ -703,7 +706,94 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
           -f "body=${NEW_COMMENT_BODY}"
- 
+
+  performance_analysis_mac:
+
+    name: Performance Analysis (Mac)
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    needs:
+      - mac_target
+      - mac_source
+
+    runs-on: macos-12
+
+    if: ${{ contains(github.event.pull_request.title, '[perf-mac]') || contains(github.event.pull_request.body, '[perf-mac]') }}
+
+    steps:
+    - name: Trigger opensim-perf workflow
+      uses: Codex-/return-dispatch@v1.12.0
+      id: return_dispatch
+      with:
+        token: ${{ secrets.PERF_DISPATCH_PAT }}
+        repo: opensim-perf
+        owner: opensim-org
+        ref: main
+        workflow: performance_analysis_mac.yml
+        workflow_inputs: |
+          '{"commit_sha": "${{ github.event.pull_request.head.sha }}", 
+            "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", 
+            "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", 
+            "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", 
+            "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+
+    - name: Await opensim-perf workflow
+      uses: Codex-/await-remote-run@v1.11.0
+      with:
+        token: ${{ secrets.PERF_DISPATCH_PAT }}
+        repo: opensim-perf
+        owner: opensim-org
+        run_id: ${{ steps.return_dispatch.outputs.run_id }}
+        run_timeout_seconds: 10000
+
+    - name: Download performance analysis results
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v3.0.0
+      with:
+        github_token: ${{ secrets.PERF_DISPATCH_PAT }}
+        run_id: ${{ steps.return_dispatch.outputs.run_id }}
+        workflow: performance_analysis_mac.yml
+        name: performance-results
+        path: results
+        repo: opensim-org/opensim-perf
+
+    - name: Post results to pull request description
+      run: |
+        PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
+        CUSTOM_HEADER="### Performance analysis"
+
+        REVIEWABLE_TAG="<!-- Reviewable:start -->"
+        REVIEWABLE_BLOCK=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+        fi
+
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        else
+          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+        fi
+
+        NEW_CONTENT="${CUSTOM_HEADER}
+
+        $(cat results/performance_results.md)
+
+        ${REVIEWABLE_BLOCK}
+        "
+        NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
+
+        # Update the existing description
+        gh api \
+          --method PATCH \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+          -f "body=${NEW_COMMENT_BODY}"
+
   ubuntu20:
     name: Ubuntu2004
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -622,8 +622,8 @@ jobs:
     name: Performance Analysis
 
     needs:
-      - mac_target
-      - mac_source
+      - windows2022_target
+      - windows2022_source
 
     runs-on: macos-12
 
@@ -642,7 +642,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -362,133 +362,134 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-win
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-#   mac_target:
-#     name: Mac [target]
+  mac_target:
+    name: Mac [target]
 
-#     runs-on: macos-12
+    runs-on: macos-12
 
-#     if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    # if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    if: false
 
-#     steps:
-#     - uses: actions/checkout@v3
-#       with:
-#         ref: ${{ github.event.pull_request.base.ref }} 
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.base.ref }} 
 
-#     - uses: actions/setup-python@v4
-#       with:
-#         python-version: '3.8'
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
         
-#     - name: Install Homebrew packages
-#       # Save the gfortran version to a file so we can use it in the cache key.
-#       run: |
-#         brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
-#         brew reinstall gcc
-#         pip3 install numpy==1.20.2
-#         gfortran -v
-#         mkdir gfortran_version
-#         gfortran -v &> gfortran_version/gfortran_version.txt
+    - name: Install Homebrew packages
+      # Save the gfortran version to a file so we can use it in the cache key.
+      run: |
+        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew reinstall gcc
+        pip3 install numpy==1.20.2
+        gfortran -v
+        mkdir gfortran_version
+        gfortran -v &> gfortran_version/gfortran_version.txt
 
-#     - name: Cache SWIG
-#       id: cache-swig
-#       uses: actions/cache@v3
-#       with:
-#         path: ~/swig
-#         key: ${{ runner.os }}-swig
+    - name: Cache SWIG
+      id: cache-swig
+      uses: actions/cache@v3
+      with:
+        path: ~/swig
+        key: ${{ runner.os }}-swig
 
-#     - name: Install SWIG
-#       # if: steps.cache-swig.outputs.cache-hit != 'true'
-#       run: |
-#         mkdir ~/swig-source && cd ~/swig-source
-#         wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-#         tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-#         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-#         make && make -j4 install
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
 
-#     - name: Cache dependencies
-#       id: cache-dependencies
-#       uses: actions/cache@v3
-#       with:
-#         path: ~/opensim_dependencies_install
-#         # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
-#         # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
-#         # undefined.
-#         key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
+        # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
+        # undefined.
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
 
-#     - name: Build dependencies
-#       if: steps.cache-dependencies.outputs.cache-hit != 'true'
-#       run: |
-#         mkdir $GITHUB_WORKSPACE/../build_deps
-#         cd $GITHUB_WORKSPACE/../build_deps
-#         DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-#         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-#         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-#         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-#         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
-#         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-#         DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
-#         DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-#         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-#         cmake "${DEP_CMAKE_ARGS[@]}"
-#         make --jobs 4
+    - name: Build dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
+        DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
 
-#     - name: Configure opensim-core
-#       id: configure
-#       run: |
-#         mkdir $GITHUB_WORKSPACE/../build
-#         cd $GITHUB_WORKSPACE/../build
-#         OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-#         OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-#         OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-#         OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-#         OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-#         OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-#         OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-#         OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
-#         OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-#         OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-#         # TODO: Update to simbody.github.io/latest
-#         OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-#         OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
-#         printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-#         cmake "${OSIM_CMAKE_ARGS[@]}"
-#         VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-#         echo $VERSION
-#         echo "VERSION=$VERSION" >> $GITHUB_ENV
-#         echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-#     - name: Build opensim-core
-#       run: |
-#         cd $GITHUB_WORKSPACE/../build
-#         make --jobs 4
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
 
-#     - name: Test opensim-core
-#       run: |
-#         cd $GITHUB_WORKSPACE/../build
-#         ctest --parallel 4 --output-on-failure
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        ctest --parallel 4 --output-on-failure
 
-#     - name: Install opensim-core
-#       run: |
-#         cd $GITHUB_WORKSPACE/../build
-#         make doxygen
-#         make install
-#         cd $GITHUB_WORKSPACE
-#         mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ github.event.pull_request.base.ref }}
-#         zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}.zip opensim-core-${{ github.event.pull_request.base.ref }}
-#         mv opensim-core-${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE/../opensim-core-install
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ github.event.pull_request.base.ref }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}.zip opensim-core-${{ github.event.pull_request.base.ref }}
+        mv opensim-core-${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE/../opensim-core-install
 
-#     - name: Test Python bindings
-#       run: |
-#         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-#         # Run the python tests, verbosely.
-#         python3 -m unittest discover --start-directory opensim/tests --verbose
+    - name: Test Python bindings
+      run: |
+        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+        # Run the python tests, verbosely.
+        python3 -m unittest discover --start-directory opensim/tests --verbose
 
-#     - name: Upload opensim-core
-#       uses: actions/upload-artifact@v4
-#       with:
-#         # The upload-artifact zipping does not preserve symlinks or executable
-#         # bits. So we zip ourselves, even though this causes a double-zip.
-#         name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
-#         path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v4
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
+        path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
 
   mac_source:
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -674,24 +674,21 @@ jobs:
         CUSTOM_HEADER="### Performance analysis (Windows)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        REVIEWABLE_CONTENT=""
+        BOTTOM_CONTENT=""
         if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          REVIEWABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+          BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
 
-        MAC_CONTENT=""
         MAC_HEADER="### Performance analysis (Mac)"
         if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
-          MAC_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,/$REVIEWABLE_TAG/")
+          BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
         fi 
-        echo "MAC_CONTENT: $MAC_CONTENT" 
+        echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 
     
         if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
           CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
         else
-          CONTENT_TO_REPLACE="${MAC_CONTENT}
-
-          ${REVIEWABLE_CONTENT}"
+          CONTENT_TO_REPLACE="${BOTTOM_CONTENT}"
         fi
         echo "CONTENT_TO_REPLACE: $CONTENT_TO_REPLACE"
 
@@ -699,9 +696,7 @@ jobs:
 
         $(cat results/performance_results.md)
 
-        ${MAC_CONTENT}
-
-        ${REVIEWABLE_CONTENT}
+        ${BOTTOM_CONTENT}
         "
         echo "NEW_CONTENT: $NEW_CONTENT"
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -264,7 +264,7 @@ jobs:
     name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
 
     outputs:
-        version: ${{ steps.configure.outputs.version }}
+      version: ${{ steps.configure.outputs.version }}
 
     steps:
     - uses: actions/checkout@v3
@@ -646,7 +646,7 @@ jobs:
         repo: opensim-perf
         owner: opensim-org
         ref: main
-        workflow: performance_analysis.yml
+        workflow: performance_analysis_win.yml
         workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
@@ -656,7 +656,7 @@ jobs:
         repo: opensim-perf
         owner: opensim-org
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
-        run_timeout_seconds: 600
+        run_timeout_seconds: 10000
 
     - name: Download performance analysis results
       id: download-artifact
@@ -943,7 +943,8 @@ jobs:
            repo: opensim-gui
            owner: opensim-org
            run_id: ${{ steps.return_dispatch.outputs.run_id }}
-           run_timeout_seconds: 10000 
+           run_timeout_seconds: 10000
+
   style:
     name: Style
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,6 +14,10 @@ on:
     tags:
       - '*'
 
+env:
+  perf_mac: ${{ (contains(github.event.pull_request.title, '[perf-mac]') || contains(github.event.pull_request.body, '[perf-mac]')) && !((contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]'))) }} 
+  perf_win: ${{ (contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]')) || (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) }}
+
 jobs:
   windows:
     name: Windows
@@ -154,7 +158,7 @@ jobs:
   windows2022_target:
     name: Windows2022 [target]
 
-    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    if: ${{ env.perf_win }}
 
     runs-on: windows-2022
 
@@ -178,7 +182,7 @@ jobs:
       run: python3 -m pip install numpy==1.20.2
 
     - name: Install SWIG
-      run: | 
+      run: |
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 
@@ -261,7 +265,7 @@ jobs:
     
     runs-on: windows-2022
     
-    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
+    name: ${{ env.perf_win && 'Windows2022 [source]' || 'Windows2022' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -367,7 +371,7 @@ jobs:
 
     runs-on: macos-12
 
-    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
+    if: ${{ env.perf_mac }}
 
     steps:
     - uses: actions/checkout@v3
@@ -494,7 +498,7 @@ jobs:
 
     runs-on: macos-12
     
-    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
+    name: ${{ env.perf_mac && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -683,19 +683,17 @@ jobs:
         MAC_HEADER="### Performance analysis (Mac)"
         if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
           MAC_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,/$REVIEWABLE_TAG/")
-        fi  
+        fi 
+        echo "MAC_CONTENT: $MAC_CONTENT" 
     
         if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
           CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
         else
-          if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
-            CONTENT_TO_REPLACE="${MAC_CONTENT}
-            
-            ${REVIEWABLE_CONTENT}"
-          else
-            CONTENT_TO_REPLACE=${REVIEWABLE_CONTENT}
-          fi
+          CONTENT_TO_REPLACE="${MAC_CONTENT}
+
+          ${REVIEWABLE_CONTENT}"
         fi
+        echo "CONTENT_TO_REPLACE: $CONTENT_TO_REPLACE"
 
         NEW_CONTENT="${CUSTOM_HEADER}
 
@@ -705,6 +703,8 @@ jobs:
 
         ${REVIEWABLE_CONTENT}
         "
+        echo "NEW_CONTENT: $NEW_CONTENT"
+
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
         # Update the existing description

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -674,44 +674,33 @@ jobs:
         CUSTOM_HEADER="### Performance analysis (Windows)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        MAC_HEADER="### Performance analysis (Mac)"
-        BOTTOM_CONTENT=""
-        if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
-          echo "MAC_HEADER found"
-          BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
-        else
-          if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-            BOTTOM_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
-          fi
-        fi 
-        
-        echo "BOTTOM_CONTENT: $BOTTOM_CONTENT" 
-    
-        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-        else
-          CONTENT_TO_REPLACE="${BOTTOM_CONTENT}"
+        REVIEWABLE_CONTENT=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
+            REVIEWABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
-        echo "CONTENT_TO_REPLACE: $CONTENT_TO_REPLACE"
+
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        else
+            CONTENT_TO_REPLACE=${REVIEWABLE_CONTENT}
+        fi
 
         NEW_CONTENT="${CUSTOM_HEADER}
 
         $(cat results/performance_results.md)
 
-        ${BOTTOM_CONTENT}
+        ${REVIEWABLE_CONTENT}
         "
-        echo "NEW_CONTENT: $NEW_CONTENT"
-
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
         # Update the existing description
         gh api \
-          --method PATCH \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
-          -f "body=${NEW_COMMENT_BODY}"
+            --method PATCH \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
+            -f "body=${NEW_COMMENT_BODY}"
 
   performance_analysis_mac:
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -671,7 +671,7 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis (Windows)"
+        CUSTOM_HEADER="### Performance analysis"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
         REVIEWABLE_CONTENT=""
@@ -686,6 +686,8 @@ jobs:
         fi
 
         NEW_CONTENT="${CUSTOM_HEADER}
+
+        Platform: Windows, self-hosted runner
 
         $(cat results/performance_results.md)
 
@@ -753,7 +755,7 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis (Mac)"
+        CUSTOM_HEADER="### Performance analysis"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
         REVIEWABLE_CONTENT=""
@@ -768,6 +770,8 @@ jobs:
         fi
 
         NEW_CONTENT="${CUSTOM_HEADER}
+
+        Platform: Mac, GitHub Actions runner
 
         $(cat results/performance_results.md)
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -151,8 +151,10 @@ jobs:
     #     asset_name: opensim-core-${{ github.ref }}.zip
     #     asset_content_type: application/zip
 
-  windows2022:
-    name: Windows2022
+  windows2022_target:
+    name: Windows2022 [target]
+
+    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
     runs-on: windows-2022
 
@@ -177,6 +179,111 @@ jobs:
 
     - name: Install SWIG
       run: | 
+        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+        swig -swiglib
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # Every time a cache is created, it's stored with this key.
+        # In subsequent runs, if the key matches the key of an existing cache,
+        # then the cache is used. We chose for this key to depend on the
+        # operating system and a hash of the hashes of all files in the
+        # dependencies directory (non-recursive).
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+
+    - name: Build dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        echo $env:GITHUB_WORKSPACE\\build_deps
+        mkdir $env:GITHUB_WORKSPACE\\build_deps
+        chdir $env:GITHUB_WORKSPACE\\build_deps
+        # /W0 disables warnings.
+        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+        # TODO: CMake provides /W3, which overrides our /W0
+        cmake -E env CXXFLAGS="/W0" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_TROPTER=ON -DOPENSIM_WITH_CASADI=ON
+        cmake --build . --config Release -- /maxcpucount:4
+
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE\\build
+        # TODO: Can remove /WX when we use that in CMakeLists.txt.
+        # Set the CXXFLAGS environment variable to turn warnings into errors.
+        # Skip timing test section included by default.
+        cmake -E env CXXFLAGS="/WX -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on -DPython3_ROOT_DIR=C:\hostedtoolcache\windows\Python\3.8.10\x64
+        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+        $version = $env:match.split('=')[1]
+        echo $version
+        echo "VERSION=$version" >> $GITHUB_ENV
+        echo "version=$version" >> $env:GITHUB_OUTPUT
+
+
+    - name: Build opensim-core
+      # Install now to avoid building bindings twice (TODO: issue when using Visual Studio 2019, is this an issue too in Visual Studio 2022?).
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        cmake --build . --config Release --target doxygen -- /maxcpucount:4
+        cmake --build . --config Release --target install -- /maxcpucount:4
+
+    - name: Test opensim-core
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        ctest --parallel 4 --output-on-failure --build-config Release -E python*
+
+    - name: Install opensim-core
+      # TODO: This is where we wish to do the installing, but it's done above for now.
+      run: |
+        chdir $env:GITHUB_WORKSPACE\\build
+        chdir $env:GITHUB_WORKSPACE
+        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ github.event.pull_request.base.ref }}" -Recurse
+        7z a "opensim-core-${{ github.event.pull_request.base.ref }}.zip" "opensim-core-${{ github.event.pull_request.base.ref }}"
+
+    - name: Test Python bindings
+      run: |
+        echo "PYTHONPATH= $env:USERPROFILE/opensim-core-install/bin">> $GITHUB_ENV
+        # Move to the installed location of the python package.
+        cd ~/opensim-core-install/sdk/python
+        # Run python tests.
+        python -m unittest discover --start-directory opensim/tests --verbose
+
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v4
+      with:
+        name: opensim-core-${{ github.event.pull_request.base.ref }}-win
+        path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
+
+  windows2022_source:
+    
+    runs-on: windows-2022
+    
+    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Doxygen
+      # choco install doxygen.portable # <-- too unreliable.
+      run: |
+        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/myosin/files/doxygen-1.8.14.windows.x64.bin.zip/download", "doxygen.zip")
+        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
+        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
+
+    - name: Install Python packages
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        
+    - name: Install numpy
+      #Need numpy to use SWIG numpy typemaps.
+      run: python3 -m pip install numpy==1.20.2
+
+    - name: Install SWIG
+      run: |
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -667,7 +667,7 @@ jobs:
       with:
         github_token: ${{ secrets.PERF_DISPATCH_PAT }}
         run_id: ${{ steps.return_dispatch.outputs.run_id }}
-        workflow: performance_analysis.yml
+        workflow: performance_analysis_win.yml
         name: performance-results
         path: results
         repo: opensim-org/opensim-perf
@@ -676,25 +676,38 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis"
+        CUSTOM_HEADER="### Performance analysis (Windows)"
+        MAC_HEADER="### Performance analysis (Mac)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        REVIEWABLE_BLOCK=""
+        REVIEWABLE_CONTENT=""
         if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+          REVIEWABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
 
-        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+        MAC_CONTENT=""
+        if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
+          MAC_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
+          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+          else
+            CONTENT_TO_REPLACE=${MAC_CONTENT}
+          fi
         else
-          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+          else
+            CONTENT_TO_REPLACE=${REVIEWABLE_CONTENT}
+          fi
         fi
 
         NEW_CONTENT="${CUSTOM_HEADER}
 
         $(cat results/performance_results.md)
 
-        ${REVIEWABLE_BLOCK}
+        ${MAC_CONTENT}
+
+        ${REVIEWABLE_CONTENT}
         "
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 
@@ -763,25 +776,25 @@ jobs:
       run: |
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
-        CUSTOM_HEADER="### Performance analysis"
+        CUSTOM_HEADER="### Performance analysis (Mac)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
-        REVIEWABLE_BLOCK=""
+        REVIEWABLE_CONTENT=""
         if [[ $EXISTING_COMMENT_CONTENT == *"$REVIEWABLE_TAG"* ]]; then
-          REVIEWABLE_BLOCK=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
+          REVIEWABLE_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$REVIEWABLE_TAG/,0")
         fi
 
         if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
           CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
         else
-          CONTENT_TO_REPLACE=${REVIEWABLE_BLOCK}
+          CONTENT_TO_REPLACE=${REVIEWABLE_CONTENT}
         fi
 
         NEW_CONTENT="${CUSTOM_HEADER}
 
         $(cat results/performance_results.md)
 
-        ${REVIEWABLE_BLOCK}
+        ${REVIEWABLE_CONTENT}
         "
         NEW_COMMENT_BODY="${EXISTING_COMMENT_CONTENT/"${CONTENT_TO_REPLACE}"/${NEW_CONTENT}}"
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -263,6 +263,9 @@ jobs:
     
     name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
 
+    outputs:
+        version: ${{ steps.configure.outputs.version }}
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -672,7 +672,6 @@ jobs:
         PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         EXISTING_COMMENT_CONTENT=$(gh api /repos/opensim-org/opensim-core/pulls/${PR_NUMBER} | jq -r '.body')
         CUSTOM_HEADER="### Performance analysis (Windows)"
-        MAC_HEADER="### Performance analysis (Mac)"
 
         REVIEWABLE_TAG="<!-- Reviewable:start -->"
         REVIEWABLE_CONTENT=""
@@ -681,16 +680,18 @@ jobs:
         fi
 
         MAC_CONTENT=""
+        MAC_HEADER="### Performance analysis (Mac)"
         if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
-          MAC_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,0")
-          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
-          else
-            CONTENT_TO_REPLACE=${MAC_CONTENT}
-          fi
+          MAC_CONTENT=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$MAC_HEADER/,/$REVIEWABLE_TAG/")
+        fi  
+    
+        if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
+          CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
         else
-          if [[ $EXISTING_COMMENT_CONTENT == *"$CUSTOM_HEADER"* ]]; then
-            CONTENT_TO_REPLACE=$(echo "$EXISTING_COMMENT_CONTENT" | awk "/$CUSTOM_HEADER/,0")
+          if [[ $EXISTING_COMMENT_CONTENT == *"$MAC_HEADER"* ]]; then
+            CONTENT_TO_REPLACE="${MAC_CONTENT}
+            
+            ${REVIEWABLE_CONTENT}"
           else
             CONTENT_TO_REPLACE=${REVIEWABLE_CONTENT}
           fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,10 +14,6 @@ on:
     tags:
       - '*'
 
-env:
-  perf_mac: ${{ (contains(github.event.pull_request.title, '[perf-mac]') || contains(github.event.pull_request.body, '[perf-mac]')) && !((contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]'))) }} 
-  perf_win: ${{ (contains(github.event.pull_request.title, '[perf-win]') || contains(github.event.pull_request.body, '[perf-win]')) || (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) }}
-
 jobs:
   windows:
     name: Windows
@@ -158,7 +154,7 @@ jobs:
   windows2022_target:
     name: Windows2022 [target]
 
-    if: ${{ env.perf_win }}
+    if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
     runs-on: windows-2022
 
@@ -182,7 +178,7 @@ jobs:
       run: python3 -m pip install numpy==1.20.2
 
     - name: Install SWIG
-      run: |
+      run: | 
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 
@@ -265,7 +261,7 @@ jobs:
     
     runs-on: windows-2022
     
-    name: ${{ env.perf_win && 'Windows2022 [source]' || 'Windows2022' }}
+    name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Windows2022 [source]' || 'Windows2022' }}
 
     steps:
     - uses: actions/checkout@v3
@@ -366,139 +362,140 @@ jobs:
         name: opensim-core-${{ steps.configure.outputs.version }}-win
         path: opensim-core-${{ steps.configure.outputs.version }}.zip
 
-  mac_target:
-    name: Mac [target]
+#   mac_target:
+#     name: Mac [target]
 
-    runs-on: macos-12
+#     runs-on: macos-12
 
-    if: ${{ env.perf_mac }}
+#     if: ${{ contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]') }}
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.base.ref }} 
+#     steps:
+#     - uses: actions/checkout@v3
+#       with:
+#         ref: ${{ github.event.pull_request.base.ref }} 
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
+#     - uses: actions/setup-python@v4
+#       with:
+#         python-version: '3.8'
         
-    - name: Install Homebrew packages
-      # Save the gfortran version to a file so we can use it in the cache key.
-      run: |
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
-        brew reinstall gcc
-        pip3 install numpy==1.20.2
-        gfortran -v
-        mkdir gfortran_version
-        gfortran -v &> gfortran_version/gfortran_version.txt
+#     - name: Install Homebrew packages
+#       # Save the gfortran version to a file so we can use it in the cache key.
+#       run: |
+#         brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+#         brew reinstall gcc
+#         pip3 install numpy==1.20.2
+#         gfortran -v
+#         mkdir gfortran_version
+#         gfortran -v &> gfortran_version/gfortran_version.txt
 
-    - name: Cache SWIG
-      id: cache-swig
-      uses: actions/cache@v3
-      with:
-        path: ~/swig
-        key: ${{ runner.os }}-swig
+#     - name: Cache SWIG
+#       id: cache-swig
+#       uses: actions/cache@v3
+#       with:
+#         path: ~/swig
+#         key: ${{ runner.os }}-swig
 
-    - name: Install SWIG
-      # if: steps.cache-swig.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-        make && make -j4 install
+#     - name: Install SWIG
+#       # if: steps.cache-swig.outputs.cache-hit != 'true'
+#       run: |
+#         mkdir ~/swig-source && cd ~/swig-source
+#         wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+#         tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+#         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+#         make && make -j4 install
 
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
-        # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
-        # undefined.
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
+#     - name: Cache dependencies
+#       id: cache-dependencies
+#       uses: actions/cache@v3
+#       with:
+#         path: ~/opensim_dependencies_install
+#         # If Homebrew updates the gcc package, then our cache of IPOPT is invalid.
+#         # Specifically, the pkgcfg_lib_IPOPT_gfortran CMake variable becomes
+#         # undefined.
+#         key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}-${{ hashFiles('gfortran_version/*') }}
 
-    - name: Build dependencies
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
-        DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
+#     - name: Build dependencies
+#       if: steps.cache-dependencies.outputs.cache-hit != 'true'
+#       run: |
+#         mkdir $GITHUB_WORKSPACE/../build_deps
+#         cd $GITHUB_WORKSPACE/../build_deps
+#         DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+#         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+#         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+#         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+#         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+#         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
+#         DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
+#         DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+#         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+#         cmake "${DEP_CMAKE_ARGS[@]}"
+#         make --jobs 4
 
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+#     - name: Configure opensim-core
+#       id: configure
+#       run: |
+#         mkdir $GITHUB_WORKSPACE/../build
+#         cd $GITHUB_WORKSPACE/../build
+#         OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+#         OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+#         OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+#         OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+#         OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=11)
+#         OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+#         OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+#         OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
+#         OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+#         OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+#         # TODO: Update to simbody.github.io/latest
+#         OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+#         OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
+#         printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+#         cmake "${OSIM_CMAKE_ARGS[@]}"
+#         VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+#         echo $VERSION
+#         echo "VERSION=$VERSION" >> $GITHUB_ENV
+#         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    - name: Build opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
+#     - name: Build opensim-core
+#       run: |
+#         cd $GITHUB_WORKSPACE/../build
+#         make --jobs 4
 
-    - name: Test opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        ctest --parallel 4 --output-on-failure
+#     - name: Test opensim-core
+#       run: |
+#         cd $GITHUB_WORKSPACE/../build
+#         ctest --parallel 4 --output-on-failure
 
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ github.event.pull_request.base.ref }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}.zip opensim-core-${{ github.event.pull_request.base.ref }}
-        mv opensim-core-${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE/../opensim-core-install
+#     - name: Install opensim-core
+#       run: |
+#         cd $GITHUB_WORKSPACE/../build
+#         make doxygen
+#         make install
+#         cd $GITHUB_WORKSPACE
+#         mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ github.event.pull_request.base.ref }}
+#         zip --symlinks --recurse-paths --quiet opensim-core-${{ github.event.pull_request.base.ref }}.zip opensim-core-${{ github.event.pull_request.base.ref }}
+#         mv opensim-core-${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE/../opensim-core-install
 
-    - name: Test Python bindings
-      run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-        # Run the python tests, verbosely.
-        python3 -m unittest discover --start-directory opensim/tests --verbose
+#     - name: Test Python bindings
+#       run: |
+#         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+#         # Run the python tests, verbosely.
+#         python3 -m unittest discover --start-directory opensim/tests --verbose
 
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v4
-      with:
-        # The upload-artifact zipping does not preserve symlinks or executable
-        # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
-        path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
+#     - name: Upload opensim-core
+#       uses: actions/upload-artifact@v4
+#       with:
+#         # The upload-artifact zipping does not preserve symlinks or executable
+#         # bits. So we zip ourselves, even though this causes a double-zip.
+#         name: opensim-core-${{ github.event.pull_request.base.ref }}-mac
+#         path: opensim-core-${{ github.event.pull_request.base.ref }}.zip
 
   mac_source:
 
     runs-on: macos-12
     
-    name: ${{ env.perf_mac && 'Mac [source]' || 'Mac' }}
+    name: Mac
+    # name: ${{ (contains(github.event.pull_request.title, '[perf]') || contains(github.event.pull_request.body, '[perf]')) && 'Mac [source]' || 'Mac' }}
 
     outputs:
       version: ${{ steps.configure.outputs.version }}
@@ -646,7 +643,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis.yml
-        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -645,12 +645,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis_win.yml
-        workflow_inputs: |
-          '{"commit_sha": "${{ github.event.pull_request.head.sha }}", 
-            "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", 
-            "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", 
-            "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", 
-            "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-win", "source_artifact_name": "opensim-core-${{ needs.windows2022_source.outputs.version }}-win", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.windows2022_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0
@@ -745,12 +740,7 @@ jobs:
         owner: opensim-org
         ref: main
         workflow: performance_analysis_mac.yml
-        workflow_inputs: |
-          '{"commit_sha": "${{ github.event.pull_request.head.sha }}", 
-            "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", 
-            "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", 
-            "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", 
-            "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
+        workflow_inputs: '{"commit_sha": "${{ github.event.pull_request.head.sha }}", "target_artifact_name": "opensim-core-${{ github.event.pull_request.base.ref }}-mac", "source_artifact_name": "opensim-core-${{ needs.mac_source.outputs.version }}-mac", "target_artifact_zip": "opensim-core-${{ github.event.pull_request.base.ref }}.zip", "source_artifact_zip": "opensim-core-${{ needs.mac_source.outputs.version }}.zip"}'
 
     - name: Await opensim-perf workflow
       uses: Codex-/await-remote-run@v1.11.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -160,6 +160,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Install Doxygen
       # choco install doxygen.portable # <-- too unreliable.
@@ -178,7 +180,7 @@ jobs:
       run: python3 -m pip install numpy==1.20.2
 
     - name: Install SWIG
-      run: | 
+      run: |
         choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 


### PR DESCRIPTION
### Brief summary of changes
Added updates to `continuous_integration.yml` to support running performance analysis jobs using either Mac or Windows runners. Since the self-hosted runner for Mac won't be ready for a while, I've set up a self-hosted runner for Windows on [opensim-perf](https://github.com/opensim-org/opensim-perf) which these changes will let us access. 

With these changes:

- a perf analysis using the self-hosted Windows runner can be accessed by adding `[perf-win]` in the PR body or title.
- a perf analysis using the (for now) GitHub hosted Mac runner can be accessed by adding `[perf-mac]` in the PR body or title.

For now, only one of the two results will be posted below (whatever comes last). Posting both will come in a future PR when Mac perf analysis has a self-hosted runner.

### Testing I've completed
The usual GitHub Actions ~~seven stages of grief~~ testing workflow.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...this is still somewhere in between finished and experimental. I will document the changes the change log and `CONTRIBUTING.md` when everything is finalized.

### Performance analysis

Platform: Mac, GitHub Actions runner

|                           Test Name | lhs [secs] | stderr [secs] | rhs [secs] | stderr [secs] | Speedup |
| ----------------------------------- | ---------- | ------------- | ---------- | ------------- | ------- |
|                               Arm26 |       0.61 |          0.48 |       0.60 |          0.48 |    1.01 |
|                      ToyDropLanding |      20.17 |         11.33 |      18.16 |          2.42 |    1.11 |
|          passive_dynamic_noanalysis |       3.90 |          0.01 |       4.53 |          0.02 |    0.86 |
| ToyDropLanding_function_based_paths |      21.38 |          4.15 |      20.65 |          0.75 |    1.04 |
|                            Gait2354 |       0.51 |          0.01 |       0.49 |          0.00 |    1.05 |
|                     passive_dynamic |       5.67 |          0.03 |       5.59 |          0.01 |    1.01 |
|            ToyDropLanding_nomuscles |       0.71 |          0.00 |       0.70 |          0.00 |    1.01 |
|                     MocoSlidingMass |       1.91 |          0.00 |       1.92 |          0.02 |    0.99 |
|                      RajagopalModel |      12.04 |          1.07 |      11.72 |          0.04 |    1.03 |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3754)
<!-- Reviewable:end -->
