### PR TITLE
TimeSeriesTable method trimToIndices is now public, added tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Added SynergyController, a controller that computes controls for a model based on a linear combination of a set of Input control signals and a set of synergy vectors. (#3796)
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
+- Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
 
 
 v4.5

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -919,7 +919,7 @@ TEST_CASE("TableUtilities::resample") {
     }
 }
 
-TEST_CASE("TimeSeriesTable trimming tests") {
+TEST_CASE("TimeSeriesTable trim methods") {
     // make time table
     TimeSeriesTable_<double> table{};
     table.appendRow(1, {10});
@@ -976,6 +976,8 @@ TEST_CASE("TimeSeriesTable trimming tests") {
         CHECK(table.getRowAtIndex(1)[0] == 30);
         // out of range indices
         SimTK_TEST_MUST_THROW(table.trimToIndices(0, 5));
+        CHECK(table.getNumRows() == 2);
+        SimTK_TEST_MUST_THROW(table.trimToIndices(-1, 1));
         CHECK(table.getNumRows() == 2);
         // trim to 1
         table.trimToIndices(1, 1);

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -133,9 +133,16 @@ class InvalidIndices : public Exception {
 public:
     InvalidIndices(const std::string& file,
                    size_t line,
-                   const std::string& func) :
+                   const std::string& func,
+                   const size_t index,
+                   const size_t min,
+                   const size_t max) :
         Exception(file, line, func) {
-        addMessage("last_index is out of bounds.");
+        std::string msg = "Index " + std::to_string(index)
+            + " is out of bounds [" + std::to_string(min)
+            + ", " + std::to_string(max) + "].";
+
+        addMessage(msg);
     }
 };
 
@@ -444,8 +451,8 @@ public:
         return row;
     }
     /**
-     * Trim TimeSeriesTable to rows that have times that lies between newStartTime,
-     * newFinalTime inclusive. The trimming is done in place, no copy is made.
+     * Trim TimeSeriesTable to rows that have times that lies between newStartTime
+     * and newFinalTime (inclusive). The trimming is done in place, no copy is made.
      * Uses getRowIndexAfterTime to locate first row and
      *      getRowIndexBeforeTime to locate last row.
      * \throws EmptyTable if the trim would make the table empty.
@@ -478,13 +485,14 @@ public:
         this->trim(this->getIndependentColumn().front(), newFinalTime);
     }
     /**
-     * trim table to rows between start_index and last_index inclusively
+     * Trim table to rows between start_index and last_index (inclusive).
      * \throws InvalidIndices if the last index is out of range.
      * \throws EmptyTable if the trim would make the table empty.
      */
     void trimToIndices(const size_t& start_index, const size_t& last_index) {
         // Error if last_index is out of bounds
-        OPENSIM_THROW_IF(last_index > this->getNumRows() - 1, InvalidIndices);
+        OPENSIM_THROW_IF(last_index > this->getNumRows() - 1, InvalidIndices,
+            last_index, 0, this->getNumRows()-1);
         // Make sure last_index >= start_index before attempting to trim
         OPENSIM_THROW_IF(last_index < start_index, EmptyTable);
 

--- a/OpenSim/Common/TimeSeriesTable.h
+++ b/OpenSim/Common/TimeSeriesTable.h
@@ -129,6 +129,16 @@ public:
     }
 };
 
+class InvalidIndices : public Exception {
+public:
+    InvalidIndices(const std::string& file,
+                   size_t line,
+                   const std::string& func) :
+        Exception(file, line, func) {
+        addMessage("last_index is out of bounds.");
+    }
+};
+
 /** TimeSeriesTable_ is a DataTable_ where the independent column is time of 
 type double. The time column is enforced to be strictly increasing.           */
 template<typename ETY = SimTK::Real>
