### PR TITLE
Allow paths fit by `PolynomialPathFitter` to depend on more than 6 coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ v4.6
     decorations were emitted for both `true` and `false`, resulting in double-emission).
   - It will now check for NaNed vectors coming from the underlying expression, skipping emission
     if one is detected (previously: it would emit decorations with `NaN`ed transforms).
+- `PolynomialPathFitter` now allows fitting paths that depend on more than 6 coordinates, matching recent changes to `MultivariatePolynomialFunction` (#4001).
 
 v4.5.1
 ======

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -842,10 +842,6 @@ void PolynomialPathFitter::filterSampledData(const Model& model,
                 momentArms.removeColumn(label);
             } else {
                 momentArmMap[path].push_back(coordinate);
-                OPENSIM_THROW_IF_FRMOBJ(momentArmMap[path].size() > 6,
-                        Exception,
-                        "The path '{}' depends on more than 6 coordinates. "
-                        "This is not supported.", path)
             }
         }
     }


### PR DESCRIPTION
Fixes issue #3995 

### Brief summary of changes

Removes a restriction in `PolynomialPathFitter` preventing paths with more than 6 coordinates from being fitted. This was a leftover check from when `MultivariatePolynomialFunction` only allow 6 or less independent coordinates.

### Testing I've completed

Tested locally using data from the OpenCap paper, which uses a model with paths that depend on more than 6 coordinates.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4001)
<!-- Reviewable:end -->
