### PR TITLE
Add OpenSim::Component overload to OpenSim::Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ v4.6
   in the intersection of names in the model and names in the provided referece/data. Remove methods that are index based from public interface.(#3951) 
 - Replace usages of `OpenSim::make_unique` with `std::make_unique` and remove wrapper function now that C++14 is used in OpenSim (#3979). 
 - Add utility method `createVectorLinspaceInterval` for the `std::vector` type and add unit tests. Utilize the new utility method to fix a bug (#3976) in creating the uniformly sampled time interval from the experimental data sampling frequency in `APDMDataReader` and `XsensDataReader` (#3977).
+- The message associated with `OpenSim::PropertyException` now includes the full absolute path to the component that threw the exception (#3987).
 
 
 v4.5.1

--- a/OpenSim/Common/AbstractProperty.cpp
+++ b/OpenSim/Common/AbstractProperty.cpp
@@ -24,14 +24,54 @@
 // INCLUDES
 //============================================================================
 #include "AbstractProperty.h"
+
 #include "Assertion.h"
+#include "Component.h"
 #include "Object.h"
 
 #include <limits>
+#include <sstream>
+#include <utility>
 
 using namespace OpenSim;
 using namespace SimTK;
 using namespace std;
+
+namespace
+{
+    static std::string generateInvalidPropertyValueMessage(
+        const std::string& propertyName,
+        const std::string& errorMsg)
+    {
+        std::stringstream ss;
+        ss << "Property '" << propertyName << "' has an invalid property value.\n";
+        ss << "(details: " << errorMsg << ").\n";
+        return std::move(ss).str();
+    }
+}
+
+InvalidPropertyValue::InvalidPropertyValue(const std::string& file,
+    size_t line,
+    const std::string& func,
+    const Object& obj,
+    const std::string& propertyName,
+    const std::string& errorMsg) :
+    Exception(file, line, func, obj) {
+
+    addMessage(generateInvalidPropertyValueMessage(propertyName, errorMsg));
+}
+
+InvalidPropertyValue::InvalidPropertyValue(
+    const std::string& file,
+    size_t line,
+    const std::string& func,
+    const Component& component,
+    const std::string& propertyName,
+    const std::string& errorMsg) :
+    Exception(file, line, func, component) {
+
+    addMessage(generateInvalidPropertyValueMessage(propertyName, errorMsg));
+}
 
 
 //=============================================================================

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -35,6 +35,7 @@
 namespace OpenSim {
 
 class Object;
+class Component;
 template <class T> class Property;
 
 //==============================================================================
@@ -42,17 +43,21 @@ template <class T> class Property;
 //==============================================================================
 class InvalidPropertyValue : public Exception {
 public:
-    InvalidPropertyValue(const std::string& file,
+    InvalidPropertyValue(
+        const std::string& file,
         size_t line,
         const std::string& func,
         const Object& obj,
         const std::string& propertyName,
-        const std::string& errorMsg) :
-        Exception(file, line, func, obj) {
-        std::string msg = "Property '" + propertyName;
-        msg += "' has an invalid value.\n(details: " + errorMsg + ").\n";
-        addMessage(msg);
-    }
+        const std::string& errorMsg);
+
+    InvalidPropertyValue(
+        const std::string& file,
+        size_t line,
+        const std::string& func,
+        const Component& component,
+        const std::string& propertyName,
+        const std::string& errorMsg);
 };
 
 

--- a/OpenSim/Common/AbstractProperty.h
+++ b/OpenSim/Common/AbstractProperty.h
@@ -41,7 +41,7 @@ template <class T> class Property;
 //==============================================================================
 /// Property Exceptions
 //==============================================================================
-class InvalidPropertyValue : public Exception {
+class OSIMCOMMON_API InvalidPropertyValue : public Exception {
 public:
     InvalidPropertyValue(
         const std::string& file,

--- a/OpenSim/Common/Exception.cpp
+++ b/OpenSim/Common/Exception.cpp
@@ -25,14 +25,15 @@
  * Author: Frank C. Anderson 
  */
 
-
-// INCLUDES
-#include <iostream>
-#include <string>
-#include "osimCommonDLL.h"
 #include "Exception.h"
+
+#include "Component.h"
 #include "IO.h"
 #include "Object.h"
+#include "osimCommonDLL.h"
+
+#include <iostream>
+#include <string>
 
 
 using namespace OpenSim;
@@ -101,6 +102,29 @@ Exception::Exception(const std::string& file,
                      const Object& obj,
                      const std::string& msg) 
     : Exception{file, line, func, obj} {
+    addMessage(msg);
+}
+
+Exception::Exception(
+    const std::string& file,
+    size_t line,
+    const std::string& func,
+    const Component& component)
+    : Exception{file, line, func} {
+
+    const std::string className = component.getConcreteClassName();
+    const std::string absolutePath = component.getAbsolutePathString();
+    addMessage("\tIn Component '" + absolutePath +  "' of type " + className + ".");
+}
+
+Exception::Exception(
+    const std::string& file,
+    size_t line,
+    const std::string& func,
+    const Component& component,
+    const std::string& msg)
+    : Exception{file, line, func, component} {
+
     addMessage(msg);
 }
 

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -45,6 +45,7 @@
 
 namespace OpenSim {
 
+class Component;
 class Object;
 
 
@@ -175,6 +176,26 @@ public:
               const std::string& func,
               const Object& obj,
               const std::string& msg);
+
+    /** The message created by this constructor will contain the class name and
+    absolute path of the provided Component. Use this when throwing from derived
+    components. Use OPENSIM_THROW<> macros at throw sites.                    */
+    Exception(
+        const std::string& file,
+        size_t line,
+        const std::string& func,
+        const Component& component);
+
+    /** The message created by this constructor will contain the class name and
+    ansolute path of the provided Component, and also accepts a message. Use this
+    when throwing from derived components. Use OPENSIM_THROW<> macros at throw
+    sites.                                                                    */
+    Exception(
+        const std::string& file,
+        size_t line,
+        const std::string& func,
+        const Component& component,
+        const std::string& msg);
 
     /** Use this when you want to throw an Exception (with OPENSIM_THROW or
     OPENSIM_THROW_IF) and also provide a message that is formatted


### PR DESCRIPTION
Adds an `OpenSim::Component` overload to `OpenSim::Exception` that uses the component's absolute path instead of the component's name.

The utility of doing this is that it's easier to figure out which `Component` is giving a headache when an `OpenSim::Exception` is thrown. When it's just the name, it can take a little more effort to figure out where the troublesome component is in the wider component tree (e.g. in a larger model).

### Brief summary of changes

- Adds an `OpenSim::Component` overload to `OpenSim::Exception` that prints the absolute path to the component, rather than just the `Component`'s name.
- Uses the overload in `PropertyException`, which is a very common exception source when building a model (e.g. when editing XML files or editing models, this exception pops up, and it's useful to know where the errant property is).

### Testing I've completed

- Manually ran it while developing [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator)

### Looking for feedback on...

### CHANGELOG.md (choose one)

- TODO

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3987)
<!-- Reviewable:end -->
