### PR TITLE
`PrescribedController` bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ delete_this_to_stop_optimization*.txt
 .idea/codeStyles/Project.xml
 .idea/editor.xml
 .vscode/settings.json
+.cache/clangd/**
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/Applications/Analyze/test/testAnalyzeTool.cpp
+++ b/Applications/Analyze/test/testAnalyzeTool.cpp
@@ -490,10 +490,8 @@ void testIMUDataReporter() {
         controller->addActuator(
                 pendulum.getComponent<CoordinateActuator>("/tau1"));
         // Specify constant torque functions to the torque actuators
-        Constant* constantTorque0 = new Constant(10.0);
-        Constant* constantTorque1 = new Constant(10.0);
-        controller->prescribeControlForActuator("tau0", constantTorque0);
-        controller->prescribeControlForActuator("tau1", constantTorque1);
+        controller->prescribeControlForActuator("tau0", Constant(10.0));
+        controller->prescribeControlForActuator("tau1", Constant(10.0));
         pendulum.addController(controller);
         state = pendulum.initSystem();
 

--- a/Applications/Analyze/test/testInducedAccelerations.cpp
+++ b/Applications/Analyze/test/testInducedAccelerations.cpp
@@ -87,8 +87,8 @@ void testDoublePendulumWithSolver()
         new PrescribedController();
 
     controller->setActuators(pendulum.getActuators());
-    controller->prescribeControlForActuator("Torq1", new Constant(torq1));
-    controller->prescribeControlForActuator("Torq2", new Constant(torq2));
+    controller->prescribeControlForActuator("Torq1", Constant(torq1));
+    controller->prescribeControlForActuator("Torq2", Constant(torq2));
     pendulum.addController(controller);
 
     State &s = pendulum.initSystem();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ v4.6
 - Added `Force::getForceIndex()` to allow accessing the `SimTK::ForceIndex` for force elements. (#3755) 
 - Improved performance in `MultivariatePolynomialFunction` and added convenience methods for automatically generating function derivatives (#3767).
 - Added options to `PolynomialPathFitter` for including moment arm and lengthening speed functions in generated `FunctionBasedPath`s (#3767).
+- The signature for `PrescribedController::prescribeControlForActuator()` was changed to take a `Function` via a const reference rather than a
+pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 
 v4.5
 ====

--- a/OpenSim/Actuators/Test/testActuators.cpp
+++ b/OpenSim/Actuators/Test/testActuators.cpp
@@ -153,7 +153,7 @@ TEST_CASE("testTorqueActuator") {
     PrescribedController* controller =  new PrescribedController();
     controller->addActuator(*actuator);
     // Apply torque about torqueAxis
-    controller->prescribeControlForActuator("torque", new Constant(torqueMag));
+    controller->prescribeControlForActuator("torque", Constant(torqueMag));
 
     model->addController(controller);
 
@@ -305,8 +305,7 @@ TEST_CASE("testClutchedPathSpring") {
     double     timePts[4] = {0.0,  5.0, 6.0, 10.0};
     double clutchOnPts[4] = {1.5, -2.0, 0.5,  0.5};
 
-    PiecewiseConstantFunction* controlfunc = 
-        new PiecewiseConstantFunction(4, timePts, clutchOnPts);
+    PiecewiseConstantFunction controlfunc(4, timePts, clutchOnPts);
 
     controller->prescribeControlForActuator("clutch_spring", controlfunc);
     model->addController(controller);
@@ -443,7 +442,7 @@ TEST_CASE("testMcKibbenActuator") {
 
     PrescribedController* controller = new PrescribedController();
     controller->addActuator(*actuator);
-    controller->prescribeControlForActuator("mckibben", new Constant(pressure));
+    controller->prescribeControlForActuator("mckibben", Constant(pressure));
 
     model->addController(controller);
 
@@ -891,7 +890,7 @@ TEST_CASE("testActivationCoordinateActuator") {
     auto* controller = new PrescribedController();
     controller->addActuator(*aca);
     const double x = 0.15;
-    controller->prescribeControlForActuator("aca", new Constant(x));
+    controller->prescribeControlForActuator("aca", Constant(x));
     model.addController(controller);
 
     auto state = model.initSystem();

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -287,7 +287,8 @@ void simulateMuscle(
         muscleController->setActuators(model.updActuators());
         // Set the individual muscle control functions 
         //for the prescribed muscle controller
-        muscleController->prescribeControlForActuator("muscle",control->clone());
+        muscleController->prescribeControlForActuator("muscle", 
+                *control->clone());
 
         // Add the control set controller to the model
         model.addController(muscleController.release());

--- a/OpenSim/Actuators/Test/testMuscles.cpp
+++ b/OpenSim/Actuators/Test/testMuscles.cpp
@@ -288,7 +288,7 @@ void simulateMuscle(
         // Set the individual muscle control functions 
         //for the prescribed muscle controller
         muscleController->prescribeControlForActuator("muscle", 
-                *control->clone());
+                *control);
 
         // Add the control set controller to the model
         model.addController(muscleController.release());

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -132,12 +132,12 @@ void simulateMuscle(
     // Create a prescribed controller that simply 
     //applies controls as function of time
     Constant control(0.5);
-    PrescribedController * muscleController = new PrescribedController();
+    PrescribedController* muscleController = new PrescribedController();
 
     muscleController->setActuators(model.updActuators());
     // Set the individual muscle control functions 
     //for the prescribed muscle controller
-    muscleController->prescribeControlForActuator("muscle", *control.clone());
+    muscleController->prescribeControlForActuator("muscle", control);
 
     // Add the control set controller to the model
     model.addController(muscleController);

--- a/OpenSim/Analyses/Test/testOutputReporter.cpp
+++ b/OpenSim/Analyses/Test/testOutputReporter.cpp
@@ -137,7 +137,7 @@ void simulateMuscle(
     muscleController->setActuators(model.updActuators());
     // Set the individual muscle control functions 
     //for the prescribed muscle controller
-    muscleController->prescribeControlForActuator("muscle", control.clone());
+    muscleController->prescribeControlForActuator("muscle", *control.clone());
 
     // Add the control set controller to the model
     model.addController(muscleController);

--- a/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
+++ b/OpenSim/Examples/CustomActuatorExample/toyLeg_example.cpp
@@ -184,9 +184,9 @@ int main()
 
         // specify the control function for each actuator
         legController->prescribeControlForActuator("piston",
-                new Constant(0.1));
+                Constant(0.1));
         legController->prescribeControlForActuator("spring", 
-                new PiecewiseLinearFunction(5, t, x));
+                PiecewiseLinearFunction(5, t, x));
 
         // add the controller to the model
         osimModel.addController(legController);     

--- a/OpenSim/Examples/ExampleHopperDevice/buildHopperModel.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/buildHopperModel.cpp
@@ -168,7 +168,7 @@ Model buildHopper(bool showVisualizer) {
     auto brain = new PrescribedController();
     brain->setActuators(hopper.updActuators());
     double t[3] = {0.0, 2.0, 3.9}, x[3] = {0.3, 1.0, 0.1};
-    auto controlFunction = new PiecewiseConstantFunction(3, t, x);
+    PiecewiseConstantFunction controlFunction(3, t, x);
     brain->prescribeControlForActuator("vastus", controlFunction);
     hopper.addController(brain);
 

--- a/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
+++ b/OpenSim/Examples/ExampleLuxoMuscle/LuxoMuscle_create_and_simulate.cpp
@@ -779,9 +779,8 @@ void createLuxoJr(OpenSim::Model& model){
     //________________________________________________________________________
     
     // specify a piecwise linear function for the muscle excitations
-    PiecewiseConstantFunction* x_of_t = new PiecewiseConstantFunction(3, times,
-                                                                  excitations);
-    
+    PiecewiseConstantFunction x_of_t(3, times, excitations);
+
     
     PrescribedController* kneeController = new PrescribedController();
     kneeController->addActuator(*kneeExtensorLeft);
@@ -789,7 +788,7 @@ void createLuxoJr(OpenSim::Model& model){
     kneeController->prescribeControlForActuator(
         kneeExtensorLeft->getAbsolutePathString(), x_of_t);
     kneeController->prescribeControlForActuator(
-        kneeExtensorRight->getAbsolutePathString(), x_of_t->clone());
+        kneeExtensorRight->getAbsolutePathString(), x_of_t);
     
     model.addController(kneeController);
     
@@ -797,9 +796,9 @@ void createLuxoJr(OpenSim::Model& model){
     backController->addActuator(*backExtensorLeft);
     backController->addActuator(*backExtensorRight);
     backController->prescribeControlForActuator(
-        backExtensorLeft->getAbsolutePathString(), x_of_t->clone());
+        backExtensorLeft->getAbsolutePathString(), x_of_t);
     backController->prescribeControlForActuator(
-        backExtensorRight->getAbsolutePathString(), x_of_t->clone());
+        backExtensorRight->getAbsolutePathString(), x_of_t);
     
     model.addController(backController);
 

--- a/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
+++ b/OpenSim/Examples/ExampleMain/OutputReference/TugOfWar_Complete.cpp
@@ -268,8 +268,8 @@ int main()
         slopeAndIntercept2[0] = 0.95/(finalTime-initialTime);  slopeAndIntercept2[1] = 0.05;
         
         // Set the individual muscle control functions for the prescribed muscle controller
-        muscleController->prescribeControlForActuator("muscle1", new LinearFunction(slopeAndIntercept1));
-        muscleController->prescribeControlForActuator("muscle2", new LinearFunction(slopeAndIntercept2));
+        muscleController->prescribeControlForActuator("muscle1", LinearFunction(slopeAndIntercept1));
+        muscleController->prescribeControlForActuator("muscle2", LinearFunction(slopeAndIntercept2));
 
         // Add the muscle controller to the model
         osimModel.addController(muscleController);

--- a/OpenSim/Examples/MuscleExample/mainFatigue.cpp
+++ b/OpenSim/Examples/MuscleExample/mainFatigue.cpp
@@ -165,8 +165,8 @@ int main()
         muscleController->setActuators(osimModel.updActuators());
     
         // Set the prescribed muscle controller to use the same muscle control function for each muscle
-        muscleController->prescribeControlForActuator("fatigable", new Constant(1.0));
-        muscleController->prescribeControlForActuator("original", new Constant(1.0));
+        muscleController->prescribeControlForActuator("fatigable", Constant(1.0));
+        muscleController->prescribeControlForActuator("original", Constant(1.0));
 
         // Add the muscle controller to the model
         osimModel.addController(muscleController);

--- a/OpenSim/Examples/checkEnvironment/checkEnvironment.cpp
+++ b/OpenSim/Examples/checkEnvironment/checkEnvironment.cpp
@@ -177,8 +177,8 @@ int main()
         slopeAndIntercept2[0] = 0.95/(finalTime-initialTime);  slopeAndIntercept2[1] = 0.05;
         
         // Set the individual muscle control functions for the prescribed muscle controller
-        muscleController->prescribeControlForActuator("muscle1", new LinearFunction(slopeAndIntercept1));
-        muscleController->prescribeControlForActuator("muscle2", new LinearFunction(slopeAndIntercept2));
+        muscleController->prescribeControlForActuator("muscle1", LinearFunction(slopeAndIntercept1));
+        muscleController->prescribeControlForActuator("muscle2", LinearFunction(slopeAndIntercept2));
 
         // Add the muscle controller to the model
         osimModel.addController(muscleController);

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -84,7 +84,7 @@ void OpenSim::prescribeControlsToModel(
         const auto& actu = model.getComponent<Actuator>(actuNames[i]);
         controller->addActuator(actu);
         controller->prescribeControlForActuator(
-                actu.getName(), function.release());
+                actu.getName(), *function);
     }
     model.addController(controller);
 }

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -469,8 +469,7 @@ MocoTrajectory runForwardSimulation(
     controller->setName("prescribed_controller");
     for (int i = 0; i < actuNames.size(); ++i) {
         const auto control = solution.getControl(actuNames[i]);
-        auto* controlFunction =
-                new GCVSpline(5, time.nrow(), &time[0], &control[0]);
+        GCVSpline controlFunction(5, time.nrow(), &time[0], &control[0]);
         const auto& actu = model.getComponent<Actuator>(actuNames[i]);
         controller->addActuator(actu);
         controller->prescribeControlForActuator(

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -2270,7 +2270,7 @@ TEMPLATE_TEST_CASE("Sliding mass with PrescribedController", "",
         controller->addActuator(
                 model.getComponent<Actuator>("/forceset/actuator"));
         controller->prescribeControlForActuator("/forceset/actuator",
-            new GCVSpline(5, control.size(), time.data(), &control[0],
+                GCVSpline(5, control.size(), time.data(), &control[0],
                     "/forceset/actuator", 0.0));
         model.addController(controller);
         model.finalizeConnections();
@@ -2305,7 +2305,7 @@ TEST_CASE("MocoControlGoal: ignoring controlled actuators") {
     controller->addActuator(
             model.getComponent<Actuator>("/forceset/actuator"));
     controller->prescribeControlForActuator("/forceset/actuator",
-            new Constant(1.0));
+            Constant(1.0));
     model.addController(controller);
     model.finalizeConnections();
 

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -136,7 +136,6 @@ void PrescribedController::extendConnectToModel(Model& model)
         Array<double> data(0.0, nrows);
         controls.getTimeColumn(time);
 
-        const FunctionSet& controlFuncs = get_ControlFunctions();
         for (int i = 0; i < columnLabels.getSize(); ++i) {
             // Skip the time column.
             if (i == tcol) continue;
@@ -176,9 +175,9 @@ void PrescribedController::extendConnectToModel(Model& model)
 
                 // Create the control function and assign it to the actuator.
                 controls.getDataColumn(
-                    controls.getStateIndex(columnLabel), data);
+                        controls.getStateIndex(columnLabel), data);
                 Function* controlFunction = createFunctionFromData(columnLabel,
-                    time, data);
+                        time, data);
                 prescribeControlForActuator(columnLabel, controlFunction);
             }
         }

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -113,7 +113,7 @@ void PrescribedController::extendConnectToModel(Model& model) {
         "number of actuators ({}) connected to the controller.",
         controlFuncs.getSize(), socket.getNumConnectees());
 
-    // If the 'ALL' keyword was provide via the actuator list (pre-4.6), then 
+    // If the 'ALL' keyword was provided via the actuator list (pre-4.6), then 
     // populate the control function index map with all actuators in 
     // connectee order. This also handles the case where control functions are
     // provided via the ControlFunctions property directly (i.e., the index map 

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -94,19 +94,6 @@ void PrescribedController::updateFromXMLNode(SimTK::Xml::Element& node,
                 _actuLabelsToControlFunctionIndexMap[actuName] = iactu++;
             }
         }
-        int ifunc = 0;
-        if (node.hasElement("FunctionSet")) {
-            auto functions = node.getRequiredElement("FunctionSet");
-            auto objects = functions.getRequiredElement("objects");
-            for (auto iter = objects.element_begin();
-                    iter != objects.element_end(); ++iter) {
-                ++ifunc;
-            }
-        }
-        OPENSIM_THROW_IF_FRMOBJ(ifunc != iactu, Exception, 
-                "Expected the number of control functions to match the "
-                "number of actuators connected to the controller, but "
-                "received {} and {}, respectively.", ifunc, iactu);
     }
 
     Super::updateFromXMLNode(node, versionNumber);

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -25,7 +25,6 @@
 // INCLUDES
 //=============================================================================
 #include "PrescribedController.h"
-#include "OpenSim/Common/Exception.h"
 #include <OpenSim/Common/Storage.h>
 #include <OpenSim/Common/GCVSpline.h>
 #include <OpenSim/Common/PiecewiseConstantFunction.h>

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -97,10 +97,13 @@ public:
     /**
      *  Assign a prescribed control function for the desired actuator identified
      *  by the provided label. The label can be either the name of the actuator,
-     *  or the absolute path to the actuator in the model. Controller takes
-     *  ownership of the function.
+     *  or the absolute path to the actuator in the model.
      *  @param actuLabel            label for the actuator in the controller
      *  @param prescribedFunction   the actuator's control function
+     *
+     *  @note As of OpenSim 4.6, PrescribedController no longer takes ownership
+     *        of the passed in Function. Rather, a clone of the Function at the 
+     *        passed in pointer is made.
      */
     void prescribeControlForActuator(const std::string& actuLabel,
                                      Function* prescribedFunction);
