### PR TITLE
Add OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,21 @@ By default, any application linking to osimCommon will create an
 written by OpenSim (incl. during static initialization) are written to
 both this file and the standard output streams." OFF)
 
+option(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+"Disable OpenSim from registering bundled `Object` types at static
+initialization time.
+
+If this is set to `ON` (i.e. disable static type registration) then
+downstream code *must* manually register the OpenSim types it plans
+on using by calling `RegisterTypes_osimLIBRARY` (e.g. `RegisterTypes_osimActuators`),
+or by manually registering each type (e.g. `Object::registerType(PhysicalOffsetFrame());`)." OFF)
+mark_as_advanced(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION)
+
 if(OPENSIM_DISABLE_LOG_FILE)
     add_definitions(-DOPENSIM_DISABLE_LOG_FILE=1)
+endif()
+if(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION)
+    add_definitions(-DOPENSIM_DISABLE_STATIC_TYPE_REGISTRATION=1)
 endif()
 
 set(OPENSIM_BUILD_INDIVIDUAL_APPS_DEFAULT OFF)

--- a/OpenSim/Actuators/RegisterTypes_osimActuators.cpp
+++ b/OpenSim/Actuators/RegisterTypes_osimActuators.cpp
@@ -37,8 +37,9 @@
 using namespace OpenSim;
 using namespace std;
 
-static osimActuatorsInstantiator instantiator;
-
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimActuatorsInstantiator instantiator;
+#endif
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
+++ b/OpenSim/Analyses/RegisterTypes_osimAnalyses.cpp
@@ -31,7 +31,9 @@
 using namespace OpenSim;
 using namespace std;
 
-static osimAnalysesInstantiator instantiator; 
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimAnalysesInstantiator instantiator;
+#endif
      
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1747,7 +1747,8 @@ extern "C" OSIMCOMMON_API void RegisterTypes_osimCommon();
 void osimCommonInstantiator::registerDllClasses() 
 { 
         RegisterTypes_osimCommon(); 
-} 
-    
-static osimCommonInstantiator instantiator; 
+}
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimCommonInstantiator instantiator;
+#endif
 /// @endcond

--- a/OpenSim/ExampleComponents/RegisterTypes_osimExampleComponents.cpp
+++ b/OpenSim/ExampleComponents/RegisterTypes_osimExampleComponents.cpp
@@ -33,7 +33,9 @@
 using namespace std;
 using namespace OpenSim;
 
-static osimExampleComponentsInstantiator osimExampleComponentsInstantiator; 
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+   static osimExampleComponentsInstantiator osimExampleComponentsInstantiator;
+#endif
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.cpp
+++ b/OpenSim/Examples/Moco/exampleMocoCustomEffortGoal/RegisterTypes_osimMocoCustomEffortGoal.cpp
@@ -20,7 +20,9 @@
 
 using namespace OpenSim;
 
-static osimMocoCustomEffortGoalInstantiator instantiator;
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimMocoCustomEffortGoalInstantiator instantiator;
+#endif
 
 OSIMMOCOCUSTOMEFFORTGOAL_API void RegisterTypes_osimMocoCustomEffortGoal() {
     try {

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/RegisterTypes_osimPlugin.cpp
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/RegisterTypes_osimPlugin.cpp
@@ -30,7 +30,9 @@
 using namespace OpenSim;
 using namespace std;
 
-static dllObjectInstantiator instantiator; 
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static dllObjectInstantiator instantiator;
+#endif
      
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Examples/SymbolicExpressionReporter/RegisterTypes_osimExpPlugin.cpp
+++ b/OpenSim/Examples/SymbolicExpressionReporter/RegisterTypes_osimExpPlugin.cpp
@@ -30,7 +30,9 @@
 using namespace OpenSim;
 using namespace std;
 
-static dllPluginObjectInstantiator dInstantiator; 
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static dllPluginObjectInstantiator dInstantiator;
+#endif
      
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Moco/RegisterTypes_osimMoco.cpp
+++ b/OpenSim/Moco/RegisterTypes_osimMoco.cpp
@@ -64,7 +64,9 @@
 
 using namespace OpenSim;
 
-static osimMocoInstantiator instantiator;
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimMocoInstantiator instantiator;
+#endif
 
 OSIMMOCO_API void RegisterTypes_osimMoco() {
     try {

--- a/OpenSim/OpenSim.h
+++ b/OpenSim/OpenSim.h
@@ -42,5 +42,8 @@ public:
     }
 };
 
-static osimInstantiator instantiator;
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimInstantiator instantiator;
+#endif
+
 #endif // _opensim_h_

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -146,7 +146,9 @@
 using namespace std;
 using namespace OpenSim;
 
-static osimSimulationInstantiator instantiator; 
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimSimulationInstantiator instantiator;
+#endif
 
 //_____________________________________________________________________________
 /**

--- a/OpenSim/Tools/RegisterTypes_osimTools.cpp
+++ b/OpenSim/Tools/RegisterTypes_osimTools.cpp
@@ -62,7 +62,9 @@
 using namespace std;
 using namespace OpenSim;
 
-static osimToolsInstantiator instantiator;
+#ifndef OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
+    static osimToolsInstantiator instantiator;
+#endif
 
 //_____________________________________________________________________________
 /**


### PR DESCRIPTION
This is a patch I've been applying downstream in [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator) that I figured might be useful for opensim-core.

This adds an `OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION` cmake `option` that can be toggled `ON` to build OpenSim without the static-init-time instantiator classes.

The motivation for doing this is:

- It lets downstream applications/libraries decide if/when to register OpenSim types. There are several reasons why downstream might want this:
  - The application wants to set up logging, log sinks, etc. before registration, so that all logged registration errors appear in a runtime-defined location (e.g. a UI).
  - The application wants to lazily-load parts of OpenSim
  - A bug has appeared in the application and it would be useful to debug step registration, skip registering something, etc. without having to recompile OpenSim.
- It lets downstream application/libraries decide load-order. The reason you'd want to do this is:
  - OpenSim is being loaded as one library/application, so the instantiators cannot lean on the fact that the dynamic loader is loading libraries in use-order. Right now, the only reason the static initializers work is because `osimActuators.dll` depends on `osimCommon.dll`, so the dynamic loader just happens to load one before the other - this may fail if they are merged into one binary. It may also fail if (e.g.) the log is statically initialized after a static registration function that writes to the log (a segfault I encountered with OpenSim Creator).

### Brief summary of changes

- Added `OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION` to `CMakeLists.txt`
- Used the resulting compile define to control whether the static initializer is emitted or not

### Testing I've completed

- Similar pattern works on OpenSim Creator, which has its own application log (shown to the user via a UI) and statically compiles OpenSim into its executable.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated TODO

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4012)
<!-- Reviewable:end -->
