### PR TITLE
Change std::cerr/std::cout usages to use the log, where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ v4.6
   - It will now check for NaNed vectors coming from the underlying expression, skipping emission
     if one is detected (previously: it would emit decorations with `NaN`ed transforms).
 - `PolynomialPathFitter` now allows fitting paths that depend on more than 6 coordinates, matching recent changes to `MultivariatePolynomialFunction` (#4001).
+- If an `Object` cannot be found when loading a list property from XML, a warning will now be emitted to the log (previously: it was emitted to `std::cerr`, #4009).
 
 v4.5.1
 ======

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -953,7 +953,7 @@ try {
 
         // NOT RECOGNIZED
         default :
-            cout<<"Object.UpdateObject: WARN- unrecognized property type."<<endl;
+            log_warn("Object.UpdateObject: WARN- unrecognized property type.");
             break;
         }
     }
@@ -1033,7 +1033,7 @@ void Object::updateXMLNode(SimTK::Xml::Element& aParent,
         // If object is not inlined we don't want to generate node in original document
         // Handle not-inlined objects first.
         if (!aParent.isValid()) {
-            cout<<"Root node must be inlined"<<*this<<endl;
+            log_warn("Root node of an OpenSim::Object must be inlined, skipping XML reading.");
         }
         else {
         // Can we make this more efficient than recreating the node again?
@@ -1211,8 +1211,8 @@ void Object::updateXMLNode(SimTK::Xml::Element& aParent,
             break; 
 
         // NOT RECOGNIZED
-        default :
-            cout<<"Object.UpdateObject: WARN- unrecognized property type."<<endl;
+        default:
+            log_warn("Object.UpdateObject: WARN- unrecognized property type.");
             break;
         }
     }

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1406,19 +1406,13 @@ ObjectProperty<T>::readFromXMLElement
             Object::getDefaultInstanceOfType(objTypeTag);
 
         if (!registeredObj) {
-            std::cerr 
-                << "Encountered unrecognized Object typename " 
-                << objTypeTag << " while reading property " << this->getName()
-                << ". There is no registered Object of this type; ignoring.\n";
-            continue;                        
+            log_error("Encountered unrecognized Object typename {} while reading property {}. There is no registered Object of this type. Ignoring.", objTypeTag, this->getName());
+            continue;
         }
 
         // Check that the object type found is derived from T.
         if (!dynamic_cast<const T*>(registeredObj)) {
-            std::cerr << "Object type " << objTypeTag  
-                        << " wrong for " << objectClassName
-                        << " property " << this->getName()
-                        << "; ignoring.\n";
+            log_error("Object type {} wrong for {} property {}. Ignoring.", objTypeTag, objectClassName, this->getName());
             continue;                        
         }
         ++objectsFound;
@@ -1437,16 +1431,18 @@ ObjectProperty<T>::readFromXMLElement
     }
 
     if (objectsFound < this->getMinListSize()) {
-        std::cerr << "Got " << objectsFound 
-                    << " object values for Property "
-                    << this->getName() << " but the minimum is " 
-                    << this->getMinListSize() << ". Continuing anyway.\n"; 
+        log_error("Got {} object values for Property {} but the minimum is {}. Continuing anyway.",
+            objectsFound ,
+            this->getName() ,
+            this->getMinListSize()
+        );
     }
     if (objectsFound > this->getMaxListSize()) {
-        std::cerr << "Got " << objectsFound
-                    << " object values for Property "
-                    << this->getName() << " but the maximum is " 
-                    << this->getMaxListSize() << ". Ignoring the rest.\n"; 
+        log_error("Got {} object values for Property {} but the maximum is {}. Ignoring the rest.",
+            objectsFound,
+            this->getName(),
+            this->getMaxListSize()
+        );
     }
 }
 


### PR DESCRIPTION
This PR patches out something that bit me during downstream development for [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator).

I'm developing new `OpenSim::Component`s downstream and, inevitably I sometimes forget to call `OpenSim::Object::registerType` on the new component type. The side-effects of this are *usually* obvious (e.g. something won't load).

However, in a recent design, I'm using `Component::addComponent` to add the new `Component`'s to the generic `<components>` element that all components have. `<components>` is a list property, but list properties aren't validated the same way as top-level or `Object` properties. If a component in the list isn't registered, the implementation emits warnings to `std::cerr`. The unfortunate side-effect is that some parts of the top-level file can silently be dropped by the XML loader if the developer isn't actively checking `cerr` (I'm not - the GUI has its own logging implementation).

### Brief summary of changes

- Grepped through all uses of `cerr`/`cout` in `Object` and replaced them with `log_` usages, so that any downstream applications that hook into OpenSim's logs (e.g. Creator's logging panel) can see the message

### Testing I've completed

- None

### Looking for feedback on...

- Is it sane, etc.

### CHANGELOG.md

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4009)
<!-- Reviewable:end -->
