### PR TITLE
Throw if passed in name or index of marker is invalid 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ v4.6
 - Added the templatized `MocoStudy::analyze<T>()` and equivalent scripting counterparts: `analyzeVec3`, `analyzeSpatialVec`, `analyzeRotation`. (#3940)
 - Added `ConstantCurvatureJoint` to the SWIG bindings; it is now available in Matlab and Python (#3957). 
 - Added methods and `Output`s for calculating the angular momentum of a `Body`. (#3962)
+- Make `InverseKinematicsSolver` methods to query for marker specific results more robust to invalid names or those without corresponding data. (#3951) 
 
 
 v4.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ v4.6
 - Added the templatized `MocoStudy::analyze<T>()` and equivalent scripting counterparts: `analyzeVec3`, `analyzeSpatialVec`, `analyzeRotation`. (#3940)
 - Added `ConstantCurvatureJoint` to the SWIG bindings; it is now available in Matlab and Python (#3957). 
 - Added methods and `Output`s for calculating the angular momentum of a `Body`. (#3962)
-- Make `InverseKinematicsSolver` methods to query for marker specific results more robust to invalid names or those without corresponding data. (#3951) 
+- Make `InverseKinematicsSolver` methods to query for specific marker or orientation-sensor errors more robust to invalid names or names not 
+  in the intersection of names in the model and names in the provided referece/data. Remove methods that are index based from public interface.(#3951) 
 
 
 v4.5.1

--- a/OpenSim/Simulation/InverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/InverseKinematicsSolver.cpp
@@ -133,6 +133,10 @@ void InverseKinematicsSolver::updateMarkerWeight(const std::string& markerName, 
 {
     const Array_<std::string> &names = _markersReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), markerName);
+    if (p == names.end())
+        throw Exception(
+                "InverseKinematicsSolver::updateMarkerWeight: "
+                "invalid or unused marker name " + markerName + ".");
     int index = (int)std::distance(names.begin(), p);
     updateMarkerWeight(index, value);
 }
@@ -175,6 +179,10 @@ void InverseKinematicsSolver::updateOrientationWeight(const std::string& orienta
 {
     const Array_<std::string> &names = _orientationsReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), orientationName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::updateOrientationWeight: "
+                        "invalid or unused orientation sensor name " +
+                        orientationName + ".");
     int index = (int)std::distance(names.begin(), p);
     updateOrientationWeight(index, value);
 }
@@ -273,6 +281,10 @@ double InverseKinematicsSolver::computeCurrentSquaredMarkerError(const std::stri
 {
     const Array_<std::string>& names = _markersReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), markerName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::computeCurrentSquaredMarkerError: "
+                        "invalid or unused marker name " +
+                        markerName + ".");
     int index = (int)std::distance(names.begin(), p);
     return computeCurrentSquaredMarkerError(index);
 }
@@ -308,6 +320,9 @@ SimTK::Rotation InverseKinematicsSolver::
 {
     const Array_<std::string>& names = _orientationsReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), osensorName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::computeCurrentSensorOrientation: "
+                        "invalid or unused orientation sensor name " + osensorName + ".");
     int index = (int)std::distance(names.begin(), p);
     return computeCurrentSensorOrientation(index);
 }
@@ -338,6 +353,9 @@ double InverseKinematicsSolver::
 {
     const Array_<std::string>& names = _orientationsReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), osensorName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::computeCurrentOrientationError: "
+                        "invalid or unused orientation sensor name " + osensorName + ".");
     int index = (int)std::distance(names.begin(), p);
     return computeCurrentOrientationError(index);
 }

--- a/OpenSim/Simulation/InverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/InverseKinematicsSolver.cpp
@@ -212,6 +212,10 @@ SimTK::Vec3 InverseKinematicsSolver::computeCurrentMarkerLocation(const std::str
 {
     const Array_<std::string> &names = _markersReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), markerName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::computeCurrentMarkerLocation: "
+                        "invalid or unused marker name " +
+                        markerName + ".");
     int index = (int)std::distance(names.begin(), p);
     return computeCurrentMarkerLocation(index);
 }
@@ -239,6 +243,9 @@ double InverseKinematicsSolver::computeCurrentMarkerError(const std::string &mar
 {
     const Array_<std::string>& names = _markersReference->getNames();
     SimTK::Array_<const std::string>::iterator p = std::find(names.begin(), names.end(), markerName);
+    if (p == names.end())
+        throw Exception("InverseKinematicsSolver::computeCurrentMarkerError: "
+                        "invalid or unused marker name "+markerName+".");
     int index = (int)std::distance(names.begin(), p);
     return computeCurrentMarkerError(index);
 }

--- a/OpenSim/Simulation/InverseKinematicsSolver.h
+++ b/OpenSim/Simulation/InverseKinematicsSolver.h
@@ -140,9 +140,6 @@ public:
     /** Change the weighting of a marker, given the marker's name. Takes effect
         when assemble() or track() is called next. */
     void updateMarkerWeight(const std::string &markerName, double value);
-    /** Change the weighting of a marker, given the marker's index. Takes effect
-        when assemble() or track() is called next. */
-    void updateMarkerWeight(int markerIndex, double value);
     /** Change the weighting of all markers. Takes effect when assemble() or
         track() is called next. Marker weights are specified in the same order
         as they appear in the MarkersReference that was passed in when the
@@ -152,9 +149,6 @@ public:
     /** Change the weighting of an orientation sensor, given its name. Takes
     effect when assemble() or track() is called next. */
     void updateOrientationWeight(const std::string& orientationName, double value);
-    /** Change the weighting of an orientation sensor, given its index. Takes
-    effect when assemble() or track() is called next. */
-    void updateOrientationWeight(int orientationIndex, double value);
     /** Change the weighting of all orientation sensors. Takes effect when
     assemble() or track() is called next. Orientation weights are specified
     in the same order as they appear in the OrientationsReference that was
@@ -164,9 +158,6 @@ public:
     /** Compute and return a marker's spatial location in the ground frame,
         given the marker's name. */
     SimTK::Vec3 computeCurrentMarkerLocation(const std::string &markerName);
-    /** Compute and return a marker's spatial location in the ground frame,
-        given the marker's index. */
-    SimTK::Vec3 computeCurrentMarkerLocation(int markerIndex);
     /** Compute and return the spatial locations of all markers, expressed in
         the ground frame. */
     void computeCurrentMarkerLocations(SimTK::Array_<SimTK::Vec3> &markerLocations);
@@ -174,9 +165,6 @@ public:
     /** Compute and return the distance error between a model marker and its
         observation, given the marker's name. */
     double computeCurrentMarkerError(const std::string &markerName);
-    /** Compute and return the distance error between a model marker and its
-        observation, given the marker's index. */
-    double computeCurrentMarkerError(int markerIndex);
     /** Compute and return the distance errors between all model markers and
         their observations. */
     void computeCurrentMarkerErrors(SimTK::Array_<double> &markerErrors);
@@ -185,10 +173,7 @@ public:
         its observation, given the marker's name. This method is cheaper than
         squaring the value returned by computeCurrentMarkerError(). */
     double computeCurrentSquaredMarkerError(const std::string &markerName);
-    /** Compute and return the squared-distance error between a model marker and
-        its observation, given the marker's index. This method is cheaper than
-        squaring the value returned by computeCurrentMarkerError(). */
-    double computeCurrentSquaredMarkerError(int markerIndex);
+
     /** Compute and return the squared-distance errors between all model markers
         and their observations. This method is cheaper than squaring the values
         returned by computeCurrentMarkerErrors(). */
@@ -203,9 +188,7 @@ public:
     /** Compute and return an orientation sensor's spatial orientation in the
     ground frame, given the o-sensor's name. */
     SimTK::Rotation computeCurrentSensorOrientation(const std::string& osensorName);
-    /** Compute and return an orientation sensor's spatial orientation in the
-    ground frame, given the o-sensor's index. */
-    SimTK::Rotation computeCurrentSensorOrientation(int osensorIndex);
+
     /** Compute and return the spatial orientations of all o-sensors, expressed in
     the ground frame. */
     void computeCurrentSensorOrientations(
@@ -214,9 +197,6 @@ public:
     /** Compute and return the orientation error between the model orientation
     sensor and its observation, given the o-sensor's name. */
     double computeCurrentOrientationError(const std::string& osensorName);
-    /** Compute and return the orientation error between the model orientation
-    sensor and its observation, given the o-sensor's index. */
-    double computeCurrentOrientationError(int osensorIndex);
     /** Compute all the orientation errors between the model orientation
     sensors and their observations. */
     void computeCurrentOrientationErrors(SimTK::Array_<double>& osensorErrors);
@@ -247,6 +227,35 @@ private:
     /** Define and apply Orientations of Frames to be tracked to the
         assembly problem. */
     void setupOrientationsGoal(SimTK::State &s);
+
+    /** Compute and return a marker's spatial location in the ground frame,
+    given the marker's index. */
+    SimTK::Vec3 computeCurrentMarkerLocation(int markerIndex);
+
+    /** Compute and return the distance error between a model marker and its
+        observation, given the marker's index. */
+    double computeCurrentMarkerError(int markerIndex);
+
+    /** Compute and return the squared-distance error between a model marker and
+        its observation, given the marker's index. This method is cheaper than
+        squaring the value returned by computeCurrentMarkerError(). */
+    double computeCurrentSquaredMarkerError(int markerIndex);
+
+    /** Change the weighting of a marker, given the marker's index. Takes effect
+    when assemble() or track() is called next. */
+    void updateMarkerWeight(int markerIndex, double value);
+
+    /** Compute and return an orientation sensor's spatial orientation in the
+    ground frame, given the o-sensor's index. */
+    SimTK::Rotation computeCurrentSensorOrientation(int osensorIndex);
+
+    /** Compute and return the orientation error between the model orientation
+    sensor and its observation, given the o-sensor's index. */
+    double computeCurrentOrientationError(int osensorIndex);
+
+    /** Change the weighting of an orientation sensor, given its index. Takes
+    effect when assemble() or track() is called next. */
+    void updateOrientationWeight(int orientationIndex, double value);
 
     // The marker reference values and weightings
     std::shared_ptr<MarkersReference> _markersReference;

--- a/OpenSim/Simulation/Model/Appearance.h
+++ b/OpenSim/Simulation/Model/Appearance.h
@@ -70,6 +70,7 @@ public:
     SurfaceProperties() {
         // Surface shaded by default
         constructProperty_representation(VisualRepresentation::DrawSurface);
+        constructProperty_texture();
     }
     virtual ~SurfaceProperties() {};
 

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -693,12 +693,6 @@ void testNumberOfMarkersMismatch()
                 ikSolver.computeCurrentMarkerLocation("junk"), Exception);
         SimTK_TEST_MUST_THROW_EXC(
                 ikSolver.updateMarkerWeight("junk", 0.1), Exception);
-        SimTK_TEST_MUST_THROW_EXC(
-                ikSolver.computeCurrentOrientationError("junk"), Exception);
-        SimTK_TEST_MUST_THROW_EXC(
-                ikSolver.computeCurrentSensorOrientation("junk"), Exception);
-        SimTK_TEST_MUST_THROW_EXC(
-                ikSolver.updateOrientationWeight("junk", 0.1), Exception);
         cout << endl;
     }
 }
