### PR TITLE
Add fixes and enhancements related to `MocoGeneralizedForceTrackingGoal`

### DIFF
--- a/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoTrack.m
+++ b/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoTrack.m
@@ -324,19 +324,15 @@ jointMomentTracking.setNormalizeTrackingError(true);
 % Ignore coordinates that are locked, prescribed, or coupled to other
 % coordinates via CoordinateCouplerConstraints (true by default).
 jointMomentTracking.setIgnoreConstrainedCoordinates(true);
-coordinateSet = model.getCoordinateSet();
-for i = 0:coordinateSet.getSize()-1
-    coordinate = coordinateSet.get(i);
-    coordName = coordinate.getName();
-    % Don't track generalized forces associated with pelvis residuals.
-    if contains(string(coordName), "pelvis")
-        jointMomentTracking.setWeightForCoordinate(coordName, 0);
-    end
-    % Encourage better tracking of the ankle joint moments.
-    if contains(string(coordName), "ankle")
-        jointMomentTracking.setWeightForCoordinate(coordName, 100);
-    end
-end
+
+% Do not track generalized forces associated with pelvis residuals.
+jointMomentTracking.setWeightForGeneralizedForcePattern(".*pelvis.*", 0);
+
+% Encourage better tracking of the ankle joint moments.
+jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_r_moment", 100);
+jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_l_moment", 100);
+
+% Add the joint moment tracking goal to the problem.
 problem.addGoal(jointMomentTracking);
 
 % Update the solver problem and tolerances.

--- a/Bindings/Python/examples/Moco/example3DWalking/exampleMocoTrack.py
+++ b/Bindings/Python/examples/Moco/example3DWalking/exampleMocoTrack.py
@@ -279,18 +279,15 @@ def muscleDrivenJointMomentTracking():
     # Ignore coordinates that are locked, prescribed, or coupled to other
     # coordinates via CoordinateCouplerConstraints (true by default).
     jointMomentTracking.setIgnoreConstrainedCoordinates(True)
