### PR TITLE
Remove Moco mentions/dependenices from OpenSim/Simulation

### DIFF
--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -1,5 +1,5 @@
-#ifndef MOCO_DEGROOTEFREGLY2016MUSCLE_H
-#define MOCO_DEGROOTEFREGLY2016MUSCLE_H
+#ifndef DEGROOTEFREGLY2016MUSCLE_H
+#define DEGROOTEFREGLY2016MUSCLE_H
 /* -------------------------------------------------------------------------- *
  *                 OpenSim:  DeGrooteFregly2016Muscle.h                       *
  * -------------------------------------------------------------------------- *
@@ -1002,4 +1002,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_DEGROOTEFREGLY2016MUSCLE_H
+#endif // DEGROOTEFREGLY2016MUSCLE_H

--- a/OpenSim/Actuators/ModelFactory.cpp
+++ b/OpenSim/Actuators/ModelFactory.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: ModelFactory.cpp                                             *
+ *                          ModelFactory.cpp                                  *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2018 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
+++ b/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: Bhargava2004Metabolics.cpp                                   *
+ *               Bhargava2004SmoothedMuscleMetabolics.cpp                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2020 Stanford University and the Authors                     *
  *                                                                            *

--- a/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.h
+++ b/OpenSim/Simulation/Model/Bhargava2004SmoothedMuscleMetabolics.h
@@ -1,7 +1,7 @@
-#ifndef MOCO_BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H
-#define MOCO_BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H
+#ifndef BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H
+#define BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: Bhargava2004SmoothedMuscleMetabolics.h                       *
+ *                 Bhargava2004SmoothedMuscleMetabolics.h                     *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2020 Stanford University and the Authors                     *
  *                                                                            *
@@ -19,7 +19,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <OpenSim/Moco/osimMocoDLL.h>
+#include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <unordered_map>
 
 #include <OpenSim/Common/PiecewiseLinearFunction.h>
@@ -380,4 +380,4 @@ private:
 
 } // namespace OpenSim
 
-#endif // MOCO_BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H
+#endif // BHARGAVA2004SMOOTHEDMUSCLEMETABOLICS_H

--- a/OpenSim/Simulation/PositionMotion.cpp
+++ b/OpenSim/Simulation/PositionMotion.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- * OpenSim Moco: PositionMotion.cpp                                           *
+ *                           PositionMotion.cpp                               *
  * -------------------------------------------------------------------------- *
  * Copyright (c) 2019 Stanford University and the Authors                     *
  *                                                                            *
@@ -20,7 +20,6 @@
 
 #include <OpenSim/Common/Function.h>
 #include <OpenSim/Common/GCVSplineSet.h>
-#include <OpenSim/Moco/MocoUtilities.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 #include <OpenSim/Simulation/StatesTrajectory.h>


### PR DESCRIPTION
Minor issue that I've been patching downstream in [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator). It looks like these headers, includes, moco mentions etc. are from an earlier copy+paste that weren't cleaned up. My downstream project doesn't use moco at all (to the point that it avoids any source files in `Moco/`) and I figure out if anything's "leaking" by `grep -ri`ing for `moco`.

### Brief summary of changes

- Minorly changes some header `#define`s, comments, and spurious `#include`s to not use `moco`

### Testing I've completed

- "Compiles downstream"

### Looking for feedback on...

### CHANGELOG.md

- no need to update because very small

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4011)
<!-- Reviewable:end -->
