### PR TITLE
[WIP] Update spdlog to latest version (v1.14.1)

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -197,7 +197,7 @@ AddDependency(NAME       docopt
 AddDependency(NAME       spdlog
               DEFAULT    ON
               GIT_URL    https://github.com/gabime/spdlog.git
-              GIT_TAG    v1.4.1
+              GIT_TAG    v1.14.1
               CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF


### PR DESCRIPTION
Fixes an issue found downstream in opensim-creator, which compiles with `/W4` on windows, but has to disable iterator warnings (`/wd4996`) because (initially) of simbody's `std::iterator` usages but now (further on), because of `spdlog`'s usage of `stdext::checked_array_iterator`. The latest version of spdlog (specifically, `fmt` within it) no longer appears to use the deprecated class.

### Brief summary of changes

- Upgraded the library

### Testing I've completed

- None, I'm assuming it's a non-breaking change to a heavily-used library

### Looking for feedback on...

- N/A: if CI passes, it'll probably be fine

### CHANGELOG.md (choose one)

- no need to update because it (should be) an internal change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3865)
<!-- Reviewable:end -->