-    coordinateSet = model.getCoordinateSet()
-    for i in range(coordinateSet.getSize()):
-        coordinate = coordinateSet.get(i)
-        coordName = coordinate.getName()
-        # Don't track generalized forces associated with pelvis residuals.
-        if 'pelvis' in coordName:
-            jointMomentTracking.setWeightForCoordinate(coordName, 0)
-        
-        # Encourage better tracking of the ankle joint moments.
-        if 'ankle' in coordName:
-            jointMomentTracking.setWeightForCoordinate(coordName, 100)
-        
+
+    # Do not track generalized forces associated with pelvis residuals.
+    jointMomentTracking.setWeightForGeneralizedForcePattern('.*pelvis.*', 0)
+
+    # Encourage better tracking of the ankle joint moments.
+    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_r_moment', 100)
+    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_l_moment', 100)
+
+    # Add the joint moment tracking goal to the problem.
     problem.addGoal(jointMomentTracking)
 
     # Update the solver tolerances.

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -299,18 +299,15 @@ void muscleDrivenJointMomentTracking() {
     // Ignore coordinates that are locked, prescribed, or coupled to other
     // coordinates via CoordinateCouplerConstraints (true by default).
     jointMomentTracking->setIgnoreConstrainedCoordinates(true);
-    for (const auto& coordinate : model.getComponentList<Coordinate>()) {
-        const auto& coordName = coordinate.getName();
-        // Don't track generalized forces associated with pelvis residuals.
-        if (coordName.find("pelvis") != std::string::npos) {
-            jointMomentTracking->setWeightForGeneralizedForce(coordName, 0);
-        }
 
-        // Encourage better tracking of the ankle joint moments.
-        if (coordName.find("ankle") != std::string::npos) {
-            jointMomentTracking->setWeightForGeneralizedForce(coordName, 100);
-        }
-    }
+    // Do not track generalized forces associated with pelvis residuals.
+    jointMomentTracking->setWeightForGeneralizedForcePattern(".*pelvis.*", 0);
+
+    // Encourage better tracking of the ankle joint moments.
+    jointMomentTracking->setWeightForGeneralizedForce(
+            "ankle_angle_r_moment", 100);
+    jointMomentTracking->setWeightForGeneralizedForce(
+            "ankle_angle_l_moment", 100);
     
     // Update the solver problem and tolerances.
     auto& solver = study.updSolver<MocoCasADiSolver>();
@@ -342,10 +339,10 @@ void muscleDrivenJointMomentTracking() {
 int main() {
 
     // Solve the torque-driven marker tracking problem.
-    torqueDrivenMarkerTracking();
+    // torqueDrivenMarkerTracking();
 
     // Solve the muscle-driven state tracking problem.
-    muscleDrivenStateTracking();
+    // muscleDrivenStateTracking();
 
     // Solve the muscle-driven joint moment tracking problem.
     muscleDrivenJointMomentTracking();

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -339,10 +339,10 @@ void muscleDrivenJointMomentTracking() {
 int main() {
 
     // Solve the torque-driven marker tracking problem.
-    // torqueDrivenMarkerTracking();
+    torqueDrivenMarkerTracking();
 
     // Solve the muscle-driven state tracking problem.
-    // muscleDrivenStateTracking();
+    muscleDrivenStateTracking();
 
     // Solve the muscle-driven joint moment tracking problem.
     muscleDrivenJointMomentTracking();

--- a/OpenSim/Moco/MocoGoal/MocoGeneralizedForceTrackingGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGeneralizedForceTrackingGoal.h
@@ -93,13 +93,15 @@ public:
     /// then the provided weight replaces the previous weight. Weight names 
     /// should match the column labels in the reference table (e.g., 
     /// `ankle_angle_r_moment`, `pelvis_tx_force`, etc.).
-    void setWeightForGeneralizedForce(const std::string& name, double weight) {
-        if (get_generalized_force_weights().contains(name)) {
-            upd_generalized_force_weights().get(name).setWeight(weight);
-        } else {
-            upd_generalized_force_weights().cloneAndAppend({name, weight});
-        }
-    }
+    void setWeightForGeneralizedForce(const std::string& name, double weight);
+
+    /// Set the tracking weight for all generalized forces whose names match the
+    /// regular expression pattern. Multiple pairs of patterns and weights can 
+    /// be provided by calling this function multiple times. If a generalized
+    /// force matches multiple patterns, the weight associated with the last
+    /// pattern is used.
+    void setWeightForGeneralizedForcePattern(const std::string& pattern, 
+            double weight);
 
     /// Set the MocoWeightSet to weight the generalized coordinate forces in
     /// the cost. Replaces the weight set if it already exists.
@@ -122,9 +124,9 @@ public:
     /// @copydoc setNormalizeTrackingError(bool tf)
     bool getNormalizeTrackingError() { return get_normalize_tracking_error(); }
 
-    /// Whether or not to ignore coordinates that are locked, prescribed, or
-    /// coupled to other coordinates. This is based on the value returned from 
-    /// `Coordinate::isConstrained()` (default: true).
+    /// Whether or not to ignore generalized forces for coordinates that are 
+    /// locked, prescribed, or coupled to other coordinates. This is based on 
+    /// the value returned from `Coordinate::isConstrained()` (default: true).
     void setIgnoreConstrainedCoordinates(bool tf) {
         set_ignore_constrained_coordinates(tf);
     }
@@ -156,6 +158,9 @@ private:
     OpenSim_DECLARE_PROPERTY(generalized_force_weights, MocoWeightSet, 
             "Set of weight objects to weight the tracking of individual "
             "generalized coordinate forces in the cost.");
+    OpenSim_DECLARE_PROPERTY(generalized_force_weights_pattern, MocoWeightSet, 
+            "Set weights for all generalized forces matching a regular "
+            "expression.");
     OpenSim_DECLARE_PROPERTY(allow_unused_references, bool,
             "Flag to determine whether or not references contained in the "
             "reference table are allowed to be ignored by the cost.");
@@ -165,14 +170,14 @@ private:
             "If the peak magnitude of the reference generalized force data is "
             "close to zero, an exception is thrown (default: false).");
     OpenSim_DECLARE_PROPERTY(ignore_constrained_coordinates, bool,
-            "Flag to determine whether or not to ignore coordinates that are "
-            "locked, prescribed, or coupled to other coordinates "
-            "(default: true).");
+            "Flag to determine whether or not to ignore generalized forces for " 
+            "coordinates that are locked, prescribed, or coupled to other "
+            "coordinates (default: true).");
 
     mutable GCVSplineSet m_refsplines;
     mutable std::vector<double> m_generalizedForceWeights;
     mutable std::vector<std::string> m_generalizedForceNames;
-    mutable std::vector<int> m_coordinateIndexes;
+    mutable std::vector<int> m_generalizedForceIndexes;
     mutable std::vector<double> m_normalizationFactors;
     mutable SimTK::Array_<SimTK::ForceIndex> m_forceIndexes;
 };


### PR DESCRIPTION
### Brief summary of changes
The `exampleMocoTrack` subexample using `MocoGeneralizedForceTrackingGoal` did not work out-of-the-box due to changes in the source code that were not propagated to the example files. The example failed because `setWeightForGeneralizedForce` expected a generalized force name (e.g., "ankle_angle_r_moment") but was currently being given only the coordinate name. This PR fixes this inconsistency and includes the following improvements:

- Adds `setWeightForGeneralizedForcePattern` to allow setting weights for multiple coordinates simultaneously using regex patterns.
- Minor updates to the documentation.
- Changed some variable names in the implementation to improve clarity.

### Testing I've completed
Ran `exampleMocoTrack` locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...example not officially released yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3887)
<!-- Reviewable:end -->