@@ -116,6 +119,8 @@ public:
 protected:
     // MODEL COMPONENT INTERFACE
     void extendConnectToModel(Model& model) override;
+    void updateFromXMLNode(SimTK::Xml::Element& node,
+                           int versionNumber) override;
 
 private:
     // Construct and initialize properties.

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -35,6 +35,9 @@ class Function;
  * PrescribedController is a concrete Controller that specifies functions that 
  * prescribe the control values of its actuators as a function of time.
  *
+ * TODO if loading from file or setting the ControlFunctions property, note that
+ *      the order of the functions must match the order of connected actuators.
+ *
  * @note Prior to OpenSim 4.6, PrescribedController support setting a prescribed
  *       control based on the actuator's index in the `ControlFunctions`
  *       property. This interface is deprecated and will be removed in a future
@@ -51,7 +54,8 @@ public:
 //=============================================================================
     OpenSim_DECLARE_PROPERTY(ControlFunctions, FunctionSet,
         "Functions (one per control) describing the controls for actuators "
-        "specified for this controller." );
+        "specified for this controller. The control function set must match "
+        "the number and order of connected actuators." );
 
     OpenSim_DECLARE_OPTIONAL_PROPERTY(controls_file, std::string,
         "Controls storage (.sto) file containing controls for individual "
@@ -136,7 +140,6 @@ private:
 
     // Member variables.
     std::unordered_map<std::string, int> _actuLabelsToControlFunctionIndexMap;
-    std::unordered_map<int, int> _actuIndexToControlFunctionIndexMap;
 
 };  // class PrescribedController
 

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -11,6 +11,7 @@
  *                                                                            *
  * Copyright (c) 2005-2024 Stanford University and the Authors                *
  * Author(s): Ajay Seth                                                       *
