### PR TITLE
Fix installation of Moco dependency libraries on Linux

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -68,7 +68,7 @@ if(UNIX AND OPENSIM_COPY_DEPENDENCIES AND (NOT (DEFINED OPENSIM_WITH_CASADI AND 
             ${CMAKE_CURRENT_BINARY_DIR}/OpenSimMocoInstallMacDependencyLibraries.cmake)
         configure_file(OpenSimMocoInstallMacDependencyLibraries.cmake.in
                 "${script}" @ONLY)
-    elseif(LINUX)
+    else()
         set(script
             ${CMAKE_CURRENT_BINARY_DIR}/OpenSimMocoInstallLinuxDependencyLibraries.cmake)
         configure_file(OpenSimMocoInstallLinuxDependencyLibraries.cmake.in


### PR DESCRIPTION
### Brief summary of changes
While building the current `main` branch inside a Docker container with Ubuntu 22.04, I encountered an issue where the `elseif(LINUX)` branch was skipped leading to the `script` CMake not being set, causing a failure when CMake tries to install the script below.

### Testing I've completed
Tested locally in a fresh Docker container. Not sure how to replicate on GitHub Actions.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal build fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4022)
<!-- Reviewable:end -->
