### PR TITLE
Bug fix in PiecewiseLinearFunction: coefficient array now properly initialized when number of function points is 1. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,23 +43,24 @@ v4.6
 - `DiscreteVariable`s and `ModelingOption`s allocated natively in Simbody can now be added to an `OpenSim::Component` and accessed via its `Component` API. To support this capability, `getDiscreteVariableIndex()` has been replaced by `getDiscreteVariableIndexes()` which returns both the index of the discrete variable and the index of the `SimTK::Subsystem` to which the descrete variable belongs. (#3745)
 - Computationally efficient methods are now available for extracting the time histories of individual state variables, discrete states, and modeling options from a state trajectory (i.e., a `SimTK::Array_<SimTK::State>`). Collectively, these methods form the basis for performing a comprehensive serialzation of a state trajectory to file. (#3745)
 - Computationally efficient methods are now available for building a state trajectory (i.e., a `SimTK::Array_<SimTK::State>`) from the time histories of individual state variables, discrete states, and modeling options. Collectively, these methods form the basis for performing a comprehenvise deserialization of a states trajectory from file. (#3745)
-- Added `Model::calcForceContributionsSum()`, a wrapper method for `GeneralForceSubsystem` for efficiently 
-  calculating a subset of a model's body and mobility forces. (#3755) 
-- Added `Force::getForceIndex()` to allow accessing the `SimTK::ForceIndex` for force elements. (#3755) 
+- Added `Model::calcForceContributionsSum()`, a wrapper method for `GeneralForceSubsystem` for efficiently
+  calculating a subset of a model's body and mobility forces. (#3755)
+- Added `Force::getForceIndex()` to allow accessing the `SimTK::ForceIndex` for force elements. (#3755)
 - Improved performance in `MultivariatePolynomialFunction` and added convenience methods for automatically generating function derivatives (#3767).
 - Added options to `PolynomialPathFitter` for including moment arm and lengthening speed functions in generated `FunctionBasedPath`s (#3767).
 - The signature for `PrescribedController::prescribeControlForActuator()` was changed to take a `Function` via a const reference rather than a
 pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Added option to `PolynomialPathFitter` to use stepwise regression for fitting a minimal set of polynomial coefficients for a `FunctionBasedPath` (#3779).
-- Fixed a bug in SimulationUtilities::analyze<T> that would provide an incorrectly sized control vector to 
+- Fixed a bug in SimulationUtilities::analyze<T> that would provide an incorrectly sized control vector to
   the model if controls were missing from the input controls table. (#3769)
-- Added InputController, an intermediate abstract class of Controller that provides supports for controllers 
-  that map scalar control values from a list Input (connected to Outputs from one or more ModelComponents) 
+- Added InputController, an intermediate abstract class of Controller that provides supports for controllers
+  that map scalar control values from a list Input (connected to Outputs from one or more ModelComponents)
   to model actuator controls. (#3769)
 - Updated Moco stack to use Casadi 3.6.5, IPOPT 3.14.16, and compatible MUMPS and Metis. (#3693, #3807)
 - Upgrade Python and NumPy versions to 3.10 and 1.25, repectively, in ci workflow (#3794).
 - Fixed bug in `report.py` preventing plotting multiple MocoParameter values. (#3808)
 - Added SynergyController, a controller that computes controls for a model based on a linear combination of a set of Input control signals and a set of synergy vectors. (#3796)
+- Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 
 
 v4.5

--- a/OpenSim/Common/PiecewiseLinearFunction.cpp
+++ b/OpenSim/Common/PiecewiseLinearFunction.cpp
@@ -313,7 +313,7 @@ void PiecewiseLinearFunction::updateFromXMLNode(SimTK::Xml::Element& aNode, int 
 {
     Function::updateFromXMLNode(aNode, versionNumber);
     calcCoefficients();
-}   
+}
 
 double PiecewiseLinearFunction::getX(int aIndex) const
 {

--- a/OpenSim/Common/PiecewiseLinearFunction.cpp
+++ b/OpenSim/Common/PiecewiseLinearFunction.cpp
@@ -414,11 +414,15 @@ int PiecewiseLinearFunction::addPoint(double aX, double aY)
 void PiecewiseLinearFunction::calcCoefficients()
 {
    int n = _x.getSize();
+   if (n == 0) return;
 
-   if (n < 2)
-      return;
-
+   // The coefficient array _b must be the same size as _x and _y.
+   // Also, it should be inititlized to 0 when the size is 1.
    _b.setSize(n);
+   if (n == 1) {
+       _b[0] = 0.0;
+      return;
+   }
 
     for (int i=0; i<n-1; i++) {
         double range = MAX(TINY_NUMBER, _x[i+1] - _x[i]);
@@ -430,7 +434,7 @@ void PiecewiseLinearFunction::calcCoefficients()
 double PiecewiseLinearFunction::calcValue(const Vector& x) const
 {
     int n = _x.getSize();
-    SimTK_ASSERT(n >= 2, "size < 2. Interpolation requires 2 or more points.");
+    //SimTK_ASSERT(n >= 2, "size < 2. Interpolation requires 2 or more points.");
     double aX = x[0];
 
     if (aX < _x[0])

--- a/OpenSim/Common/PiecewiseLinearFunction.cpp
+++ b/OpenSim/Common/PiecewiseLinearFunction.cpp
@@ -434,7 +434,6 @@ void PiecewiseLinearFunction::calcCoefficients()
 double PiecewiseLinearFunction::calcValue(const Vector& x) const
 {
     int n = _x.getSize();
-    //SimTK_ASSERT(n >= 2, "size < 2. Interpolation requires 2 or more points.");
     double aX = x[0];
 
     if (aX < _x[0])

--- a/OpenSim/Common/PiecewiseLinearFunction.cpp
+++ b/OpenSim/Common/PiecewiseLinearFunction.cpp
@@ -430,6 +430,7 @@ void PiecewiseLinearFunction::calcCoefficients()
 double PiecewiseLinearFunction::calcValue(const Vector& x) const
 {
     int n = _x.getSize();
+    SimTK_ASSERT(n >= 2, "size < 2. Interpolation requires 2 or more points.");
     double aX = x[0];
 
     if (aX < _x[0])

--- a/OpenSim/Simulation/Test/testPrescribedForce.cpp
+++ b/OpenSim/Simulation/Test/testPrescribedForce.cpp
@@ -30,7 +30,7 @@
 //      3. Force at a point
 //      4. Torque on a body
 //      4. Forces from a file.
-//     Add tests here 
+//     Add tests here
 //
 //==========================================================================================================
 #include <iostream>
@@ -174,7 +174,7 @@ void testPrescribedForce(OpenSim::Function* forceX, OpenSim::Function* forceY, O
     osim_state.setTime(0.0);
     Manager manager(*osimModel);
     manager.initialize(osim_state);
-    
+
     for (unsigned int i = 0; i < times.size(); ++i)
     {
         osim_state = manager.integrate(times[i]);


### PR DESCRIPTION
Fixes issue #3816

In class `OpenSim::PiecewiseLinearFunction`, when the number of function points was equal to one (i.e., when `_x.getSize() == 1`) initialization of the coefficient array, `_b`, was getting skipped. In such a situation, when `calcValue()` was called (sill a valid thing to do!), `_b[0]` was being accessed when the size of `_b` was still `0` (an access violation) and would often produce a spurious result.

In a `Release` build, the above access violation was causing sporadic failures in the `testPrescribedForce` unit test.

In a `Debug` build, `testPrescribedForce` always failed because of an array out-of-bounds error detected by a low-level assert.

### Brief summary of changes
Added/Altered ~6 lines of code in `PiecewiseLinearFunction::calcCoefficients()` to properly size and initialize `_b` when `n == 1`.  See lines 417 - 425 of `PiecewiseLinearFunction.cpp`.

### Testing I've completed
In both `Debug` and `Release` builds, the `testPrescribedForce` unit test is now passing.  In addition, all other unit tests pass in a `Release` build. (Note that there continue to be quite a few unit tests that do not pass in a `Debug` build for unrelated reasons.)

### CHANGELOG.md (choose one)
- Updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3817)
<!-- Reviewable:end -->
