### PR TITLE
Require SWIG version 4.1.1 exactly

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 4.1.1 REQUIRED)
+    find_package(SWIG 4.1.1 EXACT REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/scripts/build/opensim-core-windows-build-script.ps1
+++ b/scripts/build/opensim-core-windows-build-script.ps1
@@ -73,7 +73,7 @@ choco install git.install -y
 # Install dependencies of opensim-core
 choco install python3  -y
 choco install jdk8  -y
-choco install swig  -y
+choco install swig  -y --version 4.1.1
 choco install nsis  -y
 py -m pip install numpy
 


### PR DESCRIPTION
### Brief summary of changes

Installing a SWIG version greater than 4.1.1 causes the bindings to fail due to deprecated features that we do not yet have an alternative solution for. This change will lock us into 4.1.1 for now until we implement fixes for versions >4.1.1.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...not user facing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3756)
<!-- Reviewable:end -->
