### PR TITLE
Added exceptions for when CasOCSolver solve() fails in MocoCasADiSolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 - Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
-- Added error handling to the solve call in `MocoCasADiSolver::solveImpl()`. (#3834)
+- Improved exception handling for internal errors in `MocoCasADiSolver`. Problems will now abort and print a descriptive error message (rather than fail due to an empty trajectory). (#3834)
 
 
 v4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bug in `OpenSim::PiecewiseLinearFunction` that prevented proper initialization of the coefficient array when the number of function points is equal to 1. (#3817)
 - Updated `PolynomialPathFitter` to use all available hardware threads during parallelization. (#3818)
 - Exposed `TimeSeriesTable::trimToIndices` to public API. (#3824)
+- Added error handling to the solve call in `MocoCasADiSolver::solveImpl()`. (#3834)
 
 
 v4.5

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -383,10 +383,25 @@ MocoSolution MocoCasADiSolver::solveImpl() const {
     Logger::Level origLoggerLevel = Logger::getLevel();
     Logger::setLevel(Logger::Level::Warn);
     CasOC::Solution casSolution;
+    // catch solve errors
     try {
         casSolution = casSolver->solve(casGuess);
-    } catch (...) {
-        OpenSim::Logger::setLevel(origLoggerLevel);
+    }
+    // opensim exceptions
+    catch(const Exception& ex) {
+        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("MocoCasADiSolver failed internally "
+                                             "with exception message: {}",
+                                             ex.getMessage()));
+    }
+    // casadi exceptions
+    catch(const casadi::CasadiException& ex) {
+        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("MocoCasADiSolver failed internally "
+                                             "with exception message: {}",
+                                             ex.what()));
+    }
+    // all other exceptions
+    catch (...) {
+        OPENSIM_THROW_FRMOBJ(Exception, "MocoCasADiSolver failed internally.");
     }
     OpenSim::Logger::setLevel(origLoggerLevel);
 

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -383,24 +383,17 @@ MocoSolution MocoCasADiSolver::solveImpl() const {
     Logger::Level origLoggerLevel = Logger::getLevel();
     Logger::setLevel(Logger::Level::Warn);
     CasOC::Solution casSolution;
-    // catch solve errors
     try {
         casSolution = casSolver->solve(casGuess);
-    }
-    // opensim exceptions
-    catch(const Exception& ex) {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("MocoCasADiSolver failed internally "
-                                             "with exception message: {}",
-                                             ex.getMessage()));
-    }
-    // casadi exceptions
-    catch(const casadi::CasadiException& ex) {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("MocoCasADiSolver failed internally "
-                                             "with exception message: {}",
-                                             ex.what()));
-    }
-    // all other exceptions
-    catch (...) {
+    } catch(const Exception& ex) {
+        OPENSIM_THROW_FRMOBJ(Exception,
+            fmt::format("MocoCasADiSolver failed internally with message: {}",
+                ex.getMessage()));
+    } catch(const casadi::CasadiException& ex) {
+        OPENSIM_THROW_FRMOBJ(Exception,
+            fmt::format("MocoCasADiSolver failed internally with message: {}",
+                ex.what()));
+    } catch (...) {
         OPENSIM_THROW_FRMOBJ(Exception, "MocoCasADiSolver failed internally.");
     }
     OpenSim::Logger::setLevel(origLoggerLevel);


### PR DESCRIPTION
Fixes issue #3730

### Brief summary of changes
Instead of continuing on, MocoCasADiSolver will throw exceptions when the solver doesn't fails so that the next lines don't cause more errors.

### Testing I've completed
Tested putting opensim, casadi, and std errors in the try section to see the error messages when running the sliding mass problem. Without the added errors it works normally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3834)
<!-- Reviewable:end -->