+ * Contributor(s): Nicholas Bianco                                            *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -42,6 +43,14 @@ class Function;
  * after connecting the controller to the model, the added control function will
  * be placed at the correct index in the `ControlFunctions` property.
  *
+ * A controls storage file can be specified in the `controls_file` property.
+ * Each column must be either the name or path of an actuator in the model. If
+ * the actuator name is used as the column label, the first actuator with a 
+ * matching name will be connected to the controller and assigned a control 
+ * function based on the column data. Using actuator paths in the column labels
+ * is recommended to avoid ambiguity. Finally, any actuators with existing 
+ * control functions will be ignored when setting controls from file.
+ *
  * @note Prior to OpenSim 4.6, PrescribedController support setting a prescribed
  *       control based on the actuator's index in the `ControlFunctions`
  *       property. This interface is deprecated and will be removed in a future
@@ -64,8 +73,7 @@ public:
     OpenSim_DECLARE_OPTIONAL_PROPERTY(controls_file, std::string,
         "Controls storage (.sto) file containing controls for individual "
         "actuators in the model. Each column label must be either the name "
-        "of an actuator in the model's ForceSet or the absolute path to an "
-        "actuator anywhere in the model.");
+        "or path to an actuator in the model.");
 
     OpenSim_DECLARE_OPTIONAL_PROPERTY(interpolation_method, int,
         "Interpolate the controls file data using piecewise: '0-constant', "

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -118,18 +118,17 @@ public:
      *  @param prescribedFunction   the actuator's control function
      *
      *  @note As of OpenSim 4.6, PrescribedController no longer takes ownership
-     *        of the passed in Function. Rather, a clone of the Function at the 
-     *        passed in pointer is made.
+     *        of the passed in Function and instead makes a copy.
      */
     void prescribeControlForActuator(const std::string& actuLabel,
-                                     Function* prescribedFunction);
+                                     const Function& prescribedFunction);
 
