### PR TITLE
Use correct tables when writing data to file in `PolynomialPathFitter`

### DIFF
--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -432,10 +432,10 @@ void PolynomialPathFitter::run() {
     log_info("");
     log_info("Printing the sampled path lengths to '{}'...",
             pathLengthsSampledFileName);
-    STOFileAdapter::write(pathLengths, pathLengthsSampledFileName);
+    STOFileAdapter::write(pathLengthsSampled, pathLengthsSampledFileName);
     log_info("Printing the sampled moment arms to '{}'...",
             momentArmsSampledFileName);
-    STOFileAdapter::write(momentArms, momentArmsSampledFileName);
+    STOFileAdapter::write(momentArmsSampled, momentArmsSampledFileName);
 
     // Print the fitted path lengths and moment arms using the original
     // coordinate data to file.


### PR DESCRIPTION
### Brief summary of changes

Minor bug fix to use the correct tables when writing path length and moment arm data to file in `PolynomialPathFitter`.

### Testing I've completed

Tested locally. Sampled values for path lengths and moment arms are correctly written to file.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...minor fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3820)
<!-- Reviewable:end -->
