### PR TITLE
MocoOutputConstraint option for two outputs

### DIFF
--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,8 @@ Moco Change Log
 
 1.3.1
 -----
+- addition to OutputGoal log for OutputConstraint
+
 - 2024-07-08: Fixed a bug where deserialization of an OpenSim model with the `Bhargava2004SmoothedMuscleMetabolics`
               component would not properly set the muscle masses listed, resulting in incorrect
               metabolics values being computed.

--- a/OpenSim/Moco/MocoOutputConstraint.cpp
+++ b/OpenSim/Moco/MocoOutputConstraint.cpp
@@ -22,8 +22,8 @@ using namespace OpenSim;
 
 void MocoOutputConstraint::constructProperties() {
     constructProperty_output_path("");
-    constructProperty_second_output_path();
-    constructProperty_operation();
+    constructProperty_second_output_path("");
+    constructProperty_operation("");
     constructProperty_exponent(1);
     constructProperty_output_index(-1);
 }
@@ -98,10 +98,10 @@ void MocoOutputConstraint::initializeOnModelImpl(const Model&,
 
     m_useCompositeOutputValue = false;
     // if there's a second output, initialize it
-    if (!getProperty_second_output_path().empty()) {
+    if (get_second_output_path() != "") {
         m_useCompositeOutputValue = true;
         initializeComposite();
-    } else if (!getProperty_operation().empty()) {
+    } else if (get_operation() != "") {
         OPENSIM_THROW_FRMOBJ(Exception, fmt::format("An operation was provided "
                 "but a second Output path was not provided. Either provide no "
                 "operation with a single Output, or provide a value to both "

--- a/OpenSim/Moco/MocoOutputConstraint.cpp
+++ b/OpenSim/Moco/MocoOutputConstraint.cpp
@@ -123,7 +123,7 @@ void MocoOutputConstraint::initializeComposite() const {
                 "provided, but no operation was provided. Use setOperation() to"
                 "provide an operation"));
     } else {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Invalid operator: '{}', must "
+        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Invalid operation: '{}', must "
                 "be 'addition', 'subtraction', 'multiplication', or 'division'.",
                 get_operation()));
     }
@@ -248,7 +248,7 @@ void MocoOutputConstraint::printDescriptionImpl() const {
     if (m_useCompositeOutputValue) {
         str += fmt::format("\n        second output: {}", getSecondOutputPath());
         // Operation.
-        str += fmt::format("\n        operator: {}", get_operation());
+        str += fmt::format("\n        operation: {}", get_operation());
     }
 
     // Output type.

--- a/OpenSim/Moco/MocoOutputConstraint.cpp
+++ b/OpenSim/Moco/MocoOutputConstraint.cpp
@@ -140,17 +140,17 @@ void MocoOutputConstraint::initializeComposite() const {
                 " 'double'.")
         OPENSIM_THROW_IF_FRMOBJ(m_data_type != Type_double, Exception,
                 "Output types do not match. The second Output is of type double"
-                " but the first is of type {}.", getDataTypeStr(m_data_type));
+                " but the first is of type {}.", getDataTypeString(m_data_type));
     } else if (dynamic_cast<const Output<SimTK::Vec3>*>(abstractOutput)) {
         OPENSIM_THROW_IF_FRMOBJ(m_data_type != Type_Vec3, Exception,
                 "Output types do not match. The second Output is of type "
                 "SimTK::Vec3 but the first is of type {}.",
-                getDataTypeStr(m_data_type));
+                getDataTypeString(m_data_type));
     } else if (dynamic_cast<const Output<SimTK::SpatialVec>*>(abstractOutput)) {
         OPENSIM_THROW_IF_FRMOBJ(m_data_type != Type_SpatialVec, Exception,
                 "Output types do not match. The second Output is of type "
                 "SimTK::SpatialVec but the first is of type {}.",
-                getDataTypeStr(m_data_type));
+                getDataTypeString(m_data_type));
         OPENSIM_THROW_IF_FRMOBJ(m_minimizeVectorNorm &&
                 (m_operation == Multiplication || m_operation == Division),
                 Exception, "Multiplication and division operations are not "
@@ -216,8 +216,8 @@ double MocoOutputConstraint::calcCompositeOutputValue(const SimTK::State& state)
         value = applyOperation(value1, value2);
     } else if (m_data_type == Type_Vec3) {
         if (m_minimizeVectorNorm) {
-            SimTK::Vec3 value1 = getOutput<SimTK::Vec3>().getValue(state);
-            SimTK::Vec3 value2 = getSecondOutput<SimTK::Vec3>().getValue(state);
+            const SimTK::Vec3& value1 = getOutput<SimTK::Vec3>().getValue(state);
+            const SimTK::Vec3& value2 = getSecondOutput<SimTK::Vec3>().getValue(state);
             value = applyOperation(value1, value2);
         } else {
             double value1 = getOutput<SimTK::Vec3>().getValue(state)[m_index1];
@@ -226,8 +226,10 @@ double MocoOutputConstraint::calcCompositeOutputValue(const SimTK::State& state)
         }
     } else if (m_data_type == Type_SpatialVec) {
         if (m_minimizeVectorNorm) {
-            SimTK::SpatialVec value1 = getOutput<SimTK::SpatialVec>().getValue(state);
-            SimTK::SpatialVec value2 = getSecondOutput<SimTK::SpatialVec>().getValue(state);
+            const SimTK::SpatialVec& value1 = getOutput<SimTK::SpatialVec>()
+                                              .getValue(state);
+            const SimTK::SpatialVec& value2 = getSecondOutput<SimTK::SpatialVec>()
+                                              .getValue(state);
             value = applyOperation(value1, value2);
         } else {
             double value1 = getOutput<SimTK::SpatialVec>().getValue(state)
@@ -241,6 +243,7 @@ double MocoOutputConstraint::calcCompositeOutputValue(const SimTK::State& state)
     return value;
 }
 
+
 void MocoOutputConstraint::printDescriptionImpl() const {
     // Output path.
     std::string str = fmt::format("        output: {}", getOutputPath());
@@ -252,11 +255,7 @@ void MocoOutputConstraint::printDescriptionImpl() const {
     }
 
     // Output type.
-    std::string type;
-    if (m_data_type == Type_double) { type = "double"; }
-    else if (m_data_type == Type_Vec3) { type = "SimTK::Vec3"; }
-    else if (m_data_type == Type_SpatialVec) { type = "SimTK::SpatialVec"; }
-    str += fmt::format(", type: {}", type);
+    str += fmt::format(", type: {}", getDataTypeString(m_data_type));
 
     // Output index (if relevant).
     if (getOutputIndex() != -1) {

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -114,10 +114,10 @@ private:
     OpenSim_DECLARE_PROPERTY(output_path, std::string,
             "The absolute path to the Output in the model (i.e.,"
             "'/path/to/component|output_name'");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(second_output_path, std::string,
+    OpenSim_DECLARE_PROPERTY(second_output_path, std::string,
             "The absolute path to the optional second Output in the model (i.e.,"
             "'/path/to/component|output_name'");
-    OpenSim_DECLARE_OPTIONAL_PROPERTY(operation, std::string, "The operation to combine "
+    OpenSim_DECLARE_PROPERTY(operation, std::string, "The operation to combine "
             "the two outputs: 'addition', 'subtraction', 'multiplication', or "
             "'divison'.");
     OpenSim_DECLARE_PROPERTY(exponent, int,
@@ -164,7 +164,8 @@ private:
         }
     }
     /** Apply the elementwise operation to two SimTK::Vec3 values. */
-    double applyOperation(const SimTK::Vec3& value1, const SimTK::Vec3& value2) const {
+    double applyOperation(const SimTK::Vec3& value1,
+                          const SimTK::Vec3& value2) const {
         switch (m_operation) {
         case Addition       : return (value1 + value2).norm();
         case Subtraction    : return (value1 - value2).norm();
@@ -178,7 +179,8 @@ private:
     /** Apply the elementwise operation to two SimTK::SpatialVec values.
     Multiplication and divison operators are not supported for SpatialVec Outputs
     without an index. */
-    double applyOperation(const SimTK::SpatialVec& value1, const SimTK::SpatialVec& value2) const {
+    double applyOperation(const SimTK::SpatialVec& value1,
+                          const SimTK::SpatialVec& value2) const {
         switch (m_operation) {
         case Addition       : return (value1 + value2).norm();
         case Subtraction    : return (value1 - value2).norm();

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -22,6 +22,25 @@
 
 namespace OpenSim {
 
+/** This constraint allows you to constrain a Model Output value throughout the
+trajectory. You can also combine two Outputs in a constraint by supplying a
+second output path and an operation to combine them. The operators are addition,
+subtraction, multiplication, and division. The first Output is always on the
+left hand side of the operation and the second Output on the right hand side.
+The two Outputs can be different quantities, but they must be the same type.
+
+Outputs of type double, SimTK::Vec3, and SimTK::SpatialVec are supported.
+When using SimTK::Vec3 or SimTK::SpatialVec types, 'setOutputIndex()'
+may be used to select a specific element of the Output vector. If no index is
+specified, the norm of the vector will be used when calling 'calcOutputValue()'.
+
+If using two Outputs, the Output index will be used to select the same element
+from both Outputs before the operation. If two Outputs of type SimTK::Vec3 or
+SimTK::SpatialVec are provided and no index is specified, the operation will be
+applied elementwise before computing the norm. Elementwise
+multiplication and division operations are not supported when using two
+SimTK::SpatialVec Outputs (i.e., an index must be provided).
+@ingroup mocopathcon */
 class OSIMMOCO_API MocoOutputConstraint : public MocoPathConstraint {
     OpenSim_DECLARE_CONCRETE_OBJECT(MocoOutputConstraint, MocoPathConstraint);
 
@@ -52,6 +71,7 @@ public:
     void setOperation(std::string operation) {
         set_operation(std::move(operation));
     }
+    const std::string& getOperation() const { return get_operation(); }
 
     /** Set the exponent applied to the output value in the constraint. This
     exponent is applied when minimizing the norm of a vector type output. */

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -22,7 +22,7 @@
 
 namespace OpenSim {
 
-/** This constraint allows you to constrain a Model Output value throughout the
+/** This path constraint allows you to constrain a Model Output value throughout the
 trajectory. You can also combine two Outputs in a constraint by supplying a
 second output path and an operation to combine them. The operations are addition,
 subtraction, multiplication, and division. The first Output is always on the
@@ -53,10 +53,11 @@ public:
     void setOutputPath(std::string path) { set_output_path(std::move(path)); }
     const std::string& getOutputPath() const { return get_output_path(); }
 
-    /** Set the absolute path to the optional second Output in the model. The
-    format is "/path/to/component|output_name". This Output should have the same
-    type as the first Output. If providing a second Output, the user must also
-    provide an operation via `setOperation()`. */
+    /** Set the absolute path to the optional second Output in the model to be
+    used in this path constraint. The format is "/path/to/component|output_name".
+    This Output should have the same  type as the first Output. If providing a
+    second Output, the user must also provide an operation via `setOperation()`.
+    */
     void setSecondOutputPath(std::string path) {
         set_second_output_path(std::move(path));
     }
@@ -112,11 +113,11 @@ protected:
 
 private:
     OpenSim_DECLARE_PROPERTY(output_path, std::string,
-            "The absolute path to the Output in the model (i.e.,"
-            "'/path/to/component|output_name'");
+            "The absolute path to the Output in the model to be used in this "
+            "path constraint (i.e., '/path/to/component|output_name').");
     OpenSim_DECLARE_PROPERTY(second_output_path, std::string,
-            "The absolute path to the optional second Output in the model (i.e.,"
-            "'/path/to/component|output_name'");
+            "The absolute path to the optional second Output in the model to be used"
+            " in this path constraint (i.e., '/path/to/component|output_name')");
     OpenSim_DECLARE_PROPERTY(operation, std::string, "The operation to combine "
             "the two outputs: 'addition', 'subtraction', 'multiplication', or "
             "'divison'.");
@@ -132,7 +133,7 @@ private:
     void constructProperties();
 
     /** Initialize additional information when there are two Outputs:
-     * the second Output, the operation, and the dependsOnStage. */
+    the second Output, the operation, and the dependsOnStage. */
     void initializeComposite() const;
 
     /** Calculate the Output value of one Output. */
@@ -140,12 +141,12 @@ private:
     /** Calculate the two Output values and apply the operation. */
     double calcCompositeOutputValue(const SimTK::State&) const;
 
-    /** Get a reference to the Output for this goal. */
+    /** Get a reference to the Output for this path constraint. */
     template <typename T>
     const Output<T>& getOutput() const {
         return static_cast<const Output<T>&>(m_output.getRef());
     }
-    /** Get a reference to the second Output for this goal. */
+    /** Get a reference to the second Output for this path constraint. */
     template <typename T>
     const Output<T>& getSecondOutput() const {
         return static_cast<const Output<T>&>(m_second_output.getRef());
@@ -195,8 +196,8 @@ private:
         Type_Vec3,
         Type_SpatialVec,
     };
-    /** Get the string of the data type (for error messages) */
-    std::string getDataTypeStr(DataType type) const {
+    /** Get the string of the data type, for prints and error messages. */
+    std::string getDataTypeString(DataType type) const {
         switch (type) {
         case Type_double     : return "double";
         case Type_Vec3       : return "SimTK::Vec3";

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -117,7 +117,7 @@ private:
             "path constraint (i.e., '/path/to/component|output_name').");
     OpenSim_DECLARE_PROPERTY(second_output_path, std::string,
             "The absolute path to the optional second Output in the model to be used"
-            " in this path constraint (i.e., '/path/to/component|output_name')");
+            " in this path constraint (i.e., '/path/to/component|output_name').");
     OpenSim_DECLARE_PROPERTY(operation, std::string, "The operation to combine "
             "the two outputs: 'addition', 'subtraction', 'multiplication', or "
             "'divison'.");

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -24,7 +24,7 @@ namespace OpenSim {
 
 /** This constraint allows you to constrain a Model Output value throughout the
 trajectory. You can also combine two Outputs in a constraint by supplying a
-second output path and an operation to combine them. The operators are addition,
+second output path and an operation to combine them. The operations are addition,
 subtraction, multiplication, and division. The first Output is always on the
 left hand side of the operation and the second Output on the right hand side.
 The two Outputs can be different quantities, but they must be the same type.
@@ -177,7 +177,7 @@ private:
         }
     }
     /** Apply the elementwise operation to two SimTK::SpatialVec values.
-    Multiplication and divison operators are not supported for SpatialVec Outputs
+    Multiplication and divison operations are not supported for SpatialVec Outputs
     without an index. */
     double applyOperation(const SimTK::SpatialVec& value1,
                           const SimTK::SpatialVec& value2) const {

--- a/OpenSim/Moco/MocoOutputConstraint.h
+++ b/OpenSim/Moco/MocoOutputConstraint.h
@@ -34,6 +34,22 @@ public:
     void setOutputPath(std::string path) { set_output_path(std::move(path)); }
     const std::string& getOutputPath() const { return get_output_path(); }
 
+    /** Set the absolute path to the optional second output in the model to be
+    used in this path constraint. The format is "/path/to/component|output_name".
+    This Output should have the same type as the first Output. If providing a
+    second Output, the user should also set an operation. */
+    void setSecondOutputPath(std::string path) {
+        set_second_output_path(std::move(path));
+    }
+    const std::string& getSecondOutputPath() const {
+        return get_second_output_path();
+    }
+
+    /** Set the operation to combine the outputs. It can be "addition",
+    "subtraction", "multiplication", or "division". If providing an operation,
+    the user should also set a second output path. */
+    void setOperation(std::string operation) { set_operation(operation); }
+
     /** Set the exponent applied to the output value in the constraint. This
     exponent is applied when minimizing the norm of a vector type output. */
     void setExponent(int exponent) { set_exponent(exponent); }
@@ -77,6 +93,12 @@ private:
     OpenSim_DECLARE_PROPERTY(output_path, std::string,
             "The absolute path to the output in the model to be used in this "
             "path constraint.");
+    OpenSim_DECLARE_PROPERTY(second_output_path, std::string,
+            "The absolute path to the second output in the model to be used in"
+            " this path constraint");
+    OpenSim_DECLARE_PROPERTY(operation, std::string, "The operation to combine "
+            "the two outputs: 'addition', 'subtraction', 'multiplication', or "
+            "'divison'.");
     OpenSim_DECLARE_PROPERTY(exponent, int,
             "The exponent applied to the output value in the constraint "
             "(default: 1).");
@@ -88,6 +110,53 @@ private:
             "indicates to constrain the vector norm (default: -1).");
     void constructProperties();
 
+    /** Initializes additional info for the case that there are two Outputs:
+     * the second Output, the operation, and the dependsOnStage. */
+    void initializeComposite() const;
+
+    /** Calculate the Output value of one Output. */
+    double calcSingleOutputValue(const SimTK::State&) const;
+    /** Calculate the two Output values and apply the operation. */
+    double calcCompositeOutputValue(const SimTK::State&) const;
+
+    /** Gets a reference to the Output for this goal. */
+    template <typename T>
+    const Output<T>& getOutput() const {
+        return static_cast<const Output<T>&>(m_output.getRef());
+    }
+    /** Gets a reference to the second Output for this goal. */
+    template <typename T>
+    const Output<T>& getSecondOutput() const {
+        return static_cast<const Output<T>&>(m_second_output.getRef());
+    }
+
+    /** Apply the operation to two double values. **/
+    double applyOperation(double value1, double value2) const {
+        switch (m_operation) {
+        case Addition       : return value1 + value2;
+        case Subtraction    : return value1 - value2;
+        case Multiplication : return value1 * value2;
+        case Division       : return value1 / value2;
+        default             : OPENSIM_THROW_FRMOBJ(Exception,
+                                "Internal error: invalid operation type");
+        }
+    }
+    /** Apply the operation to two Vec valuee. If the operation is addition or
+    subtraction, it will take the norm after the operator has been applied, and
+    if the operation is multiplication or division, the norm of both values will
+    be taken before applying the operation. */
+    template <typename T>
+    double applyOperation(T value1, T value2) const {
+        switch (m_operation) {
+        case Addition       : return (value1 + value2).norm();
+        case Subtraction    : return (value1 - value2).norm();
+        case Multiplication : return value1.norm() * value2.norm();
+        case Division       : return value1.norm() / value2.norm();
+        default             : OPENSIM_THROW_FRMOBJ(Exception,
+                                "Internal error: invalid operation type");
+        }
+    }
+
     enum DataType {
         Type_double,
         Type_Vec3,
@@ -95,6 +164,9 @@ private:
     };
     mutable DataType m_data_type;
     mutable SimTK::ReferencePtr<const AbstractOutput> m_output;
+    mutable SimTK::ReferencePtr<const AbstractOutput> m_second_output;
+    enum OperationType { Addition, Subtraction, Multiplication, Division };
+    mutable OperationType m_operation;
     mutable std::function<double(const double&)> m_power_function;
     mutable int m_index1;
     mutable int m_index2;

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -1195,8 +1195,7 @@ TEMPLATE_TEST_CASE("MocoOutputGoal with two outputs", "", MocoCasADiSolver,
 
         // analyze result for starting distance between spheres
         StatesTrajectory trajectory = solution.exportToStatesTrajectory(*model);
-        const SimTK::State& 
-          ialState = trajectory.front();
+        const SimTK::State& initialState = trajectory.front();
         model->realizePosition(initialState);
         const SimTK::Vec3& startPosition1 = model->getComponent<Body>("/body")
                                         .getPositionInGround(initialState);


### PR DESCRIPTION
Fixes issue #3848

### Brief summary of changes
Similar to #3851 , add optional second output and operator to combine the two outputs for the constraint. 

### Testing I've completed
Added a test to testMocoGoals.cpp

### Looking for feedback on...

### CHANGELOG.md (choose one)

- to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3855)
<!-- Reviewable:end -->
