### PR TITLE
fix negative scale factor of coordinate function due to spatial transform axis direction

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
@@ -193,7 +193,9 @@ void SpatialTransform::scale(const SimTK::Vec3 scaleFactors)
             }
             SimTK::Vec3 axis;
             transform.getAxis(axis);
-            double scaleFactor = ~axis * scaleFactors;
+            // we want weighted aggregate of scale factors but to ignore the sign
+            // ignoring sign due to issue #3991 resulting -ve scale factor
+            double scaleFactor = ~axis.abs() * scaleFactors;
             // If the function is already a MultiplierFunction, just update its scale factor.
             // Otherwise, make a MultiplierFunction from it and make the transform axis use
             // the new MultiplierFunction.


### PR DESCRIPTION
Fixes issue #3991 

### Brief summary of changes
Use absolute values from transform axis when computing aggregate scale factor to avoid erroneous sign flip

### Testing I've completed
Tested model/files from bug report on simtk.org

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3992)
<!-- Reviewable:end -->
