### PR TITLE
Make `GeometryPath::produceForces` pre-add its point forces

### DIFF
--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -405,7 +405,7 @@ void GeometryPath::produceForces(const SimTK::State& s,
     ForceConsumer& forceConsumer) const
 {
     // Retains the body index from the previous iteration of the main loop
-    // and the previous direction between the previous point and the current
+    // and the previous force between the previous point and the current
     // one (if applicable). This is used to ensure that only one point force
     // is produced per path point (#3903, #3891).
     MobilizedBodyIndex previousBodyIndex = MobilizedBodyIndex::Invalid();
@@ -425,20 +425,14 @@ void GeometryPath::produceForces(const SimTK::State& s,
         const AbstractPathPoint* nextPoint = i < currentPath.getSize()-1 ? currentPath[i+1] : nullptr;
         if (nextPoint && nextPoint->getParentFrame().getMobilizedBodyIndex() != currentBodyIndex) {
             const SimTK::Vec3 currentDirection = directionBetweenPointsInGroundOrNaNIfCoincident(s, currentPoint, *nextPoint);
-            const SimTK::Vec3 currentToNextForce = tension * currentDirection;
-            force += currentToNextForce;
+            force += tension * currentDirection;
 
             // Additionally, account for the work done due to the movement of a `MovingPathPoint`
             // relative to the body it is on.
             if (const auto* movingCurrentPoint = dynamic_cast<const MovingPathPoint*>(&currentPoint)) {
                 const Vec3 dPodq_G = currentPoint.getParentFrame().expressVectorInGround(s, currentPoint.getdPointdQ(s));
-                const double fo = ~dPodq_G*currentToNextForce;
+                const double fo = ~dPodq_G*force;
                 forceConsumer.consumeGeneralizedForce(s, movingCurrentPoint->getXCoordinate(), fo);
-            }
-            if (const auto* nextMovingPoint = dynamic_cast<const MovingPathPoint*>(nextPoint)) {
-                const Vec3 dPfdq_G = nextPoint->getParentFrame().expressVectorInGround(s, nextPoint->getdPointdQ(s));
-                const double ff = ~dPfdq_G*(-currentToNextForce);
-                forceConsumer.consumeGeneralizedForce(s, nextMovingPoint->getXCoordinate(), ff);
             }
 
             previousBodyIndex = currentBodyIndex;


### PR DESCRIPTION
Related #3891

This is a cleanup of the existing implementation so that it's easier to work with, followed by reimplementing the loop such that it adds the tensile force on either side of each non-terminal pathpoint before calling `consumePointForce`. The utility of doing it this way is that the API receives a more easy-to-understand representation of the forces along the path (e.g. for visualization, users probably don't care about the parts of the forces that ultimately cancel out).

### Brief summary of changes

- Refactors `GeometryPath::produceForces` to clean it up
- Changes the `produceForces` algorithm to handle non-terminal points by computing forces either side of the point and adding it them together before throwing them into the `ForceConsumer`

### Testing I've completed

This algorithm is extensively tested by a large amount of OpenSim (i.e. anything with muscles).

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it's an internal change and no downstream users are using the impacted API get (`ForceConsumer`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3903)
<!-- Reviewable:end -->
