### PR TITLE
Upgrade required language level to C++17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ v4.6
   sphere torques) to be consistent with the center of pressure GRF representation.
 - Fixed an issue where a copy of an `OpenSim::Model` containing a `OpenSim::ExternalLoads` could not be
   finalized (#3926)
-- Updated all code examples to use c++14 (#3929)
+- Updated all code examples to use C++17 (after a few months of compiling as C++14 : #3929).
 - Added class `OpenSim::StateDocument` as a systematic means of serializing and deserializing a complete trajectory
   (i.e., time history) of all states in the `SimTK::State` to and from a single `.ostates` file. Prior to `StatesDocument`,
   only the trajectories of continuous states (e.g., joint angles, joint speeds, muscle forces, and the like) could be systematically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -600,10 +600,10 @@ if (NOT OPENSIM_PYTHON_CONDA)
     include(InstallRequiredSystemLibraries)
 endif()
 
-# C++14
+# C++17
 # -----
-set(CMAKE_CXX_STANDARD 14)
-# Using c++14 is not optional.
+set(CMAKE_CXX_STANDARD 17)
+# Using C++17 is not optional.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 

--- a/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
+++ b/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
@@ -3,8 +3,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(BuildDynamicWalker)
 
-# OpenSim requires a compiler that supports c++14.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim requires a compiler that supports C++17.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find the OpenSim libraries and header files.

--- a/OpenSim/Examples/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Examples/ControllerExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleController CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleCustomActuator CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleLuxoMuscle CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleMain/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMain CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Examples/MuscleExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMuscle CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET optimizationExample CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "osimPlugin" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "BodyDragForce" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
@@ -8,8 +8,8 @@ file(GLOB INCLUDE_FILES *.h)
 set(PLUGIN_NAME "osimCoupledBushingForcePlugin"
     CACHE STRING "Name of shared library to create")
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET simpleOptimizationExample CACHE TYPE STRING)
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
+++ b/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
@@ -40,8 +40,8 @@ set(PLUGIN_NAME "osimExpressionReporter")
 
 # Settings.
 # ---------
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses C++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/checkEnvironment/CMakeLists.txt
+++ b/OpenSim/Examples/checkEnvironment/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET checkEnvironment CACHE STRING "Name of example to build")
 
-# OpenSim uses c++14 language features.
-set(CMAKE_CXX_STANDARD 14)
+# OpenSim uses c++17 language features.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Sandbox/xsens/CMakeLists.txt
+++ b/OpenSim/Sandbox/xsens/CMakeLists.txt
@@ -6,8 +6,8 @@ if(NOT WIN32)
     return()
 endif()
 
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 14)
 
 set(XSENS_SDK_DIR "" CACHE PATH "Directory containing XSENS SDK.")
 

--- a/OpenSim/Tools/ForwardTool.h
+++ b/OpenSim/Tools/ForwardTool.h
@@ -127,7 +127,7 @@ public:
     //--------------------------------------------------------------------------
     bool run() override SWIG_DECLARE_EXCEPTION;
     /// <b>(Deprecated)</b> Use setPrintResultFiles(true) and run() instead.
-    DEPRECATED_14("Use setPrintResultFiles(true) and run() instead.")
+    [[deprecated("Use setPrintResultFiles(true) and run() instead.")]]
     void printResults();
 private:
     void printResultsInternal();

--- a/Vendors/tropter/CMakeLists.txt
+++ b/Vendors/tropter/CMakeLists.txt
@@ -13,8 +13,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Compiler flags.
 # ---------------
-set(CMAKE_CXX_STANDARD 14)
-# Using c++14 is not optional.
+set(CMAKE_CXX_STANDARD 17)
+# Using C++17 is not optional.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Copy dependencies' libraries into tropter's installation?

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -11,7 +11,7 @@ project(myexe)
 set(my_source_files myexe.cpp)
 set(my_header_files myexe.h)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This depends on OpenSimConfig.cmake being located somewhere predictable


### PR DESCRIPTION
Related, the C++14 upgrade in Oct 2024: #3931

This PR upgrades the required language level from C++14 to C++17. The motivation for this is because I would like to implement caching mesh data between copies of `OpenSim::Mesh`, but doing so robustly requires filesystem queries like `std::filesystem::last_write_time` to handle edge-cases like "the file path didn't change but the timestamp did, so reload".

In terms of compatibility, C++17 is generally available in Ubuntu18+, and even (e.g.) Ubuntu16 with a backported `libstdc++`. MacOS (Apple Clang) and Windows (MSVC) have had very good feature coverage for C++17 for around 5 or 6 years (save a few library functions in Apple Clang's case). OpenSim Creator has been compiling for C++20 for the last year, but the required OS-level is higher (Ubuntu20/Mac Sonoma/Windows 10).

Additional benefits are the inclusion of `std::optional<T>` and `std::string_view`, which I imagine will slip into the codebase over time. This PR only addresses setting the flags, so that future PRs don't have to handle two things at one (e.g. "here's my new mesh caching routine, oh, also we need C++17").

### Brief summary of changes

- Relevant compiler flags updated

### Testing I've completed

- None required. CI (GitHub Actions) should be using representative operating systems for the target audience. If CI can't build C++17 as new in-source usages are added, then those usages will need to be fixed. This is independent of the compiler language level: telling a compiler to use C++17 doesn't imply 100 % language and library conformance - the only way to know that is to actually compile the code on each representative system (e.g. via CI).

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4000)
<!-- Reviewable:end -->