-    [[deprecated("Use prescribeControlForActuator(const std::string&, Function*) instead")]]
+    [[deprecated("Use prescribeControlForActuator(const std::string&, const Function&) instead")]]
     void prescribeControlForActuator(int index, Function* prescribedFunction) {
         OPENSIM_THROW_FRMOBJ(Exception,
             "PrescribedController::prescribeControlForActuator(int, Function*) "
             "is deprecated. Use prescribeControlForActuator(const std::string&, "
-            "Function*) instead.");
+            "const Function&) instead.");
     }
 
 protected:
@@ -143,7 +142,7 @@ private:
     void constructProperties();
 
     // Utility functions.
-    Function* createFunctionFromData(const std::string& name,
+    std::unique_ptr<Function> createFunctionFromData(const std::string& name,
         const Array<double>& time, const Array<double>& data) const;
     int getActuatorIndexFromLabel(const std::string& actuLabel) const;
 

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -35,8 +35,12 @@ class Function;
  * PrescribedController is a concrete Controller that specifies functions that 
  * prescribe the control values of its actuators as a function of time.
  *
- * TODO if loading from file or setting the ControlFunctions property, note that
- *      the order of the functions must match the order of connected actuators.
+ * The control functions are specified in the `ControlFunctions` property. The
+ * number and order of functions must match the number and order of actuators 
+ * connected to the controller. Use `prescribeControlForActuator()` to assign a
+ * control function to an actuator based on the name or path of the actuator;
+ * after connecting the controller to the model, the added control function will
+ * be placed at the correct index in the `ControlFunctions` property.
  *
  * @note Prior to OpenSim 4.6, PrescribedController support setting a prescribed
  *       control based on the actuator's index in the `ControlFunctions`

--- a/OpenSim/Simulation/Control/PrescribedController.h
+++ b/OpenSim/Simulation/Control/PrescribedController.h
@@ -36,12 +36,22 @@ class Function;
  * PrescribedController is a concrete Controller that specifies functions that 
  * prescribe the control values of its actuators as a function of time.
  *
- * The control functions are specified in the `ControlFunctions` property. The
- * number and order of functions must match the number and order of actuators 
- * connected to the controller. Use `prescribeControlForActuator()` to assign a
- * control function to an actuator based on the name or path of the actuator;
- * after connecting the controller to the model, the added control function will
- * be placed at the correct index in the `ControlFunctions` property.
+ * The control functions are specified in the `ControlFunctions` property. Use 
+ * `prescribeControlForActuator()` to assign a control function to an actuator 
+ * based on the name or path of the actuator. After connecting the controller to 
+ * the model, the added control function will be placed at the correct index in 
+ * the `ControlFunctions` property. If modifying the `ControlFunctions` property
+ * directly, the number and order of functions must match the number and order 
+ * of actuators connected to the controller. However, it is recommended to use
+ * `prescribeControlForActuator()` to ensure the correct mapping between 
+ * actuator and control function.
+ *
+ * When loading from file, the order of the control functions in the file must
+ * match the order of actuators connected to the controller. If 
+ * `prescribeControlForActuator()` is used to assign control functions, the 
+ * control functions will be stored in the correct order in the 
+ * `ControlFunctions` when saving the controller to file (since they are 
+ * reordered as described above).
  *
  * A controls storage file can be specified in the `controls_file` property.
  * Each column must be either the name or path of an actuator in the model. If

--- a/OpenSim/Simulation/Test/testManager.cpp
+++ b/OpenSim/Simulation/Test/testManager.cpp
@@ -284,9 +284,8 @@ void testExcitationUpdatesWithManager()
     const Set<Muscle> &muscleSet = arm.getMuscles();
     PrescribedController* controller = new PrescribedController();
     controller->addActuator(muscleSet.get(0));
-    Constant* fn = new Constant(0);
     controller->prescribeControlForActuator(
-        muscleSet.get(0).getAbsolutePathString(), fn);
+        muscleSet.get(0).getAbsolutePathString(), Constant(0));
     arm.addController(controller);
 
     SimTK::State& state = arm.initSystem();

