### PR TITLE
MocoOrientationTrackingGoal::initializeOnModelImpl fixes and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 - Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
+- Fixed `MocoOrientationTrackingGoal::initializeOnModelImpl` to check for missing kinematic states, but allow other missing columns. (#3830)
 
 
 v4.5

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -82,16 +82,18 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
         // Check that the reference state names match the model state names.
         checkLabelsMatchModelStates(model, statesTableToUse.getColumnLabels());
 
-        // Check that all coordinates are in the table
+        // Check that all coordinate values are in the table
         const CoordinateSet& coords = model.getCoordinateSet();
-        std::vector<std::string> columns = statesTableToUse.getColumnLabels();
+        auto columns = statesTableToUse.getColumnLabels();
         for (int i = 0; i < coords.getSize(); ++i) {
-            const Coordinate& c = coords.get(i);
-            std::string path = fmt::format("{}/value", c.getAbsolutePathString());
+            const Coordinate& coord = coords.get(i);
+            std::string path = fmt::format("{}/value", coord.getAbsolutePathString());
             OPENSIM_THROW_IF(
                 std::find(columns.begin(), columns.end(), path) == columns.end(),
                 Exception,
-                fmt::format("Coordinate {} not found in states table.", path));
+                fmt::format("Expected the states reference table to contain "
+                            "columns for all coordinate values in the model, "
+                            "but {} was not found.", path));
         }
 
         // Create the StatesTrajectory.

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -82,9 +82,21 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
         // Check that the reference state names match the model state names.
         checkLabelsMatchModelStates(model, statesTableToUse.getColumnLabels());
 
+        // Check that all coordinates are in the table
+        const CoordinateSet& coords = model.getCoordinateSet();
+        std::vector<std::string> columns = statesTableToUse.getColumnLabels();
+        for (int i = 0; i < coords.getSize(); ++i) {
+            const Coordinate& c = coords.get(i);
+            std::string path = fmt::format("{}/value", c.getAbsolutePathString());
+            OPENSIM_THROW_IF(
+                std::find(columns.begin(), columns.end(), path) == columns.end(),
+                Exception,
+                fmt::format("Coordinate {} not found in states table.", path));
+        }
+
         // Create the StatesTrajectory.
         auto statesTraj = StatesTrajectory::createFromStatesTable(
-                model, statesTableToUse);
+                model, statesTableToUse, true, true, false);
 
         // Use all paths provided in frame_paths.
         OPENSIM_THROW_IF_FRMOBJ(getProperty_frame_paths().empty(), Exception,

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.h
@@ -95,11 +95,12 @@ public:
     /** Provide a table containing values of model state variables. These data
     are used to create a StatesTrajectory internally, from which the
     rotation data for the frames specified in setFramePaths() are computed.
-    Each column label in the reference must be the path of a state variable,
-    e.g., `/jointset/ankle_angle_r/value`. Calling this function clears the
-    table provided via setRotationReference(), or the
-    `rotation_reference_file` property, if any. The table is not loaded
-    until the MocoProblem is initialized. */
+    Each column label in the reference should be the path of a coordinate value,
+    e.g., `/jointset/ankle_r/ankle_angle_r/value`. Columns for states that body
+    orientations do not depend on (e.g., `/forceset/soleus_r/activation`) are
+    not needed. Calling this function clears the table provided via
+    setRotationReference(), or the `rotation_reference_file` property, if any.
+    The table is not loaded until the MocoProblem is initialized. */
     void setStatesReference(const TableProcessor& ref) {
         set_rotation_reference_file("");
         m_rotation_table = TimeSeriesTable_<SimTK::Rotation_<double>>();

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -303,7 +303,7 @@ TEMPLATE_TEST_CASE("Test tracking goals", "", MocoCasADiSolver,
 
         SECTION("normal") {
             testDoublePendulumTracking<TestType, MocoOrientationTrackingGoal>(
-            studyOrientationTracking, solutionEffort);
+                studyOrientationTracking, solutionEffort);
         }
 
         SECTION("removed column") {

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -301,14 +301,13 @@ TEMPLATE_TEST_CASE("Test tracking goals", "", MocoCasADiSolver,
         MocoStudy studyOrientationTracking =
                 setupMocoStudyDoublePendulumMinimizeEffort<TestType>();
 
-        SECTION("normal") {
+        SECTION("Accurately tracks states reference") {
             testDoublePendulumTracking<TestType, MocoOrientationTrackingGoal>(
                 studyOrientationTracking, solutionEffort);
         }
 
-        SECTION("removed column") {
+        SECTION("Missing coordinate value in states reference") {
             auto& problem = study.updProblem();
-            problem.updPhase(0).updGoal("effort").setWeight(0.001);
             auto* tracking = problem.addGoal<MocoOrientationTrackingGoal>("tracking");
             tracking->setFramePaths({"/bodyset/b0", "/bodyset/b1"});
             TimeSeriesTable table = solutionEffort.exportToStatesTable();


### PR DESCRIPTION
Fixes issue #3766

### Brief summary of 

- changed flags to createFromStatesTable as written in the issue
- added a check before the call that all of the coordinates in the model are in the table
- added a test for the new check

### Testing I've completed

the MocoGoals tests

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3830)
<!-- Reviewable:end -->
