### PR TITLE
Add activation dynamics smoothing property to `DeGrooteFregly2016Muscle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,9 @@ v4.6
     decorations were emitted for both `true` and `false`, resulting in double-emission).
   - It will now check for NaNed vectors coming from the underlying expression, skipping emission
     if one is detected (previously: it would emit decorations with `NaN`ed transforms).
-- Added the property `activation_dynamics_smoothing` to `DeGrooteFregly2016Muscle`. This
-property uses the model's original value of 0.1 as a default, but users may consider
-increasing this value (e.g., 10.0) so that the activation and deactivation speeds of the model better match the activation and deactivation time constants.
+- Added the property `activation_dynamics_smoothing` to `DeGrooteFregly2016Muscle`. This property uses the model's original 
+  value of 0.1 as a default, but users may consider increasing this value (e.g., 10.0) so that the activation and deactivation 
+  speeds of the model better match the activation and deactivation time constants.
 
 v4.5.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ v4.6
   default, but users may consider increasing this value (e.g., 10.0) so that the activation and deactivation speeds of the model better match the 
   activation and deactivation time constants.
 
->>>>>>> 0fe06d6b198a11b9fbf321618d352fc9fb8a1c28
 
 v4.5.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ v4.6
     decorations were emitted for both `true` and `false`, resulting in double-emission).
   - It will now check for NaNed vectors coming from the underlying expression, skipping emission
     if one is detected (previously: it would emit decorations with `NaN`ed transforms).
+- Added the property `activation_dynamics_smoothing` to `DeGrooteFregly2016Muscle`. This
+property uses the model's original value of 0.1 as a default, but users may consider
+increasing this value (e.g., 10.0) so that the activation and deactivation speeds of the model better match the activation and deactivation time constants.
 
 v4.5.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ v4.6
 - Make `InverseKinematicsSolver` methods to query for specific marker or orientation-sensor errors more robust to invalid names or names not 
   in the intersection of names in the model and names in the provided referece/data. Remove methods that are index based from public interface.(#3951) 
 - Replace usages of `OpenSim::make_unique` with `std::make_unique` and remove wrapper function now that C++14 is used in OpenSim (#3979). 
-- Add utility method `createVectorLinspaceInterval` for the `std::vector` type and add unit tests. Utilize the new utility method to fix a bug (#3976) in creating the uniformly sampled time interval from the experimental data sampling frequency in `APDMDataReader` and `XsensDataReader` (#3977).
+- Add utility method `createVectorLinspaceInterval` for the `std::vector` type and add unit tests. Utilize the new utility method to fix a bug (#3976) 
+  in creating the uniformly sampled time interval from the experimental data sampling frequency in `APDMDataReader` and `XsensDataReader` (#3977).
 - Fix Point Kinematics Reporter variable and initialization error and add unit tests (#3966)
 - `OpenSim::ContactHalfSpace`, `OpenSim::ContactMesh`, and `OpenSim::ContactSphere` now check their associated `Appearance`'s `is_visible` flag when deciding whether to emit their associated decorations (#3993).
 - The message associated with `OpenSim::PropertyException` now includes the full absolute path to the component that threw the exception (#3987).
@@ -66,7 +67,7 @@ v4.6
   - It will now check for NaNed vectors coming from the underlying expression, skipping emission
     if one is detected (previously: it would emit decorations with `NaN`ed transforms).
 - `PolynomialPathFitter` now allows fitting paths that depend on more than 6 coordinates, matching recent changes to `MultivariatePolynomialFunction` (#4001).
-- Added the property `activation_dynamics_smoothing` to `DeGrooteFregly2016Muscle`. This   property uses the model's original value of 0.1 as a 
+- Added the property `activation_dynamics_smoothing` to `DeGrooteFregly2016Muscle`. This property uses the model's original value of 0.1 as a 
   default, but users may consider increasing this value (e.g., 10.0) so that the activation and deactivation speeds of the model better match the 
   activation and deactivation time constants.
 

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -35,7 +35,7 @@ namespace OpenSim {
 //       might be slow.
 // TODO prohibit fiber length from going below 0.2.
 
-/** This muscle model was published in De Groote et al. 2016. 
+/** This muscle model was published in De Groote et al. (2016). 
 
 The parameters of the active force-length and force-velocity curves have
 been slightly modified from what was published to ensure the curves go

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -85,6 +85,7 @@ The acceptable bounds for each property are enforced at model initialization.
 These bounds are:
  - activation_time_constant: (0, inf]
  - deactivation_time_constant: (0, inf]
+ - activation_dynamics_smoothing: (0, inf]
  - active_force_width_scale: [1, inf]
  - fiber_damping: [0, inf]
  - passive_fiber_strain_at_one_norm_force: (0, inf]
@@ -94,7 +95,13 @@ These bounds are:
  - default_normalized_tendon_force: [0, 5]
 
 @note The methods getMinNormalizedTendonForce() and
-   getMaxNormalizedTendonForce() provide these bounds for use in custom solvers.
+      getMaxNormalizedTendonForce() provide these bounds for use in custom 
+      solvers.
+
+@note The default value for activation_dynamics_smoothing is set to 0.1 to 
+      match the originally published model, but a value of 10 is recommended 
+      to achieve activation and deactivation speeds closer to the intended 
+      time constants.
 
 @note Muscle properties can be optimized using MocoParameter. The acceptable
 bounds for each property are **not** enforced during parameter optimization, so
@@ -155,6 +162,14 @@ public:
     OpenSim_DECLARE_PROPERTY(tendon_compliance_dynamics_mode, std::string,
             "The dynamics method used to enforce tendon compliance dynamics. "
             "Options: 'explicit' or 'implicit'. Default: 'explicit'. ");
+    OpenSim_DECLARE_PROPERTY(activation_dynamics_smoothing, double,
+            "The parameter that determines the smoothness of the transition "
+            "of the tanh function used to smooth the switch between muscle "
+            "activation (a-e < 0) and deactivation (a-e > 0). The default "
+            "value is 0.1 to match the originally published model, but a value "
+            "of 10 is recommended to to achieve activation and deactivation "
+            "speeds closer to the intended time constants. Larger values "
+            "steepen the transition, but may slow optimization convergence.");
 
     OpenSim_DECLARE_OUTPUT(passive_fiber_elastic_force, double,
             getPassiveFiberElasticForce, SimTK::Stage::Dynamics);

--- a/OpenSim/Actuators/Test/testDeGrooteFregly2016Muscle.cpp
+++ b/OpenSim/Actuators/Test/testDeGrooteFregly2016Muscle.cpp
@@ -662,9 +662,7 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
         }
 
         SECTION("(active force width scale) = 1.2") {
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
-            mutMuscle.set_active_force_width_scale(1.2);
+            muscle.set_active_force_width_scale(1.2);
             muscle.setActivation(state, 1.0);
             const double normFiberLength = 0.8;
             coord.setValue(
@@ -726,9 +724,7 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
         }
 
         SECTION("(activation dynamics smoothing) = 10.0") {
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
-            mutMuscle.set_activation_dynamics_smoothing(10.0);
+            muscle.set_activation_dynamics_smoothing(10.0);
             muscle.setActivation(state, 1.0);
             const double normFiberLength = 0.8;
             coord.setValue(
@@ -790,11 +786,9 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
         }
 
         SECTION("pennation") {
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
             const double pennOpt = 0.12;
             const double cosPenn = cos(pennOpt);
-            mutMuscle.set_pennation_angle_at_optimal(pennOpt);
+            muscle.set_pennation_angle_at_optimal(pennOpt);
             state = model.initSystem();
             muscle.setActivation(state, 1.0);
             coord.setValue(state, muscle.get_optimal_fiber_length() * cosPenn +
@@ -904,14 +898,12 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
         }
 
         SECTION("initial equilibrium") {
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
-            mutMuscle.set_ignore_tendon_compliance(false);
-            mutMuscle.set_tendon_compliance_dynamics_mode("explicit");
+            muscle.set_ignore_tendon_compliance(false);
+            muscle.set_tendon_compliance_dynamics_mode("explicit");
 
             const double pennOpt = 0.12;
             double cosPenn = cos(pennOpt);
-            mutMuscle.set_pennation_angle_at_optimal(pennOpt);
+            muscle.set_pennation_angle_at_optimal(pennOpt);
             state = model.initSystem();
             muscle.setActivation(state, 1.0);
             const double muscleLength =
@@ -930,21 +922,19 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
             CHECK(muscle.getNormalizedTendonForceDerivative(state) ==
                     Approx(0.0).margin(1e-6));
 
-            mutMuscle.set_tendon_compliance_dynamics_mode("implicit");
+            muscle.set_tendon_compliance_dynamics_mode("implicit");
             model.realizeDynamics(state);
             CHECK(muscle.getEquilibriumResidual(state) ==
                     Approx(0.0).margin(1e-6));
         }
 
         SECTION("tendon compliance") {
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
-            mutMuscle.set_ignore_tendon_compliance(false);
-            mutMuscle.set_tendon_compliance_dynamics_mode("implicit");
+            muscle.set_ignore_tendon_compliance(false);
+            muscle.set_tendon_compliance_dynamics_mode("implicit");
 
             const double pennOpt = 0.12;
             double cosPenn = cos(pennOpt);
-            mutMuscle.set_pennation_angle_at_optimal(pennOpt);
+            muscle.set_pennation_angle_at_optimal(pennOpt);
             state = model.initSystem();
             muscle.setActivation(state, 1.0);
             const double muscleLength =
@@ -1100,10 +1090,8 @@ TEST_CASE("DeGrooteFregly2016Muscle basics") {
 
         SECTION("calcEquilibriumResidual()") {
             // Check the value of the equilibrium residual for a given state.
-            auto& mutMuscle =
-                    model.updComponent<DeGrooteFregly2016Muscle>("muscle");
-            mutMuscle.set_ignore_tendon_compliance(false);
-            mutMuscle.set_tendon_compliance_dynamics_mode("implicit");
+            muscle.set_ignore_tendon_compliance(false);
+            muscle.set_tendon_compliance_dynamics_mode("implicit"); 
             const double muscleTendonLength = muscle.getOptimalFiberLength() +
                             muscle.getTendonSlackLength();
             const double normTendonForce = 0.7;


### PR DESCRIPTION
Fixes issue #3990

### Brief summary of changes
Adds property to `DeGrooteFregly2016Muscle` to control the smoothing applied to the switch between muscle activation and deactivation. The default value of the property is set to the original model value, but the model will issue a warning to recommend increasing the value to 10.0 based on @tvdbogert's suggestion. 

### Testing I've completed
Add a subtest to `DeGrooteFregly2016Muscle`

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4007)
<!-- Reviewable:end -->
