### PR TITLE
Ignore warnings related to deprecated `stdext::checked_array_iterator` on MSVC

### DIFF
--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -221,6 +221,12 @@ function(OpenSimAddLibrary)
     # This target links to the libraries provided as arguments to this func.
     target_link_libraries(${OSIMADDLIB_LIBRARY_NAME} ${OSIMADDLIB_LINKLIBS})
 
+    target_compile_options(${OSIMADDLIB_LIBRARY_NAME} PUBLIC
+        # disable warning 4996 on Windows: `spdlog` transitively 
+        # uses a deprecated `stdext::checked_array_iterator`
+        $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
+    )
+
     # This is for exporting classes on Windows.
     if(OSIMADDLIB_VENDORLIB)
         set(OSIMADDLIB_FOLDER "Vendor Libraries")

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -197,7 +197,7 @@ AddDependency(NAME       docopt
 AddDependency(NAME       spdlog
               DEFAULT    ON
               GIT_URL    https://github.com/gabime/spdlog.git
-              GIT_TAG    v1.14.1
+              GIT_TAG    v1.4.1
               CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -197,7 +197,7 @@ AddDependency(NAME       docopt
 AddDependency(NAME       spdlog
               DEFAULT    ON
               GIT_URL    https://github.com/gabime/spdlog.git
-              GIT_TAG    v1.4.1
+              GIT_TAG    v1.14.1
               CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF


### PR DESCRIPTION
Fixes issue with the Windows 2022 GitHub Actions runner failing because [MSVC deprecated `stdext::checked_array_iterator`](https://github.com/fmtlib/fmt/issues/3540), which was used by an older version of `fmtlib` (dependency of spdlog). 

### Brief summary of changes

~~Updated spdlog to v1.14.1.~~

Update: rather than try to update `spdlog`, I've changed this PR to ignore the warning on MSVC (per @adamkewley's suggestion).

### Testing I've completed

Running the CI suite.

### Looking for feedback on...

Should the added `target_compile_options` be moved outside of the macro (i.e., used only for libraries compiled with `spdlog`)?

### CHANGELOG.md (choose one)

- no need to update because...CI fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3895)
<!-- Reviewable:end -->
