### PR TITLE
Initialize the texture string property previously unused.

### DIFF
--- a/OpenSim/Simulation/Model/Appearance.h
+++ b/OpenSim/Simulation/Model/Appearance.h
@@ -70,6 +70,7 @@ public:
     SurfaceProperties() {
         // Surface shaded by default
         constructProperty_representation(VisualRepresentation::DrawSurface);
+        constructProperty_texture();
     }
     virtual ~SurfaceProperties() {};
 


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
SurfaceProperties (used to support visualization) had an optional property of texture that was never used, now I'm trying to use it but it appears the initialization of the property was missing. Adding it back.
### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal bug

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3961)
<!-- Reviewable:end -->
