### PR TITLE
Fix typo in test_sockets_inputs_outputs.py (assertEquals should be as…

### DIFF
--- a/Bindings/Python/tests/test_sockets_inputs_outputs.py
+++ b/Bindings/Python/tests/test_sockets_inputs_outputs.py
@@ -133,7 +133,7 @@ class TestInputsOutputs(unittest.TestCase):
 
         # AbstractChannel.
         coord = model.getCoordinateSet().get(0)
-        self.assertEquals(coord.getOutput('speed').getChannel('').getPathName(),
+        self.assertEqual(coord.getOutput('speed').getChannel('').getPathName(),
                 '/jointset/r_shoulder/r_shoulder_elev|speed')
 
         # Access the value of a concrete Channel.


### PR DESCRIPTION
…sertEqual or the test does not work)

Fixes issue #4003 

### Brief summary of changes
Just a typo fix

### Testing I've completed
The test now works (I am compiling OpenSim on Windows 11)

### Looking for feedback on...
NA

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4004)
<!-- Reviewable:end -->
