### PR TITLE
Refactor static variables in OpenSim::IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ v4.6
   states belong, a date/time stamp of when the file was written, and a user-specified note. `.ostate` files also support a
   configurable output precision. At the highest ouput precsion (~20 significant figures), serialization/deserialization is
   a lossless process. (#3902)
+- Improved `OpenSim::IO::stod` string-to-decimal parsing function by making it not-locale-dependant (#3943, #3924; thanks @alexbeattie42)
 
 v4.5.1
 ======

--- a/OpenSim/Common/IO.h
+++ b/OpenSim/Common/IO.h
@@ -35,7 +35,6 @@
 
 // DEFINES
 constexpr int IO_STRLEN = 2048;
-constexpr int IO_DBLFMTLEN = 256;
 
 
 namespace OpenSim { 
@@ -53,19 +52,6 @@ class OSIMCOMMON_API IO {
 // DATA
 //=============================================================================
 private:
-    // NUMBER OUTPUT
-    /** Specifies whether number output is in scientific or float format. */
-    static bool _Scientific;
-    /** Specifies whether number output is in %g format or not. */
-    static bool _GFormatForDoubleOutput;
-    /** Specifies number of digits of padding in number output. */ 
-    static int _Pad;
-    /** Specifies the precision of number output. */
-    static int _Precision;
-    /** The output format string. */
-    static char _DoubleFormat[IO_DBLFMTLEN];
-    /** Whether offline documents should also be printed when Object::print is called. */
-    static bool _PrintOfflineDocuments;
 
 
 //=============================================================================


### PR DESCRIPTION
Minor cleanup to #3943 

- Moves static variables in `IO` into the cpp file as static-**linkage** variables
- Removes `_locale` static variable and instead just calls `std::locale::classic()` (no comments etc. were written to justify why it's worth caching - probably doesn't matter)
- Adds missing CHANGELOG.md entry for #3943 

The reason I'm throwing this in separately is because it's much less tedious than slowly back-and-forthing on a separate PR. I'll merge this once it's through CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3948)
<!-- Reviewable:end -->