@@ -434,10 +444,11 @@ public:
         return row;
     }
     /**
-     * Trim TimeSeriesTable to rows that have times that lies between 
-     * newStartTime, newFinalTime. The trimming is done in place, no copy is made. 
+     * Trim TimeSeriesTable to rows that have times that lies between newStartTime,
+     * newFinalTime inclusive. The trimming is done in place, no copy is made.
      * Uses getRowIndexAfterTime to locate first row and
-     * getNearestRowIndexForTime method to locate last row.
+     *      getRowIndexBeforeTime to locate last row.
+     * \throws EmptyTable if the trim would make the table empty.
      */
     void trim(const double& newStartTime, const double& newFinalTime) {
         OPENSIM_THROW_IF(newFinalTime < newStartTime, EmptyTable);
@@ -448,8 +459,6 @@ public:
         // or newFinalTime is greater than last value in table
         start_index = this->getRowIndexAfterTime(newStartTime);
         last_index = this->getRowIndexBeforeTime(newFinalTime);
-        // Make sure last_index >= start_index before attempting to trim
-        OPENSIM_THROW_IF(last_index < start_index, EmptyTable);
         // do the actual trimming based on index instead of time.
         trimToIndices(start_index, last_index);
         // If resulting table is empty, throw
@@ -467,6 +476,31 @@ public:
      */
     void trimTo(const double& newFinalTime) {
         this->trim(this->getIndependentColumn().front(), newFinalTime);
+    }
+    /**
+     * trim table to rows between start_index and last_index inclusively
+     * \throws InvalidIndices if the last index is out of range.
+     * \throws EmptyTable if the trim would make the table empty.
+     */
+    void trimToIndices(const size_t& start_index, const size_t& last_index) {
+        // Error if last_index is out of bounds
+        OPENSIM_THROW_IF(last_index > this->getNumRows() - 1, InvalidIndices);
+        // Make sure last_index >= start_index before attempting to trim
+        OPENSIM_THROW_IF(last_index < start_index, EmptyTable);
+
+        // This uses the rather invasive but efficient mechanism to copy a
+        // block of the underlying Matrix.
+        // Side effect may include that headers/metaData may be left stale.
+        // Alternatively we can create a new TimeSeriesTable and copy contents
+        // one row at a time but that's rather overkill
+        SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()((int)start_index, 0,
+                (int)(last_index - start_index + 1),
+                (int)this->getNumColumns());
+        this->updMatrix() = matrixBlock;
+        std::vector<double> newIndependentVector = std::vector<double>(
+                this->getIndependentColumn().begin() + start_index,
+                this->getIndependentColumn().begin() + last_index + 1);
+        this->_indData = newIndependentVector;
     }
 protected:
     /** Validate the given row. 
@@ -492,23 +526,6 @@ protected:
                              TimestampGreaterThanEqualToNext, rowIndex, time, 
                              DT::_indData[rowIndex + 1]);
         }
-    }
-    /** trim table to rows between start_index and last_index inclusively
-     */
-    void trimToIndices(const size_t& start_index, const size_t& last_index) {
-        // This uses the rather invasive but efficient mechanism to copy a
-        // block of the underlying Matrix.
-        // Side effect may include that headers/metaData may be left stale.
-        // Alternatively we can create a new TimeSeriesTable and copy contents
-        // one row at a time but that's rather overkill
-        SimTK::Matrix_<ETY> matrixBlock = this->updMatrix()((int)start_index, 0,
-                (int)(last_index - start_index + 1),
-                (int)this->getNumColumns());
-        this->updMatrix() = matrixBlock;
-        std::vector<double> newIndependentVector = std::vector<double>(
-                this->getIndependentColumn().begin() + start_index,
-                this->getIndependentColumn().begin() + last_index + 1);
-        this->_indData = newIndependentVector;
     }
 
     friend class TableUtilities;


### PR DESCRIPTION
Fixes issue #3751

### Brief summary of changes
Moved trimToIndices method from protected to public. Updated its error handling.
Wrote tests for trim, trimTo, trimFrom, and trimToIndices in testDataTable

### Testing I've completed
The dataTable tests

### Looking for feedback on...
The error handling for when the table could be empty, indices out of bounds

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3824)
<!-- Reviewable:end -->
