### PR TITLE
Update simbody to a version with `SimTK::CableSpan` support

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -185,7 +185,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    d98f05fa1899633b544757e6c179562940f0849d
+              GIT_TAG    f853397efad00798a169ff3dd1c52f5e20a24ba9
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Fixes issue N/A (@pepbos , @nickbianco )

### Brief summary of changes

- Update upstream simbody to a version that includes https://github.com/simbody/simbody/pull/791 (commit: aff36c1c4b4c6020866d3a4c66471e037fcb1ce2 )

### Testing I've completed

- None

### Looking for feedback on...

N/A

### CHANGELOG.md (choose one)

- no need to update because internal, until we start building prototypes on top of it etc. etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3911)
<!-- Reviewable:end -->
