### PR TITLE
Use `std::make_unique` in wrapper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ v4.6
   The original behavior (no trimming) can be enabled via the new property `trim_to_original_time_range`. (#3969)
 - Make `InverseKinematicsSolver` methods to query for specific marker or orientation-sensor errors more robust to invalid names or names not 
   in the intersection of names in the model and names in the provided referece/data. Remove methods that are index based from public interface.(#3951) 
+- Replace usages of `OpenSim::make_unique` with `std::make_unique` and remove wrapper function now that C++14 is used in OpenSim (#3979). 
 
 
 

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.cpp
@@ -944,7 +944,7 @@ void DeGrooteFregly2016Muscle::replaceMuscles(
 
         // Pre-emptively create a default DeGrooteFregly2016Muscle
         // (TODO: not ideal to do this).
-        auto actu = OpenSim::make_unique<DeGrooteFregly2016Muscle>();
+        auto actu = std::make_unique<DeGrooteFregly2016Muscle>();
 
         // Perform muscle-model-specific mappings or throw exception if the
         // muscle is not supported.

--- a/OpenSim/Actuators/ModelFactory.cpp
+++ b/OpenSim/Actuators/ModelFactory.cpp
@@ -165,7 +165,7 @@ void ModelFactory::replaceMusclesWithPathActuators(OpenSim::Model &model) {
     auto& muscleSet = model.updMuscles();
     for (int im = 0; im < muscleSet.getSize(); ++im) {
         auto& musc = muscleSet.get(im);
-        auto actu = OpenSim::make_unique<PathActuator>();
+        auto actu = std::make_unique<PathActuator>();
         actu->setName(musc.getName());
         musc.setName(musc.getName() + "_delete");
         actu->set_appliesForce(musc.get_appliesForce());

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -1029,7 +1029,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
             lengthFunction.setDimension(numCoordinatesThisForce);
             lengthFunction.setOrder(order);
             lengthFunction.setCoefficients(coefficients);
-            auto functionBasedPath = make_unique<FunctionBasedPath>();
+            auto functionBasedPath = std::make_unique<FunctionBasedPath>();
             functionBasedPath->setName(forcePath);
             functionBasedPath->setCoordinatePaths(coordinatePathsThisForce);
             functionBasedPath->setLengthFunction(lengthFunction);

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -36,12 +36,12 @@
 
 namespace OpenSim {
 
-/// Since OpenSim does not require C++14 (which contains std::make_unique()),
-/// here is an implementation of make_unique().
+/// OpenSim now requires C++14 (which contains std::make_unique()),
+/// this wrapper now uses the standard std::make_unique().
 /// @ingroup commonutil
 template <typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    return std::make_unique<T>(std::forward<Args>(args)...);
 }
 
 /// Get a string with the current date and time formatted as %Y-%m-%dT%H%M%S

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -36,14 +36,6 @@
 
 namespace OpenSim {
 
-/// OpenSim now requires C++14 (which contains std::make_unique()),
-/// this wrapper now uses the standard std::make_unique().
-/// @ingroup commonutil
-template <typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-    return std::make_unique<T>(std::forward<Args>(args)...);
-}
-
 /// Get a string with the current date and time formatted as %Y-%m-%dT%H%M%S
 /// (year, month, day, "T", hour, minute, second). You can change the datetime
 /// format via the `format` parameter.

--- a/OpenSim/Common/TableUtilities.cpp
+++ b/OpenSim/Common/TableUtilities.cpp
@@ -187,7 +187,7 @@ void TableUtilities::pad(
 namespace {
 template <typename FunctionType>
 std::unique_ptr<FunctionSet> createFunctionSet(const TimeSeriesTable& table) {
-    auto set = make_unique<FunctionSet>();
+    auto set = std::make_unique<FunctionSet>();
     const auto& time = table.getIndependentColumn();
     const auto numRows = (int)table.getNumRows();
     for (int icol = 0; icol < (int)table.getNumColumns(); ++icol) {
@@ -202,7 +202,7 @@ template <>
 inline std::unique_ptr<FunctionSet> createFunctionSet<GCVSpline>(
         const TimeSeriesTable& table) {
     const auto& time = table.getIndependentColumn();
-    return OpenSim::make_unique<GCVSplineSet>(table, std::vector<std::string>{},
+    return std::make_unique<GCVSplineSet>(table, std::vector<std::string>{},
             std::min((int)time.size() - 1, 5));
 }
 } // namespace

--- a/OpenSim/Examples/Moco/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
+++ b/OpenSim/Examples/Moco/exampleCustomImplicitAuxiliaryDynamics/exampleCustomImplicitAuxiliaryDynamics.cpp
@@ -161,7 +161,7 @@ int main() {
         {
             MocoStudy study;
             auto& problem = study.updProblem();
-            auto model = OpenSim::make_unique<Model>();
+            auto model = std::make_unique<Model>();
             model->addComponent(new MyImplicitAuxiliaryDynamics("implicit"));
             problem.setModel(std::move(model));
             problem.setTimeBounds(0, 1.0);

--- a/OpenSim/Examples/Moco/exampleMarkerTracking/exampleMarkerTracking.cpp
+++ b/OpenSim/Examples/Moco/exampleMarkerTracking/exampleMarkerTracking.cpp
@@ -29,7 +29,7 @@ using namespace OpenSim;
 /// This model is torque-actuated.
 std::unique_ptr<Model> createDoublePendulumModel() {
     // This function is similar to ModelFactory::createNLinkPendulum().
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("double_pendulum");
 
     using SimTK::Vec3;

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/exampleMocoCustomEffortGoal.cpp
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/exampleMocoCustomEffortGoal.cpp
@@ -53,7 +53,7 @@ using namespace OpenSim;
 /// @endverbatim
 
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 2.0, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
@@ -41,7 +41,7 @@
 using namespace OpenSim;
 
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 2.0, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Examples/Moco/exampleSlidingMassAdvanced/exampleSlidingMassAdvanced.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMassAdvanced/exampleSlidingMassAdvanced.cpp
@@ -42,7 +42,7 @@
 using namespace OpenSim;
 
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 2.0, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Examples/Moco/exampleTracking/exampleTracking.cpp
+++ b/OpenSim/Examples/Moco/exampleTracking/exampleTracking.cpp
@@ -29,7 +29,7 @@ using namespace OpenSim;
 std::unique_ptr<Model> createDoublePendulumModel() {
     // This function is similar to ModelFactory::createNLinkPendulum().
 
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("double_pendulum");
 
     using SimTK::Vec3;

--- a/OpenSim/Examples/Moco/exampleVariableScaling/exampleVariableScaling.cpp
+++ b/OpenSim/Examples/Moco/exampleVariableScaling/exampleVariableScaling.cpp
@@ -33,7 +33,7 @@
 using namespace OpenSim;
 
 std::unique_ptr<Model> createRocketModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(9.81, 0, 0));
     auto* body = new Body("body", 500000.0, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Moco/Components/ControlDistributor.cpp
+++ b/OpenSim/Moco/Components/ControlDistributor.cpp
@@ -98,7 +98,7 @@ ControlDistributor::addControlDistributorAndConnectInputControllers(
                 "present in the model, but found '{}'.",
                 controlDistributor.getAbsolutePathString());
     }
-    auto controlDistributorUPtr = make_unique<ControlDistributor>();
+    auto controlDistributorUPtr = std::make_unique<ControlDistributor>();
     controlDistributorUPtr->setName("control_distributor");
 
     const auto& output = controlDistributorUPtr->getOutput("controls");

--- a/OpenSim/Moco/Components/ControlDistributor.h
+++ b/OpenSim/Moco/Components/ControlDistributor.h
@@ -41,7 +41,7 @@ namespace OpenSim {
  *
  * Constructing a ControlDistributor and adding controls:
  * @code
- * auto controlDistributor = make_unique<ControlDistributor>();
+ * auto controlDistributor = std::make_unique<ControlDistributor>();
  * controlDistributor->addControl("/forceset/soleus_r");
  * controlDistributor->addControl("/my_input_controller_value");
  * controlDistributor->addControl("/my_custom_component_input");

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.h
@@ -260,11 +260,11 @@ protected:
                 OpenSim::Exception, "numIntegrals must be 0 or 1.");
         std::unique_ptr<CostIntegrand> integrand_function;
         if (numIntegrals) {
-            integrand_function = OpenSim::make_unique<CostIntegrand>();
+            integrand_function = std::make_unique<CostIntegrand>();
         }
         m_costInfos.emplace_back(std::move(name), numOutputs,
                 std::move(integrand_function),
-                OpenSim::make_unique<Cost>());
+                std::make_unique<Cost>());
     }
     /// Add an endpoint constraint to the problem.
     void addEndpointConstraint(
@@ -274,7 +274,7 @@ protected:
         std::unique_ptr<EndpointConstraintIntegrand> integrand_function;
         if (numIntegrals) {
             integrand_function =
-                    OpenSim::make_unique<EndpointConstraintIntegrand>();
+                    std::make_unique<EndpointConstraintIntegrand>();
         }
         casadi::DM lower(bounds.size(), 1);
         casadi::DM upper(bounds.size(), 1);
@@ -284,7 +284,7 @@ protected:
         }
         m_endpointConstraintInfos.emplace_back(std::move(name),
                 (int)bounds.size(), std::move(integrand_function),
-                OpenSim::make_unique<EndpointConstraint>(), std::move(lower),
+                std::make_unique<EndpointConstraint>(), std::move(lower),
                 std::move(upper));
     }
     /// The size of bounds must match the number of outputs in the function.
@@ -296,7 +296,7 @@ protected:
             upper(ibound, 0) = bounds[ibound].upper;
         }
         m_pathInfos.push_back({std::move(name), std::move(lower),
-                std::move(upper), OpenSim::make_unique<PathConstraint>()});
+                std::move(upper), std::make_unique<PathConstraint>()});
     }
     void setDynamicsMode(std::string dynamicsMode) {
         OPENSIM_THROW_IF(
@@ -463,7 +463,7 @@ public:
             // Construct a full implicit multibody system (i.e. including
             // kinematic constraints).
             mutThis->m_implicitMultibodyFunc =
-                    OpenSim::make_unique<MultibodySystemImplicit<true>>();
+                    std::make_unique<MultibodySystemImplicit<true>>();
             mutThis->m_implicitMultibodyFunc->constructFunction(this,
                     "implicit_multibody_system", finiteDiffScheme,
                     pointsForSparsityDetection);
@@ -471,20 +471,20 @@ public:
             // Construct an implicit multibody system ignoring kinematic
             // constraints.
             mutThis->m_implicitMultibodyFuncIgnoringConstraints =
-                    OpenSim::make_unique<MultibodySystemImplicit<false>>();
+                    std::make_unique<MultibodySystemImplicit<false>>();
             mutThis->m_implicitMultibodyFuncIgnoringConstraints
                     ->constructFunction(this,
                             "implicit_multibody_system_ignoring_constraints",
                             finiteDiffScheme, pointsForSparsityDetection);
         } else {
             mutThis->m_multibodyFunc =
-                    OpenSim::make_unique<MultibodySystemExplicit<true>>();
+                    std::make_unique<MultibodySystemExplicit<true>>();
             mutThis->m_multibodyFunc->constructFunction(this,
                     "explicit_multibody_system", finiteDiffScheme,
                     pointsForSparsityDetection);
 
             mutThis->m_multibodyFuncIgnoringConstraints =
-                    OpenSim::make_unique<MultibodySystemExplicit<false>>();
+                    std::make_unique<MultibodySystemExplicit<false>>();
             mutThis->m_multibodyFuncIgnoringConstraints->constructFunction(this,
                     "multibody_system_ignoring_constraints", finiteDiffScheme,
                     pointsForSparsityDetection);
@@ -494,13 +494,13 @@ public:
                 getNumKinematicConstraintEquations()) {
             if (isKinematicConstraintMethodBordalba2023()) {
                 mutThis->m_stateProjectionFunc =
-                    OpenSim::make_unique<StateProjection>();
+                    std::make_unique<StateProjection>();
                 mutThis->m_stateProjectionFunc->constructFunction(this,
                     "state_projection", finiteDiffScheme,
                     pointsForSparsityDetection);
             } else {
                 mutThis->m_velocityCorrectionFunc =
-                    OpenSim::make_unique<VelocityCorrection>();
+                    std::make_unique<VelocityCorrection>();
                 mutThis->m_velocityCorrectionFunc->constructFunction(this,
                     "velocity_correction", finiteDiffScheme,
                     pointsForSparsityDetection);

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCSolver.cpp
@@ -31,53 +31,53 @@ namespace CasOC {
 std::unique_ptr<Transcription> Solver::createTranscription() const {
     std::unique_ptr<Transcription> transcription;
     if (m_transcriptionScheme == "trapezoidal") {
-        transcription = OpenSim::make_unique<Trapezoidal>(*this, m_problem);
+        transcription = std::make_unique<Trapezoidal>(*this, m_problem);
     } else if (m_transcriptionScheme == "hermite-simpson") {
-        transcription = OpenSim::make_unique<HermiteSimpson>(*this, m_problem);
+        transcription = std::make_unique<HermiteSimpson>(*this, m_problem);
     } else if (m_transcriptionScheme == "legendre-gauss-1") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 1);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 1);
     } else if (m_transcriptionScheme == "legendre-gauss-2") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 2);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 2);
     } else if (m_transcriptionScheme == "legendre-gauss-3") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 3);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 3);
     } else if (m_transcriptionScheme == "legendre-gauss-4") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 4);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 4);
     } else if (m_transcriptionScheme == "legendre-gauss-5") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 5);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 5);
     } else if (m_transcriptionScheme == "legendre-gauss-6") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 6);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 6);
     } else if (m_transcriptionScheme == "legendre-gauss-7") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 7);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 7);
     } else if (m_transcriptionScheme == "legendre-gauss-8") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 8);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 8);
     } else if (m_transcriptionScheme == "legendre-gauss-9") {
-        transcription = OpenSim::make_unique<LegendreGauss>(*this, m_problem, 9);
+        transcription = std::make_unique<LegendreGauss>(*this, m_problem, 9);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-1") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 1);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-2") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 2);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-3") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 3);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-4") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 4);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-5") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 5);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-6") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 6);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-7") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 7);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-8") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 8);
     } else if (m_transcriptionScheme == "legendre-gauss-radau-9") {
-        transcription = OpenSim::make_unique<LegendreGaussRadau>(
+        transcription = std::make_unique<LegendreGaussRadau>(
                 *this, m_problem, 9);
     } else {
         OPENSIM_THROW(Exception, "Unknown transcription scheme '{}'.",
@@ -132,7 +132,7 @@ Solution Solver::solve(const Iterate& guess) const {
         pointsForSparsityDetection->push_back(guessCopy.variables);
     } else if (m_sparsity_detection == "random") {
         // Make sure the exact same sparsity pattern is used every time.
-        auto randGen = OpenSim::make_unique<SimTK::Random::Uniform>(-1, 1);
+        auto randGen = std::make_unique<SimTK::Random::Uniform>(-1, 1);
         randGen->setSeed(0);
         for (int i = 0; i < m_sparsity_detection_random_count; ++i) {
             pointsForSparsityDetection->push_back(

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -194,7 +194,7 @@ std::unique_ptr<MocoCasOCProblem> MocoCasADiSolver::createCasOCProblem() const {
             "but received '{}'.", get_transcription_scheme());
     }
 
-    return OpenSim::make_unique<MocoCasOCProblem>(*this, problemRep,
+    return std::make_unique<MocoCasOCProblem>(*this, problemRep,
             createProblemRepJar(numThreads), get_multibody_dynamics_mode(),
             get_kinematic_constraint_method());
 #else
@@ -205,7 +205,7 @@ std::unique_ptr<MocoCasOCProblem> MocoCasADiSolver::createCasOCProblem() const {
 std::unique_ptr<CasOC::Solver> MocoCasADiSolver::createCasOCSolver(
         const MocoCasOCProblem& casProblem) const {
 #ifdef OPENSIM_WITH_CASADI
-    auto casSolver = OpenSim::make_unique<CasOC::Solver>(casProblem);
+    auto casSolver = std::make_unique<CasOC::Solver>(casProblem);
 
     // Set solver options.
     // -------------------

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
@@ -281,7 +281,7 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
         addPathConstraint(name, casBounds);
     }
 
-    m_fileDeletionThrower = OpenSim::make_unique<FileDeletionThrower>(
+    m_fileDeletionThrower = std::make_unique<FileDeletionThrower>(
             fmt::format("delete_this_to_stop_optimization_{}_{}.txt",
                     problemRep.getName(), m_formattedTimeString));
 }

--- a/OpenSim/Moco/MocoGoal/MocoContactImpulseTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoContactImpulseTrackingGoal.cpp
@@ -116,7 +116,7 @@ void MocoContactImpulseTrackingGoal::initializeOnModelImpl(const Model& model) c
         extLoads = &get_external_loads();
     }
     else if (!get_external_loads_file().empty()) {
-        extLoadsFromFile = OpenSim::make_unique<ExternalLoads>(
+        extLoadsFromFile = std::make_unique<ExternalLoads>(
             get_external_loads_file(), true);
         extLoads = extLoadsFromFile.get();
     }

--- a/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoContactTrackingGoal.cpp
@@ -123,7 +123,7 @@ void MocoContactTrackingGoal::initializeOnModelImpl(const Model& model) const {
                 "were provided.");
         extLoads = &get_external_loads();
     } else if (!get_external_loads_file().empty()) {
-        extLoadsFromFile = OpenSim::make_unique<ExternalLoads>(
+        extLoadsFromFile = std::make_unique<ExternalLoads>(
                 get_external_loads_file(), true);
         extLoads = extLoadsFromFile.get();
     } else {

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -153,7 +153,7 @@ void MocoProblemRep::initialize() {
     // order (we verified this with checkOrderSystemControls() above). 
     // Therefore, this is valid whether or not solvers need to compute the 
     // controls from the model.
-    auto actuatorController = make_unique<ActuatorInputController>();
+    auto actuatorController = std::make_unique<ActuatorInputController>();
     actuatorController->setName("actuator_controller");
     for (const auto& actu : m_model_base.getComponentList<Actuator>()) {
         if (!controlledActuatorPaths.count(actu.getAbsolutePathString()) &&
@@ -267,7 +267,7 @@ void MocoProblemRep::initialize() {
     // The constraint forces will be applied to the copied model via an
     // OpenSim::DiscreteForces component, a thin wrapper to Simbody's
     // DiscreteForces class, which adds discrete variables to the state.
-    auto constraintForcesUPtr = make_unique<DiscreteForces>();
+    auto constraintForcesUPtr = std::make_unique<DiscreteForces>();
     constraintForcesUPtr->setName("constraint_forces");
     m_constraint_forces.reset(constraintForcesUPtr.get());
     m_model_disabled_constraints.addComponent(constraintForcesUPtr.release());
@@ -285,7 +285,7 @@ void MocoProblemRep::initialize() {
         // forces can be computed correctly from the solver-supplied UDot
         // (otherwise, Simbody will compute its own "incorrect" UDot using
         // forward dynamics).
-        auto accelMotionUPtr = make_unique<AccelerationMotion>("motion");
+        auto accelMotionUPtr = std::make_unique<AccelerationMotion>("motion");
         m_acceleration_motion.reset(accelMotionUPtr.get());
         m_model_disabled_constraints.addModelComponent(
                 accelMotionUPtr.release());

--- a/OpenSim/Moco/MocoSolver.cpp
+++ b/OpenSim/Moco/MocoSolver.cpp
@@ -109,7 +109,7 @@ void MocoSolver::setSolutionStats(MocoSolution& sol, bool success,
 
 std::unique_ptr<ThreadsafeJar<const MocoProblemRep>>
         MocoSolver::createProblemRepJar(int size) const {
-    auto jar = OpenSim::make_unique<ThreadsafeJar<const MocoProblemRep>>();
+    auto jar = std::make_unique<ThreadsafeJar<const MocoProblemRep>>();
     for (int i = 0; i < size; ++i) {
         jar->leave(std::unique_ptr<MocoProblemRep>(m_problem->createRepHeap()));
     }

--- a/OpenSim/Moco/MocoTropterSolver.cpp
+++ b/OpenSim/Moco/MocoTropterSolver.cpp
@@ -145,7 +145,7 @@ MocoTropterSolver::createTropterSolver(
     std::unique_ptr<tropter::DirectCollocationSolver<double>> dircol;
 
     if (getProperty_mesh().empty()) {
-        dircol = OpenSim::make_unique<tropter::DirectCollocationSolver<double>>(
+        dircol = std::make_unique<tropter::DirectCollocationSolver<double>>(
                 ocp, get_transcription_scheme(), get_optim_solver(),
                 get_num_mesh_intervals());
     } else {
@@ -153,7 +153,7 @@ MocoTropterSolver::createTropterSolver(
         for (int i = 0; i < getProperty_mesh().size(); ++i) {
             mesh.push_back(get_mesh(i));
         }
-        dircol = OpenSim::make_unique<tropter::DirectCollocationSolver<double>>(
+        dircol = std::make_unique<tropter::DirectCollocationSolver<double>>(
                 ocp, get_transcription_scheme(), get_optim_solver(), mesh);
     }
 

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -46,14 +46,14 @@ template <typename FunctionType>
 std::unique_ptr<Function> createFunction(
         const SimTK::Vector& x, const SimTK::Vector& y) {
     OPENSIM_THROW_IF(x.size() != y.size(), Exception, "x.size() != y.size()");
-    return OpenSim::make_unique<FunctionType>(
+    return std::make_unique<FunctionType>(
             x.size(), x.getContiguousScalarData(), y.getContiguousScalarData());
 }
 template <>
 std::unique_ptr<Function> createFunction<GCVSpline>(
         const SimTK::Vector& x, const SimTK::Vector& y) {
     OPENSIM_THROW_IF(x.size() != y.size(), Exception, "x.size() != y.size()");
-    return OpenSim::make_unique<GCVSpline>(5, x.size(),
+    return std::make_unique<GCVSpline>(5, x.size(),
             x.getContiguousScalarData(), y.getContiguousScalarData());
 }
 } // anonymous namespace

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -55,7 +55,7 @@ static const double ConstraintTol = 1e-10;
 
 /// creates a model with one sliding mass
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 10.0, SimTK::Vec3(0), SimTK::Inertia(0));
@@ -439,7 +439,7 @@ TEST_CASE("PrescribedMotion", "") {
 /// Create a torque-actuated double pendulum model. Each subtest will add to the
 /// model the relevant constraint(s).
 std::unique_ptr<Model> createDoublePendulumModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("double_pendulum");
 
     using SimTK::Inertia;

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -2160,7 +2160,7 @@ MocoStudy createSlidingMassMocoStudy(const Model& model,
     MocoStudy study;
     study.setName("sliding_mass");
     MocoProblem& mp = study.updProblem();
-    mp.setModel(make_unique<Model>(model));
+    mp.setModel(std::make_unique<Model>(model));
     mp.setTimeBounds(0, {0, 10});
     mp.setStateInfo("/slider/position/value",{0, 1}, 0, 1);
     mp.setStateInfo("/slider/position/speed", {-100, 100});

--- a/OpenSim/Moco/Test/testMocoContact.cpp
+++ b/OpenSim/Moco/Test/testMocoContact.cpp
@@ -583,7 +583,7 @@ TEST_CASE("MocoContactTrackingGoal", "[casadi]") {
         auto* contactTracking = problem.addGoal<MocoContactTrackingGoal>();
         ExternalLoads extLoads;
         extLoads.setDataFileName(dataFileName);
-        auto extForce = make_unique<ExternalForce>();
+        auto extForce = std::make_unique<ExternalForce>();
         extForce->setName("right");
         extForce->set_applied_to_body("ball");
         extForce->set_force_identifier("ground_force_r_v");

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -36,7 +36,7 @@ using namespace OpenSim;
 
 /// creates a model with one sliding mass
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 10.0, SimTK::Vec3(0), SimTK::Inertia(0));
@@ -1507,7 +1507,7 @@ const double STIFFNESS = 100.0; // N/m
 const double MASS = 5.0; // kg
 const double FINAL_TIME = SimTK::Pi * sqrt(MASS / STIFFNESS);
 std::unique_ptr<Model> createOscillatorTwoSpringsModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("oscillator_two_springs");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", MASS, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -432,7 +432,7 @@ TEST_CASE("Implicit auxiliary dynamics") {
     SECTION("Direct collocation implicit") {
        MocoStudy study;
        auto& problem = study.updProblem();
-       auto model = OpenSim::make_unique<Model>();
+       auto model = std::make_unique<Model>();
        model->addComponent(new MyAuxiliaryImplicitDynamics());
        problem.setModel(std::move(model));
        problem.setTimeBounds(0, 1);
@@ -448,7 +448,7 @@ TEST_CASE("Implicit auxiliary dynamics") {
     SECTION("MocoTropterSolver does not support implicit auxiliary dynamics") {
         MocoStudy study;
         auto& problem = study.updProblem();
-        auto model = OpenSim::make_unique<Model>();
+        auto model = std::make_unique<Model>();
         model->addComponent(new MyAuxiliaryImplicitDynamics());
         problem.setModel(std::move(model));
         problem.setTimeBounds(0, 1);

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -46,7 +46,7 @@ using namespace OpenSim;
 namespace {
     std::unique_ptr<Model> createSlidingMassModel(
             double mass = 10.0, bool lock_coordinate = false) {
-        auto model = make_unique<Model>();
+        auto model = std::make_unique<Model>();
         model->setName("sliding_mass");
         model->set_gravity(SimTK::Vec3(0, 0, 0));
         auto* body = new Body("body", mass, SimTK::Vec3(0), SimTK::Inertia(0));
@@ -186,7 +186,7 @@ TEMPLATE_TEST_CASE("Non-uniform mesh", "", MocoCasADiSolver, MocoTropterSolver) 
 
 /// This model is torque-actuated.
 std::unique_ptr<Model> createPendulumModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("pendulum");
 
     using SimTK::Inertia;
@@ -377,7 +377,7 @@ TEST_CASE("Building a problem", "") {
 
         // Goals have the name "goal" by default.
         {
-            auto c0 = make_unique<MocoFinalTimeGoal>();
+            auto c0 = std::make_unique<MocoFinalTimeGoal>();
             SimTK_TEST(c0->getName() == "goal");
             mp.addGoal(std::move(c0));
         }
@@ -395,7 +395,7 @@ TEST_CASE("Building a problem", "") {
         }
         // Parameters have the name "parameter" by default.
         {
-            auto p0 = make_unique<MocoParameter>();
+            auto p0 = std::make_unique<MocoParameter>();
             SimTK_TEST(p0->getName() == "parameter");
             p0->appendComponentPath("/body");
             p0->setPropertyName("mass");
@@ -414,7 +414,7 @@ TEST_CASE("Building a problem", "") {
         }
         // Parameters must have a name.
         {
-            auto pEmptyName = make_unique<MocoParameter>();
+            auto pEmptyName = std::make_unique<MocoParameter>();
             pEmptyName->setName("");
             mp.addParameter(std::move(pEmptyName));
             SimTK_TEST_MUST_THROW_EXC(mp.createRep(), Exception);

--- a/OpenSim/Moco/Test/testMocoParameters.cpp
+++ b/OpenSim/Moco/Test/testMocoParameters.cpp
@@ -35,7 +35,7 @@ const double STIFFNESS = 100.0; // N/m
 const double MASS = 5.0; // kg
 const double FINAL_TIME = SimTK::Pi * sqrt(MASS / STIFFNESS);
 std::unique_ptr<Model> createOscillatorModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("oscillator");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     // We will optimize the mass of this body in the test below. Here, we'll set 
@@ -105,7 +105,7 @@ TEMPLATE_TEST_CASE("Oscillator mass", "", MocoCasADiSolver,
 }
 
 std::unique_ptr<Model> createOscillatorTwoSpringsModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("oscillator_two_springs");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", MASS, SimTK::Vec3(0), SimTK::Inertia(0));
@@ -174,7 +174,7 @@ TEMPLATE_TEST_CASE("One parameter two springs", "",
 const double L = 1; 
 const double xCOM = -0.25*L;
 std::unique_ptr<Model> createSeeSawModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("seesaw");
     model->set_gravity(SimTK::Vec3(0, -9.81, 0));
     // Set body with z-rotational inertia and COM at the geometric center.

--- a/OpenSim/Moco/tropter/TropterProblem.h
+++ b/OpenSim/Moco/tropter/TropterProblem.h
@@ -79,7 +79,7 @@ protected:
         addGenericPathConstraints();
 
         std::string formattedTimeString(getFormattedDateTime(true));
-        m_fileDeletionThrower = OpenSim::make_unique<FileDeletionThrower>(
+        m_fileDeletionThrower = std::make_unique<FileDeletionThrower>(
                 fmt::format("delete_this_to_stop_optimization_{}_{}.txt",
                         m_mocoProbRep.getName(), formattedTimeString));
     }

--- a/OpenSim/Sandbox/Moco/sandboxCasADi.cpp
+++ b/OpenSim/Sandbox/Moco/sandboxCasADi.cpp
@@ -307,7 +307,7 @@ private:
 };
 
 std::unique_ptr<Model> createSlidingMassModel() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("sliding_mass");
     model->set_gravity(SimTK::Vec3(0, 0, 0));
     auto* body = new Body("body", 10.0, SimTK::Vec3(0), SimTK::Inertia(0));

--- a/OpenSim/Sandbox/Moco/sandboxContact.cpp
+++ b/OpenSim/Sandbox/Moco/sandboxContact.cpp
@@ -104,7 +104,7 @@ Model createModel() {
 }
 
 std::unique_ptr<Model> createModel2D() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("point_mass");
     auto* intermed = new Body("intermed", 0, Vec3(0), SimTK::Inertia(0));
     model->addComponent(intermed);
@@ -224,7 +224,7 @@ void ball2d() {
 
 std::unique_ptr<Model> createModelPendulum(double linkLength, double jointHeight,
         double dissipation, double frictionCoeff) {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("pendulum");
     auto* body = new Body("body", 50.0, Vec3(0), SimTK::Inertia(1));
     model->addComponent(body);
@@ -304,7 +304,7 @@ void pendulum() {
 std::unique_ptr<Model> createModelPendulumActivationCoordinateActuator() {
     const double jointHeight = 0.6;
     const double linkLength = 1.0;
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("pendulum");
     auto* body = new Body("body", 50.0, Vec3(0), SimTK::Inertia(1));
     model->addComponent(body);
@@ -441,7 +441,7 @@ void addResidualCoordinateActuators(Model& model) {
 }
 
 std::unique_ptr<Model> createModelSLIP() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("SLIP");
     auto* foot = new Body("foot", 15.0, Vec3(0), SimTK::Inertia(1));
     model->addComponent(foot);
@@ -517,7 +517,7 @@ std::unique_ptr<Model> createModelSLIP() {
 }
 
 std::unique_ptr<Model>createModelSLIPActuated() {
-    auto model = make_unique<Model>();
+    auto model = std::make_unique<Model>();
     model->setName("SLIP");
     auto* foot = new Body("foot", 15.0, Vec3(0), SimTK::Inertia(1));
     model->addComponent(foot);

--- a/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/sandboxMarkerTrackingWholeBody.cpp
+++ b/OpenSim/Sandbox/Moco/sandboxMarkerTrackingWholeBody/sandboxMarkerTrackingWholeBody.cpp
@@ -221,7 +221,7 @@ MocoSolution solveMarkerTrackingProblem(
 
     // Model(dynamics).
     // -----------------
-    auto model = make_unique<Model>("subject01.osim");
+    auto model = std::make_unique<Model>("subject01.osim");
     addCoordinateActuator(model, "lumbar_extension", 500);
     addCoordinateActuator(model, "pelvis_tilt", 500);
     addCoordinateActuator(model, "pelvis_tx", 1000);

--- a/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/sandboxMocoUserControlCost.cpp
+++ b/OpenSim/Sandbox/Moco/sandboxMocoUserControlCost/sandboxMocoUserControlCost.cpp
@@ -66,7 +66,7 @@ int main() {
     // ----------------------------------
 
     // get the base model
-    auto model = make_unique<Model>("subject01.osim");
+    auto model = std::make_unique<Model>("subject01.osim");
 
     // add coordinate actuators
     addCoordinateActuator(model, "lumbar_extension", 500);

--- a/OpenSim/Simulation/Control/PrescribedController.cpp
+++ b/OpenSim/Simulation/Control/PrescribedController.cpp
@@ -270,12 +270,12 @@ std::unique_ptr<Function> PrescribedController::createFunctionFromData(
     }
 
     if(method > 0) {
-        return OpenSim::make_unique<GCVSpline>(method, time.getSize(), 
+        return std::make_unique<GCVSpline>(method, time.getSize(), 
                 &time[0], &data[0], name);
     }
 
     if(method == 0) {
-        return OpenSim::make_unique<PiecewiseConstantFunction>(
+        return std::make_unique<PiecewiseConstantFunction>(
                 time.getSize(), &time[0], &data[0], name);
     }
 


### PR DESCRIPTION
### Brief summary of changes

Now that OpenSim uses `c++14` use `std::make_unique` instead of the custom implementation

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3979)
<!-- Reviewable:end -->
