### PR TITLE
Fix toggling ContactGeometry::Appearance::is_visible has no effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ v4.6
 - Replace usages of `OpenSim::make_unique` with `std::make_unique` and remove wrapper function now that C++14 is used in OpenSim (#3979). 
 - Add utility method `createVectorLinspaceInterval` for the `std::vector` type and add unit tests. Utilize the new utility method to fix a bug (#3976) in creating the uniformly sampled time interval from the experimental data sampling frequency in `APDMDataReader` and `XsensDataReader` (#3977).
 - Fix Point Kinematics Reporter variable and initialization error and add unit tests (#3966)
-
+- `OpenSim::ContactHalfSpace`, `OpenSim::ContactMesh`, and `OpenSim::ContactSphere` now check their associated `Appearance`'s `is_visible` flag when deciding whether to emit their associated decorations (#3993).
 
 v4.5.1
 ======

--- a/OpenSim/Simulation/Model/ContactHalfSpace.cpp
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.cpp
@@ -69,7 +69,12 @@ void ContactHalfSpace::generateDecorations(bool fixed, const ModelDisplayHints& 
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
 
-    if (!hints.get_show_contact_geometry()) return;
+    // Model-wide hints indicate that contact geometry shouldn't be shown.
+    if (!hints.get_show_contact_geometry()) { return; }
+
+    // The decoration has been toggled off by its `Appearance` block.
+    if (!get_Appearance().get_visible())  { return; }
+
     // B: base Frame (Body or Ground)
     // F: PhysicalFrame that this ContactGeometry is connected to
     // P: the frame defined (relative to F) by the location and orientation

--- a/OpenSim/Simulation/Model/ContactMesh.cpp
+++ b/OpenSim/Simulation/Model/ContactMesh.cpp
@@ -136,9 +136,15 @@ void ContactMesh::generateDecorations(bool fixed, const ModelDisplayHints& hints
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
 
+    // Model-wide hints indicate that contact geometry shouldn't be shown.
+    if (!hints.get_show_contact_geometry()) { return; }
+
+    // The decoration has been toggled off by its `Appearance` block.
+    if (!get_Appearance().get_visible())  { return; }
+
     // Guard against the case where the Force was disabled or mesh failed to load.
-    if (_decorativeGeometry == nullptr) return;
-    if (!hints.get_show_contact_geometry()) return;
+    if (_decorativeGeometry == nullptr) { return; }
+
     // B: base Frame (Body or Ground)
     // F: PhysicalFrame that this ContactGeometry is connected to
     // P: the frame defined (relative to F) by the location and orientation

--- a/OpenSim/Simulation/Model/ContactSphere.cpp
+++ b/OpenSim/Simulation/Model/ContactSphere.cpp
@@ -86,7 +86,12 @@ void ContactSphere::generateDecorations(bool fixed, const ModelDisplayHints& hin
     // There is no fixed geometry to generate here.
     if (fixed) { return; }
 
-    if (!hints.get_show_contact_geometry())  return;
+    // Model-wide hints indicate that contact geometry shouldn't be shown.
+    if (!hints.get_show_contact_geometry()) { return; }
+
+    // The decoration has been toggled off by its `Appearance` block.
+    if (!get_Appearance().get_visible())  { return; }
+
     // B: base Frame (Body or Ground)
     // F: PhysicalFrame that this ContactGeometry is connected to
     // P: the frame defined (relative to F) by the location and orientation


### PR DESCRIPTION
Fixes a downstream issue:

- https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/980

Some `ContactGeometry` implementations aren't using the `is_visible` part of their `Appearance`. This adds necessary checks to ensure that they check it.

### Brief summary of changes

- Add checks to each contact geometry's `generateDecorations`

### Testing I've completed

- Local testing, plus osc automated testing

### Looking for feedback on...

- Usual stuff

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3993)
<!-- Reviewable:end -->
