### PR TITLE
log_cout logs at current level instead of "critical"

### DIFF
--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -145,15 +145,15 @@ public:
     }
 
     /// Use this function to log messages that would normally be sent to
-    /// std::cout. These messages always appear (unless the logger is off), and
-    /// are also logged to the filesink (addFileSink()) and any sinks added via
-    /// addSink(). The main use case for this function is inside of functions
-    /// whose intent is to print information (e.g., Component::printSubcomponentInfo()).
+    /// std::cout. These messages always appear, and are also logged to the
+    /// filesink (addFileSink()) and any sinks added via addSink().
+    /// The main use case for this function is inside of functions whose intent
+    /// is to print information (e.g., Component::printSubcomponentInfo()).
     /// Besides such use cases, this function should be used sparingly to
     /// give users control over what gets logged.
     template <typename... Args>
     static void cout(spdlog::string_view_t fmt, const Args&... args) {
-        getCoutLogger().log(spdlog::level::critical, fmt, args...);
+        getCoutLogger().log(getCoutLogger().level(), fmt, args...);
     }
 
     /// @}


### PR DESCRIPTION
Fixes issue #3428

### Brief summary of changes
Revision of PR #3826, instead of logging at the level critical, log_cout will log at the current level. So it will always log, including when the logger is off. 

### Testing I've completed
Changing the logger level and testing log_cout

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because... functionality is nearly the same as before

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3844)
<!-- Reviewable:end -->
