### PR TITLE
Model triangle inequality

### DIFF
--- a/Applications/opensense/test/calibrated_pelvis_rot.osim
+++ b/Applications/opensense/test/calibrated_pelvis_rot.osim
@@ -1167,7 +1167,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.045194398031267034 0.0089390420348554826 -0.017218832924826396</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--List of components that this component owns and serializes.-->
@@ -1923,7 +1923,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.043770381117720983 0.0087206439945598027 0.017499337630711414</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Applications/opensense/test/model_Rajagopal2015_posed.osim
+++ b/Applications/opensense/test/model_Rajagopal2015_posed.osim
@@ -1095,7 +1095,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.045194398031267034 0.0089390420348554826 -0.017218832924826396</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1797,7 +1797,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.043770381117720983 0.0087206439945598027 0.017499337630711414</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Applications/opensense/test/std_calibrated_pelvis_rot.osim
+++ b/Applications/opensense/test/std_calibrated_pelvis_rot.osim
@@ -1167,7 +1167,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.045194398031267034 0.0089390420348554826 -0.017218832924826396</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--List of components that this component owns and serializes.-->
@@ -1923,7 +1923,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.043770381117720983 0.0087206439945598027 0.017499337630711414</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.00010536482737565871 0.00021072965475131742 0.0010536482737565872 0 0 0</inertia>
+					<inertia>0.00010536482737565871 0.001159013101132246 0.0010536482737565872 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Bindings/Java/Matlab/OpenSenseExample/Rajagopal_2015.osim
+++ b/Bindings/Java/Matlab/OpenSenseExample/Rajagopal_2015.osim
@@ -1043,7 +1043,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="femur_l">
 					<!--The geometry used to display the axes of this Frame.-->
@@ -1708,7 +1708,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/Bindings/Java/Matlab/examples/Moco/exampleSquatToStand/squatToStand_3dof9musc.osim
+++ b/Bindings/Java/Matlab/examples/Moco/exampleSquatToStand/squatToStand_3dof9musc.osim
@@ -1146,7 +1146,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 				<Body name="torso">
 					<!--The geometry used to display the axes of this Frame.-->

--- a/OpenSim/Sandbox/Moco/sandboxOneLegCouplerKnee/Rajagopal2015_right_leg_9musc.osim
+++ b/OpenSim/Sandbox/Moco/sandboxOneLegCouplerKnee/Rajagopal2015_right_leg_9musc.osim
@@ -1045,7 +1045,7 @@
 					<!--The location (Vec3) of the mass center in the body frame.-->
 					<mass_center>0.034599999999999999 0.0060000000000000001 -0.017500000000000002</mass_center>
 					<!--The elements of the inertia tensor (Vec6) as [Ixx Iyy Izz Ixy Ixz Iyz] measured about the mass_center and not the body origin.-->
-					<inertia>0.0001 0.00020000000000000001 0.001 0 0 0</inertia>
+					<inertia>0.0001 0.00110000000000000001 0.001 0 0 0</inertia>
 				</Body>
 			</objects>
 			<groups />


### PR DESCRIPTION
Fixes issue #3941

### Brief summary of changes
Resolves [this issue](https://github.com/opensim-org/opensim-core/issues/3941#issuecomment-2504573351)
Related [PR in model repository](https://github.com/opensim-org/opensim-models/pull/183)

I created [this python script](https://github.com/gateway240/opensim-core-examples/blob/main/TriangleInequalityRepair/repair-triangle-inequality.py) which identifies in a `.osim` model which inertial constraints will fail the triangle inequality and calculates the minimum change in one element required to fix them.

### Testing I've completed

 I have tested with the models before and after and in my testing the models do not work prior to the repair and do work after.

### Looking for feedback on...

@aymanhab can you take a look at these?

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3980)
<!-- Reviewable:end -->
