### PR TITLE
Add extrapolate option for `interpolate()`, use this when creating initial guess

### DIFF
--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -115,9 +115,7 @@ SimTK::Vector OpenSim::interpolate(const SimTK::Vector& x,
             (int)x_no_nans.size(), &x_no_nans[0], &y_no_nans[0]);
     SimTK::Vector newY(newX.size(), SimTK::NaN);
     for (int i = 0; i < newX.size(); ++i) {
-        const auto& newXi = newX[i];
-        if (x_no_nans[0] <= newXi && newXi <= x_no_nans[x_no_nans.size() - 1])
-            newY[i] = function.calcValue(SimTK::Vector(1, newXi));
+        newY[i] = function.calcValue(SimTK::Vector(1, newX[i]));
     }
     return newY;
 }

--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -85,7 +85,7 @@ SimTK::Vector OpenSim::createVector(
 
 SimTK::Vector OpenSim::interpolate(const SimTK::Vector& x,
         const SimTK::Vector& y, const SimTK::Vector& newX,
-        const bool ignoreNaNs) {
+        const bool ignoreNaNs, const bool extrapolate) {
 
     OPENSIM_THROW_IF(x.size() != y.size(), Exception,
             "Expected size of x to equal size of y, but size of x "
@@ -115,7 +115,12 @@ SimTK::Vector OpenSim::interpolate(const SimTK::Vector& x,
             (int)x_no_nans.size(), &x_no_nans[0], &y_no_nans[0]);
     SimTK::Vector newY(newX.size(), SimTK::NaN);
     for (int i = 0; i < newX.size(); ++i) {
-        newY[i] = function.calcValue(SimTK::Vector(1, newX[i]));
+        const auto& newXi = newX[i];
+        bool inBounds = (x_no_nans[0] <= newXi) &&
+                        (newXi <= x_no_nans[x_no_nans.size() - 1]);
+        if (extrapolate || inBounds) {
+            newY[i] = function.calcValue(SimTK::Vector(1, newXi));
+        }
     }
     return newY;
 }

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -92,7 +92,9 @@ SimTK::Vector createVector(std::initializer_list<SimTK::Real> elements);
 /// argument will ignore any NaN values contained in the input vectors and
 /// create the interpolant from the non-NaN values only. Note that this option
 /// does not necessarily prevent NaN values from being returned in 'newX', which
-/// will have NaN for any values of newX outside of the range of x.
+/// will have NaN for any values of newX outside of the range of x. If 'newX'
+/// contains values outside the range of 'x', the 'newY' values will be
+/// extrapolated based on a piecewise function.
 /// @throws Exception if x and y are different sizes, or x or y is empty.
 /// @ingroup commonutil
 OSIMCOMMON_API

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -92,14 +92,17 @@ SimTK::Vector createVector(std::initializer_list<SimTK::Real> elements);
 /// argument will ignore any NaN values contained in the input vectors and
 /// create the interpolant from the non-NaN values only. Note that this option
 /// does not necessarily prevent NaN values from being returned in 'newX', which
-/// will have NaN for any values of newX outside of the range of x. If 'newX'
-/// contains values outside the range of 'x', the 'newY' values will be
-/// extrapolated based on a piecewise function.
+/// will have NaN for any values of newX outside of the range of x. If the
+/// optional 'extrapolate' argument is true, then if 'newX' contains values
+/// outside the range of 'x', the interpolant values will be extrapolated based
+/// on a piecewise function. Setting 'extrapolate' to true also prevents NaN
+/// values for occuring in the interpolant.
 /// @throws Exception if x and y are different sizes, or x or y is empty.
 /// @ingroup commonutil
 OSIMCOMMON_API
 SimTK::Vector interpolate(const SimTK::Vector& x, const SimTK::Vector& y,
-        const SimTK::Vector& newX, const bool ignoreNaNs = false);
+        const SimTK::Vector& newX, const bool ignoreNaNs = false,
+        const bool extrapolate = false);
 
 /// An OpenSim XML file may contain file paths that are relative to the
 /// directory containing the XML file; use this function to convert that

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -91,12 +91,12 @@ SimTK::Vector createVector(std::initializer_list<SimTK::Real> elements);
 /// Linearly interpolate y(x) at new values of x. The optional 'ignoreNaNs'
 /// argument will ignore any NaN values contained in the input vectors and
 /// create the interpolant from the non-NaN values only. Note that this option
-/// does not necessarily prevent NaN values from being returned in 'newX', which
-/// will have NaN for any values of newX outside of the range of x. If the
-/// optional 'extrapolate' argument is true, then if 'newX' contains values
-/// outside the range of 'x', the interpolant values will be extrapolated based
-/// on a piecewise function. Setting 'extrapolate' to true also prevents NaN
-/// values for occuring in the interpolant.
+/// does not necessarily prevent NaN values from being returned, which will
+/// have NaN for any values of newX outside of the range of x. This is done with
+/// the 'extrapolate' option. If the 'extrapolate' argument is true, then the
+/// interpolant values will be extrapolated based on a piecewise function.
+/// Setting 'extrapolate' to true prevents NaN values for occuring in the
+/// interpolant.
 /// @throws Exception if x and y are different sizes, or x or y is empty.
 /// @ingroup commonutil
 OSIMCOMMON_API

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -95,8 +95,8 @@ SimTK::Vector createVector(std::initializer_list<SimTK::Real> elements);
 /// have NaN for any values of newX outside of the range of x. This is done with
 /// the 'extrapolate' option. If the 'extrapolate' argument is true, then the
 /// interpolant values will be extrapolated based on a piecewise function.
-/// Setting 'extrapolate' to true prevents NaN values for occuring in the
-/// interpolant.
+/// Setting both 'ignoreNaNs' and 'extrapolate' to true prevents NaN values from
+/// occuring in the interpolant.
 /// @throws Exception if x and y are different sizes, or x or y is empty.
 /// @ingroup commonutil
 OSIMCOMMON_API

--- a/OpenSim/Common/Test/testFunctions.cpp
+++ b/OpenSim/Common/Test/testFunctions.cpp
@@ -107,12 +107,36 @@ TEST_CASE("Interpolate using PiecewiseLinearFunction") {
     }
     SECTION("First and last Y are NaN, extrapolate") {
         SimTK::Vector x = createVector({0, 1, 2, 3, 4, 5});
-        SimTK::Vector y = createVector({std::nan("0"), 0, 3, 4, std::nan("1"), std::nan("2")});
+        SimTK::Vector y = createVector({SimTK::NaN, 0, 3, 4, SimTK::NaN, SimTK::NaN});
         SimTK::Vector newY = OpenSim::interpolate(x, y, x, true, true);
 
         for (int i = 0; i < newY.size(); ++i) {
             SimTK_TEST(!SimTK::isNaN(newY[i]));
         }
+    }
+
+    SimTK::Vector x = createVector({0, 1, 2, 3});
+    SimTK::Vector y = createVector({SimTK::NaN, 1, 2, SimTK::NaN});
+    SECTION("Ignore NaNs, extrapolate") {
+        SimTK::Vector newY = OpenSim::interpolate(x, y, x, true, true);
+        SimTK_TEST_EQ(newY[0], 0);
+        SimTK_TEST_EQ(newY[1], 1);
+        SimTK_TEST_EQ(newY[2], 2);
+        SimTK_TEST_EQ(newY[3], 3);
+    }
+    SECTION("Don't ignore NaNs, extrapolate") {
+        SimTK::Vector newY = OpenSim::interpolate(x, y, x, false, true);
+        SimTK_TEST(SimTK::isNaN(newY[0]));
+        SimTK_TEST_EQ(newY[1], 1);
+        SimTK_TEST(SimTK::isNaN(newY[2]));
+        SimTK_TEST(SimTK::isNaN(newY[3]));
+    }
+    SECTION("Ignore NaNs, don't extrapolate") {
+        SimTK::Vector newY = OpenSim::interpolate(x, y, x, true, false);
+        SimTK_TEST(SimTK::isNaN(newY[0]));
+        SimTK_TEST_EQ(newY[1], 1);
+        SimTK_TEST_EQ(newY[2], 2);
+        SimTK_TEST(SimTK::isNaN(newY[3]));
     }
 }
 

