### PR TITLE
A few tweaks to `MocoExpressionBasedParameterGoal`

### DIFF
--- a/OpenSim/Common/ExpressionBasedFunction.cpp
+++ b/OpenSim/Common/ExpressionBasedFunction.cpp
@@ -69,11 +69,15 @@ public:
             }
         } catch (Lepton::Exception& ex) {
             std::string msg = ex.what();
-            std::string undefinedVar = msg.substr(32, msg.size() - 32);
-            OPENSIM_THROW(Exception, 
-                    fmt::format("Variable '{}' is not defined. Use "
-                    "setVariables() to explicitly define this variable. Or, "
-                    "remove it from the expression.", undefinedVar));
+            if (msg.compare(0, 30, "No value specified for variable")) { 
+                std::string undefinedVar = msg.substr(32, msg.size() - 32);
+                OPENSIM_THROW(Exception, 
+                        fmt::format("Variable '{}' is not defined. Use "
+                        "setVariables() to explicitly define this variable. "
+                        "Or, remove it from the expression.", undefinedVar));
+            } else {
+                OPENSIM_THROW(Exception, "Lepton parsing error: {}", msg);
+            }
         }
     }
 

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
@@ -67,16 +67,13 @@ void MocoExpressionBasedParameterGoal::initializeOnModelImpl(const Model& model)
     }
 
     // test to make sure all variables are there
