### PR TITLE
Fix CMC_TaskSet copy constructor

### DIFF
--- a/OpenSim/Tools/CMC_TaskSet.h
+++ b/OpenSim/Tools/CMC_TaskSet.h
@@ -104,8 +104,9 @@ public:
     }
     CMC_TaskSet(const CMC_TaskSet& aCMCTaskSet) :
         Set<TrackingTask>(aCMCTaskSet),
-        _dataFileName(_dataFileNameProp.getValueStr()) {
-        _propertySet = aCMCTaskSet.getPropertySet();
+        _dataFileNameProp(aCMCTaskSet._dataFileNameProp),
+        _dataFileName(_dataFileNameProp.getValueStr()){
+
     }
 
 private:


### PR DESCRIPTION
Fixes issue: opensim-gui#1506
https://github.com/opensim-org/opensim-gui/issues/1506
### Brief summary of changes
CMC_TaskSet copy constructor (exercised exclusively by the GUI when creating a CMC_TaskSet from a file was not handling initalization of old-style Properties correctly resulting in an exception and/or crash.
### Testing I've completed
Built the GUI with this change and was able to edit CMC_TaskSet as explained in the bug report.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- Will update once a build is available and tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3789)
<!-- Reviewable:end -->
