### PR TITLE
Update setting PATH env for Linux build script

### DIFF
--- a/scripts/build/opensim-core-linux-build-script.sh
+++ b/scripts/build/opensim-core-linux-build-script.sh
@@ -212,5 +212,23 @@ ctest --parallel $NUM_JOBS --output-on-failure
 echo "LOG: INSTALL OPENSIM-CORE..."
 cd ~/opensim-workspace/opensim-core-build
 cmake --install .
-echo 'export PATH=~/opensim-core/bin:$PATH' >> ~/.bashrc
-source ~/.bashrc
+# Update the .bashrc path to include the opensim-core install directory
+if [ -n "$BASH" ]; then
+  rcFile="$HOME/.bashrc"
+  prop="PATH"                     # export property to insert
+  val="~/opensim-core/bin:\$PATH" # the desired value
+  echo -e "Current script $0 running in bash."
+  echo -e "Updating shell env file: $rcFile"
+  # Check if the PATH variable exits and update it
+  if grep -q "^export $prop=" "$rcFile"; then
+    sed -i "s|^export $prop=.*|export $prop=$val|" "$rcFile" &&
+      echo "[updated] export $prop=$val"
+  else
+    echo -e "export $prop=$val" >>"$rcFile"
+    echo "[inserted] export $prop=$val"
+  fi
+  source $rcFile
+else
+  echo -e "Current shell is not bash. Please manually update your shell env file to add the opensim install to your path:"
+  echo -e "export PATH=~/opensim-core/bin:$PATH"
+fi

--- a/scripts/build/opensim-core-linux-build-script.sh
+++ b/scripts/build/opensim-core-linux-build-script.sh
@@ -212,23 +212,5 @@ ctest --parallel $NUM_JOBS --output-on-failure
 echo "LOG: INSTALL OPENSIM-CORE..."
 cd ~/opensim-workspace/opensim-core-build
 cmake --install .
-# Update the .bashrc path to include the opensim-core install directory
-if [ -n "$BASH" ]; then
-  rcFile="$HOME/.bashrc"
-  prop="PATH"                     # export property to insert
-  val="~/opensim-core/bin:\$PATH" # the desired value
-  echo -e "Current script $0 running in bash."
-  echo -e "Updating shell env file: $rcFile"
-  # Check if the PATH variable exits and update it
-  if grep -q "^export $prop=" "$rcFile"; then
-    sed -i "s|^export $prop=.*|export $prop=$val|" "$rcFile" &&
-      echo "[updated] export $prop=$val"
-  else
-    echo -e "export $prop=$val" >>"$rcFile"
-    echo "[inserted] export $prop=$val"
-  fi
-  source $rcFile
-else
-  echo -e "Current shell is not bash. Please manually update your shell env file to add the opensim install to your path:"
-  echo -e "export PATH=~/opensim-core/bin:$PATH"
-fi
+
+cd ~/opensim-core/bin && echo -e "yes" | ./opensim-install-command-line.sh


### PR DESCRIPTION
Fixes issue #3928

### Brief summary of changes

Check which shell the user is using and attempt to update path if the shell is bash. 

### Testing I've completed

Ran the build script multiple times to ensure that `.bashrc` is updated if variable exists and created if it doesn't.

### Looking for feedback on...

- Is is suitable to assume the system will have `grep`, and `sed` available? 

### CHANGELOG.md (choose one)

- no need to update because the change only affects a build script

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3932)
<!-- Reviewable:end -->
