### PR TITLE
Add `MocoStateBoundConstraint` class

### DIFF
--- a/Bindings/OpenSimHeaders_moco.h
+++ b/Bindings/OpenSimHeaders_moco.h
@@ -7,6 +7,7 @@
 #include <OpenSim/Moco/MocoBounds.h>
 #include <OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.h>
 #include <OpenSim/Moco/MocoControlBoundConstraint.h>
+#include <OpenSim/Moco/MocoStateBoundConstraint.h>
 #include <OpenSim/Moco/MocoFrameDistanceConstraint.h>
 #include <OpenSim/Moco/MocoOutputConstraint.h>
 #include <OpenSim/Moco/MocoGoal/MocoAccelerationTrackingGoal.h>

--- a/Bindings/moco.i
+++ b/Bindings/moco.i
@@ -48,6 +48,7 @@ namespace OpenSim {
 %include <OpenSim/Moco/MocoConstraint.h>
 
 %include <OpenSim/Moco/MocoControlBoundConstraint.h>
+%include <OpenSim/Moco/MocoStateBoundConstraint.h>
 %include <OpenSim/Moco/MocoFrameDistanceConstraint.h>
 %include <OpenSim/Moco/MocoOutputConstraint.h>
 

--- a/CHANGELOG_MOCO.md
+++ b/CHANGELOG_MOCO.md
@@ -3,6 +3,9 @@ Moco Change Log
 
 1.3.1
 -----
+- 2024-07-25: Added `MocoStateBoundConstraint` to enable bounding state variables by one or two
+              `Function`s, similar to `MocoControlBoundConstraint`.
+
 - 2024-07-22: Added support for `MocoOutputGoal`s that are composed of two `Output`s. This applies
               to all types of Output goals (`MocoInitialOutputGoal`, `MocoFinalOutputGoal`, etc.). 
               The two `Output`s can be combined by addition, subtraction, multiplication, or division.

--- a/OpenSim/Moco/CMakeLists.txt
+++ b/OpenSim/Moco/CMakeLists.txt
@@ -111,7 +111,7 @@ set(MOCO_SOURCES
         MocoScaleFactor.cpp
         MocoStateBoundConstraint.cpp
         MocoStateBoundConstraint.h
-)
+        )
 if(OPENSIM_WITH_CASADI)
     list(APPEND MOCO_SOURCES
             MocoCasADiSolver/CasOCProblem.h

--- a/OpenSim/Moco/CMakeLists.txt
+++ b/OpenSim/Moco/CMakeLists.txt
@@ -109,7 +109,9 @@ set(MOCO_SOURCES
         MocoStudyFactory.cpp
         MocoScaleFactor.h
         MocoScaleFactor.cpp
-        )
+        MocoStateBoundConstraint.cpp
+        MocoStateBoundConstraint.h
+)
 if(OPENSIM_WITH_CASADI)
     list(APPEND MOCO_SOURCES
             MocoCasADiSolver/CasOCProblem.h

--- a/OpenSim/Moco/MocoControlBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoControlBoundConstraint.cpp
@@ -147,7 +147,7 @@ void MocoControlBoundConstraint::calcPathConstraintErrorsImpl(
     int icontrol = 0;
     SimTK::Vector time(1);
     for (const auto& controlIndex : m_controlIndices) {
-        const auto& control = m_isInputControl[icontrol] ? 
+        const auto& control = m_isInputControl[icontrol] ?
                 input_controls[controlIndex] : controls[controlIndex];
         time[0] = state.getTime();
         // These if-statements work correctly for either value of

--- a/OpenSim/Moco/MocoStateBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoStateBoundConstraint.cpp
@@ -1,9 +1,9 @@
 /* -------------------------------------------------------------------------- *
-* OpenSim Moco: MocoStateBoundConstraint.cpp                               *
+ * OpenSim: MocoStateBoundConstraint.cpp                                      *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2024 Stanford University and the Authors                     *
  *                                                                            *
- * Author(s): Christopher Dembia, Allison John                                *
+ * Author(s): Allison John                                                    *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *

--- a/OpenSim/Moco/MocoStateBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoStateBoundConstraint.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
-* OpenSim Moco: MocoControlBoundConstraint.cpp                               *
+* OpenSim Moco: MocoStateBoundConstraint.cpp                               *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2024 Stanford University and the Authors                     *
  *                                                                            *
@@ -81,14 +81,14 @@ void MocoStateBoundConstraint::initializeOnModelImpl(
     if (m_hasLower) checkTimeRange(get_lower_bound());
     if (m_hasUpper) checkTimeRange(get_upper_bound());
 
-    int numEqsPerControl;
+    int numEqsPerState;
     if (get_equality_with_lower()) {
-        numEqsPerControl = 1;
+        numEqsPerState = 1;
     } else {
-        numEqsPerControl = (int)m_hasLower + (int)m_hasUpper;
+        numEqsPerState = (int)m_hasLower + (int)m_hasUpper;
     }
 
-    setNumEquations(numEqsPerControl * (int)m_stateIndices.size());
+    setNumEquations(numEqsPerState * (int)m_stateIndices.size());
 
     // TODO: setConstraintInfo() is not really intended for use here.
     MocoConstraintInfo info;

--- a/OpenSim/Moco/MocoStateBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoStateBoundConstraint.cpp
@@ -1,0 +1,110 @@
+//
+// Created by Allison John on 7/23/24.
+//
+
+#include "MocoStateBoundConstraint.h"
+
+#include "MocoProblemInfo.h"
+#include "Components/ControlDistributor.h"
+
+#include <OpenSim/Common/GCVSpline.h>
+#include <OpenSim/Simulation/SimulationUtilities.h>
+
+using namespace OpenSim;
+
+void MocoStateBoundConstraint::constructProperties() {
+    constructProperty_state_paths();
+    constructProperty_lower_bound();
+    constructProperty_upper_bound();
+    constructProperty_equality_with_lower(false);
+}
+
+void MocoStateBoundConstraint::initializeOnModelImpl(
+        const Model& model, const MocoProblemInfo& problemInfo) const {
+
+    auto systemStateIndexMap = createSystemYIndexMap(model);
+
+    m_hasLower = !getProperty_lower_bound().empty();
+    m_hasUpper = !getProperty_upper_bound().empty();
+    if (!getProperty_state_paths().empty() && !m_hasLower && !m_hasUpper) {
+        log_warn("In MocoControlBoundConstraint '{}', control paths are "
+                 "specified but no bounds are provided.", getName());
+    }
+    // Make sure there are no nonexistent states.
+    // ignore input control
+    if (m_hasLower || m_hasUpper) {
+        for (int i = 0; i < getProperty_state_paths().size(); ++i) {
+            const auto& thisName = get_state_paths(i);
+            OPENSIM_THROW_IF_FRMOBJ(!systemStateIndexMap.count(thisName),
+                    Exception,
+                    "State path '{}' was provided but no such "
+                    "state exists in the model.",
+                    thisName)
+            m_stateIndices.push_back(systemStateIndexMap[thisName]);
+        }
+    }
+
+    // stop here
+
+    OPENSIM_THROW_IF_FRMOBJ(get_equality_with_lower() && m_hasUpper, Exception,
+            "If equality_with_lower==true, upper bound function must not be "
+            "set.");
+    OPENSIM_THROW_IF_FRMOBJ(get_equality_with_lower() && !m_hasLower, Exception,
+            "If equality_with_lower==true, lower bound function must be set.");
+
+    auto checkTimeRange = [&](const Function& f) {
+        if (auto* spline = dynamic_cast<const GCVSpline*>(&f)) {
+            OPENSIM_THROW_IF_FRMOBJ(
+                    spline->getMinX() > problemInfo.minInitialTime, Exception,
+                    "The function's minimum domain value ({}) must "
+                    "be less than or equal to the minimum possible "
+                    "initial time ({}).",
+                    spline->getMinX(), problemInfo.minInitialTime);
+            OPENSIM_THROW_IF_FRMOBJ(
+                    spline->getMaxX() < problemInfo.maxFinalTime, Exception,
+                    "The function's maximum domain value ({}) must "
+                    "be greater than or equal to the maximum possible "
+                    "final time ({}).",
+                    spline->getMaxX(), problemInfo.maxFinalTime);
+        }
+    };
+    if (m_hasLower) checkTimeRange(get_lower_bound());
+    if (m_hasUpper) checkTimeRange(get_upper_bound());
+
+    int numEqsPerControl;
+    if (get_equality_with_lower()) {
+        numEqsPerControl = 1;
+    } else {
+        numEqsPerControl = (int)m_hasLower + (int)m_hasUpper;
+    }
+
+    setNumEquations(numEqsPerControl * (int)m_controlIndices.size());
+
+    // TODO: setConstraintInfo() is not really intended for use here.
+    MocoConstraintInfo info;
+    std::vector<MocoBounds> bounds;
+    for (int i = 0; i < (int)m_controlIndices.size(); ++i) {
+        if (get_equality_with_lower()) {
+            bounds.emplace_back(0, 0);
+        } else {
+            // The lower and upper bounds on the path constraint must be
+            // constants, so we cannot use the lower and upper bound functions
+            // directly. Therefore, we use a pair of constraints where the
+            // lower/upper bound functions are part of the path constraint
+            // functions and the lower/upper bounds for the path constraints are
+            // -inf, 0, and/or inf.
+            // If a lower bound function is provided, we enforce
+            //      lower_bound_function <= control
+            // by creating the constraint
+            //      0 <= control - lower_bound_function <= inf
+            if (m_hasLower) { bounds.emplace_back(0, SimTK::Infinity); }
+            // If an upper bound function is provided, we enforce
+            //      control <= upper_bound_function
+            // by creating the constraint
+            //      -inf <= control - upper_bound_function <= 0
+            if (m_hasUpper) { bounds.emplace_back(-SimTK::Infinity, 0); }
+        }
+    }
+    info.setBounds(bounds);
+    const_cast<MocoControlBoundConstraint*>(this)->setConstraintInfo(info);
+}

--- a/OpenSim/Moco/MocoStateBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoStateBoundConstraint.cpp
@@ -31,7 +31,6 @@ void MocoStateBoundConstraint::initializeOnModelImpl(
                  "specified but no bounds are provided.", getName());
     }
     // Make sure there are no nonexistent states.
-    // ignore input control
     if (m_hasLower || m_hasUpper) {
         for (int i = 0; i < getProperty_state_paths().size(); ++i) {
             const auto& thisName = get_state_paths(i);
@@ -109,9 +108,9 @@ void MocoStateBoundConstraint::initializeOnModelImpl(
 
 void MocoStateBoundConstraint::calcPathConstraintErrorsImpl(
         const SimTK::State& state, SimTK::Vector& errors) const {
-    getModel().realizeAcceleration(state);      // change to largest getDependsOnState later
+    getModel().realizeAcceleration(state);      // change to largest getDependsOnState
     const auto& svValues = getModel().getStateVariableValues(state);
-    int iconstr = 0; // idk what this is an abbreviation of
+    int iconstr = 0;
     int istate = 0;
     SimTK::Vector time(1);
     for (const auto& stateIndex : m_stateIndices) {

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -1,11 +1,11 @@
 #ifndef OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H
 #define OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: MocoStateBoundConstraint.cpp                               *
+ * OpenSim: MocoStateBoundConstraint.h                                        *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2024 Stanford University and the Authors                     *
  *                                                                            *
- * Author(s): Christopher Dembia, Allsion John                                *
+ * Author(s): Allison John                                                    *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -1,0 +1,86 @@
+#ifndef MOCOSTATEBOUNDCONSTRAINT_H
+#define MOCOSTATEBOUNDCONSTRAINT_H
+//
+// Created by Allison John on 7/23/24.
+//
+
+#include "MocoConstraint.h"
+#include "osimMocoDLL.h"
+
+/** A bound constraint for states of the model
+ * the state can be between two bounds or equal to the lower bound
+ *
+ * use Simulation Utilities createSystemYIndexMap
+ * realize at level acceleration
+ */
+namespace OpenSim {
+
+class OSIMMOCO_API MocoStateBoundConstraint : public MocoPathConstraint {
+    OpenSim_DECLARE_CONCRETE_OBJECT(
+            MocoStateBoundConstraint, MocoPathConstraint);
+
+public:
+    MocoStateBoundConstraint() { constructProperties(); }
+
+    void addStatePath(std::string statePath) {
+        append_state_paths(std::move(statePath));
+    }
+    void setStatePaths(const std::vector<std::string>& statePaths) {
+        updProperty_state_paths().clear();
+        for (const auto& path : statePaths) { append_state_paths(path); }
+    }
+    void clearControlPaths() { updProperty_state_paths().clear(); }
+    std::vector<std::string> getControlPaths() const {
+        std::vector<std::string> paths;
+        for (int i = 0; i < getProperty_state_paths().size(); ++i) {
+            paths.push_back(get_state_paths(i));
+        }
+        return paths;
+    }
+
+    void setLowerBound(const Function& f) { set_lower_bound(f); }
+    void clearLowerBound() { updProperty_lower_bound().clear(); }
+    bool hasLowerBound() const { return !getProperty_lower_bound().empty(); }
+    const Function& getLowerBound() const { return get_lower_bound(); }
+
+    void setUpperBound(const Function& f) { set_upper_bound(f); }
+    void clearUpperBound() { updProperty_upper_bound().clear(); }
+    bool hasUpperBound() const { return !getProperty_upper_bound().empty(); }
+    const Function& getUpperBound() const { return get_upper_bound(); }
+
+    /// Should the state be constrained to be equal to the lower bound (rather
+    /// than an inequality constraint)? In this case, the upper bound must be
+    /// unspecified.
+    void setEqualityWithLower(bool v) { set_equality_with_lower(v); }
+    //// @copydoc setEqualityWithLower()
+    bool getEqualityWithLower() const { return get_equality_with_lower(); }
+
+
+protected:
+    void initializeOnModelImpl(
+            const Model& model, const MocoProblemInfo&) const override;
+
+    void calcPathConstraintErrorsImpl(
+            const SimTK::State& state, SimTK::Vector& errors) const override;
+
+private:
+    OpenSim_DECLARE_LIST_PROPERTY(state_paths, std::string,
+            "Constrain the state variables specified by these paths.")
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(
+            lower_bound, Function, "Lower bound as a function of time.");
+    OpenSim_DECLARE_OPTIONAL_PROPERTY(
+            upper_bound, Function, "Upper bound as a function of time.");
+    OpenSim_DECLARE_PROPERTY(equality_with_lower, bool,
+            "The control must be equal to the lower bound; "
+            "upper must be unspecified (default: false).");
+
+    void constructProperties();
+
+    mutable bool m_hasLower;
+    mutable bool m_hasUpper;
+    mutable std::vector<int> m_stateIndices;
+};
+
+} // OpenSim
+
+#endif //MOCOSTATEBOUNDCONSTRAINT_H

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -1,5 +1,5 @@
-#ifndef MOCOSTATEBOUNDCONSTRAINT_H
-#define MOCOSTATEBOUNDCONSTRAINT_H
+#ifndef OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H
+#define OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H
 /* -------------------------------------------------------------------------- *
  * OpenSim Moco: MocoStateBoundConstraint.cpp                               *
  * -------------------------------------------------------------------------- *
@@ -23,7 +23,8 @@
 
 /** This path contraint allows you to bound any number of state variables
 between two time-based functions. It is possible to constrain the state variable
-to match the value from a provided function; see the equality_with_lower property.
+to match the value from a provided function; see the equality_with_lower
+property.
 
 If a function is a GCVSpline, we ensure that the spline covers the entire
 possible time range in the problem (using the problem's time bounds). We do
@@ -103,6 +104,6 @@ private:
     mutable std::vector<int> m_stateIndices;
 };
 
-} // OpenSim
+} // namespace OpenSim
 
-#endif //MOCOSTATEBOUNDCONSTRAINT_H
+#endif //OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -106,4 +106,4 @@ private:
 
 } // namespace OpenSim
 
-#endif //OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H
+#endif // OPENSIM_MOCOSTATEBOUNDCONSTRAINT_H

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -22,7 +22,7 @@
 #include "osimMocoDLL.h"
 
 /** This path contraint allows you to bound any number of state variables
-between two time-based functions. It is possible to constrain the control signal
+between two time-based functions. It is possible to constrain the state variable
 to match the value from a provided function; see the equality_with_lower property.
 
 If a function is a GCVSpline, we ensure that the spline covers the entire
@@ -30,7 +30,7 @@ possible time range in the problem (using the problem's time bounds). We do
 not perform such a check for other types of functions.
 
 @note If you omit the lower and upper bounds, then this class will not
-constrain any control signals, even if you have provided control paths.
+constrain any state variable, even if you have provided state paths.
 
 @ingroup mocopathcon */
 namespace OpenSim {
@@ -51,8 +51,8 @@ public:
         updProperty_state_paths().clear();
         for (const auto& path : statePaths) { append_state_paths(path); }
     }
-    void clearControlPaths() { updProperty_state_paths().clear(); }
-    std::vector<std::string> getControlPaths() const {
+    void clearStatePaths() { updProperty_state_paths().clear(); }
+    std::vector<std::string> getStatePaths() const {
         std::vector<std::string> paths;
         for (int i = 0; i < getProperty_state_paths().size(); ++i) {
             paths.push_back(get_state_paths(i));

--- a/OpenSim/Moco/MocoStateBoundConstraint.h
+++ b/OpenSim/Moco/MocoStateBoundConstraint.h
@@ -1,18 +1,38 @@
 #ifndef MOCOSTATEBOUNDCONSTRAINT_H
 #define MOCOSTATEBOUNDCONSTRAINT_H
-//
-// Created by Allison John on 7/23/24.
-//
+/* -------------------------------------------------------------------------- *
+ * OpenSim Moco: MocoStateBoundConstraint.cpp                               *
+ * -------------------------------------------------------------------------- *
+ * Copyright (c) 2024 Stanford University and the Authors                     *
+ *                                                                            *
+ * Author(s): Christopher Dembia, Allsion John                                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0          *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
 
 #include "MocoConstraint.h"
 #include "osimMocoDLL.h"
 
-/** A bound constraint for states of the model
- * the state can be between two bounds or equal to the lower bound
- *
- * use Simulation Utilities createSystemYIndexMap
- * realize at level acceleration
- */
+/** This path contraint allows you to bound any number of state variables
+between two time-based functions. It is possible to constrain the control signal
+to match the value from a provided function; see the equality_with_lower property.
+
+If a function is a GCVSpline, we ensure that the spline covers the entire
+possible time range in the problem (using the problem's time bounds). We do
+not perform such a check for other types of functions.
+
+@note If you omit the lower and upper bounds, then this class will not
+constrain any control signals, even if you have provided control paths.
+
+@ingroup mocopathcon */
 namespace OpenSim {
 
 class OSIMMOCO_API MocoStateBoundConstraint : public MocoPathConstraint {
@@ -22,6 +42,8 @@ class OSIMMOCO_API MocoStateBoundConstraint : public MocoPathConstraint {
 public:
     MocoStateBoundConstraint() { constructProperties(); }
 
+    /** Add a state path (absolute path to state varaibles in the model)
+    to be constrained by this class  (e.g., "/slider/position/speed"). */
     void addStatePath(std::string statePath) {
         append_state_paths(std::move(statePath));
     }
@@ -48,9 +70,9 @@ public:
     bool hasUpperBound() const { return !getProperty_upper_bound().empty(); }
     const Function& getUpperBound() const { return get_upper_bound(); }
 
-    /// Should the state be constrained to be equal to the lower bound (rather
-    /// than an inequality constraint)? In this case, the upper bound must be
-    /// unspecified.
+    /** Set whether the state should be constrained to be equal to the lower
+    bound (rather than an inequality constraint). In this case, the upper bound
+    must be unspecified. */
     void setEqualityWithLower(bool v) { set_equality_with_lower(v); }
     //// @copydoc setEqualityWithLower()
     bool getEqualityWithLower() const { return get_equality_with_lower(); }
@@ -71,7 +93,7 @@ private:
     OpenSim_DECLARE_OPTIONAL_PROPERTY(
             upper_bound, Function, "Upper bound as a function of time.");
     OpenSim_DECLARE_PROPERTY(equality_with_lower, bool,
-            "The control must be equal to the lower bound; "
+            "The state must be equal to the lower bound; "
             "upper must be unspecified (default: false).");
 
     void constructProperties();

--- a/OpenSim/Moco/RegisterTypes_osimMoco.cpp
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.cpp
@@ -24,6 +24,7 @@
 #include "MocoBounds.h"
 #include "MocoCasADiSolver/MocoCasADiSolver.h"
 #include "MocoControlBoundConstraint.h"
+#include "MocoStateBoundConstraint.h"
 #include "MocoFrameDistanceConstraint.h"
 #include "MocoGoal/MocoAccelerationTrackingGoal.h"
 #include "MocoGoal/MocoAngularVelocityTrackingGoal.h"

--- a/OpenSim/Moco/RegisterTypes_osimMoco.cpp
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.cpp
@@ -112,6 +112,7 @@ OSIMMOCO_API void RegisterTypes_osimMoco() {
         Object::registerType(MocoTropterSolver());
 
         Object::registerType(MocoControlBoundConstraint());
+        Object::registerType(MocoStateBoundConstraint());
         Object::registerType(MocoFrameDistanceConstraint());
         Object::registerType(MocoFrameDistanceConstraintPair());
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -1647,7 +1647,7 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double speed = solutionSpeed[i];
             time[0] = times[i];
             double max = upperBound.calcValue(time);
-            CHECK(speed <= max);
+            CHECK(Catch::Approx(speed).margin(1e-8) <= max);
         }
     }
 
@@ -1713,9 +1713,9 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double speed = solutionSpeed[i];
             time[0] = times[i];
             double max = upperBound.calcValue(time);
-            CHECK(speed <= max);
+            CHECK(Catch::Approx(speed).margin(1e-8) <= max);
             double min = lowerBound.calcValue(time);
-            CHECK(speed >= min);
+            CHECK(Catch::Approx(speed) >= min);
         }
     }
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -1647,7 +1647,7 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double speed = solutionSpeed[i];
             time[0] = times[i];
             double max = upperBound.calcValue(time);
-            CHECK(speed < max + 1e-6);
+            CHECK(speed <= max);
         }
     }
 
@@ -1662,16 +1662,6 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
         auto* constr = problem.addPathConstraint<MocoStateBoundConstraint>();
         constr->addStatePath("/slider/position/speed");
         constr->setEqualityWithLower(true);
-        /*PiecewiseLinearFunction lowerBound;
-        lowerBound.addPoint(0, 0);
-        lowerBound.addPoint(1, 1);
-        lowerBound.addPoint(2, 0);
-        lowerBound.addPoint(3, -1);
-        lowerBound.addPoint(4, 0);
-        lowerBound.addPoint(5, 1);
-        lowerBound.addPoint(6, 0);
-        lowerBound.addPoint(7, -1);
-        lowerBound.addPoint(8, 0);*/
         Sine lowerBound;
         constr->setLowerBound(lowerBound);
         // can't have upper bound when set to equal lower bound
@@ -1723,9 +1713,9 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double speed = solutionSpeed[i];
             time[0] = times[i];
             double max = upperBound.calcValue(time);
-            CHECK(speed < max + 1e-6);
+            CHECK(speed <= max);
             double min = lowerBound.calcValue(time);
-            CHECK(speed > min - 1e-6);
+            CHECK(speed >= min);
         }
     }
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -1715,7 +1715,7 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double max = upperBound.calcValue(time);
             CHECK(Catch::Approx(speed).margin(1e-8) <= max);
             double min = lowerBound.calcValue(time);
-            CHECK(Catch::Approx(speed) >= min);
+            CHECK(Catch::Approx(speed).margin(1e-8) >= min);
         }
     }
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -16,7 +16,12 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "OpenSim/Moco/MocoStateBoundConstraint.h"
+#include "Testing.h"
+#include <catch2/catch_all.hpp>
+
 #include <simbody/internal/Constraint.h>
