### PR TITLE
Replaced i with d in format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 - Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
+- Fixed bugs in `MocoCasOCProblem` and `CasOC::Problem` with incorrect string formatting. (#3828)
 
 
 v4.5

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.cpp
@@ -45,7 +45,7 @@ std::vector<std::string>
 Problem::createKinematicConstraintEquationNamesImpl() const {
     std::vector<std::string> names(getNumKinematicConstraintEquations());
     for (int i = 0; i < getNumKinematicConstraintEquations(); ++i) {
-        names[i] = fmt::format("kinematic_constraint_{:03i}", i);
+        names[i] = fmt::format("kinematic_constraint_{:03d}", i);
     }
     return names;
 }

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -544,7 +544,7 @@ private:
     void intermediateCallbackWithIterateImpl(
             const CasOC::Iterate& iterate) const override {
         std::string filename =
-                fmt::format("MocoCasADiSolver_{}_trajectory{:06i}.sto",
+                fmt::format("MocoCasADiSolver_{}_trajectory{:06d}.sto",
                         m_formattedTimeString, iterate.iteration);
         convertToMocoTrajectory(iterate).write(filename);
     }


### PR DESCRIPTION
Fixes issue #3827

### Brief summary of changes
i->d

### Testing I've completed
Tested formats in sandbox, using i creates this error: libc++abi: terminating due to uncaught exception of type fmt::v6::format_error: invalid type specifier
while using d works as expected.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3828)
<!-- Reviewable:end -->
