### PR TITLE
Use swig4.2 or later

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 4.1.1 EXACT REQUIRED)
+    find_package(SWIG 4.1.1 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.

--- a/OpenSim/Common/DelimFileAdapter.h
+++ b/OpenSim/Common/DelimFileAdapter.h
@@ -307,6 +307,7 @@ DelimFileAdapter<T>::clone() const {
 template<typename T>
 typename DelimFileAdapter<T>::OutputTables
 DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
+#ifndef SWIG
     OPENSIM_THROW_IF(fileName.empty(),
                      EmptyFileName);
 
@@ -468,6 +469,7 @@ DelimFileAdapter<T>::extendRead(const std::string& fileName) const {
     output_tables.emplace(tableString(), table);
 
     return output_tables;
+#endif
 }
 
 template<typename T>

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -173,9 +173,9 @@ OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(
         std::vector<std::string> negateAndShiftPatterns = {
                                             ".*pelvis_list/value",
                                             ".*pelvis_tz/value",
-                                                   ".*lumbar_bending/value"},
+                                            ".*lumbar_bending/value"},
         std::vector<std::pair<std::string, std::string>> symmetryPatterns =
-                {{R"(_r(/|_|$))", "_l$1"}, {R"(_l(/|_|$))", "_r$1"}});
+                {{R"(_r(\/|_|$))", "_l$1"}, {R"(_l(\/|_|$))", "_r$1"}});
 #else 
 // Variant that doesn't take symmetryPatterns which are unusable from scripting
 OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -174,8 +174,10 @@ OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(
                                                    ".*pelvis_list/value",
                                                    ".*pelvis_tz/value",
                                                    ".*lumbar_bending/value"},
-        std::vector<std::pair<std::string, std::string>> symmetryPatterns =
-                {{R"(_r(\/|_|$))", "_l$1"}, {R"(_l(\/|_|$))", "_r$1"}});
+        std::vector<std::pair<std::string, std::string>> symmetryPatterns = {
+                {"(_r(\\|_|$|/))", "_l$1"}, 
+                {"(_l(\\|_|$|/))", "_r$1"}
+        });
 
 /// This obtains the value of the OPENSIM_MOCO_PARALLEL environment variable.
 /// The value has the following meanings:

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -117,7 +117,7 @@ OSIMMOCO_API void prescribeControlsToModel(const MocoTrajectory& trajectory,
 OSIMMOCO_API MocoTrajectory simulateTrajectoryWithTimeStepping(
         const MocoTrajectory& trajectory, Model model,
         double integratorAccuracy = SimTK::NaN);
-
+#ifndef SWIG
 /// Convert a trajectory covering half the period of a symmetric motion into a
 /// trajectory over the full period. This is useful for simulations of half a
 /// gait cycle.
@@ -173,16 +173,21 @@ OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(
         std::vector<std::string> negateAndShiftPatterns = {
                                             ".*pelvis_list/value",
                                             ".*pelvis_tz/value",
-                                            ".*lumbar_bending/value"}
-#ifndef SWIG
-                                            ,
-        std::vector<std::pair<std::string, std::string>> symmetryPatterns = {
-                {R"(_r(\\|_|$|/))", "_l$1"}, 
-                {R"(_l(\\|_|$|/))", "_r$1"}
-        }
+                                                   ".*lumbar_bending/value"},
+        std::vector<std::pair<std::string, std::string>> symmetryPatterns =
+                {{R"(_r(/|_|$))", "_l$1"}, {R"(_l(/|_|$))", "_r$1"}});
+#else 
+// Variant that doesn't take symmetryPatterns which are unusable from scripting
+OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(
+        const MocoTrajectory& halfPeriodTrajectory,
+        std::vector<std::string> addPatterns = {".*pelvis_tx/value"},
+        std::vector<std::string> negatePatterns = {".*pelvis_list(?!/value).*",
+                ".*pelvis_rotation.*", ".*pelvis_tz(?!/value).*",
+                ".*lumbar_bending(?!/value).*", ".*lumbar_rotation.*"},
+        std::vector<std::string> negateAndShiftPatterns = {
+                ".*pelvis_list/value", ".*pelvis_tz/value",
+                ".*lumbar_bending/value"});
 #endif
-);
-
 /// This obtains the value of the OPENSIM_MOCO_PARALLEL environment variable.
 /// The value has the following meanings:
 /// - 0: run in series (not parallel).

--- a/OpenSim/Moco/MocoUtilities.h
+++ b/OpenSim/Moco/MocoUtilities.h
@@ -171,13 +171,17 @@ OSIMMOCO_API MocoTrajectory createPeriodicTrajectory(
                                             ".*lumbar_bending(?!/value).*",
                                             ".*lumbar_rotation.*"},
         std::vector<std::string> negateAndShiftPatterns = {
-                                                   ".*pelvis_list/value",
-                                                   ".*pelvis_tz/value",
-                                                   ".*lumbar_bending/value"},
+                                            ".*pelvis_list/value",
+                                            ".*pelvis_tz/value",
+                                            ".*lumbar_bending/value"}
+#ifndef SWIG
+                                            ,
         std::vector<std::pair<std::string, std::string>> symmetryPatterns = {
-                {"(_r(\\|_|$|/))", "_l$1"}, 
-                {"(_l(\\|_|$|/))", "_r$1"}
-        });
+                {R"(_r(\\|_|$|/))", "_l$1"}, 
+                {R"(_l(\\|_|$|/))", "_r$1"}
+        }
+#endif
+);
 
 /// This obtains the value of the OPENSIM_MOCO_PARALLEL environment variable.
 /// The value has the following meanings:


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes

Changed CMakeLists to not require exact version match and SWIG out references to functions that are not useful to scripting 
### Testing I've completed

### Looking for feedback on...
Is there a chance the function in MocoUtilities is actually used? Should we remove it altogether from bindings?
### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3985)
<!-- Reviewable:end -->
