### PR TITLE
Fix issues in `OpenSim::ExpressionBasedBushingForce::generateDecorations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,14 @@ v4.6
 - `OpenSim::ContactHalfSpace`, `OpenSim::ContactMesh`, and `OpenSim::ContactSphere` now check their associated `Appearance`'s `is_visible` flag when deciding whether to emit their associated decorations (#3993).
 - The message associated with `OpenSim::PropertyException` now includes the full absolute path to the component that threw the exception (#3987).
 - Add an improved uniform sampling check for `std::vector` containers to `CommonUtilities` and use the implemented method in the `TableUtilities::filterLowpass` method (#3968, #3978).
-
+- Several bugs in `OpenSim::ExpressionBasedBushingForce::generateDecorations` were fixed:
+  - It will now check for `0.0` values for `visual_aspect_ratio`, `moment_visual_scale`,
+    and `force_visual_scale` when emitting decorations, skipping emission where `0.0` is
+    found (previously: it would emit objects scaled by 0.0, causing downstream issues).
+  - It will only emit decorations when called with `fixed` set to `false` (previously, frame
+    decorations were emitted for both `true` and `false`, resulting in double-emission).
+  - It will now check for NaNed vectors coming from the underlying expression, skipping emission
+    if one is detected (previously: it would emit decorations with `NaN`ed transforms).
 
 v4.5.1
 ======


### PR DESCRIPTION
Issue found when working on a student's model, which contained an `ExpressionBasedBushingForce`. The student had set the visual properties (`visual_aspect_ratio`, `moment_visual_scale`, and `force_visual_scale`) to zero in order to hide the frame/moment/force decorations that the component emits, but that resulted in `NaN`ed geometry being emitted by the component, which then caused weird issues in [opensim-creator](https://www.opensimcreator.com/)'s renderer.

When diagnosing that issue I also noticed that the function emits both of the frame decorations twice: once when `fixed` is `true` and once when `fixed` is false, and the `NaN` problem returns if the underlying implementation produces a `NaN` or zero-length vector (here, `F_GM`). The check against `normSqr` serves the double-purpose of checking for NaNs and zero-length results.

### Brief summary of changes

Adds `if` checks etc. to the existing implementation to ensure that it filters out the edge cases.

### Testing I've completed

Running it via OpenSim Creator

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/3999)
<!-- Reviewable:end -->
