### PR TITLE
Convert testConstraints to catch2

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Test/CMakeLists.txt
+++ b/OpenSim/Simulation/SimbodyEngine/Test/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 file(GLOB TEST_PROGS "test*.cpp")
 file(GLOB TEST_FILES *.osim *.xml *.sto *.mot)
@@ -5,5 +7,5 @@ file(GLOB TEST_FILES *.osim *.xml *.sto *.mot)
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_PROGS}
     DATAFILES ${TEST_FILES}
-    LINKLIBS osimSimulation osimCommon osimAnalyses
+    LINKLIBS osimSimulation osimCommon osimAnalyses Catch2::Catch2WithMain
     )

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -135,38 +135,6 @@ public:
     }
 }; // End of MultidimensionalFunction
 
-void testRollingOnSurfaceConstraint();
-void testCoordinateLocking();
-void testWeldConstraint();
-void testPointOnLineConstraint();
-void testCoordinateCouplerConstraint();
-void testPointConstraint();
-void testConstantDistanceConstraint();
-void testSerializeDeserialize();
-
-int main()
-{
-    try {
-        testPointConstraint();
-        testConstantDistanceConstraint();
-        testCoordinateLocking();
-        testWeldConstraint();
-        // Compare behavior of PointOnLineConstraint between the foot and ground
-        testPointOnLineConstraint();
-        // Compare behavior of CoordinateCouplerConstraint as a custom knee
-        testCoordinateCouplerConstraint();
-        // test OpenSim roll constraint against a composite of Simbody constraints
-        testRollingOnSurfaceConstraint();
-        testSerializeDeserialize();
-    }
-    catch(const OpenSim::Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
-}
-
 //==============================================================================
 // Common Functions 
 //==============================================================================
@@ -320,7 +288,7 @@ void compareSimulations(SimTK::MultibodySystem &system, SimTK::State &state, Mod
 // Test Cases
 //==========================================================================================================
 
-void testPointConstraint()
+TEST_CASE("testPointConstraint")
 {
     using namespace SimTK;
 
@@ -391,7 +359,7 @@ void testPointConstraint()
     compareSimulations(system, state, osimModel, osim_state, "testPointConstraint FAILED\n");
 }
 
-void testConstantDistanceConstraint()
+TEST_CASE("testConstantDistanceConstraint")
 {
     using namespace SimTK;
 
@@ -472,7 +440,7 @@ void testConstantDistanceConstraint()
     compareSimulations(system, state, &osimModel, osim_state,
                        "testConstantDistanceConstraint FAILED\n");
 }
-void testCoordinateLocking()
+TEST_CASE("testCoordinateLocking")
 {
     using namespace SimTK;
 
@@ -568,7 +536,7 @@ void testCoordinateLocking()
     ASSERT(fabs(qf[1]-fixedKneeAngle) <= integ_accuracy, __FILE__, __LINE__, errorMessage.str());
 }
 
-void testWeldConstraint()
+TEST_CASE("testWeldConstraint")
 {
     using namespace SimTK;
 
@@ -673,7 +641,7 @@ void testWeldConstraint()
         "testWeldConstraint FAILED\n");
 }
 
-void testPointOnLineConstraint()
+TEST_CASE("testPointOnLineConstraint")
 {
     using namespace SimTK;
 
@@ -751,7 +719,7 @@ void testPointOnLineConstraint()
     compareSimulations(system, state, osimModel, osim_state, "testPointOnLineConstraint FAILED\n");
 } // end testPointOnLineConstraint
 
-void testCoordinateCouplerConstraint()
+TEST_CASE("testCoordinateCouplerConstraint")
 {
     using namespace SimTK;
 
@@ -955,7 +923,7 @@ void testCoordinateCouplerConstraint()
     }
 }
 
-void testRollingOnSurfaceConstraint()
+TEST_CASE("testRollingOnSurfaceConstraint")
 {
     using namespace SimTK;
 
@@ -1092,7 +1060,8 @@ void testRollingOnSurfaceConstraint()
     compareSimulations(system, state, osimModel, osim_state, "testRollingOnSurfaceConstraint FAILED\n");
 }
 
-void testSerializeDeserialize() {
+TEST_CASE("testSerializeDeserialize")
+{
     std::cout << "Test serialize & deserialize." << std::endl;
 
     std::string origModelFile{"testJointConstraints.osim"};

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -36,6 +36,8 @@
 //     Add tests here as new constraint types are added to OpenSim
 //
 //==============================================================================
+#include <catch2/catch_all.hpp>
+
 #include <OpenSim/Analyses/Kinematics.h>
 #include <OpenSim/Analyses/PointKinematics.h>
 #include <OpenSim/Analyses/ForceReporter.h>
@@ -65,6 +67,8 @@
 #include <OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include "SimTKsimbody.h"
+
+
 
 using namespace OpenSim;
 using namespace std;

--- a/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testConstraints.cpp
@@ -36,14 +36,12 @@
 //     Add tests here as new constraint types are added to OpenSim
 //
 //==============================================================================
-#include <catch2/catch_all.hpp>
 
 #include <OpenSim/Analyses/Kinematics.h>
 #include <OpenSim/Analyses/PointKinematics.h>
 #include <OpenSim/Analyses/ForceReporter.h>
 #include <OpenSim/Common/LinearFunction.h>
 #include <OpenSim/Common/osimCommon.h>
-
 #include <OpenSim/Common/FunctionAdapter.h>
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Simulation/Model/Model.h>
@@ -58,7 +56,6 @@
 #include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/CustomJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/SpatialTransform.h>
-
 #include <OpenSim/Simulation/SimbodyEngine/PointConstraint.h>
 #include <OpenSim/Simulation/SimbodyEngine/ConstantDistanceConstraint.h>
 #include <OpenSim/Simulation/SimbodyEngine/WeldConstraint.h>
@@ -67,7 +64,7 @@
 #include <OpenSim/Simulation/SimbodyEngine/RollingOnSurfaceConstraint.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include "SimTKsimbody.h"
-
+#include <catch2/catch_all.hpp>
 
 
 using namespace OpenSim;


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes
Added catch2 to the cmake file for SimbodyEngine and converted testConstraints to catch2

### Testing I've completed
testConstaints still passes

### Looking for feedback on...

### CHANGELOG.md (choose one)
- no need to update because... internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3837)
<!-- Reviewable:end -->
