### PR TITLE
Bump Ubuntu versions on CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -876,119 +876,6 @@ jobs:
           repos/opensim-org/opensim-core/pulls/${PR_NUMBER} \
           -f "body=${NEW_COMMENT_BODY}"
 
-  ubuntu20:
-    name: Ubuntu 20.04
-    runs-on: ubuntu-20.04
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install Python packages
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-
-    - name: Install Numpy
-      run: |
-        pip install pip --upgrade
-        pip install numpy==1.25
-
-    - name: Install packages
-      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen patchelf
-
-    - name: Install SWIG
-      # if: steps.cache-swig.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
-        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-        make && make -j4 install
-
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
-
-    - name: Build dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
-
-    - name: Configure opensim-core
-      id: configure
-      run: |
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-    - name: Build opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
-
-    - name: Test opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        # TODO: Temporary for python to find Simbody libraries.
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-        ctest --parallel 4 --output-on-failure
-
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make --jobs 4 install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ubuntu20.zip opensim-core-${{ steps.configure.outputs.version }}
-        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
-
-    - name: Test Python bindings
-      run: |
-         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
-         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-         # Run the python tests, verbosely.
-         python3 -m unittest discover --start-directory opensim/tests --verbose
-
-    - name: Upload opensim-core
-      uses: actions/upload-artifact@v4
-      with:
-        # The upload-artifact zipping does not preserve symlinks or executable
-        # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-ubuntu20-linux
-        path: opensim-core-${{ steps.configure.outputs.version }}-ubuntu20.zip
-
   ubuntu22:
     name: Ubuntu 22.04
     runs-on: ubuntu-22.04
@@ -1089,6 +976,119 @@ jobs:
 
     - name: Test Python bindings
       run: |
+         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+         # Run the python tests, verbosely.
+         python3 -m unittest discover --start-directory opensim/tests --verbose
+
+    - name: Upload opensim-core
+      uses: actions/upload-artifact@v4
+      with:
+        # The upload-artifact zipping does not preserve symlinks or executable
+        # bits. So we zip ourselves, even though this causes a double-zip.
+        name: opensim-core-${{ steps.configure.outputs.version }}-ubuntu22-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ubuntu22.zip
+
+  ubuntu24:
+    name: Ubuntu 24.04
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Python packages
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install Numpy
+      run: |
+        pip install pip --upgrade
+        pip install numpy==1.25
+
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install --yes build-essential libtool autoconf pkg-config gfortran libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen patchelf
+
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+
+    - name: Build dependencies
+      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build_deps
+        cd $GITHUB_WORKSPACE/../build_deps
+        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
+        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
+        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_TROPTER=ON)
+        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
+        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
+        cmake "${DEP_CMAKE_ARGS[@]}"
+        make --jobs 4
+
+    - name: Configure opensim-core
+      id: configure
+      run: |
+        mkdir $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
+        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
+        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=on -DBUILD_JAVA_WRAPPING=on)
+        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
+        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=off)
+        # TODO: Update to simbody.github.io/latest
+        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
+        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
+        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
+        cmake "${OSIM_CMAKE_ARGS[@]}"
+        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Build opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make --jobs 4
+
+    - name: Test opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        # TODO: Temporary for python to find Simbody libraries.
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
+        ctest --parallel 4 --output-on-failure
+
+    - name: Install opensim-core
+      run: |
+        cd $GITHUB_WORKSPACE/../build
+        make doxygen
+        make --jobs 4 install
+        cd $GITHUB_WORKSPACE
+        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ubuntu24.zip opensim-core-${{ steps.configure.outputs.version }}
+        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+
+    - name: Test Python bindings
+      run: |
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/opensim_dependencies_install/simbody/lib
         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
         # Run the python tests, verbosely.
@@ -1099,8 +1099,8 @@ jobs:
       with:
         # The upload-artifact zipping does not preserve symlinks or executable
         # bits. So we zip ourselves, even though this causes a double-zip.
-        name: opensim-core-${{ steps.configure.outputs.version }}-ubuntu22-linux
-        path: opensim-core-${{ steps.configure.outputs.version }}-ubuntu22.zip
+        name: opensim-core-${{ steps.configure.outputs.version }}-ubuntu24-linux
+        path: opensim-core-${{ steps.configure.outputs.version }}-ubuntu24.zip
 
   build_gui:
     name: Build GUI

--- a/OpenSim/Common/DataTable.h
+++ b/OpenSim/Common/DataTable.h
@@ -505,7 +505,7 @@ public:
     DataTable<double, Vec3>       | Vec3         | 3
     DataTable<double, Quaternion> | Quaternion   | 4                          */
     unsigned numComponentsPerElement() const override {
-        return numComponentsPerElement_impl(ETY{});
+        return numComponentsPerElement_impl(ETY());
     }
 
     /// @name Row accessors/mutators.

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1676,7 +1676,7 @@ std::string Object::dump() const {
     updateXMLNode(elem);
     Object::setSerializeAllDefaults(false);
     doc.getRootElement().node_begin()->writeToString(outString);
-    return std::move(outString);
+    return outString;
 }
 
 

--- a/OpenSim/Common/XsensDataReader.cpp
+++ b/OpenSim/Common/XsensDataReader.cpp
@@ -128,7 +128,7 @@ XsensDataReader::extendRead(const std::string& folderName) const {
                 gyro_row_vector[imu_index] = SimTK::Vec3(OpenSim::IO::stod(nextRow[gyroIndex]),
                     OpenSim::IO::stod(nextRow[gyroIndex + 1]), OpenSim::IO::stod(nextRow[gyroIndex + 2]));
             // Create Mat33 then convert into Quaternion
-            SimTK::Mat33 imu_matrix(SimTK::NaN);
+            SimTK::Mat33 imu_matrix;
             int matrix_entry_index = 0;
             for (int mcol = 0; mcol < 3; mcol++) {
                 for (int mrow = 0; mrow < 3; mrow++) {

--- a/OpenSim/Common/XsensDataReader.cpp
+++ b/OpenSim/Common/XsensDataReader.cpp
@@ -128,7 +128,7 @@ XsensDataReader::extendRead(const std::string& folderName) const {
                 gyro_row_vector[imu_index] = SimTK::Vec3(OpenSim::IO::stod(nextRow[gyroIndex]),
                     OpenSim::IO::stod(nextRow[gyroIndex + 1]), OpenSim::IO::stod(nextRow[gyroIndex + 2]));
             // Create Mat33 then convert into Quaternion
-            SimTK::Mat33 imu_matrix{ SimTK::NaN };
+            SimTK::Mat33 imu_matrix(SimTK::NaN);
             int matrix_entry_index = 0;
             for (int mcol = 0; mcol < 3; mcol++) {
                 for (int mrow = 0; mrow < 3; mrow++) {
@@ -137,7 +137,7 @@ XsensDataReader::extendRead(const std::string& folderName) const {
                 }
             }
             // Convert imu_matrix to Quaternion
-            SimTK::Rotation imu_rotation{ imu_matrix };
+            SimTK::Rotation imu_rotation(imu_matrix);
             orientation_row_vector[imu_index] = imu_rotation.convertRotationToQuaternion();
         }
         if (done) 


### PR DESCRIPTION
### Brief summary of changes
Bump the Ubuntu version on CI to 22.04 and 24.04 since the 20.04 GitHub Actions runner will be soon removed.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...CI change only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4014)
<!-- Reviewable:end -->
