### PR TITLE
Drop std::iterator from ComponentListIterator

### DIFF
--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -4294,8 +4294,9 @@ void ComponentListIterator<T>::advanceToNextValidComponent() {
     // Advance _node to next valid (of type T) if needed
     // Similar logic to operator++ but applies _filter->isMatch()
     while (_node != nullptr && (dynamic_cast<const T*>(_node) == nullptr ||
-                                !_filter.isMatch(*_node) ||
-                                (_node == _root))){
+                                !(!_filter || _filter->isMatch(*_node)) ||
+                                (_node == _root))) {
+
         if (_node->_memberSubcomponents.size() > 0) {
             _node = _node->_memberSubcomponents[0].get();
         }

--- a/OpenSim/Common/ComponentList.h
+++ b/OpenSim/Common/ComponentList.h
@@ -153,8 +153,7 @@ public:
         _root(root), _filter(f) {
     }
     /** Constructor that takes only a Component to iterate over (itself and its
-    descendants). ComponentFilterMatchAll is used internally. You can
-    change the filter using setFilter() method. 
+    descendants). You can change the filter using setFilter() method.
     */
     ComponentList(const Component& root) :
         _root(root) {

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -33,11 +33,10 @@
 using namespace OpenSim;
 using namespace std;
 
-// `LegacyInputIterator` compatibility for `ComponentListIterator`
-static_assert(std::is_copy_constructible<ComponentListIterator<Component>>::value);
-static_assert(std::is_copy_assignable<ComponentListIterator<Component>>::value);
-static_assert(std::is_destructible<ComponentListIterator<Component>>::value);
-static_assert(std::is_same<std::iterator_traits<ComponentListIterator<Component>>::value_type, Component>::value);
+static_assert(std::is_copy_constructible<ComponentListIterator<Component>>::value, "required by standard library's LegacyInputIterator");
+static_assert(std::is_copy_assignable<ComponentListIterator<Component>>::value, "required by standard library's LegacyInputIterator");
+static_assert(std::is_destructible<ComponentListIterator<Component>>::value, "required by standard library's LegacyInputIterator");
+static_assert(std::is_same<std::iterator_traits<ComponentListIterator<Component>>::value_type, Component>::value, "required by standard library's LegacyInputIterator");
 // static_assert(std::is_swappable<ComponentListIterator<Component>>::value);  // C++17
 
 // Example filter that allows for iterating only through Components that have

--- a/OpenSim/Tests/testIterators/testIterators.cpp
+++ b/OpenSim/Tests/testIterators/testIterators.cpp
@@ -21,14 +21,24 @@
  * See the License for the specific language governing permissions and        *
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
-#include <iostream>
 #include <OpenSim/Simulation/Model/Model.h>
 #include "OpenSim/Simulation/SimbodyEngine/PinJoint.h"
 #include <OpenSim/Common/LoadOpenSimLibrary.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <iterator>
+#include <iostream>
+#include <type_traits>
+
 using namespace OpenSim;
 using namespace std;
+
+// `LegacyInputIterator` compatibility for `ComponentListIterator`
+static_assert(std::is_copy_constructible<ComponentListIterator<Component>>::value);
+static_assert(std::is_copy_assignable<ComponentListIterator<Component>>::value);
+static_assert(std::is_destructible<ComponentListIterator<Component>>::value);
+static_assert(std::is_same<std::iterator_traits<ComponentListIterator<Component>>::value_type, Component>::value);
+// static_assert(std::is_swappable<ComponentListIterator<Component>>::value);  // C++17
 
 // Example filter that allows for iterating only through Components that have
 // state variables, used for demonstration purposes.
@@ -242,7 +252,7 @@ void testComponentListConst() {
     cout << "numModelComponentsWithStateVariables ="
         << numModelComponentsWithStateVariables << endl;
 
-    //Now test a std::iterator method
+    // ensure the iterator is compatible with stdlib iterator methods (e.g. `std::advance`)
     ComponentList<const Frame> allFrames = model.getComponentList<Frame>();
     ComponentList<Frame>::const_iterator skipIter = allFrames.begin();
     int countSkipFrames = 0;
@@ -371,7 +381,7 @@ void testComponentListNonConstWithConstIterator() {
         cout << comp.getConcreteClassName() << ":" << comp.getAbsolutePathString() << endl;
         numModelComponentsWithStateVariables++;
     }
-    //Now test a std::iterator method
+    // ensure the iterator is compatible with stdlib iterator methods (e.g. `std::advance`)
     ComponentList<Frame> allFrames = model.updComponentList<Frame>();
     // This line uses implicit conversion from iterator to const_iterator.
     ComponentList<Frame>::const_iterator skipIter = allFrames.begin();
@@ -487,7 +497,7 @@ void testComponentListNonConstWithNonConstIterator() {
         numModelComponentsWithStateVariables++;
         comp.setName(comp.getName());
     }
-    //Now test a std::iterator method
+    // ensure the iterator is compatible with stdlib iterator methods (e.g. `std::advance`)
     ComponentList<Frame> allFrames = model.updComponentList<Frame>();
     ComponentList<Frame>::iterator skipIter = allFrames.begin();
     int countSkipFrames = 0;


### PR DESCRIPTION
Drop std::iterator from ComponentListIterator and make ComponentList (+iter) more algorithm-compatible

This is related to `opensim-creator`, which is compiled using `/W4` on MSVC.

One warning that's emitted by high-warning-levels is the deprecation of `std::iterator`.  The compiler will throw a tantrum when compiling with OpenSim's headers because `ComponentListIterator` uses the deprecated pattern. I currently disable this warning with `/wd4996` ([explanation(https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-170)) but that also disables other deprecation warnings.

The more modern way of achieving the same goal is to implement typedefs on `ComponentListIterator` such that `std::iterator_traits` will work with it. I did that (and it worked), but I also found that `ComponentListIterator` doesn't strictly abide by the iterator that it advertises via the traits (namely `std::forward_iterator_tag`). Those requirements are listed here:

- https://en.cppreference.com/w/cpp/named_req/ForwardIterator
- https://en.cppreference.com/w/cpp/named_req/InputIterator
- https://en.cppreference.com/w/cpp/named_req/Iterator

Specifically, the most important requirements are things like "can copy-construct and copy-assign the iterator". They're important because some of the algorithms in `<algorithm>` may depend on it. So I also implemented the minimum of those requirements, which required changing reference members (not copy-assignable) to pointers. This also led to an "optimization" where a `nullptr` means that the implementation can skip calling into a filter object (and skip allocating a "let everything through" filter), which is why this PR is messier than the bare-minimum of adding the necessary typedefs.

Fixes issue #<issue_number>

- N/A

### Brief summary of changes

- Added `std::iterator_traits<It>` typedefs
- Added `static_assert` tests into the test suite to verify the `ComponentListIterator` is suitable for generic algorithms (initially failed)
- Changed data members in `ComponentListIterator`  (the `static_asserts` then passed)
- Added a null check onto the `_filter` member (most common case - doing this avoids memory allocation, virtual method calling, etc.)

### Testing I've completed

- The `static_assert`s
- The remainder of the codebase is very sensitive to changes in this class's behavior, so I'm *guessing* that any faults in the logic would pop up 

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because mostly internal change? (could mention it, if we want to be pedantic about dropping `std::iterator`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3852)
<!-- Reviewable:end -->
