### PR TITLE
Decrease log level for NaN parsing

### DIFF
--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -508,7 +508,7 @@ stod(const std::string& __str, std::size_t* __idx)
     iss >> result;
     if (iss.fail()) {
         result = std::numeric_limits<double>::quiet_NaN();
-        log_warn("Encountered non-numeric string value: {} ; parsed value:{}",__str, result);
+        log_debug("Encountered non-numeric string value: {} ; parsed value:{}",__str, result);
     }
     return result;
 }


### PR DESCRIPTION
Decrease the log level for NaN parsing. When I originally implemented this I thought this is a rare occurrence or indicative of a typo (ex `0` vs. `O`). After working with `.trc` files I now see that `NaN` values are very prevalent and logging a warning every time you try to parse one makes the log output unusable. This drops the log level to debug so you can get the output if you want but it doesn't spam the logs for regular usage.

@nickbianco can you take a look?

### CHANGELOG.md (choose one)

- no need to update

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3998)
<!-- Reviewable:end -->
