### PR TITLE
Update Examples to Use c++14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ v4.6
   sphere torques) to be consistent with the center of pressure GRF representation.
 - Fixed an issue where a copy of an `OpenSim::Model` containing a `OpenSim::ExternalLoads` could not be
   finalized (#3926)
+- Update all code examples to use c++14 (#3929) 
 
 v4.5.1
 ======

--- a/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
+++ b/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
@@ -3,8 +3,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(BuildDynamicWalker)
 
-# OpenSim requires a compiler that supports C++11.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim requires a compiler that supports c++14.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find the OpenSim libraries and header files.

--- a/OpenSim/Examples/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Examples/ControllerExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleController CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleCustomActuator CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleLuxoMuscle CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleMain/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMain CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Examples/MuscleExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMuscle CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET optimizationExample CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "osimPlugin" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "BodyDragForce" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
@@ -8,8 +8,8 @@ file(GLOB INCLUDE_FILES *.h)
 set(PLUGIN_NAME "osimCoupledBushingForcePlugin"
     CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET simpleOptimizationExample CACHE TYPE STRING)
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
+++ b/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
@@ -40,8 +40,8 @@ set(PLUGIN_NAME "osimExpressionReporter")
 
 # Settings.
 # ---------
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/checkEnvironment/CMakeLists.txt
+++ b/OpenSim/Examples/checkEnvironment/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET checkEnvironment CACHE STRING "Name of example to build")
 
-# OpenSim uses C++11 language features.
-set(CMAKE_CXX_STANDARD 11)
+# OpenSim uses c++14 language features.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Sandbox/xsens/CMakeLists.txt
+++ b/OpenSim/Sandbox/xsens/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WIN32)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 set(XSENS_SDK_DIR "" CACHE PATH "Directory containing XSENS SDK.")
 

--- a/Vendors/tropter/CMakeLists.txt
+++ b/Vendors/tropter/CMakeLists.txt
@@ -13,8 +13,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Compiler flags.
 # ---------------
-set(CMAKE_CXX_STANDARD 11)
-# Using c++11 is not optional.
+set(CMAKE_CXX_STANDARD 14)
+# Using c++14 is not optional.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Copy dependencies' libraries into tropter's installation?

--- a/Vendors/tropter/README.md
+++ b/Vendors/tropter/README.md
@@ -10,7 +10,7 @@ Goals
 1. Detailed and helpful error messages and diagnostics (visualizing a 
 sparsity pattern, inspecting constraint violations).
 
-2. A simple and modern (C++11) interface for specifying the optimal control 
+2. A simple and modern (c++14) interface for specifying the optimal control 
    problem.
 
 3. Users do not need to supply derivative information (gradient, Jacobian, 

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -11,7 +11,7 @@ project(myexe)
 set(my_source_files myexe.cpp)
 set(my_header_files myexe.h)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This depends on OpenSimConfig.cmake being located somewhere predictable


### PR DESCRIPTION
Fixes issue #3929

### Brief summary of changes

Update `CMakeLists.txt` files to use c++14

### Testing I've completed

Built examples independently (from an open-sim core installation) and everything compiles and runs. 

### Looking for feedback on...

None

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3931)
<!-- Reviewable:end -->
