### PR TITLE
Changed method setWeight variable names for clarity. 

### DIFF
--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
@@ -88,11 +88,11 @@ public:
     already set for the requested measure, then the provided weight
     replaces the previous weight. An exception is thrown during
     initialization if a weight for an unknown measure is provided. */
-    void setWeight(const std::string& stateName, const double& weight) {
-        if (get_reaction_weights().contains(stateName)) {
-            upd_reaction_weights().get(stateName).setWeight(weight);
+    void setWeight(const std::string& measure, const double& weight) {
+        if (get_reaction_weights().contains(measure)) {
+            upd_reaction_weights().get(measure).setWeight(weight);
         } else {
-            upd_reaction_weights().cloneAndAppend({stateName, weight});
+            upd_reaction_weights().cloneAndAppend({measure, weight});
         }
     }
     /** Provide a MocoWeightSet to weight the reaction measures in the cost.


### PR DESCRIPTION
Changed variable name to `measure` rather than `stateName`, which I thought was misleading. I thought this makes it easier to figure out what users are passing into the method if they are selecting a particular reaction measure - rather than a state name. 

### Brief summary of changes
Changed the input variable name in the header for `MocoJointReactionGoal->setWeight()`. It was written as `stateName`, but really we are passing in a reaction measure (Options: "moment-x", "moment-y", "moment-z", "force-x", "force-y", and "force-z"). 

### Looking for feedback on...
- clarity / needed testing?

### CHANGELOG.md (choose one)
- no need to update - small change in header variable name only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3878)
<!-- Reviewable:end -->
