### PR TITLE
Converting use of property variables to getter method calls in DeGrooteFregly2016Muscle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bugs in `MocoCasOCProblem` and `CasOC::Problem` with incorrect string formatting. (#3828)
 - Fixed `MocoOrientationTrackingGoal::initializeOnModelImpl` to check for missing kinematic states, but allow other missing columns. (#3830)
 - Improved exception handling for internal errors in `MocoCasADiSolver`. Problems will now abort and print a descriptive error message (rather than fail due to an empty trajectory). (#3834)
-
+- Fixed `DeGrooteFregly2016Muscle` so that its properties are recalculated every time they are used, instead of only updating inside `extendFinalizeFromProperties`. (#3836)
 
 
 v4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ pointer to avoid crashes in scripting due to invalid pointer ownership (#3781).
 - Fixed bugs in `MocoCasOCProblem` and `CasOC::Problem` with incorrect string formatting. (#3828)
 - Fixed `MocoOrientationTrackingGoal::initializeOnModelImpl` to check for missing kinematic states, but allow other missing columns. (#3830)
 - Improved exception handling for internal errors in `MocoCasADiSolver`. Problems will now abort and print a descriptive error message (rather than fail due to an empty trajectory). (#3834)
-- Fixed `DeGrooteFregly2016Muscle` so that its properties are recalculated every time they are used, instead of only updating inside `extendFinalizeFromProperties`. (#3836)
+
 
 
 v4.5

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,16 @@ Moco Change Log
 
 1.3.1
 -----
+- 2024-07-08: Fixed a bug in `DeGrooteFregly2016Muscle` where updates to properties 
+              `pennation_angle_at_optimal`, `optimal_fiber_length`, `max_contraction_velocity`, 
+              and `tendon_strain_at_one_norm_force` during parameter optimization did not 
+              affect certain model calculations, and as a result were not changing during
+              optimization.
+
+- Fixed `DeGrooteFregly2016Muscle` so that its properties are recalculated 
+              every time they are used, instead of only updating inside 
+              `extendFinalizeFromProperties`.
+
 - 2024-04-29: Added support for optimizing "Input controls" associated with 
               `InputController`s in a model. Support includes updates to the 
               MocoProblem interface (e.g., setInputControlInfo()) and MocoTrajectory 

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -152,16 +152,12 @@ void DeGrooteFregly2016Muscle::extendFinalizeFromProperties() {
             "Pennation angle at optimal fiber length must be in the range [0, "
             "Pi/2).");
 
-    using SimTK::square;
-    const auto normFiberWidth = sin(get_pennation_angle_at_optimal());
-    m_fiberWidth = get_optimal_fiber_length() * normFiberWidth;
-    m_squareFiberWidth = square(m_fiberWidth);
+    m_fiberWidth = get_m_fiberWidth();
+    m_squareFiberWidth = get_m_squareFiberWidth();
     m_maxContractionVelocityInMetersPerSecond =
-            get_max_contraction_velocity() * get_optimal_fiber_length();
-    m_kT = log((1.0 + c3) / c1) /
-           (1.0 + get_tendon_strain_at_one_norm_force() - c2);
-    m_isTendonDynamicsExplicit =
-            get_tendon_compliance_dynamics_mode() == "explicit";
+            get_m_maxContractionVelocityInMetersPerSecond();
+    m_kT = get_m_kT();
+    m_isTendonDynamicsExplicit = get_m_isTendonDynamicsExplicit();
 }
 
 void DeGrooteFregly2016Muscle::extendAddToSystem(
@@ -279,13 +275,13 @@ void DeGrooteFregly2016Muscle::calcMuscleLengthInfoHelper(
     // ------
     mli.fiberLengthAlongTendon = muscleTendonLength - mli.tendonLength;
     mli.fiberLength = sqrt(
-            SimTK::square(mli.fiberLengthAlongTendon) + m_squareFiberWidth);
+            SimTK::square(mli.fiberLengthAlongTendon) + get_m_squareFiberWidth());
     mli.normFiberLength = mli.fiberLength / get_optimal_fiber_length();
 
     // Pennation.
     // ----------
     mli.cosPennationAngle = mli.fiberLengthAlongTendon / mli.fiberLength;
-    mli.sinPennationAngle = m_fiberWidth / mli.fiberLength;
+    mli.sinPennationAngle = get_m_fiberWidth() / mli.fiberLength;
     mli.pennationAngle = asin(mli.sinPennationAngle);
 
     // Multipliers.
@@ -311,7 +307,7 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfoHelper(
         fvi.normFiberVelocity =
                 calcForceVelocityInverseCurve(fvi.fiberForceVelocityMultiplier);
         fvi.fiberVelocity = fvi.normFiberVelocity *
-                            m_maxContractionVelocityInMetersPerSecond;
+                            get_m_maxContractionVelocityInMetersPerSecond();
         fvi.fiberVelocityAlongTendon =
                 fvi.fiberVelocity / mli.cosPennationAngle;
         fvi.tendonVelocity =
@@ -331,13 +327,13 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfoHelper(
         fvi.fiberVelocity =
                 fvi.fiberVelocityAlongTendon * mli.cosPennationAngle;
         fvi.normFiberVelocity =
-                fvi.fiberVelocity / m_maxContractionVelocityInMetersPerSecond;
+                fvi.fiberVelocity / get_m_maxContractionVelocityInMetersPerSecond();
         fvi.fiberForceVelocityMultiplier =
                 calcForceVelocityMultiplier(fvi.normFiberVelocity);
     }
 
     const SimTK::Real tanPennationAngle =
-            m_fiberWidth / mli.fiberLengthAlongTendon;
+            get_m_fiberWidth() / mli.fiberLengthAlongTendon;
     fvi.pennationAngularVelocity =
             -fvi.fiberVelocity / mli.fiberLength * tanPennationAngle;
 }

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -152,12 +152,7 @@ void DeGrooteFregly2016Muscle::extendFinalizeFromProperties() {
             "Pennation angle at optimal fiber length must be in the range [0, "
             "Pi/2).");
 
-    m_fiberWidth = get_m_fiberWidth();
-    m_squareFiberWidth = get_m_squareFiberWidth();
-    m_maxContractionVelocityInMetersPerSecond =
-            get_m_maxContractionVelocityInMetersPerSecond();
-    m_kT = get_m_kT();
-    m_isTendonDynamicsExplicit = get_m_isTendonDynamicsExplicit();
+    m_isTendonDynamicsExplicit = get_tendon_compliance_dynamics_mode() == "explicit";
 }
 
 void DeGrooteFregly2016Muscle::extendAddToSystem(
@@ -275,13 +270,13 @@ void DeGrooteFregly2016Muscle::calcMuscleLengthInfoHelper(
     // ------
     mli.fiberLengthAlongTendon = muscleTendonLength - mli.tendonLength;
     mli.fiberLength = sqrt(
-            SimTK::square(mli.fiberLengthAlongTendon) + get_m_squareFiberWidth());
+            SimTK::square(mli.fiberLengthAlongTendon) + getSquareFiberWidth());
     mli.normFiberLength = mli.fiberLength / get_optimal_fiber_length();
 
     // Pennation.
     // ----------
     mli.cosPennationAngle = mli.fiberLengthAlongTendon / mli.fiberLength;
-    mli.sinPennationAngle = get_m_fiberWidth() / mli.fiberLength;
+    mli.sinPennationAngle = getFiberWidth() / mli.fiberLength;
     mli.pennationAngle = asin(mli.sinPennationAngle);
 
     // Multipliers.
@@ -307,7 +302,7 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfoHelper(
         fvi.normFiberVelocity =
                 calcForceVelocityInverseCurve(fvi.fiberForceVelocityMultiplier);
         fvi.fiberVelocity = fvi.normFiberVelocity *
-                            get_m_maxContractionVelocityInMetersPerSecond();
+                            getMaxContractionVelocityInMetersPerSecond();
         fvi.fiberVelocityAlongTendon =
                 fvi.fiberVelocity / mli.cosPennationAngle;
         fvi.tendonVelocity =
@@ -327,13 +322,13 @@ void DeGrooteFregly2016Muscle::calcFiberVelocityInfoHelper(
         fvi.fiberVelocity =
                 fvi.fiberVelocityAlongTendon * mli.cosPennationAngle;
         fvi.normFiberVelocity =
-                fvi.fiberVelocity / get_m_maxContractionVelocityInMetersPerSecond();
+                fvi.fiberVelocity / getMaxContractionVelocityInMetersPerSecond();
         fvi.fiberForceVelocityMultiplier =
                 calcForceVelocityMultiplier(fvi.normFiberVelocity);
     }
 
     const SimTK::Real tanPennationAngle =
-            get_m_fiberWidth() / mli.fiberLengthAlongTendon;
+            getFiberWidth() / mli.fiberLengthAlongTendon;
     fvi.pennationAngularVelocity =
             -fvi.fiberVelocity / mli.fiberLength * tanPennationAngle;
 }

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -92,15 +92,16 @@ These bounds are:
  - pennation_angle_at_optimal: [0, Pi/2)
  - default_activation: (0, inf]
  - default_normalized_tendon_force: [0, 5]
+
 @note The methods getMinNormalizedTendonForce() and
    getMaxNormalizedTendonForce() provide these bounds for use in custom solvers.
 
-@note Muscle properties can be optimized as a MocoParameter. The acceptable
+@note Muscle properties can be optimized using MocoParameter. The acceptable
 bounds for each property are **not** enforced during parameter optimization, so
 the user must supply these bounds to MocoParameter.
 
-@note Default properties cannot be optimized because they are applied during
-initialization only.
+@note The properties `default_activation` and `default_normalized_tendon_force`
+cannot be optimized because they are applied during model initialization only.
 
 @section departures Departures from the Muscle base class
 

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -99,6 +99,9 @@ These bounds are:
 bounds for each property are **not** enforced during parameter optimization, so
 the user must supply these bounds to MocoParameter.
 
+@note Default properties cannot be optimized because they are applied during
+initialization only.
+
 @section departures Departures from the Muscle base class
 
 The documentation for Muscle::MuscleLengthInfo states that the

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -493,14 +493,14 @@ public:
     // TODO: In explicit mode, do not allow negative tendon forces?
     SimTK::Real calcTendonForceMultiplier(
             const SimTK::Real& normTendonLength) const {
-        return c1 * exp(get_m_kT() * (normTendonLength - c2)) - c3;
+        return c1 * exp(getkT() * (normTendonLength - c2)) - c3;
     }
 
     /// This is the derivative of the tendon-force length curve with respect to
     /// normalized tendon length.
     SimTK::Real calcTendonForceMultiplierDerivative(
             const SimTK::Real& normTendonLength) const {
-        return c1 * get_m_kT() * exp(get_m_kT() * (normTendonLength - c2));
+        return c1 * getkT() * exp(getkT() * (normTendonLength - c2));
     }
 
     /// This is the integral of the tendon-force length curve with respect to
@@ -513,8 +513,8 @@ public:
         const double minNormTendonLength =
                 calcTendonForceLengthInverseCurve(m_minNormTendonForce);
         const double temp1 =
-                exp(get_m_kT() * normTendonLength) - exp(get_m_kT() * minNormTendonLength);
-        const double temp2 = c1 * exp(-c2 * get_m_kT()) / get_m_kT();
+                exp(getkT() * normTendonLength) - exp(getkT() * minNormTendonLength);
+        const double temp2 = c1 * exp(-c2 * getkT()) / getkT();
         const double temp3 = c3 * (normTendonLength - minNormTendonLength);
         return temp1 * temp2 - temp3;
     }
@@ -523,7 +523,7 @@ public:
     /// normalized tendon length as a function of the normalized tendon force.
     SimTK::Real calcTendonForceLengthInverseCurve(
             const SimTK::Real& normTendonForce) const {
-        return log((1.0 / c1) * (normTendonForce + c3)) / get_m_kT() + c2;
+        return log((1.0 / c1) * (normTendonForce + c3)) / getkT() + c2;
     }
 
     /// This returns normalized tendon velocity given the derivative of 
@@ -535,7 +535,7 @@ public:
             const SimTK::Real& derivNormTendonForce,
             const SimTK::Real& normTendonLength) const {
         return derivNormTendonForce /
-               (c1 * get_m_kT() * exp(get_m_kT() * (normTendonLength - c2)));
+               (c1 * getkT() * exp(getkT() * (normTendonLength - c2)));
     }
 
     /// This computes both the total fiber force and the individual components
@@ -632,8 +632,8 @@ public:
         // pennationAngle = asin(fiberWidth/fiberLength)
         // d_pennationAngle/d_fiberLength =
         //          d/d_fiberLength (asin(fiberWidth/fiberLength))
-        return (-get_m_fiberWidth() / square(fiberLength)) /
-               sqrt(1.0 - square(get_m_fiberWidth() / fiberLength));
+        return (-getFiberWidth() / square(fiberLength)) /
+               sqrt(1.0 - square(getFiberWidth() / fiberLength));
     }
 
     /// The derivative of the fiber force along the tendon with respect to fiber
@@ -838,24 +838,21 @@ private:
     void calcMusclePotentialEnergyInfoHelper(const bool& ignoreTendonCompliance,
             const MuscleLengthInfo& mli, MusclePotentialEnergyInfo& mpei) const;
 
-    //
-    SimTK::Real get_m_fiberWidth() const {
+    SimTK::Real getFiberWidth() const {
         const auto normFiberWidth = sin(get_pennation_angle_at_optimal());
         return get_optimal_fiber_length() * normFiberWidth;
     }
-    SimTK::Real get_m_squareFiberWidth() const {
-        using SimTK::square;
-        return square(get_m_fiberWidth());
+    SimTK::Real getSquareFiberWidth() const {
+        return SimTK::square(getFiberWidth());
     }
-    SimTK::Real get_m_maxContractionVelocityInMetersPerSecond() const {
+    SimTK::Real getMaxContractionVelocityInMetersPerSecond() const {
         return get_max_contraction_velocity() * get_optimal_fiber_length();
     }
-    SimTK::Real get_m_kT() const {
+    /// Tendon stiffness parameter from De Groote et al., 2016. Instead of
+    /// kT, users specify tendon strain at 1 norm force, which is more intuitive.
+    SimTK::Real getkT() const {
         return log((1.0 + c3) / c1) /
            (1.0 + get_tendon_strain_at_one_norm_force() - c2);
-    }
-    bool get_m_isTendonDynamicsExplicit() const {
-        return get_tendon_compliance_dynamics_mode() == "explicit";
     }
 
     /// This is a Gaussian-like function used in the active force-length curve.
@@ -969,14 +966,6 @@ private:
 
     // Computed from properties.
     // -------------------------
-
-    // The square of (fiber_width / optimal_fiber_length).
-    SimTK::Real m_fiberWidth = SimTK::NaN;
-    SimTK::Real m_squareFiberWidth = SimTK::NaN;
-    SimTK::Real m_maxContractionVelocityInMetersPerSecond = SimTK::NaN;
-    // Tendon stiffness parameter from De Groote et al., 2016. Instead of
-    // kT, users specify tendon strain at 1 norm force, which is more intuitive.
-    SimTK::Real m_kT = SimTK::NaN;
     bool m_isTendonDynamicsExplicit = true;
 
     // Indices for MuscleDynamicsInfo::userDefinedDynamicsExtras.

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -80,27 +80,24 @@ that support implicit dynamics (i.e. Moco) and cannot be used to perform a
 time-stepping forward simulation with Manager; use explicit mode for 
 time-stepping.
 
-@section property Property Optimization
-To include properties in optimization, add them as a MocoParameter. The
-acceptable bounds for each property will be automatically enforced at
-initialization but NOT during parameter optimization, so the user must supply
-these bounds to MocoParameter. The acceptable bounds for each property are:
-
-activation_time_constant > 0
-deactivation_time_constant > 0
-active_force_width_scale >= 1
-fiber_damping >= 0
-passive_fiber_strain_at_one_norm_force > 0
-tendon_strain_at_one_norm_force > 0
-pennation_angle_at_optimal: [0, Pi/2)
-
-The following properties cannot be optimized because they are applied during
-model initialization only. Their acceptable bounds are:
-
-default_activation > 0
-default_normalized_tendon_force: [0, 5]
+@section property Property Bounds
+The acceptable bounds for each property are enforced at model initialization.
+These bounds are:
+ - activation_time_constant: (0, inf]
+ - deactivation_time_constant: (0, inf]
+ - active_force_width_scale: [1, inf]
+ - fiber_damping: [0, inf]
+ - passive_fiber_strain_at_one_norm_force: (0, inf]
+ - tendon_strain_at_one_norm_force: (0, inf]
+ - pennation_angle_at_optimal: [0, Pi/2)
+ - default_activation: (0, inf]
+ - default_normalized_tendon_force: [0, 5]
 @note The methods getMinNormalizedTendonForce() and
    getMaxNormalizedTendonForce() provide these bounds for use in custom solvers.
+
+@note Muscle properties can be optimized as a MocoParameter. The acceptable
+bounds for each property are **not** enforced during parameter optimization, so
+the user must supply these bounds to MocoParameter.
 
 @section departures Departures from the Muscle base class
 
@@ -125,32 +122,32 @@ class OSIMACTUATORS_API DeGrooteFregly2016Muscle : public Muscle {
 public:
     OpenSim_DECLARE_PROPERTY(activation_time_constant, double,
             "Smaller value means activation can increase more rapidly. "
-            "Default: 0.015 seconds. Bounds: > 0.");
+            "Default: 0.015 seconds. Bounds: (0, inf]");
     OpenSim_DECLARE_PROPERTY(deactivation_time_constant, double,
             "Smaller value means activation can decrease more rapidly. "
-            "Default: 0.060 seconds. Bounds: > 0.");
+            "Default: 0.060 seconds. Bounds: (0, inf]");
     OpenSim_DECLARE_PROPERTY(default_activation, double,
             "Value of activation in the default state returned by "
-            "initSystem(). Default: 0.5. Bounds: > 0.");
+            "initSystem(). Default: 0.5. Bounds: (0, inf]");
     OpenSim_DECLARE_PROPERTY(default_normalized_tendon_force, double,
             "Value of normalized tendon force in the default state returned by "
             "initSystem(). Default: 0.5. Bounds: [0, 5].");
     OpenSim_DECLARE_PROPERTY(active_force_width_scale, double,
             "Scale factor for the width of the active force-length curve. "
-            "Larger values make the curve wider. Default: 1.0. Bounds: >= 1.");
+            "Larger values make the curve wider. Default: 1.0. Bounds: [1, inf]");
     OpenSim_DECLARE_PROPERTY(fiber_damping, double,
             "Use this property to define the linear damping force that is "
             "added to the total muscle fiber force. It is computed by "
             "multiplying this damping parameter by the normalized fiber "
-            "velocity and the max isometric force. Default: 0. Bounds: >= 0.");
+            "velocity and the max isometric force. Default: 0. Bounds: [0, inf]");
     OpenSim_DECLARE_PROPERTY(ignore_passive_fiber_force, bool,
             "Make the passive fiber force 0. Default: false.");
     OpenSim_DECLARE_PROPERTY(passive_fiber_strain_at_one_norm_force, double,
             "Fiber strain when the passive fiber force is 1 normalized force. "
-            "Default: 0.6. Bounds: > 0.");
+            "Default: 0.6. Bounds: (0, inf]");
     OpenSim_DECLARE_PROPERTY(tendon_strain_at_one_norm_force, double,
             "Tendon strain at a tension of 1 normalized force. "
-            "Default: 0.049. Bounds: > 0.");
+            "Default: 0.049. Bounds: (0, inf]");
     OpenSim_DECLARE_PROPERTY(tendon_compliance_dynamics_mode, std::string,
             "The dynamics method used to enforce tendon compliance dynamics. "
             "Options: 'explicit' or 'implicit'. Default: 'explicit'. ");

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -156,6 +156,7 @@ public:
 
     DeGrooteFregly2016Muscle() { constructProperties(); }
 
+
 protected:
     //--------------------------------------------------------------------------
     // COMPONENT INTERFACE
@@ -493,14 +494,14 @@ public:
     // TODO: In explicit mode, do not allow negative tendon forces?
     SimTK::Real calcTendonForceMultiplier(
             const SimTK::Real& normTendonLength) const {
-        return c1 * exp(getkT() * (normTendonLength - c2)) - c3;
+        return c1 * exp(getTendonStiffnessParameter() * (normTendonLength - c2)) - c3;
     }
 
     /// This is the derivative of the tendon-force length curve with respect to
     /// normalized tendon length.
     SimTK::Real calcTendonForceMultiplierDerivative(
             const SimTK::Real& normTendonLength) const {
-        return c1 * getkT() * exp(getkT() * (normTendonLength - c2));
+        return c1 * getTendonStiffnessParameter() * exp(getTendonStiffnessParameter() * (normTendonLength - c2));
     }
 
     /// This is the integral of the tendon-force length curve with respect to
@@ -513,8 +514,10 @@ public:
         const double minNormTendonLength =
                 calcTendonForceLengthInverseCurve(m_minNormTendonForce);
         const double temp1 =
-                exp(getkT() * normTendonLength) - exp(getkT() * minNormTendonLength);
-        const double temp2 = c1 * exp(-c2 * getkT()) / getkT();
+                exp(getTendonStiffnessParameter() * normTendonLength)
+                - exp(getTendonStiffnessParameter() * minNormTendonLength);
+        const double temp2 = c1 * exp(-c2 * getTendonStiffnessParameter())
+                                / getTendonStiffnessParameter();
         const double temp3 = c3 * (normTendonLength - minNormTendonLength);
         return temp1 * temp2 - temp3;
     }
@@ -523,7 +526,8 @@ public:
     /// normalized tendon length as a function of the normalized tendon force.
     SimTK::Real calcTendonForceLengthInverseCurve(
             const SimTK::Real& normTendonForce) const {
-        return log((1.0 / c1) * (normTendonForce + c3)) / getkT() + c2;
+        return log((1.0 / c1) * (normTendonForce + c3))
+                / getTendonStiffnessParameter() + c2;
     }
 
     /// This returns normalized tendon velocity given the derivative of 
@@ -534,8 +538,8 @@ public:
     SimTK::Real calcTendonForceLengthInverseCurveDerivative(
             const SimTK::Real& derivNormTendonForce,
             const SimTK::Real& normTendonLength) const {
-        return derivNormTendonForce /
-               (c1 * getkT() * exp(getkT() * (normTendonLength - c2)));
+        return derivNormTendonForce / (c1 * getTendonStiffnessParameter()
+            * exp(getTendonStiffnessParameter() * (normTendonLength - c2)));
     }
 
     /// This computes both the total fiber force and the individual components
@@ -848,9 +852,9 @@ private:
     SimTK::Real getMaxContractionVelocityInMetersPerSecond() const {
         return get_max_contraction_velocity() * get_optimal_fiber_length();
     }
-    /// Tendon stiffness parameter from De Groote et al., 2016. Instead of
+    /// Tendon stiffness parameter kT from De Groote et al., 2016. Instead of
     /// kT, users specify tendon strain at 1 norm force, which is more intuitive.
-    SimTK::Real getkT() const {
+    SimTK::Real getTendonStiffnessParameter() const {
         return log((1.0 + c3) / c1) /
            (1.0 + get_tendon_strain_at_one_norm_force() - c2);
     }

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -80,8 +80,26 @@ that support implicit dynamics (i.e. Moco) and cannot be used to perform a
 time-stepping forward simulation with Manager; use explicit mode for 
 time-stepping.
 
-@note Normalized tendon force is bounded in the range [0, 5] in this class.
-   The methods getMinNormalizedTendonForce() and 
+@section property Property Optimization
+To include properties in optimization, add them as a MocoParameter. The
+acceptable bounds for each property will be automatically enforced at
+initialization but NOT during parameter optimization, so the user must supply
+these bounds to MocoParameter. The acceptable bounds for each property are:
+
+activation_time_constant > 0
+deactivation_time_constant > 0
+active_force_width_scale >= 1
+fiber_damping >= 0
+passive_fiber_strain_at_one_norm_force > 0
+tendon_strain_at_one_norm_force > 0
+pennation_angle_at_optimal: [0, Pi/2)
+
+The following properties cannot be optimized because they are applied during
+model initialization only. Their acceptable bounds are:
+
+default_activation > 0
+default_normalized_tendon_force: [0, 5]
+@note The methods getMinNormalizedTendonForce() and
    getMaxNormalizedTendonForce() provide these bounds for use in custom solvers.
 
 @section departures Departures from the Muscle base class
@@ -107,32 +125,32 @@ class OSIMACTUATORS_API DeGrooteFregly2016Muscle : public Muscle {
 public:
     OpenSim_DECLARE_PROPERTY(activation_time_constant, double,
             "Smaller value means activation can increase more rapidly. "
-            "Default: 0.015 seconds.");
+            "Default: 0.015 seconds. Bounds: > 0.");
     OpenSim_DECLARE_PROPERTY(deactivation_time_constant, double,
             "Smaller value means activation can decrease more rapidly. "
-            "Default: 0.060 seconds.");
+            "Default: 0.060 seconds. Bounds: > 0.");
     OpenSim_DECLARE_PROPERTY(default_activation, double,
             "Value of activation in the default state returned by "
-            "initSystem(). Default: 0.5.");
+            "initSystem(). Default: 0.5. Bounds: > 0.");
     OpenSim_DECLARE_PROPERTY(default_normalized_tendon_force, double,
             "Value of normalized tendon force in the default state returned by "
-            "initSystem(). Default: 0.5.");
+            "initSystem(). Default: 0.5. Bounds: [0, 5].");
     OpenSim_DECLARE_PROPERTY(active_force_width_scale, double,
             "Scale factor for the width of the active force-length curve. "
-            "Larger values make the curve wider. Default: 1.0.");
+            "Larger values make the curve wider. Default: 1.0. Bounds: >= 1.");
     OpenSim_DECLARE_PROPERTY(fiber_damping, double,
             "Use this property to define the linear damping force that is "
             "added to the total muscle fiber force. It is computed by "
             "multiplying this damping parameter by the normalized fiber "
-            "velocity and the max isometric force. Default: 0.");
+            "velocity and the max isometric force. Default: 0. Bounds: >= 0.");
     OpenSim_DECLARE_PROPERTY(ignore_passive_fiber_force, bool,
             "Make the passive fiber force 0. Default: false.");
     OpenSim_DECLARE_PROPERTY(passive_fiber_strain_at_one_norm_force, double,
             "Fiber strain when the passive fiber force is 1 normalized force. "
-            "Default: 0.6.");
+            "Default: 0.6. Bounds: > 0.");
     OpenSim_DECLARE_PROPERTY(tendon_strain_at_one_norm_force, double,
             "Tendon strain at a tension of 1 normalized force. "
-            "Default: 0.049.");
+            "Default: 0.049. Bounds: > 0.");
     OpenSim_DECLARE_PROPERTY(tendon_compliance_dynamics_mode, std::string,
             "The dynamics method used to enforce tendon compliance dynamics. "
             "Options: 'explicit' or 'implicit'. Default: 'explicit'. ");


### PR DESCRIPTION
Fixes issue #3483

### Brief summary of changes
- Made get methods for the properties so that they can update more often
- Replaced all usages of the instance variables with get method calls, got rid of variables
- Except for m_isTendonDynamicsExplicit because it would cause errors

### Testing I've completed

- running testDeGrooteFregly2016Muscle
- [perf-win]
- using the HangingMuscleModel example, added the properties as parameters and checked that they changed after the solve

### Looking for feedback on...
Previously extendFinalizeFromProperties had several checks for the properties before changing the variables. So is it a problem if we are now changing the variables without doing these checks?

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3836)
<!-- Reviewable:end -->
