### PR TITLE
Fixed log_cout bug to log at all levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `Logger::cout`, now it works at any logger level. (#3826)
 
 
+
 v4.5
 ====
 - Added `AbstractGeometryPath` which is a base class for `GeometryPath` and other path types (#3388). All path-based

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 - Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
+- Fixed bug in `Logger::cout`, now it works at any logger level. (#3826)
 
 
 v4.5

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -145,15 +145,15 @@ public:
     }
 
     /// Use this function to log messages that would normally be sent to
-    /// std::cout. These messages always appear, and are also logged to the
-    /// filesink (addFileSink()) and any sinks added via addSink().
-    /// The main use case for this function is inside of functions whose intent
-    /// is to print information (e.g., Component::printSubcomponentInfo()).
+    /// std::cout. These messages always appear (unless the logger is off), and
+    /// are also logged to the filesink (addFileSink()) and any sinks added via
+    /// addSink(). The main use case for this function is inside of functions
+    /// whose intent is to print information (e.g., Component::printSubcomponentInfo()).
     /// Besides such use cases, this function should be used sparingly to
     /// give users control over what gets logged.
     template <typename... Args>
     static void cout(spdlog::string_view_t fmt, const Args&... args) {
-        getCoutLogger().log(spdlog::level::info, fmt, args...);
+        getCoutLogger().log(spdlog::level::critical, fmt, args...);
     }
 
     /// @}


### PR DESCRIPTION
Fixes issue #3428

### Brief summary of changes
Changed logger cout message level from info to critical

### Testing I've completed
Calling log_cout at every logger level (in sandbox)

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3826)
<!-- Reviewable:end -->
