### PR TITLE
Allow empty controls table when creating time-stepping guesses

### DIFF
--- a/OpenSim/Moco/MocoSolver.cpp
+++ b/OpenSim/Moco/MocoSolver.cpp
@@ -64,7 +64,7 @@ MocoTrajectory MocoSolver::createGuessTimeStepping() const {
     const auto& statesTable = manager.getStatesTable();
 
     TimeSeriesTable controlsTable;
-    if (model.getNumControls()) {
+    if (model.getNumControls() > 0) {
         controlsTable = model.getControlsTable();
         // Forward simulations populate the model's ControlsTables, using the 
         // names of actuators for column labels. MocoTrajectory uses actuator 

--- a/OpenSim/Moco/MocoSolver.cpp
+++ b/OpenSim/Moco/MocoSolver.cpp
@@ -62,16 +62,22 @@ MocoTrajectory MocoSolver::createGuessTimeStepping() const {
     manager.integrate(finalTime);
 
     const auto& statesTable = manager.getStatesTable();
-    auto controlsTable = model.getControlsTable();
 
-    // Forward simulations populate the model's ControlsTables, using the names
-    // of actuators for column labels. MocoTrajectory uses actuator paths, not
-    // names, so we convert the names into paths. We assume all actuators are in
-    // the model's ForceSet. Ideally, the model's ControlsTable would use
-    // actuator paths instead of actuator names.
-    auto labels = controlsTable.getColumnLabels();
-    for (auto& label : labels) { label = "/forceset/" + label; }
-    controlsTable.setColumnLabels(labels);
+    TimeSeriesTable controlsTable;
+    if (model.getNumControls()) {
+        controlsTable = model.getControlsTable();
+        // Forward simulations populate the model's ControlsTables, using the 
+        // names of actuators for column labels. MocoTrajectory uses actuator 
+        // paths, not names, so we convert the names into paths. We assume all 
+        // actuators are in the model's ForceSet. Ideally, the model's 
+        // ControlsTable would use actuator paths instead of actuator names.
+        auto labels = controlsTable.getColumnLabels();
+        for (auto& label : labels) { label = "/forceset/" + label; }
+        controlsTable.setColumnLabels(labels);
+    } else {
+        // If the model has no controls, create an empty controls table.
+        controlsTable = TimeSeriesTable(statesTable.getIndependentColumn());
+    }
 
     // TODO handle parameters.
     // TODO handle derivatives.

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -1087,7 +1087,11 @@ void MocoTrajectory::randomize(bool add, const SimTK::Random& randGen) {
                 i, statesTime, controlsTime);
     }
 
-    // TODO Support controlsTrajectory being empty.
+    // If the controls trajectory has no columns, create an empty vector for the
+    // control names.
+    std::vector<std::string> controlNames = controlsTrajectory.getNumColumns()
+            ? controlsTrajectory.getColumnLabels()
+            : std::vector<std::string>();
 
     const auto& statesTimes = statesTrajectory.getIndependentColumn();
     // The "true" means to not copy the data.
@@ -1096,8 +1100,8 @@ void MocoTrajectory::randomize(bool add, const SimTK::Random& randGen) {
     // TODO MocoProblem should be able to produce a MocoTrajectory template;
     // it's what knows the state, control, and parameter names.
     return MocoTrajectory(time, statesTrajectory.getColumnLabels(),
-            controlsTrajectory.getColumnLabels(), {}, // TODO (multiplier_names)
-            {},                                       // TODO (parameter_names)
+            controlNames, {}, // TODO (multiplier_names)
+            {},               // TODO (parameter_names)
             statesTrajectory.getMatrix(), controlsTrajectory.getMatrix(),
             SimTK::Matrix(0, 0),  // TODO (multipliersTrajectory)
             SimTK::RowVector(0)); // TODO (parameters)

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -1089,7 +1089,8 @@ void MocoTrajectory::randomize(bool add, const SimTK::Random& randGen) {
 
     // If the controls trajectory has no columns, create an empty vector for the
     // control names.
-    std::vector<std::string> controlNames = controlsTrajectory.getNumColumns()
+    std::vector<std::string> controlNames = 
+            controlsTrajectory.getNumColumns() > 0
             ? controlsTrajectory.getColumnLabels()
             : std::vector<std::string>();
 


### PR DESCRIPTION
Fixes the failing test in `testMocoInterface.cpp` on branch `upgrade_ipopt`. 

### Brief summary of changes
The subtest in `testMocoInterface.cpp` was failing because the OCP Moco was trying to solve was actually overconstrained. Somehow the previous Ipopt stack had no issues with this problem, but the updated stack struggles with it. 

These changes allow the test to be run with no control in the model. It required a few additional changes in Moco to allow empty controls tables when creating time-stepping guesses. 

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...patch for existing PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3791)
<!-- Reviewable:end -->