--- a/OpenSim/Simulation/Test/testProbes.cpp
+++ b/OpenSim/Simulation/Test/testProbes.cpp
@@ -274,12 +274,12 @@ void simulateMuscle(
 
     // Create a prescribed controller that simply 
     //applies controls as function of time
-    PrescribedController * muscleController = new PrescribedController();
+    PrescribedController* muscleController = new PrescribedController();
     if (control != NULL){
         muscleController->setActuators(model.updActuators());
         // Set the individual muscle control functions 
         //for the prescribed muscle controller
-        muscleController->prescribeControlForActuator("muscle", control->clone());
+        muscleController->prescribeControlForActuator("muscle", *control->clone());
 
         // Add the control set controller to the model
         model.addController(muscleController);

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -157,7 +157,7 @@ void createStateStorageFile() {
         controller->addActuator(model.getMuscles()[im]);
         controller->prescribeControlForActuator(
             model.getMuscles()[im].getName(),
-            new Constant(distribution(generator))
+            Constant(distribution(generator))
             );
     }
 

--- a/OpenSim/Tests/README/testREADME.cpp
+++ b/OpenSim/Tests/README/testREADME.cpp
@@ -84,7 +84,7 @@ int main() {
     brain->addActuator(*biceps);
     // Muscle excitation is 0.3 for the first 0.5 seconds, then increases to 1.
     brain->prescribeControlForActuator("biceps",
-            new StepFunction(0.5, 3, 0.3, 1));
+            StepFunction(0.5, 3, 0.3, 1));
 
     // Add components to the model.
     model.addBody(humerus);    model.addBody(radius);

--- a/OpenSim/Tests/Wrapping/testWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testWrapping.cpp
@@ -88,7 +88,7 @@ namespace {
         for (int i = 0; i < (int)socket.getNumConnectees(); ++i) {
             actuController.prescribeControlForActuator(
                     actuatorsSet.get(i).getAbsolutePathString(),
-                    new Constant(activation));
+                    Constant(activation));
         }
     
         // Add the controller to the model. We need to call disownAllComponents

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -48,8 +48,8 @@ TEST_CASE("Test Controller interface") {
 
     Model model = ModelFactory::createNLinkPendulum(2);
     auto* controller = new PrescribedController();
-    controller->prescribeControlForActuator("/tau0", new Constant(1.0));
-    controller->prescribeControlForActuator("/tau1", new Constant(2.0));
+    controller->prescribeControlForActuator("/tau0", Constant(1.0));
+    controller->prescribeControlForActuator("/tau1", Constant(2.0));
 
     SECTION("No actuators connecteed") {
         model.addController(controller);
@@ -216,7 +216,7 @@ TEST_CASE("testPrescribedControllerOnBlock") {
     actuatorController.setActuators(osimModel.updActuators());
     actuatorController.prescribeControlForActuator(
         osimModel.getActuators().get(0).getAbsolutePathString(),
-        new Constant(controlForce));
+        Constant(controlForce));
     actuatorController.setEnabled(enabled);
 
     // add the controller to the model
@@ -426,9 +426,9 @@ TEST_CASE("PrescribedController control function ordering") {
     controller->addActuator(model.getComponent<Actuator>("/tau2"));
 
     GIVEN("Controls prescribed out of order") {
-        controller->prescribeControlForActuator("/tau1", new Constant(2.0));
-        controller->prescribeControlForActuator("/tau0", new Constant(1.0));
-        controller->prescribeControlForActuator("/tau2", new Constant(3.0));
+        controller->prescribeControlForActuator("/tau1", Constant(2.0));
+        controller->prescribeControlForActuator("/tau0", Constant(1.0));
+        controller->prescribeControlForActuator("/tau2", Constant(3.0));
         // Control function reordering happens during 
         // PrescribedController::extendConnectToModel().
         model.addController(controller);
@@ -466,13 +466,13 @@ TEST_CASE("PrescribedController behavior") {
 
     SECTION("Overwriting control function with same label") {
         controller.prescribeControlForActuator(
-                "actu_slider", new Constant(1.0));
+                "actu_slider", Constant(1.0));
         CHECK_NOTHROW(model.initSystem());
     }
 
     SECTION("Different label for same actuator should throw") {
         controller.prescribeControlForActuator(
-                "/forceset/actu_slider", new Constant(1.0));
+                "/forceset/actu_slider", Constant(1.0));
         std::string msg = "The number of control functions (2) does not match"; 
         CHECK_THROWS_WITH(model.initSystem(), ContainsSubstring(msg));
     }

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -473,8 +473,7 @@ TEST_CASE("PrescribedController behavior") {
     SECTION("Different label for same actuator should throw") {
         controller.prescribeControlForActuator(
                 "/forceset/actu_slider", new Constant(1.0));
-        std::string msg = "Expected actuator /forceset/actu_slider to have " 
-                          "one control function";
+        std::string msg = "The number of control functions (2) does not match"; 
         CHECK_THROWS_WITH(model.initSystem(), ContainsSubstring(msg));
     }
 

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -37,10 +37,7 @@
 
 #include <OpenSim/OpenSim.h>
 
-#include "OpenSim/Simulation/Control/PrescribedController.h"
 #include <catch2/catch_all.hpp>
-#include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_string.hpp>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
 using namespace OpenSim;

--- a/OpenSim/Tools/Test/testControllers.cpp
+++ b/OpenSim/Tools/Test/testControllers.cpp
@@ -73,6 +73,32 @@ TEST_CASE("Test Controller interface") {
     }
 }
 
+TEST_CASE("PrescribedController control function ordering") {
+    Model model = ModelFactory::createNLinkPendulum(3);
+    auto* controller = new PrescribedController();
+    controller->addActuator(model.getComponent<Actuator>("/tau0"));
+    controller->addActuator(model.getComponent<Actuator>("/tau1"));
+    controller->addActuator(model.getComponent<Actuator>("/tau2"));
+
+    GIVEN("Controls prescribed out of order") {
+        controller->prescribeControlForActuator("/tau1", new Constant(2.0));
+        controller->prescribeControlForActuator("/tau0", new Constant(1.0));
+        controller->prescribeControlForActuator("/tau2", new Constant(3.0));
+        // Control function reordering happens during 
+        // PrescribedController::extendConnectToModel().
+        model.addController(controller);
+        model.finalizeConnections();
+
+        THEN("Control functions are reordered based on connectee order") {
+            SimTK::Vector time(1, 0.0);
+            const auto& controlFunctions = controller->get_ControlFunctions();
+            CHECK(controlFunctions.get(0).calcValue(time) == 1.0);
+            CHECK(controlFunctions.get(1).calcValue(time) == 2.0);
+            CHECK(controlFunctions.get(2).calcValue(time) == 3.0);
+        }
+    }    
+}
+
 TEST_CASE("PrescribedController behavior") {
     Model model("testControllers_TugOfWar.osim");
     model.initSystem();

--- a/OpenSim/Tools/Test/testControllers_TugOfWar.osim
+++ b/OpenSim/Tools/Test/testControllers_TugOfWar.osim
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<OpenSimDocument Version="40000">
+	<Model name="Tug_of_War">
+		<!--The model's ground reference frame.-->
+		<Ground name="ground">
+			<!--List of components that this component owns and serializes.-->
+			<components>
+			</components>
+			<!--The geometry used to display the axes of this Frame.-->
+			<FrameGeometry name="frame_geometry">
+				<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
+				<socket_frame>..</socket_frame>
+				<!--Scale factors in X, Y, Z directions respectively.-->
+				<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
+			</FrameGeometry>
+			<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
+			<attached_geometry>
+			</attached_geometry>
+			<!--Set of wrap objects fixed to this body that GeometryPaths can wrap over.This property used to be a member of Body but was moved up with the introduction of Frames.-->
+			<WrapObjectSet name="wrapobjectset">
+				<objects />
+				<groups />
+			</WrapObjectSet>
+		</Ground>
+		<!--Acceleration due to gravity, expressed in ground.-->
+		<gravity>0 -9.8066499999999994 0</gravity>
+		<!--Credits (e.g., model author names) associated with the model.-->
+		<credits>Author: The OpenSim Teams License: Creative Commons (CCBY 3.0). You are free to distribute, remix, tweak, and build upon this work, even commercially, as long as you credit us for the original creation. http://creativecommons.org/licenses/by/3.0/</credits>
+		<!--Publications and references associated with the model.-->
+		<publications></publications>
+		<!--Units for all lengths.-->
+		<length_units>meters</length_units>
+		<!--Units for all forces.-->
+		<force_units>N</force_units>
+		<!--List of bodies that make up this model.-->
+		<BodySet name="bodyset">
+			<objects>
+				<Body name="block">
+					<!--The geometry used to display the axes of this Frame.-->
+					<FrameGeometry name="frame_geometry">
+						<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
+						<socket_frame>..</socket_frame>
+						<!--Scale factors in X, Y, Z directions respectively.-->
+						<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
+					</FrameGeometry>
+					<!--List of geometry attached to this Frame. Note, the geometry are treated as fixed to the frame and they share the transform of the frame when visualized-->
+					<attached_geometry>
+						<Mesh name="block_geom_1">
+							<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
+							<socket_frame>..</socket_frame>
+							<!--Scale factors in X, Y, Z directions respectively.-->
+							<scale_factors>1 1 1</scale_factors>
+							<!--Default appearance attributes for this Geometry-->
+							<Appearance>
+								<!--The opacity used to display the geometry between 0:transparent, 1:opaque.-->
+								<opacity>1</opacity>
+								<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
+								<color>1 1 1</color>
+							</Appearance>
+							<!--Name of geometry file.-->
+							<mesh_file>block.vtp</mesh_file>
+						</Mesh>
+					</attached_geometry>
+					<!--Set of wrap objects fixed to this body that GeometryPaths can wrap over.This property used to be a member of Body but was moved up with the introduction of Frames.-->
+					<WrapObjectSet name="wrapobjectset">
+						<objects />
+						<groups />
+					</WrapObjectSet>
+					<!--The mass of the body (kg)-->
+					<mass>20</mass>
+					<!--The location (Vec3) of the mass center in the body frame.-->
+					<mass_center>0 0 0</mass_center>
+					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
+					<inertia>0.13333300000000001 0.13333300000000001 0.13333300000000001 0 0 0</inertia>
+				</Body>
+			</objects>
+			<groups />
+		</BodySet>
+		<!--List of joints that connect the bodies.-->
+		<JointSet name="jointset">
+			<objects>
+				<SliderJoint name="ground_block">
+					<!--Path to a Component that satisfies the Socket 'parent_frame' of type PhysicalFrame (description: The parent frame for the joint.).-->
+					<socket_parent_frame>ground_offset</socket_parent_frame>
+					<!--Path to a Component that satisfies the Socket 'child_frame' of type PhysicalFrame (description: The child frame for the joint.).-->
+					<socket_child_frame>block_offset</socket_child_frame>
+					<!--List containing the generalized coordinates (q's) that parameterize this joint.-->
+					<coordinates>
+						<Coordinate name="block_tz">
+							<!--The value of this coordinate before any value has been set. Rotational coordinate value is in radians and Translational in meters.-->
+							<default_value>0</default_value>
+							<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
+							<default_speed_value>0</default_speed_value>
+							<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->
+							<range>-0.29999999999999999 0.29999999999999999</range>
+							<!--Flag indicating whether or not the values of the coordinates should be limited to the range, above.-->
+							<clamped>true</clamped>
+							<!--Flag indicating whether or not the values of the coordinates should be constrained to the current (e.g. default) value, above.-->
+							<locked>false</locked>
+							<!--If specified, the coordinate can be prescribed by a function of time. It can be any OpenSim Function with valid second order derivatives.-->
+							<prescribed_function />
+							<!--Flag indicating whether or not the values of the coordinates should be prescribed according to the function above. It is ignored if the no prescribed function is specified.-->
+							<prescribed>false</prescribed>
+						</Coordinate>
+					</coordinates>
+					<!--Physical offset frames owned by the Joint that are typically used to satisfy the owning Joint's parent and child frame connections (sockets). PhysicalOffsetFrames are often used to describe the fixed transformation from a Body's origin to another location of interest on the Body (e.g., the joint center). When the joint is deleted, so are the PhysicalOffsetFrame components in this list.-->
+					<frames>
+						<PhysicalOffsetFrame name="ground_offset">
+							<!--The geometry used to display the axes of this Frame.-->
+							<FrameGeometry name="frame_geometry">
+								<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
+								<socket_frame>..</socket_frame>
+								<!--Scale factors in X, Y, Z directions respectively.-->
+								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
+							</FrameGeometry>
+							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
+							<socket_parent>/ground</socket_parent>
+							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
+							<translation>0 0 0</translation>
+							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
+							<orientation>0 -1.5708 0</orientation>
+						</PhysicalOffsetFrame>
+						<PhysicalOffsetFrame name="block_offset">
+							<!--The geometry used to display the axes of this Frame.-->
+							<FrameGeometry name="frame_geometry">
+								<!--Path to a Component that satisfies the Socket 'frame' of type Frame.-->
+								<socket_frame>..</socket_frame>
+								<!--Scale factors in X, Y, Z directions respectively.-->
+								<scale_factors>0.20000000000000001 0.20000000000000001 0.20000000000000001</scale_factors>
+							</FrameGeometry>
+							<!--Path to a Component that satisfies the Socket 'parent' of type C (description: The parent frame to this frame.).-->
+							<socket_parent>/bodyset/block</socket_parent>
+							<!--Translational offset (in meters) of this frame's origin from the parent frame's origin, expressed in the parent frame.-->
+							<translation>0 -0.050000000000000003 0</translation>
+							<!--Orientation offset (in radians) of this frame in its parent frame, expressed as a frame-fixed x-y-z rotation sequence.-->
+							<orientation>0 -1.5708 0</orientation>
+						</PhysicalOffsetFrame>
+					</frames>
+				</SliderJoint>
+			</objects>
+		</JointSet>
+		<!--Controllers that provide the control inputs for Actuators.-->
+		<ControllerSet name="controllerset">
+			<objects>
+				<PrescribedController name="prescribedcontroller">
+					<!--The list of model actuators that this controller will control.The keyword ALL indicates the controller will control all the actuators in the model-->
+					<actuator_list>actu_slider</actuator_list>
+					<!--Functions (one per control) describing the controls for actuatorsspecified for this controller.-->
+					<FunctionSet name="ControlFunctions">
+						<objects>
+							<GCVSpline name="spline_slider">
+								<half_order>3</half_order>
+								<error_variance>0</error_variance>
+								<x> 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1</x>
+								<y> 0.573621 0.44629 0.319214 0.183898 0.0920755 0.0407125 -0.0085371 -0.040781 -0.0774591 -0.133466 -0.219896</y>
+								<weights> 1 1 1 1 1 1 1 1 1 1 1</weights>
+								<coefficients> 0 0 0 0 0 0 0 0 0 0 0</coefficients>
+							</GCVSpline>
+						</objects>
+						<groups />
+					</FunctionSet>
+				</PrescribedController>
+			</objects>
+			<groups />
+		</ControllerSet>
+		<!--Constraints in the model.-->
+		<ConstraintSet name="constraintset">
+			<objects />
+			<groups />
+		</ConstraintSet>
+		<!--Forces in the model (includes Actuators).-->
+		<ForceSet name="forceset">
+			<objects>
+				<CoordinateActuator name="actu_slider">
+					<!--Minimum allowed value for control signal. Used primarily when solving for control values.-->
+					<min_control>-1</min_control>
+					<!--Maximum allowed value for control signal. Used primarily when solving for control values.-->
+					<max_control>1</max_control>
+					<!--Name of the generalized coordinate to which the actuator applies.-->
+					<coordinate>block_tz</coordinate>
+					<!--The maximum generalized force produced by this actuator.-->
+					<optimal_force>150</optimal_force>
+				</CoordinateActuator>
+			</objects>
+			<groups />
+		</ForceSet>
+		<!--Markers in the model.-->
+		<MarkerSet name="markerset">
+			<objects />
+			<groups />
+		</MarkerSet>
+		<!--Geometry to be used in contact forces.-->
+		<ContactGeometrySet name="contactgeometryset">
+			<objects />
+			<groups />
+		</ContactGeometrySet>
+		<!--Probes in the model.-->
+		<ProbeSet name="probeset">
+			<objects />
+			<groups />
+		</ProbeSet>
+		<!--Additional components in the model.-->
+		<ComponentSet name="componentset">
+			<objects />
+			<groups />
+		</ComponentSet>
+	</Model>
+</OpenSimDocument>


### PR DESCRIPTION
Fixes issue #3749, #3750

### Brief summary of changes

These changes fix bugs in `PrescribedController` recently introduced after converting `Controller` to support a list `Socket` to maintain actuator connections. This PR also changes the behavior of `prescribeControlForActuator()` by making a copy of the `Function` at the passed in `Function` pointer rather than taking ownership. This change protects users from possible crashes when `Function` ownership is passed to the controller (e.g., during garbage collection in Java/Matlab).

The main changes:
- ~~A check was added during deserialization to ensure that the number of actuators in the list `Socket` matches the number of control function.~~ EDIT: removed, this was causing serialization tests to fail.
- The map `_actuLabelsToControlFunctionIndexMap` is also updated during deserialization to account for any control functions existing the model.
- The functions in `ControlFunctions` are now reordered based on the order of actuators connected via the list `Socket` to provide the correct order for `computeControls()` and serialization. This actually fixes an undetected bug: the member variable `_actuIndexToControlFunctionIndexMap` was not being used within `computeControls()` as it should have been. However, reordering `ControlFunctions` makes `_actuIndexToControlFunctionIndexMap` unnecessary, so it has been removed.

### Testing I've completed
- Added relavant tests to `testControllers.cpp`.
- Tested the changes on the sample scripts included in the related issues: no crashes occur when passing functions to `prescribeControlForActuator`.

### Looking for feedback on...
- If we're going to copy the `Function` passed via `prescribeControlForActuator()`, should change the signature to use a const reference to the function (i.e., `const Function& prescribedFunction`), rather than a pointer? It would change usage in C++, but scripting users wouldn't notice a difference.

### CHANGELOG.md (choose one)

- no need to update because...bug fixes (unless we change the signature for `prescribeControlForActuator()`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3781)
<!-- Reviewable:end -->
