### PR TITLE
Require SWIG 4.1.1 exactly

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 4.1.1 REQUIRED)
+    find_package(SWIG 4.1.1 EXACT REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.


### PR DESCRIPTION
Related to issue #3758

### Brief summary of changes
There are still issues with building the bindings with SWIG 4.2, so let's pin the SWIG version to 4.1.1 until they are resolved.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal change to bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4005)
<!-- Reviewable:end -->