-    try
-    {
+    try {
         std::map<std::string, double> parameterVars;
         for (int i = 0; i < getProperty_variable_names().size(); ++i) {
             parameterVars[get_variable_names(i)] = getPropertyValue(i);
         }
         m_program.evaluate(parameterVars);
-    }
-    catch (Lepton::Exception& ex)
-    {
+    } catch (Lepton::Exception& ex) {
         std::string msg = ex.what();
         std::string help = "";
         if (msg.compare(0, 30, "No value specified for variable")) {

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
@@ -75,11 +75,15 @@ void MocoExpressionBasedParameterGoal::initializeOnModelImpl(const Model& model)
         m_program.evaluate(parameterVars);
     } catch (Lepton::Exception& ex) {
         const std::string msg = ex.what();
-        std::string undefinedVar = msg.substr(32, msg.size() - 32);
-        OPENSIM_THROW_FRMOBJ(Exception, 
-                fmt::format("Parameter variable '{}' is not defined. Use "
-                "addParameter() to explicitly define this variable. Or, "
-                "remove it from the expression.", undefinedVar));
+        if (msg.compare(0, 30, "No value specified for variable")) {
+            std::string undefinedVar = msg.substr(32, msg.size() - 32);
+            OPENSIM_THROW_FRMOBJ(Exception, 
+                    fmt::format("Parameter variable '{}' is not defined. Use "
+                    "addParameter() to explicitly define this variable. Or, "
+                    "remove it from the expression.", undefinedVar));
+        } else {
+            OPENSIM_THROW_FRMOBJ(Exception, "Lepton parsing error: {}", msg);
+        }
     }
 }
 

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
@@ -88,9 +88,9 @@ public:
     expression string. All variables in the expression must have a corresponding
     parameter, but parameters with variables that are not in the expression are
     ignored. */
-    void addParameter(const MocoParameter& parameter, std::string variableName) {
+    void addParameter(const MocoParameter& parameter, std::string variable) {
         append_parameters(parameter);
-        append_variable_names(std::move(variableName));
+        append_variables(std::move(variable));
     }
 
 protected:
@@ -109,11 +109,11 @@ private:
     double getPropertyValue(int i) const;
 
     OpenSim_DECLARE_PROPERTY(expression, std::string,
-            "The expression string with variables q0-q9.");
+            "The expression string defining this cost or endpoint constraint.");
     OpenSim_DECLARE_LIST_PROPERTY(parameters, MocoParameter,
-            "MocoParameters to use in the expression.");
-    OpenSim_DECLARE_LIST_PROPERTY(variable_names, std::string,
-            "Variable names of the MocoParameters to use in the expression.");
+            "Parameters included in the expression.");
+    OpenSim_DECLARE_LIST_PROPERTY(variables, std::string,
+            "Variables names corresponding to parameters in the expression.");
 
     mutable Lepton::ExpressionProgram m_program;
     // stores references to one property per parameter

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
@@ -26,18 +26,19 @@
 namespace OpenSim {
 class Model;
 
-/** Minimize an arithmetic expression of parameters. This goal supports any
-number of MocoParameters that are combined into a single goal. The expression
-string should match the Lepton (lightweight expression parser) format.
+/** Minimize or constrain an arithmetic expression of parameters. 
+
+This goal supports both "cost" and "endpoint constraint" modes and can be 
+defined using any number of MocoParameters. The expression string should match 
+the Lepton (lightweight expression parser) format.
 
 # Creating Expressions
 
 Expressions can be any string that represents a mathematical expression, e.g.,
 "x*sqrt(y-8)". Expressions can contain variables, constants, operations,
-parentheses, commas, spaces, and scientific e notation. The full list of
-operations (also in Lepton::Operation) is:
-sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, sinh, cosh,
-tanh, erf, erfc, step, delta, square, cube, recip, min, max, abs, as well as
+parentheses, commas, spaces, and scientific "e" notation. The full list of
+operations is: sqrt, exp, log, sin, cos, sec, csc, tan, cot, asin, acos, atan, 
+sinh, cosh, tanh, erf, erfc, step, delta, square, cube, recip, min, max, abs, 
 +, -, *, /, and ^.
 
 # Examples
@@ -50,7 +51,7 @@ auto* spring2_parameter = mp.addParameter("spring2_stiffness", "spring2",
 auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>();
 double STIFFNESS = 100.0;
 // minimum is when p + q = STIFFNESS
-spring_goal->setExpression(fmt::format("square( p+q-{} )", STIFFNESS));
+spring_goal->setExpression(fmt::format("square(p+q-{})", STIFFNESS));
 spring_goal->addParameter(*spring1_parameter, "p");
 spring_goal->addParameter(*spring2_parameter, "q");
 @endcode
@@ -75,10 +76,10 @@ public:
         set_expression(std::move(expression));
     }
 
-    /** Set the mathematical expression to minimize. Variable names should match
-    the names set with addParameter(). See "Creating Expressions" in the class
-    documentation above for an explanation of how to create expressions.
-    */
+    /** Set the mathematical expression to minimize or constraint. Variable 
+    names should match the names set with addParameter(). See "Creating 
+    Expressions" in the class documentation above for an explanation of how to 
+    create expressions. */
     void setExpression(std::string expression) {
         set_expression(std::move(expression));
     }
@@ -104,7 +105,7 @@ private:
 
     /** Get the value of the property from its index in the property_refs vector.
     This will use m_data_types to get the type, and if it is a Vec type, it uses
-    m_indices to get the element to return, both at the same index i.*/
+    m_indices to get the element to return, both at the same index i. */
     double getPropertyValue(int i) const;
 
     OpenSim_DECLARE_PROPERTY(expression, std::string,

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
@@ -76,7 +76,7 @@ public:
         set_expression(std::move(expression));
     }
 
-    /** Set the mathematical expression to minimize or constraint. Variable 
+    /** Set the arithmetic expression to minimize or constrain. Variable 
     names should match the names set with addParameter(). See "Creating 
     Expressions" in the class documentation above for an explanation of how to 
     create expressions. */


### PR DESCRIPTION
### Brief summary of changes

A handful of changes made to some aspects of `MocoExpressionBasedParameterGoal` that I noticed while using this as a reference for `ExpressionBasedFunction`. I've also opted to change the property `variable_names` to simply `variables`.

### Testing I've completed

Ran the existing tests in `testMocoGoals.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...tweaks to existing goal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3893)
<!-- Reviewable:end -->