+
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Actuators/ModelOperators.h>
@@ -28,9 +33,6 @@
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/osimSimulation.h>
-
-#include <catch2/catch_all.hpp>
-#include "Testing.h"
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Approx;
@@ -1613,6 +1615,118 @@ TEMPLATE_TEST_CASE("MocoControlBoundConstraint", "",
         study.solve();
         constr->addControlPath("/tau0");
         study.solve();
+    }
+}
+
+TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
+        MocoCasADiSolver, MocoTropterSolver) {
+    SECTION("Upper bounded speed") {
+        MocoSolution solutionControl;
+        MocoStudy study;
+        auto& problem = study.updProblem();
+        problem.setModelAsCopy(ModelFactory::createSlidingPointMass());
+        problem.setTimeBounds(0, 3);
+        problem.setStateInfo("/slider/position/speed", {-10, 10}, 0);
+        auto* effort = problem.addGoal<MocoControlGoal>();
+        effort->setName("effort");
+        effort->setWeight(0.001);
+        // decreasing speed constraint
+        auto* constr = problem.addPathConstraint<MocoStateBoundConstraint>();
+        constr->addStatePath("/slider/position/speed");
+        PiecewiseLinearFunction upperBound;
+        upperBound.addPoint(0, 2);
+        upperBound.addPoint(3, -3);
+        constr->setUpperBound(upperBound);
+        study.initSolver<TestType>();
+        MocoSolution solution = study.solve();
+        // ensure that at every state, the speed is under the bound
+        auto solutionSpeed = solution.getState("/slider/position/speed");
+        auto times = solution.getTime();
+        SimTK::Vector time(1);
+        for (int i = 0; i < solution.getNumTimes(); ++i) {
+            double speed = solutionSpeed[i];
+            time[0] = times[i];
+            double max = upperBound.calcValue(time);
+            CHECK(speed < max + 1e-6);
+        }
+    }
+
+    SECTION("Equality bounded speed") {
+        MocoSolution solutionControl;
+        MocoStudy study;
+        auto& problem = study.updProblem();
+        problem.setModelAsCopy(ModelFactory::createSlidingPointMass());
+        problem.setTimeBounds(0, 10);
+        problem.setStateInfo("/slider/position/speed", {-10, 10}, 0);
+        // add constraint of changing speed
+        auto* constr = problem.addPathConstraint<MocoStateBoundConstraint>();
+        constr->addStatePath("/slider/position/speed");
+        constr->setEqualityWithLower(true);
+        PiecewiseLinearFunction lowerBound;
+        lowerBound.addPoint(0, 0);
+        lowerBound.addPoint(1, 1);
+        lowerBound.addPoint(2, 0);
+        lowerBound.addPoint(3, -1);
+        lowerBound.addPoint(4, 0);
+        lowerBound.addPoint(5, 1);
+        lowerBound.addPoint(6, 0);
+        lowerBound.addPoint(7, -1);
+        lowerBound.addPoint(8, 0);
+        constr->setLowerBound(lowerBound);
+        // can't have upper bound when set to equal lower bound
+        constr->setUpperBound(Constant(1));
+        CHECK_THROWS(study.initSolver<TestType>());
+        // undo upper bound and solve
+        constr->clearUpperBound();
+        study.initSolver<TestType>();
+        MocoSolution solution = study.solve();
+        // check that the speed is always close to the lower bound
+        auto solutionSpeed = solution.getState("/slider/position/speed");
+        auto times = solution.getTime();
+        SimTK::Vector time(1);
+        for (int i = 0; i < solution.getNumTimes(); ++i) {
+            double speed = solutionSpeed[i];
+            time[0] = times[i];
+            double max = lowerBound.calcValue(time);
+            CHECK(speed < max + 0.1);
+            CHECK(speed > max - 0.1);
+        }
+    }
+
+    SECTION("Double bounded speed") {
+        MocoSolution solutionControl;
+        MocoStudy study;
+        auto& problem = study.updProblem();
+        problem.setModelAsCopy(ModelFactory::createSlidingPointMass());
+        problem.setTimeBounds(0, 4);
+        problem.setStateInfo("/slider/position/speed", {-10, 10});
+        // add speed constraint with changing upper and lower bounds
+        auto* constr = problem.addPathConstraint<MocoStateBoundConstraint>();
+        constr->addStatePath("/slider/position/speed");
+        PiecewiseLinearFunction lowerBound;
+        lowerBound.addPoint(0, -2);
+        lowerBound.addPoint(2, 1);
+        lowerBound.addPoint(4, -3);
+        constr->setLowerBound(lowerBound);
+        PiecewiseLinearFunction upperBound;
+        upperBound.addPoint(0, -1);
+        upperBound.addPoint(2, 4);
+        upperBound.addPoint(4, 0);
+        constr->setUpperBound(upperBound);
+        study.initSolver<TestType>();
+        MocoSolution solution = study.solve();
+        // check that the speed is between the bounds
+        auto solutionSpeed = solution.getState("/slider/position/speed");
+        auto times = solution.getTime();
+        SimTK::Vector time(1);
+        for (int i = 0; i < solution.getNumTimes(); ++i) {
+            double speed = solutionSpeed[i];
+            time[0] = times[i];
+            double max = upperBound.calcValue(time);
+            CHECK(speed < max + 1e-6);
+            double min = lowerBound.calcValue(time);
+            CHECK(speed > min - 1e-6);
+        }
     }
 }
 

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -16,10 +16,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "OpenSim/Moco/MocoStateBoundConstraint.h"
-#include "Testing.h"
-#include <catch2/catch_all.hpp>
-
 #include <simbody/internal/Constraint.h>
 
 #include <OpenSim/Actuators/CoordinateActuator.h>