--- a/OpenSim/Common/Test/testFunctions.cpp
+++ b/OpenSim/Common/Test/testFunctions.cpp
@@ -82,22 +82,33 @@ TEST_CASE("SignalGenerator") {
     }
 }
 
-TEST_CASE("Interpolate using PiecewiseLinearFunction extrapolation") {
+TEST_CASE("Interpolate using PiecewiseLinearFunction") {
     SECTION("New X out of original range") {
         SimTK::Vector x = createVector({0, 1});
         SimTK::Vector y = createVector({1, 0});
         SimTK::Vector newX = createVector({-1, 0.25, 0.75, 1.5});
         SimTK::Vector newY = OpenSim::interpolate(x, y, newX);
 
+        SimTK_TEST(SimTK::isNaN(newY[0]));
+        SimTK_TEST_EQ(newY[1], 0.75);
+        SimTK_TEST_EQ(newY[2], 0.25);
+        SimTK_TEST(SimTK::isNaN(newY[3]));
+    }
+    SECTION("New X out of original range, extrapolate") {
+        SimTK::Vector x = createVector({0, 1});
+        SimTK::Vector y = createVector({1, 0});
+        SimTK::Vector newX = createVector({-1, 0.25, 0.75, 1.5});
+        SimTK::Vector newY = OpenSim::interpolate(x, y, newX, false, true);
+
         SimTK_TEST(!SimTK::isNaN(newY[0]));
         SimTK_TEST_EQ(newY[1], 0.75);
         SimTK_TEST_EQ(newY[2], 0.25);
         SimTK_TEST(!SimTK::isNaN(newY[3]));
     }
-    SECTION("First and last Y are NaN") {
+    SECTION("First and last Y are NaN, extrapolate") {
         SimTK::Vector x = createVector({0, 1, 2, 3, 4, 5});
         SimTK::Vector y = createVector({std::nan("0"), 0, 3, 4, std::nan("1"), std::nan("2")});
-        SimTK::Vector newY = OpenSim::interpolate(x, y, x, true);
+        SimTK::Vector newY = OpenSim::interpolate(x, y, x, true, true);
 
         for (int i = 0; i < newY.size(); ++i) {
             SimTK_TEST(!SimTK::isNaN(newY[i]));

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -234,7 +234,8 @@ TOut convertToMocoTrajectory(const CasOC::Iterate& casIt,
         for (int i = 0; i < (int)casIt.slack_names.size(); ++i) {
             if (simtkSlacksLength != simtkTimes.size()) {
                 mocoTraj.appendSlack(casIt.slack_names[i],
-                        interpolate(slackTime, simtkSlacks.col(i), simtkTimes));
+                        interpolate(slackTime, simtkSlacks.col(i), simtkTimes,
+                                    false, true));
             } else {
                 mocoTraj.appendSlack(casIt.slack_names[i], simtkSlacks.col(i));
             }

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -235,7 +235,7 @@ TOut convertToMocoTrajectory(const CasOC::Iterate& casIt,
             if (simtkSlacksLength != simtkTimes.size()) {
                 mocoTraj.appendSlack(casIt.slack_names[i],
                         interpolate(slackTime, simtkSlacks.col(i), simtkTimes,
-                                    false, true));
+                                    true, true));
             } else {
                 mocoTraj.appendSlack(casIt.slack_names[i], simtkSlacks.col(i));
             }

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -876,7 +876,7 @@ void MocoTrajectory::resample(SimTK::Vector time) {
     // does not resize the slacks trajectory.
     for (int icol = 0; icol < m_slacks.ncol(); ++icol) {
         m_slacks.updCol(icol) =
-                interpolate(m_time, m_slacks.col(icol), m_time, true);
+                interpolate(m_time, m_slacks.col(icol), m_time, false, true);
     }
 
     const TimeSeriesTable table = convertToTable();

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -876,7 +876,7 @@ void MocoTrajectory::resample(SimTK::Vector time) {
     // does not resize the slacks trajectory.
     for (int icol = 0; icol < m_slacks.ncol(); ++icol) {
         m_slacks.updCol(icol) =
-                interpolate(m_time, m_slacks.col(icol), m_time, false, true);
+                interpolate(m_time, m_slacks.col(icol), m_time, true, true);
     }
 
     const TimeSeriesTable table = convertToTable();

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -1733,10 +1733,10 @@ TEST_CASE("Interpolate", "") {
 
     SimTK::Vector newY = interpolate(x, y, newX);
 
-    SimTK_TEST(!SimTK::isNaN(newY[0]));
+    SimTK_TEST(SimTK::isNaN(newY[0]));
     SimTK_TEST_EQ(newY[1], 0.75);
     SimTK_TEST_EQ(newY[2], 0.25);
-    SimTK_TEST(!SimTK::isNaN(newY[3]));
+    SimTK_TEST(SimTK::isNaN(newY[3]));
 }
 
 template <typename SolverType>

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -1733,10 +1733,10 @@ TEST_CASE("Interpolate", "") {
 
     SimTK::Vector newY = interpolate(x, y, newX);
 
-    SimTK_TEST(SimTK::isNaN(newY[0]));
+    SimTK_TEST(!SimTK::isNaN(newY[0]));
     SimTK_TEST_EQ(newY[1], 0.75);
     SimTK_TEST_EQ(newY[2], 0.25);
-    SimTK_TEST(SimTK::isNaN(newY[3]));
+    SimTK_TEST(!SimTK::isNaN(newY[3]));
 }
 
 template <typename SolverType>


### PR DESCRIPTION
Fixes issue #3866

### Brief summary of changes
Optional parameter allows caller to ensure that the interpolant will never have NaN values. I changed two interpolate calls to set this flag to true so that the example would work without NaN errors.

### Testing I've completed
Added tests with and without extrapolate flag. Ran the linked test [here](https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=91&t=18504&p=0&start=0&view=) and it works with the change.

### Looking for feedback on...
Are there more NaNs to test other than std::nan?

### CHANGELOG.md (choose one)

- to be updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3867)
<!-- Reviewable:end -->
