### PR TITLE
Clean up OpenSim::PointForceDirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
+Upcoming Release
+================
+
+- `PointForceDirection` no longer has a virtual destructor, is `final`, and its `scale` functionality
+  has been marked as `[[deprecated]]`
+
 v4.6
 ====
 - The performance of `getStateVariableValue`, `getStateVariableDerivativeValue`, and `getModelingOption` was improved in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
-Upcoming Release
-================
-
-- `PointForceDirection` no longer has a virtual destructor, is `final`, and its `scale` functionality
-  has been marked as `[[deprecated]]`
-
 v4.6
 ====
 - The performance of `getStateVariableValue`, `getStateVariableDerivativeValue`, and `getModelingOption` was improved in
@@ -22,6 +16,8 @@ v4.6
   allow extrapolation using the `extrapolate` flag. Combined with the `ignoreNaNs` flag, this prevents NaNs from 
   occurring in the output. (#3867)
 - Added `Output`s to `ExpressionBasedCoordinateForce`, `ExpressionBasedPointToPointForce`, and `ExpressionBasedBushingForce` for accessing force values. (#3872)
+- `PointForceDirection` no longer has a virtual destructor, is `final`, and its `scale` functionality
+  has been marked as `[[deprecated]]` (#3890)
 
 v4.5.1
 ======

--- a/OpenSim/Simulation/Model/PointForceDirection.h
+++ b/OpenSim/Simulation/Model/PointForceDirection.h
@@ -9,8 +9,8 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
- * Author(s): Ajay Seth                                                       *
+ * Copyright (c) 2005-2024 Stanford University and the Authors                *
+ * Author(s): Ajay Seth, Adam Kewley                                          *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -23,70 +23,74 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDES
+#include <OpenSim/Simulation/Model/PhysicalFrame.h>
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 
 namespace OpenSim {
 
 class Body;
 class PhysicalFrame;
-//=============================================================================
-//=============================================================================
-/** Convenience class for a generic representation of geometry of a complex
-    Force (or any other object) with multiple points of contact through
-    which forces are applied to bodies. This represents one such point and an
-    array of these objects defines a complete Force distribution (ie. path).
+
+/**
+ * Convenience class for a generic representation of geometry of a complex
+ * Force (or any other object) with multiple points of contact through
+ * which forces are applied to bodies. This represents one such point and an
+ * array of these objects defines a complete Force distribution (ie. path).
  *
  * @author Ajay Seth
  * @version 1.0
  */
-
-class OSIMSIMULATION_API PointForceDirection
-{
-
-//=============================================================================
-// MEMBER VARIABLES
-//=============================================================================
-private:
-    /** Point of "contact" with a body, defined in the body frame */
-    SimTK::Vec3 _point;
-    /** The frame in which the point is defined */
-    const PhysicalFrame &_frame;
-    /** Direction of the force at the point, defined in ground */
-    SimTK::Vec3 _direction;
-    /** Optional parameter to scale the force that results from a scalar 
-        (tension) multiplies the direction */
-    double _scale;
-//=============================================================================
-// METHODS
-//=============================================================================
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
+class OSIMSIMULATION_API PointForceDirection final {
 public:
-    virtual ~PointForceDirection() {};
-    /** Default constructor takes the point, body, direction and scale
-        as arguments */
-    PointForceDirection(SimTK::Vec3 point, const PhysicalFrame &frame, 
-        SimTK::Vec3 direction, double scale=1):
-            _point(point), _frame(frame), _direction(direction), _scale(scale)
+    PointForceDirection(
+        SimTK::Vec3 point,
+        const PhysicalFrame& frame,
+        SimTK::Vec3 direction) :
+
+        _point(point), _frame(&frame), _direction(direction)
+    {}
+
+    [[deprecated("the 'scale' functionality should not be used in new code: OpenSim already assumes 'direction' is non-unit-length")]]
+    PointForceDirection(
+        SimTK::Vec3 point,
+        const PhysicalFrame& frame,
+        SimTK::Vec3 direction,
+        double scale) :
+
+        _point(point), _frame(&frame), _direction(direction), _scale(scale)
     {}
 
     /** get point of "contact" with on a body defined in the body frame */
-    SimTK::Vec3 point() {return _point; }
+    SimTK::Vec3 point() { return _point; }
+
     /** get the body in which the point is defined */
-    const PhysicalFrame& frame() {return _frame; }
+    const PhysicalFrame& frame() { return *_frame; }
+
     /** get direction of the force at the point defined in ground */
-    SimTK::Vec3 direction() {return _direction; }
+    SimTK::Vec3 direction() { return _direction; }
+
     /** get the scale factor on the force */
-    double scale() {return _scale; }
+    [[deprecated("this functionality should not be used in new code: OpenSim already assumes 'direction' is non-unit-length")]]
+    double scale() { return _scale; }
 
     /** replace the current direction with the resultant with a new direction */
-    void addToDirection(SimTK::Vec3 newDirection) {_direction+=newDirection;}
+    void addToDirection(SimTK::Vec3 newDirection) { _direction += newDirection; }
 
-//=============================================================================
-};  // END of class PointForceDirection
-//=============================================================================
+private:
+    /** Point of "contact" with a body, defined in the body frame */
+    SimTK::Vec3 _point;
+
+    /** The frame in which the point is defined */
+    const PhysicalFrame* _frame;
+
+    /** Direction of the force at the point, defined in ground */
+    SimTK::Vec3 _direction;
+
+    /** Deprecated parameter to scale the force that results from a scalar
+    (tension) multiplies the direction */
+    double _scale = 1.0;
+};
+
 } // namespace
 
 #endif // __PointForceDirection_h__

--- a/OpenSim/Simulation/Model/PointForceDirection.h
+++ b/OpenSim/Simulation/Model/PointForceDirection.h
@@ -35,7 +35,7 @@ class PhysicalFrame;
  * Convenience class for a generic representation of geometry of a complex
  * Force (or any other object) with multiple points of contact through
  * which forces are applied to bodies. This represents one such point and an
- * array of these objects defines a complete Force distribution (ie. path).
+ * array of these objects defines a complete Force distribution (i.e., path).
  *
  * @author Ajay Seth
  * @version 1.0
@@ -60,20 +60,20 @@ public:
         _point(point), _frame(&frame), _direction(direction), _scale(scale)
     {}
 
-    /** get point of "contact" with on a body defined in the body frame */
+    /** Returns the point of "contact", defined in `frame()` */
     SimTK::Vec3 point() { return _point; }
 
-    /** get the body in which the point is defined */
+    /** Returns the frame in which `point()` is defined */
     const PhysicalFrame& frame() { return *_frame; }
 
-    /** get direction of the force at the point defined in ground */
+    /** Returns the (potentially, non-unit-length) direction, defined in ground, of the force at `point()` */
     SimTK::Vec3 direction() { return _direction; }
 
-    /** get the scale factor on the force */
+    /** Returns the scale factor of the force */
     [[deprecated("this functionality should not be used in new code: OpenSim already assumes 'direction' is non-unit-length")]]
     double scale() { return _scale; }
 
-    /** replace the current direction with the resultant with a new direction */
+    /** Replaces the current direction with `direction + newDirection` */
     void addToDirection(SimTK::Vec3 newDirection) { _direction += newDirection; }
 
 private:


### PR DESCRIPTION
Minor clean-up. The motivation for doing so is that I'm currently working on a new `ForceEmitter` base class, which can re-use `PointForceDirection`, rather than (e.g.) having to introduce its own point-force holding class. 

Fixes issue N/A

### Brief summary of changes

- Remove `virtual` destructor. It's unused codebase-wide
- Deprecate `scale` feature. It's unused in `opensim-core`, which uses the magnitude of `direction` to encode the force
- BREAKING: add a `final` qualifier to the class, which will cause all code that was inheriting `PointForceDirection` to no longer compile, which is a requirement for removing the virtual destructor
  - It's unlikely downstream code will be inheriting from this. It's a mostly-internal-use class that only pops up as a datastructure passed out by `GeometryPath`

### Testing I've completed

- None: they're basic depecations

### Looking for feedback on...

- Basics

### CHANGELOG.md (choose one)

- Updated with a note about the `final` and `[[deprecated]]` changes. Unlikely to affect downstream users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3890)
<!-- Reviewable:end -->
