### PR TITLE
Add ComponentPath overrides to Component interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ v4.6
   `appendSocketConnectee_*` can be used to connect `Object`s to a list `Socket`. In addition, `Component` and Socket have
   new `getConnectee` overloads that take an index to a desired object in the list `Socket` (#3652).
 - Added `ComponentPath::root()`, which returns a `ComponentPath` equivalent to "/"
+- Added `ComponentPath::separator()`, which returns the separator that's placed between elements of the path (i.e. `'/'`)
 - `ComponentPath` is now less-than (`<`) comparable, making it usable in (e.g.) `std::map`
 - `ComponentPath` now has a `std::hash<T>` implementation, making it usable in (e.g.) `std::unordered_map`
 - Added `.clear()` and `.empty()` to `ComponentPath` for more parity with `std::string`'s semantics
@@ -67,6 +68,8 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bugs in `MocoCasOCProblem` and `CasOC::Problem` with incorrect string formatting. (#3828)
 - Fixed `MocoOrientationTrackingGoal::initializeOnModelImpl` to check for missing kinematic states, but allow other missing columns. (#3830)
 - Improved exception handling for internal errors in `MocoCasADiSolver`. Problems will now abort and print a descriptive error message (rather than fail due to an empty trajectory). (#3834)
+- The performance of `getStateVariableValue`, `getStateVariableDerivativeValue`, and `getModelingOption` was improved in
+  the case where provided string is just the name of the value, rather than a path to it (#3782)
 
 
 

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -1449,6 +1449,8 @@ public:
      */
     int getModelingOption(const SimTK::State& state,
         const std::string& path) const;
+    int getModelingOption(const SimTK::State& state,
+        const ComponentPath& path) const;
 
     /**
      * Based on a specified path, set the value of a modeling option.
@@ -1476,6 +1478,8 @@ public:
      * @see Component::resolveVariableNameAndOwner()
      */
     void setModelingOption(SimTK::State& state, const std::string& path,
+        int flag) const;
+    void setModelingOption(SimTK::State& state, const ComponentPath& path,
         int flag) const;
 
     /**
@@ -1550,7 +1554,7 @@ public:
      *  @endcode
      *
      * @param state   the State for which to get the value
-     * @param name    path to the state variable of interest
+     * @param path    path to the state variable of interest
      * @throws ComponentHasNoSystem if this Component has not been added to a
      *         System (i.e., if initSystem has not been called)
      */
@@ -1610,6 +1614,17 @@ public:
      */
     double getStateVariableDerivativeValue(const SimTK::State& state,
         const std::string& name) const;
+
+    /**
+     * Get the value of a state variable derivative computed by this Component.
+     *
+     * @param state   the State for which to get the derivative value
+     * @param path    path to the state variable of interest
+     * @throws ComponentHasNoSystem if this Component has not been added to a
+     *         System (i.e., if initSystem has not been called)
+     */
+    double getStateVariableDerivativeValue(const SimTK::State& state,
+        const ComponentPath& path) const;
 
     /**
     * Based on a specified path, resolve the name of a state variable,

--- a/OpenSim/Common/ComponentPath.h
+++ b/OpenSim/Common/ComponentPath.h
@@ -50,6 +50,11 @@ namespace OpenSim {
 class OSIMCOMMON_API ComponentPath {
 public:
     /**
+     * Returns the separator used to delimit path elements in the path
+     */
+    static constexpr char separator() { return '/'; }
+
+    /**
      * Returns the root component path (i.e. "/")
      */
     static ComponentPath root();
@@ -84,13 +89,21 @@ public:
     }
 
     /**
+     * Writes the `ComponentPath` to the output stream as a string
+     */
+    friend std::ostream& operator<<(std::ostream& lhs, const ComponentPath& rhs)
+    {
+        return lhs << rhs.toString();
+    }
+
+    /**
      * Clears the content of the ComponentPath
      */
     void clear() {
         _path.clear();
     }
 
-    char getSeparator() const;
+    char getSeparator() const { return separator(); }
 
     /**
      * Returns a string containing a sequence of all invalid characters.

--- a/OpenSim/Common/Test/testPath.cpp
+++ b/OpenSim/Common/Test/testPath.cpp
@@ -26,6 +26,8 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <sstream>
+
 /* The purpose of this test is strictly to check that classes derived from
  * the Path class work outside of the objects/components they are meant to 
  * service (i.e. check that the path logic works).
@@ -376,4 +378,11 @@ TEST_CASE("std::hash<ComponentPath> returns equivalent results to hashing the un
 
     // ... but beware of normalization...
     REQUIRE(std::hash<ComponentPath>{}(OpenSim::ComponentPath{"normalizable/././path"}) != std::hash<std::string>{}("normalizable/././path"));
+}
+
+TEST_CASE("ComponentPath can be written to an ostream, which writes the equivalent of toString")
+{
+    std::stringstream ss;
+    ss << ComponentPath{"some//path/"};
+    REQUIRE(ss.str() == ComponentPath{"some//path/"}.toString());
 }


### PR DESCRIPTION
[perf-win]

… and integrate into Millard muscles and scalar actuators

### Brief summary of changes

- Adds `ComponentPath` overrides for path-dependent parts of `Component`'s public interface
- Changes Millard muscles, and scalar actuators to use `ComponentPath`, rather than `std::string`, so that the path is pre-parsed ahead of time, which can improve performance
- Performance numbers (i.e. biggest benefit when used with models that need to retrieve state variables this way):

|                  Test Name | lhs [secs] | σ [secs] | rhs [secs] | σ [secs] | Speedup |
| -------------------------- | ---------- | -------- | ---------- | -------- | ------- |
|   ToyDropLanding_nomuscles |       0.04 |     0.00 |       0.04 |     0.00 |    1.07 |
|             RajagopalModel |       3.69 |     0.00 |       3.45 |     0.00 |    1.07 |
|                   Gait2354 |       0.19 |     0.00 |       0.19 |     0.00 |    1.02 |
| passive_dynamic_noanalysis |       1.21 |     0.00 |       1.21 |     0.00 |    1.00 |
|            passive_dynamic |       1.81 |     0.00 |       1.81 |     0.00 |    1.00 |
|                      Arm26 |       0.16 |     0.00 |       0.16 |     0.00 |    1.02 |
|             ToyDropLanding |       0.04 |     0.00 |       0.04 |     0.00 |    1.01 |

### Testing I've completed

- Existing test suite
- Performance testing

### Looking for feedback on...

- Whether it makes sense (that there's a performance upside to not constructing an `OpenSim::CompnentPath` to traverse a string when it's just the name of the value)

### CHANGELOG.md (choose one)

- Updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3782)
<!-- Reviewable:end -->
