### PR TITLE
Fix java binding of ExternalForce to account for ForceProducer

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -70,6 +70,8 @@ OpenSim::ModelComponentSet<OpenSim::Constraint>;
 %include <OpenSim/Simulation/Model/ConstraintSet.h>
 
 %include <OpenSim/Simulation/Model/Force.h>
+%include <OpenSim/Simulation/Model/ForceProducer.h>
+
 %template(SetForces) OpenSim::Set<OpenSim::Force, OpenSim::ModelComponent>;
 %template(ModelComponentSetForces) OpenSim::ModelComponentSet<OpenSim::Force>;
 %include <OpenSim/Simulation/Model/ForceSet.h>
@@ -77,7 +79,6 @@ OpenSim::ModelComponentSet<OpenSim::Constraint>;
 %template(SetExternalForces) OpenSim::Set<OpenSim::ExternalForce, OpenSim::ModelComponent>;
 %template(ModelComponentSetExternalForces) OpenSim::ModelComponentSet<OpenSim::ExternalForce>;
 
-%include <OpenSim/Simulation/Model/ForceProducer.h>
 %include <OpenSim/Simulation/Model/TwoFrameLinker.h>
 %template(TwoFrameLinkerForce) OpenSim::TwoFrameLinker<OpenSim::Force, OpenSim::PhysicalFrame>;
 %template(TwoFrameLinkerForceProducer) OpenSim::TwoFrameLinker<OpenSim::ForceProducer, OpenSim::PhysicalFrame>;


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
While the java bindings compiled successfully, the ExternalForce class had the wrong inheritance since the corresponding header was wrapped before ForceProducer.h This PR fixes this problem so that ExternalForce can be treated as Force in gui code
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3914)
<!-- Reviewable:end -->