@@ -818,6 +812,12 @@ void testNumberOfOrientationsMismatch()
         }
         cout << endl;
     }
+    SimTK_TEST_MUST_THROW_EXC(
+            ikSolver.computeCurrentOrientationError("junk"), Exception);
+    SimTK_TEST_MUST_THROW_EXC(
+            ikSolver.computeCurrentSensorOrientation("junk"), Exception);
+    SimTK_TEST_MUST_THROW_EXC(
+            ikSolver.updateOrientationWeight("junk", 0.1), Exception);
 }
 
 Model* constructPendulumWithMarkers()

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -685,6 +685,12 @@ void testNumberOfMarkersMismatch()
                     "InverseKinematicsSolver mangled marker order.");
             }
         }
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentMarkerError("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentMarkerLocation("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentMarkerError(1000), Exception);
         cout << endl;
     }
 }

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -688,7 +688,17 @@ void testNumberOfMarkersMismatch()
         SimTK_TEST_MUST_THROW_EXC(
                 ikSolver.computeCurrentMarkerError("junk"), Exception);
         SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentSquaredMarkerError("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
                 ikSolver.computeCurrentMarkerLocation("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.updateMarkerWeight("junk", 0.1), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentOrientationError("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.computeCurrentSensorOrientation("junk"), Exception);
+        SimTK_TEST_MUST_THROW_EXC(
+                ikSolver.updateOrientationWeight("junk", 0.1), Exception);
         cout << endl;
     }
 }

--- a/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
+++ b/OpenSim/Simulation/Test/testInverseKinematicsSolver.cpp
@@ -689,8 +689,6 @@ void testNumberOfMarkersMismatch()
                 ikSolver.computeCurrentMarkerError("junk"), Exception);
         SimTK_TEST_MUST_THROW_EXC(
                 ikSolver.computeCurrentMarkerLocation("junk"), Exception);
-        SimTK_TEST_MUST_THROW_EXC(
-                ikSolver.computeCurrentMarkerError(1000), Exception);
         cout << endl;
     }
 }


### PR DESCRIPTION
Fixes issue #3951

### Brief summary of changes

This was mainly an issue with trying to call methods on markers that are not in the intersection of model markers and those in the trc file. Code innocently assumed names passed in to be valid. Now throw exceptions and test case beefed up accordingly.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3970)
<!-- Reviewable:end -->
