### PR TITLE
Speedup component path traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ v4.6
   configurable output precision. At the highest ouput precsion (~20 significant figures), serialization/deserialization is
   a lossless process. (#3902)
 - Improved `OpenSim::IO::stod` string-to-decimal parsing function by making it not-locale-dependant (#3943, #3924; thanks @alexbeattie42)
+- Improved the performance of `ComponentPath` traversal (e.g. as used by `Component::getComponent`, `Component::getStateVariableValue`)
 
 v4.5.1
 ======


### PR DESCRIPTION
Adds (internal) `Component::forEachImmediateSubcomponent`, `Component::findImmediateSubcomponentByName` APIs and uses them to reimplement `Component` (so that it isn't manually looping as much) and reimplement `traversePathToComponent` (which was over-templated and allocated memory for subcomponent vectors.

I noticed that path traversal in OpenSim takes significant time. One of the reasons that this is the case is because `traversePathToComponent` ends up allocating and pushing pack pointers to subcomponents in order to perform a linear name search. 

Fixes issue N/A

### Brief summary of changes

- Adds a `private` helper function: `Component::forEachImmediateSubcomponent`, which can be used in cases where code wants to iterate over the three collections of subcomponents stored by `Component`.
- Adds a `private` helper function: `Component::findImmediateSubcomponentByName`, which can be used to find an immediate subcomponent by its name (currently, via linear probing).
- Rolls out `forEachImmediateSubcomponent` the parts of `Component` where it makes sense, so that the code is ready for a next-stage refactor (e.g. of adding a `Subcomponents` class that encapsulates the subcomponent mess).
- Rolls out `findImmediateSubcomponentByName` to `traversePathToComponent`, so that it can find an immediate subcomponent by name without having to first allocate a vector of pointers to subcomponents
- Cleans up `traversePathToComponent`

### Testing I've completed

- Ran the existing test suite, which uses this code very very extensively

### Looking for feedback on...

### CHANGELOG.md

- updated.
