### PR TITLE
Add `ConstantCurvatureJoint` to the bindings

### DIFF
--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -102,6 +102,7 @@
 #include <OpenSim/Simulation/SimbodyEngine/UniversalJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/PlanarJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/ScapulothoracicJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/ConstantCurvatureJoint.h>
 #include <OpenSim/Simulation/Model/JointSet.h>
 
 #include <OpenSim/Simulation/Model/Marker.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -95,6 +95,7 @@ OpenSim::ModelComponentSet<OpenSim::Constraint>;
 %include <OpenSim/Simulation/SimbodyEngine/UniversalJoint.h>
 %include <OpenSim/Simulation/SimbodyEngine/PlanarJoint.h>
 %include <OpenSim/Simulation/SimbodyEngine/ScapulothoracicJoint.h>
+%include <OpenSim/Simulation/SimbodyEngine/ConstantCurvatureJoint.h>
 
 %include <OpenSim/Simulation/SimbodyEngine/WeldConstraint.h>
 %include <OpenSim/Simulation/SimbodyEngine/PointConstraint.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ v4.6
   a lossless process. (#3902)
 - Improved `OpenSim::IO::stod` string-to-decimal parsing function by making it not-locale-dependant (#3943, #3924; thanks @alexbeattie42)
 - Improved the performance of `ComponentPath` traversal (e.g. as used by `Component::getComponent`, `Component::getStateVariableValue`)
+- Added `ConstantCurvatureJoint` to the SWIG bindings; it is now available in Matlab and Python (#3957). 
 
 v4.5.1
 ======


### PR DESCRIPTION
### Brief summary of changes
Self-explanatory: adds `ConstantCurvatureJoint` to the bindings.

### Testing I've completed
Installed bindings locally in Python and instantiated a `ConstantCurvatureJoint` object successfully in a Python interpreter.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3957)
<!-- Reviewable:end -->
