### PR TITLE
Add if check before calculating strings for log_debug

### DIFF
--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -196,12 +196,14 @@ void AssemblySolver::assemble(SimTK::State &state)
     _assembler->initialize(s);
     
     // Useful to include through debug message/log in the future
-    log_debug("UNASSEMBLED CONFIGURATION (normerr={}, maxerr={}, cost={})",
-        _assembler->calcCurrentErrorNorm(),
-        max(abs(_assembler->getInternalState().getQErr())),
-        _assembler->calcCurrentGoal());
-    log_debug("Model numQs: {} Assembler num freeQs: {}",  
-        _assembler->getInternalState().getNQ(),  _assembler->getNumFreeQs());
+    if (Logger::getLevel() <= Logger::Level::Debug) {
+        log_debug("UNASSEMBLED CONFIGURATION (normerr={}, maxerr={}, cost={})",
+            _assembler->calcCurrentErrorNorm(),
+            max(abs(_assembler->getInternalState().getQErr())),
+            _assembler->calcCurrentGoal());
+        log_debug("Model numQs: {} Assembler num freeQs: {}",  
+            _assembler->getInternalState().getNQ(),  _assembler->getNumFreeQs());
+    }
 
     try{
         // Now do the assembly and return the updated state.
@@ -219,16 +221,19 @@ void AssemblySolver::assemble(SimTK::State &state)
             if(isLocked)
                 modelCoordSet[i].setLocked(state, isLocked);
         }
-        // TODO: Useful to include through debug message/log in the future
-        log_debug("ASSEMBLED CONFIGURATION (acc={} tol={} normerr={}, maxerr={}, cost={})",
-            _assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
-            _assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
-            _assembler->calcCurrentGoal());
-        log_debug("# initializations={}", _assembler->getNumInitializations());
-        log_debug("# assembly steps: {}", _assembler->getNumAssemblySteps());
-        log_debug(" evals: goal={} grad={} error={} jac={}",
-            _assembler->getNumGoalEvals(), _assembler->getNumGoalGradientEvals(),
-            _assembler->getNumErrorEvals(), _assembler->getNumErrorJacobianEvals());
+
+        if (Logger::getLevel() <= Logger::Level::Debug) {
+            // TODO: Useful to include through debug message/log in the future
+            log_debug("ASSEMBLED CONFIGURATION (acc={} tol={} normerr={}, maxerr={}, cost={})",
+                _assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
+                _assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
+                _assembler->calcCurrentGoal());
+            log_debug("# initializations={}", _assembler->getNumInitializations());
+            log_debug("# assembly steps: {}", _assembler->getNumAssemblySteps());
+            log_debug(" evals: goal={} grad={} error={} jac={}",
+                _assembler->getNumGoalEvals(), _assembler->getNumGoalGradientEvals(),
+                _assembler->getNumErrorEvals(), _assembler->getNumErrorJacobianEvals());
+        }
     }
     catch (const std::exception& ex)
     {
@@ -258,12 +263,14 @@ void AssemblySolver::track(SimTK::State &s)
     }
 
     // TODO: Useful to include through debug message/log in the future
-    log_debug("UNASSEMBLED(track) CONFIGURATION (normerr={}, maxerr={}, cost={})",
-        _assembler->calcCurrentErrorNorm(), 
-        max(abs(_assembler->getInternalState().getQErr())), 
-        _assembler->calcCurrentGoal() );
-    log_debug("Model numQs: {}  Assembler num freeQs: {}",
-        _assembler->getInternalState().getNQ(), _assembler->getNumFreeQs());
+    if (Logger::getLevel() <= Logger::Level::Debug) {
+        log_debug("UNASSEMBLED(track) CONFIGURATION (normerr={}, maxerr={}, cost={})",
+            _assembler->calcCurrentErrorNorm(), 
+            max(abs(_assembler->getInternalState().getQErr())), 
+            _assembler->calcCurrentGoal() );
+        log_debug("Model numQs: {}  Assembler num freeQs: {}",
+            _assembler->getInternalState().getNQ(), _assembler->getNumFreeQs());
+    }
 
     try{
         // Now do the assembly and return the updated state.
@@ -273,11 +280,13 @@ void AssemblySolver::track(SimTK::State &s)
         _assembler->updateFromInternalState(s);
         
         // TODO: Useful to include through debug message/log in the future
-        log_debug("Tracking: t= {} (acc={} tol={} normerr={}, maxerr={}, cost={})", 
-            s.getTime(),
-            _assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
-            _assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
-            _assembler->calcCurrentGoal()); 
+        if (Logger::getLevel() <= Logger::Level::Debug) {
+            log_debug("Tracking: t= {} (acc={} tol={} normerr={}, maxerr={}, cost={})", 
+                s.getTime(),
+                _assembler->getAccuracyInUse(), _assembler->getErrorToleranceInUse(), 
+                _assembler->calcCurrentErrorNorm(), max(abs(_assembler->getInternalState().getQErr())),
+                _assembler->calcCurrentGoal()); 
+        }
     }
     catch (const std::exception& ex)
     {


### PR DESCRIPTION
Fixes issue  N/A

Noticed that debug logging takes a bit of CPU during assembly - even if the log is disabled. Turns out, it's because `log_debug` etc. aren't macros and, therefore, fully evaluate all arguments before forwarding to the logger. If the logger doesn't need to sink the resulting message, then the evaluation is wasted.

### Brief summary of changes

- Check if the log level is `Debug` before computing quantities that may appear in a debug log message

### Testing I've completed

- None

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because tiny change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3963)
<!-- Reviewable:end -->
