### PR TITLE
Fix typo in doxygen for ExpressionBasedPointToPointForce

### DIFF
--- a/OpenSim/Simulation/Model/ExpressionBasedPointToPointForce.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedPointToPointForce.h
@@ -35,7 +35,7 @@ class MobilizedBody;
 namespace OpenSim { 
 
 /**
- * A point-to-point Force who's force magnitude is determined by a user-defined
+ * A point-to-point Force whose force magnitude is determined by a user-defined
  * expression, with the distance (d) and its time derivative (ddot) as variables. 
  * The direction of the force is directed along the line connecting the two 
  * points. 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3768)
<!-- Reviewable:end -->
