### PR TITLE
Use all available hardware threads in `PolynomialPathFitter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,23 +43,24 @@ v4.6
 - `DiscreteVariable`s and `ModelingOption`s allocated natively in Simbody can now be added to an `OpenSim::Component` and accessed via its `Component` API. To support this capability, `getDiscreteVariableIndex()` has been replaced by `getDiscreteVariableIndexes()` which returns both the index of the discrete variable and the index of the `SimTK::Subsystem` to which the descrete variable belongs. (#3745)
 - Computationally efficient methods are now available for extracting the time histories of individual state variables, discrete states, and modeling options from a state trajectory (i.e., a `SimTK::Array_<SimTK::State>`). Collectively, these methods form the basis for performing a comprehensive serialzation of a state trajectory to file. (#3745)
 - Computationally efficient methods are now available for building a state trajectory (i.e., a `SimTK::Array_<SimTK::State>`) from the time histories of individual state variables, discrete states, and modeling options. Collectively, these methods form the basis for performing a comprehenvise deserialization of a states trajectory from file. (#3745)
-- Added `Model::calcForceContributionsSum()`, a wrapper method for `GeneralForceSubsystem` for efficiently 
-  calculating a subset of a model's body and mobility forces. (#3755) 
-- Added `Force::getForceIndex()` to allow accessing the `SimTK::ForceIndex` for force elements. (#3755) 
+- Added `Model::calcForceContributionsSum()`, a wrapper method for `GeneralForceSubsystem` for efficiently
+  calculating a subset of a model's body and mobility forces. (#3755)
+- Added `Force::getForceIndex()` to allow accessing the `SimTK::ForceIndex` for force elements. (#3755)
 - Improved performance in `MultivariatePolynomialFunction` and added convenience methods for automatically generating function derivatives (#3767).
 - Added options to `PolynomialPathFitter` for including moment arm and lengthening speed functions in generated `FunctionBasedPath`s (#3767).
 - The signature for `PrescribedController::prescribeControlForActuator()` was changed to take a `Function` via a const reference rather than a
 pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Added option to `PolynomialPathFitter` to use stepwise regression for fitting a minimal set of polynomial coefficients for a `FunctionBasedPath` (#3779).
-- Fixed a bug in SimulationUtilities::analyze<T> that would provide an incorrectly sized control vector to 
+- Fixed a bug in SimulationUtilities::analyze<T> that would provide an incorrectly sized control vector to
   the model if controls were missing from the input controls table. (#3769)
-- Added InputController, an intermediate abstract class of Controller that provides supports for controllers 
-  that map scalar control values from a list Input (connected to Outputs from one or more ModelComponents) 
+- Added InputController, an intermediate abstract class of Controller that provides supports for controllers
+  that map scalar control values from a list Input (connected to Outputs from one or more ModelComponents)
   to model actuator controls. (#3769)
 - Updated Moco stack to use Casadi 3.6.5, IPOPT 3.14.16, and compatible MUMPS and Metis. (#3693, #3807)
 - Upgrade Python and NumPy versions to 3.10 and 1.25, repectively, in ci workflow (#3794).
 - Fixed bug in `report.py` preventing plotting multiple MocoParameter values. (#3808)
 - Added SynergyController, a controller that computes controls for a model based on a linear combination of a set of Input control signals and a set of synergy vectors. (#3796)
+- Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 
 
 v4.5

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -220,7 +220,7 @@ void PolynomialPathFitter::run() {
             get_moment_arm_tolerance(), 1);
 
     // Stepwise regression
-    log_info("Use stepwise regression = {}", 
+    log_info("Use stepwise regression = {}",
             get_use_stepwise_regression() ? "true" : "false");
 
     // Output directory.
@@ -565,12 +565,12 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     // every time point.
     Logger::Level origLoggerLevel = Logger::getLevel();
     Logger::setLevel(Logger::Level::Warn);
-    
+
     // Create a Latin hypercube design to sample the coordinate values.
     LatinHypercubeDesign lhs;
     lhs.setNumSamples(get_num_samples_per_frame());
     lhs.setNumVariables((int)values.getNumColumns());
-    
+
     // Helper function for sampling the coordinate values between two time
     // indexes.
     auto sampleCoordinateValuesSubset = [this, lhs](
@@ -578,7 +578,7 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
             std::vector<int>::iterator end_iter,
             const TimeSeriesTable& values)
                 -> SimTK::Matrix {
-        
+
         SimTK::Matrix results(
                 lhs.getNumSamples()*(int)std::distance(begin_iter, end_iter),
                 (int)values.getNumColumns());
@@ -593,20 +593,20 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
             }
             design.elementwiseSubtractFromScalarInPlace(0.5);
             design *= 2;
-            
+
             int icol = 0;
             for (const std::string& label : values.getColumnLabels()) {
-                const SimTK::VectorView column = 
+                const SimTK::VectorView column =
                         values.getDependentColumn(label);
                 const auto& bounds = m_coordinateBoundsMap.at(label);
                 const auto& range = m_coordinateRangeMap.at(label);
-                
-                // Linearly transform the design to the specified bounds for 
+
+                // Linearly transform the design to the specified bounds for
                 // each coordinate.
                 double slope = 0.5*(bounds[1] - bounds[0]);
                 SimTK::Vector candidateCol = slope*(design.col(icol) + 1.0) +
                         bounds[0] + column[*it];
-                
+
                 // Check that all elements in the column are within the range of
                 // motion. If not, move the element inside the range of motion
                 // that is closest to the original value.
@@ -620,9 +620,9 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
                 design.updCol(icol) = candidateCol;
                 ++icol;
             }
-            
+
             // Store the results.
-            results.updBlock(thisTimeIndex*lhs.getNumSamples(), 0, 
+            results.updBlock(thisTimeIndex*lhs.getNumSamples(), 0,
                     lhs.getNumSamples(), (int)values.getNumColumns()) = design;
             ++thisTimeIndex;
         }
@@ -654,7 +654,7 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     for (int i = 0; i < get_num_parallel_threads(); ++i) {
         outputs.push_back(futures[i].get());
     }
-    
+
     // Reset the logger.
     OpenSim::Logger::setLevel(origLoggerLevel);
 
@@ -667,13 +667,13 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
         int numTimeIndexes = outputs[i].nrow() / get_num_samples_per_frame();
         for (int j = 0; j < numTimeIndexes; ++j) {
             // Append the original values.
-            valuesSampled.appendRow(times[timeIdx], 
+            valuesSampled.appendRow(times[timeIdx],
                     values.getRowAtIndex(timeIdx));
 
             // Update the time step, if possible. Otherwise, use the last time
             // step.
             if (timeIdx+1 < static_cast<int>(values.getNumRows())) {
-                dt = (times[timeIdx+1] - times[timeIdx]) / 
+                dt = (times[timeIdx+1] - times[timeIdx]) /
                      (get_num_samples_per_frame() + 2);
             }
 
@@ -1015,11 +1015,11 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
             int order;
             if (get_use_stepwise_regression()) {
                 order = get_maximum_polynomial_order();
-                fitCoefficientsStepwiseRegression(coordinatesThisForce, b, 
+                fitCoefficientsStepwiseRegression(coordinatesThisForce, b,
                         order, coefficients);
             } else {
-                order = fitAllCoefficients(coordinatesThisForce, b, 
-                        get_minimum_polynomial_order(), 
+                order = fitAllCoefficients(coordinatesThisForce, b,
+                        get_minimum_polynomial_order(),
                         get_maximum_polynomial_order(),
                         coefficients);
             }
@@ -1042,7 +1042,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
                 }
             }
             if (getIncludeLengtheningSpeedFunction()) {
-                MultivariatePolynomialFunction lengtheningSpeedFunction = 
+                MultivariatePolynomialFunction lengtheningSpeedFunction =
                         lengthFunction.generatePartialVelocityFunction();
                 functionBasedPath->setLengtheningSpeedFunction(
                         lengtheningSpeedFunction);
@@ -1276,7 +1276,7 @@ void PolynomialPathFitter::removeMomentArmColumns(TimeSeriesTable& momentArms,
 }
 
 int PolynomialPathFitter::fitAllCoefficients(
-        const SimTK::Matrix& coordinates, const SimTK::Vector& b, int minOrder, 
+        const SimTK::Matrix& coordinates, const SimTK::Vector& b, int minOrder,
         int maxOrder, SimTK::Vector& coefficients) const {
 
     int numTimes = coordinates.nrow();
@@ -1377,9 +1377,9 @@ void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
         }
     }
 
-    // Manage the coefficient indexes that will be included in the final 
+    // Manage the coefficient indexes that will be included in the final
     // polynomial. The "out" indexes are the indexes that are not included in
-    // the final polynomial, which is initialized to all indexes. The "keep" 
+    // the final polynomial, which is initialized to all indexes. The "keep"
     // indexes are the indexes that are included in the final polynomial, which
     // is initialized to an empty vector.
     std::vector<int> outIndexes;
@@ -1391,9 +1391,9 @@ void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
     SimTK::Vector x_sol;
     while (true) {
 
-        // Initialize the 'A' matrix. 
-        // The number of terms in the polynomial is the number of "kept" 
-        // coefficients plus one. 
+        // Initialize the 'A' matrix.
+        // The number of terms in the polynomial is the number of "kept"
+        // coefficients plus one.
         int numTerms = static_cast<int>(keepIndexes.size()) + 1;
         SimTK::Matrix A(numTimes * (numCoordinates + 1), numTerms, 0.0);
         SimTK::Vector x(numTerms, 0.0);
@@ -1404,7 +1404,7 @@ void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
             A.updCol(icol++) = Afull.col(ki);
         }
 
-        // Next, loop through all of the remaining "out" coefficients and fit 
+        // Next, loop through all of the remaining "out" coefficients and fit
         // the polynomial. We will keep the coefficient that results in the
         // smallest RMS error.
         SimTK::Real bestError = SimTK::Infinity;
@@ -1463,7 +1463,7 @@ void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
                 break;
             }
         }
-        
+
         int numOutIndexes = static_cast<int>(outIndexes.size());
         if ((pathLengthMet && momentArmMet) || !numOutIndexes) {
             x_sol = x;
@@ -1471,7 +1471,7 @@ void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
         }
     }
 
-    // Update the coefficients vector 
+    // Update the coefficients vector
     coefficients.resize(numCoefficients);
     coefficients.setToZero();
     int icoeff = 0;
@@ -1602,7 +1602,7 @@ void PolynomialPathFitter::constructProperties() {
     constructProperty_minimum_polynomial_order(2);
     constructProperty_maximum_polynomial_order(6);
     constructProperty_num_parallel_threads(
-            (int)std::thread::hardware_concurrency()-2);
+            (int)std::thread::hardware_concurrency());
     constructProperty_global_coordinate_sampling_bounds({-10.0, 10.0});
     constructProperty_coordinate_sampling_bounds();
     constructProperty_num_samples_per_frame(25);

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -90,9 +90,9 @@ private:
  * lengths computed from the original model paths and the fitted polynomial
  * paths. The `setNumSamplesPerFrame` method specifies the number of samples
  * taken per time frame in the coordinate values table used to fit each path.
- * The `setNumParallelThreads` method specifies the number of threads used to 
- * parallelize the path fitting process. The `setLatinHypercubeAlgorithm` method 
- * specifies the Latin hypercube sampling algorithm used to sample coordinate 
+ * The `setNumParallelThreads` method specifies the number of threads used to
+ * parallelize the path fitting process. The `setLatinHypercubeAlgorithm` method
+ * specifies the Latin hypercube sampling algorithm used to sample coordinate
  * values for path fitting.
  *
  * The default settings are as follows:
@@ -104,7 +104,7 @@ private:
  *    - Moment arm tolerance: 1e-4 meters
  *    - Path length tolerance: 1e-4 meters
  *    - Number of samples per frame: 25
- *    - Number of threads: (# of available hardware threads) - 2
+ *    - Number of threads: number of available hardware threads
  *    - Latin hypercube sampling algorithm: "random"
  *    - Use stepwise regression: False
  *
@@ -272,18 +272,18 @@ public:
     std::string getOutputDirectory() const;
 
     /**
-     * Whether or not to use stepwise regression to fit a minimal set of 
+     * Whether or not to use stepwise regression to fit a minimal set of
      * polynomial coefficients.
-     * 
-     * Stepwise regression builds a vector of coefficients by individually 
+     *
+     * Stepwise regression builds a vector of coefficients by individually
      * adding polynomial terms that result in the smallest path length and
      * moment arm error. When a new term is added, the fitting process is
      * repeated to recompute the coefficients. Polynomial terms are added until
      * the path length and moment arm tolerances are met, or the maximum number
      * of terms is reached.
-     * 
+     *
      * @note By default, this setting is false.
-     * @note If enabled, stepwise regression will fit coefficients using the 
+     * @note If enabled, stepwise regression will fit coefficients using the
      *       maximum polynomial order based on `setMaximumPolynomialOrder()`.
      */
     void setUseStepwiseRegression(bool tf);
@@ -420,8 +420,7 @@ public:
      * moment arm computations, and path fitting across multiple threads. The
      * number of threads must be greater than zero.
      *
-     * @note The default number of threads is set to two fewer than the number
-     *       of available hardware threads.
+     * @note The default is the number of available hardware threads.
      */
     void setNumParallelThreads(int numThreads);
     /// @copydoc setNumParallelThreads(int numThreads)
@@ -445,11 +444,11 @@ public:
     std::string getLatinHypercubeAlgorithm() const;
 
     /**
-     * Whether or not to include moment arm functions in the fitted path 
+     * Whether or not to include moment arm functions in the fitted path
      * (default: false).
-     * 
+     *
      * The moment arm functions are constructed by taking the derivative of the
-     * path length function with respect to the coordinate values using 
+     * path length function with respect to the coordinate values using
      * symbolic differentiation. The function coefficients are negated to match
      * the moment arm convention in OpenSim.
     */
@@ -464,17 +463,17 @@ public:
     /**
      * Whether or not to include the lengthening speed function in the fitted
      * path (default: false).
-     * 
-     * The lengthening speed function is computed by taking dot product of the 
-     * moment arm functions by the vector of time derivatives of the coordinate 
-     * values using symbolic math. The result is negated to offset the negation 
+     *
+     * The lengthening speed function is computed by taking dot product of the
+     * moment arm functions by the vector of time derivatives of the coordinate
+     * values using symbolic math. The result is negated to offset the negation
      * applied to the moment arm function expressions.
-     * 
-     * @note Since FunctionBasedPath uses cached moment arm values to compute 
-     *       lengthening speed, including this function in the path definition 
+     *
+     * @note Since FunctionBasedPath uses cached moment arm values to compute
+     *       lengthening speed, including this function in the path definition
      *       may make lengthening speed evaluation slower compared to
      *       only including the moment arm functions (the moment arm expressions
-     *       are effectively evaluated twice). Therefore, this setting is 
+     *       are effectively evaluated twice). Therefore, this setting is
      *       disabled by default.
      */
     void setIncludeLengtheningSpeedFunction(bool tf) {
@@ -515,7 +514,7 @@ private:
             "path fitting.");
     OpenSim_DECLARE_PROPERTY(output_directory, std::string,
             "The directory to which the path fitting results are written.");
-    OpenSim_DECLARE_PROPERTY(use_stepwise_regression, bool, 
+    OpenSim_DECLARE_PROPERTY(use_stepwise_regression, bool,
             "Whether or not to use stepwise regression to fit a minimal set of "
             "polynomial coefficients.");
     OpenSim_DECLARE_PROPERTY(moment_arm_threshold, double,
@@ -555,8 +554,7 @@ private:
             "values table used to fit each path (default: 25).");
     OpenSim_DECLARE_PROPERTY(num_parallel_threads, int,
             "The number of threads used to parallelize the path fitting "
-            "process (default: two fewer than the number of available "
-            "hardware threads).");
+            "process (default: the number of available hardware threads).");
     OpenSim_DECLARE_PROPERTY(latin_hypercube_algorithm, std::string,
             "The Latin hypercube sampling algorithm used to sample coordinate "
             "values for path fitting (default: 'random').");
@@ -669,22 +667,22 @@ private:
      * polynomial coefficients. `coordinates` is the matrix of coordinate values
      * for coordinates that the current path depends on. The vector `b` contains
      * the path length and moment arm values for the current path.
-     * 
+     *
      * We solve for the coefficients of the polynomial using a least squares of
-     * fit, `Ax = b`. Each row of `A` contains polynomial terms evaluated using 
+     * fit, `Ax = b`. Each row of `A` contains polynomial terms evaluated using
      * the coordinate values from a particular point in time. `x` is the vector
-     * polynomial coefficients. The first N elements of `b` contain the path 
-     * length values, where N is the number of time points. The remaining N*Nc 
-     * rows of `b` contain the moment arm values, where Nc is the number of 
+     * polynomial coefficients. The first N elements of `b` contain the path
+     * length values, where N is the number of time points. The remaining N*Nc
+     * rows of `b` contain the moment arm values, where Nc is the number of
      * coordinates the path depends on.
      */
-    int fitAllCoefficients(const SimTK::Matrix& coordinates, 
+    int fitAllCoefficients(const SimTK::Matrix& coordinates,
             const SimTK::Vector& b, int minOrder, int maxOrder,
             SimTK::Vector& coefficients) const;
 
     /**
      * Fit to the path length and moment arm samples using stepwise regression
-     * to find a minimal set of polynomial coefficients. `coordinates` is the 
+     * to find a minimal set of polynomial coefficients. `coordinates` is the
      * matrix of coordinate values for coordinates that the current path depends
      * on. The vector `b` contains the path length and moment arm values for the
      * current path.


### PR DESCRIPTION
### Brief summary of changes

This change updates the number of threads used by `PolynomialPathFitter` to the total number of available hardware threads. Previously it used the number of hardware threads minus two, which obviously is an issue if there are only two threads available.

### Testing I've completed
Tested the `PolynomialPathFitter` examples locally and ran test suite.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3818)
<!-- Reviewable:end -->
