### PR TITLE
Update `report.py` to support tabulating multiple parameters

### DIFF
--- a/Bindings/Python/report.py
+++ b/Bindings/Python/report.py
@@ -545,12 +545,13 @@ class Report(object):
                 fig.patch.set_visible(False)
                 ax = plt.axes()
 
-                cell_text = []
                 parameters = convert(self.trajectory.getParameters())
-                cell_text.append(['%10.5f' % p for p in parameters])
+                cell_text = [['%.3f' % p] for p in parameters]
 
                 plt.table(cellText=cell_text, rowLabels=parameter_names,
-                          colLabels=[self.trajectory_fname], loc='center')
+                          colLabels=[self.trajectory_fname], colWidths=[0.75], 
+                          loc='center', cellLoc='center', rowLoc='center', 
+                          colLoc='center', fontsize=16)
                 ax.axis('off')
                 ax.axis('tight')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
   to model actuator controls. (#3769)
 - Updated Moco stack to use Casadi 3.5.5, IPOPT 3.14.16, and compatible coinmumps & metis
 - Upgrade Python and NumPy versions to 3.10 and 1.25, repectively, in ci workflow (#3794).
+- Fixed bug in `report.py` preventing plotting multiple MocoParameter values. (#3808)
 
 
 v4.5


### PR DESCRIPTION
### Brief summary of changes

Minor fix to the `report.py` plotting utility script to allow plotting multiple parameters.

### Testing I've completed

Tested locally plotting results from a MocoStudy with two MocoParameters. Table with optimized parameter values was plotted successfully.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3808)
<!-- Reviewable:end -->