@@ -33,6 +29,9 @@
 #include <OpenSim/Common/TimeSeriesTable.h>
 #include <OpenSim/Moco/osimMoco.h>
 #include <OpenSim/Simulation/osimSimulation.h>
+
+#include "Testing.h"
+#include <catch2/catch_all.hpp>
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Approx;
@@ -1662,7 +1661,7 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
         auto* constr = problem.addPathConstraint<MocoStateBoundConstraint>();
         constr->addStatePath("/slider/position/speed");
         constr->setEqualityWithLower(true);
-        PiecewiseLinearFunction lowerBound;
+        /*PiecewiseLinearFunction lowerBound;
         lowerBound.addPoint(0, 0);
         lowerBound.addPoint(1, 1);
         lowerBound.addPoint(2, 0);
@@ -1671,7 +1670,8 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
         lowerBound.addPoint(5, 1);
         lowerBound.addPoint(6, 0);
         lowerBound.addPoint(7, -1);
-        lowerBound.addPoint(8, 0);
+        lowerBound.addPoint(8, 0);*/
+        Sine lowerBound;
         constr->setLowerBound(lowerBound);
         // can't have upper bound when set to equal lower bound
         constr->setUpperBound(Constant(1));
@@ -1688,8 +1688,7 @@ TEMPLATE_TEST_CASE("MocoStateBoundConstraint", "",
             double speed = solutionSpeed[i];
             time[0] = times[i];
             double max = lowerBound.calcValue(time);
-            CHECK(speed < max + 0.1);
-            CHECK(speed > max - 0.1);
+            REQUIRE_THAT(speed, Catch::Matchers::WithinAbs(max, 1e-4));
         }
     }
 

--- a/OpenSim/Moco/osimMoco.h
+++ b/OpenSim/Moco/osimMoco.h
@@ -26,6 +26,7 @@
 #include "MocoCasADiSolver/MocoCasADiSolver.h"
 #include "MocoConstraint.h"
 #include "MocoControlBoundConstraint.h"
+#include "MocoStateBoundConstraint.h"
 #include "MocoFrameDistanceConstraint.h"
 #include "MocoGoal/MocoAccelerationTrackingGoal.h"
 #include "MocoGoal/MocoAngularVelocityTrackingGoal.h"


### PR DESCRIPTION
Fixes issue #3857

### Brief summary of changes
Created MocoStateBoundConstraint class which is heavily based on MocoControlBoundConstraint

### Testing I've completed
added to testMocoConstraints

### Looking for feedback on...
need any more test cases?
if the changes to the cmake file and the #includes in the test file are ok

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3858)
<!-- Reviewable:end -->
