### PR TITLE
Add `ExpressionBasedPathForce`

### DIFF
--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -209,6 +209,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/ExpressionBasedCoordinateForce.h>
 
 %include <OpenSim/Simulation/Model/PathSpring.h>
+%include <OpenSim/Simulation/Model/ExpressionBasedPathForce.h>
 %include <OpenSim/Simulation/Model/BushingForce.h>
 %include <OpenSim/Simulation/Model/FunctionBasedBushingForce.h>
 %include <OpenSim/Simulation/Model/ExpressionBasedBushingForce.h>

--- a/OpenSim/Sandbox/Moco/CMakeLists.txt
+++ b/OpenSim/Sandbox/Moco/CMakeLists.txt
@@ -18,15 +18,7 @@ endfunction()
 
 MocoAddSandboxExecutable(NAME sandboxSandbox LIB_DEPENDS osimMoco)
 
-MocoAddSandboxExecutable(NAME sandboxTendonForceState
-        LIB_DEPENDS osimMoco)
-MocoAddSandboxExecutable(NAME sandboxImplicitActivationDynamics
-        LIB_DEPENDS osimMoco)
-
-
 # MocoStudy-related.
-MocoAddSandboxExecutable(NAME sandboxSlidingMass
-        LIB_DEPENDS osimMoco)
 MocoAddSandboxExecutable(NAME sandboxContact
         LIB_DEPENDS osimMoco osimAnalyses)
 MocoAddSandboxExecutable(NAME sandboxMuscle
@@ -44,7 +36,6 @@ add_subdirectory(sandboxWholeBodyTracking)
 add_subdirectory(sandboxMarkerTrackingWholeBody)
 add_subdirectory(sandboxJointReaction)
 add_subdirectory(sandboxOneLegCouplerKnee)
-add_subdirectory(sandboxMarkerTrackingContactWholeBody)
 add_subdirectory(sandboxSquatToStand)
 add_subdirectory(sandboxMocoTrack)
 add_subdirectory(sandboxMocoUserControlCost)

--- a/OpenSim/Simulation/Model/ExpressionBasedPathForce.cpp
+++ b/OpenSim/Simulation/Model/ExpressionBasedPathForce.cpp
@@ -1,0 +1,169 @@
+/* -------------------------------------------------------------------------- *
+ *                 OpenSim:  ExpressionBasedPathForce.cpp                    *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "ExpressionBasedPathForce.h"
+
+#include <lepton/Parser.h>
+#include <lepton/ParsedExpression.h>
+
+using namespace OpenSim;
+
+//=============================================================================
+// CONSTRUCTOR(S) AND DESTRUCTOR
+//=============================================================================
+ExpressionBasedPathForce::ExpressionBasedPathForce() {
+    constructProperties();
+}
+
+ExpressionBasedPathForce::ExpressionBasedPathForce(const std::string& name, 
+        double restLength, const std::string& expression) {
+    constructProperties();
+    setName(name);
+    set_resting_length(restLength);
+    set_expression(expression);
+}
+
+ExpressionBasedPathForce::ExpressionBasedPathForce(const std::string& name, 
+        double restLength, const std::string& expression, bool clampStretch) {
+    constructProperties();
+    setName(name);
+    set_resting_length(restLength);
+    set_expression(expression);
+    set_clamp_stretch(clampStretch);
+}
+
+void ExpressionBasedPathForce::constructProperties() {
+    constructProperty_path(GeometryPath());
+    constructProperty_resting_length(0);
+    constructProperty_expression("0.0");
+    constructProperty_clamp_stretch(true);
+
+    // override default GeometryPath color (at time of writing, grey) with
+    // green for backwards-compatibility
+    upd_path().upd_Appearance().set_color({0, 1, 0});
+}
+
+//=============================================================================
+// MODEL COMPONENT INTERFACE
+//=============================================================================
+void ExpressionBasedPathForce::extendFinalizeFromProperties() {
+    Super::extendFinalizeFromProperties();
+
+    OPENSIM_THROW_IF_FRMOBJ(
+        (SimTK::isNaN(get_resting_length()) || get_resting_length() < 0),
+        Exception,
+        "Expected the 'resting_length' property to be less than zero, but "
+        "received {}.", get_resting_length());
+
+    // Remove whitespace from the expression.
+    std::string& expression = upd_expression();
+    expression.erase(remove_if(expression.begin(), expression.end(), ::isspace), 
+            expression.end());
+    
+    // Parse the expression and create the program.
+    _tensionProg = Lepton::Parser::parse(expression).optimize().createProgram();
+}
+
+void ExpressionBasedPathForce::extendAddToSystem(
+        SimTK::MultibodySystem& system) const {
+    Super::extendAddToSystem(system);
+    this->_tensionCV = addCacheVariable("tension", 0.0, SimTK::Stage::Velocity);
+}
+
+//==============================================================================
+// METHODS
+//==============================================================================
+double ExpressionBasedPathForce::getLength(const SimTK::State& s) const {
+    return getPath().getLength(s);
+}
+
+double ExpressionBasedPathForce::getStretch(const SimTK::State& s) const {
+    const double& length = getLength(s);
+    const double& restingLength = get_resting_length();
+    return length < restingLength && getClampStretch() ? 0.0 
+                                                       : length - restingLength;
+}
+
+double ExpressionBasedPathForce::getLengtheningSpeed(
+        const SimTK::State& s) const {
+    return getPath().getLengtheningSpeed(s);
+}
+
+double ExpressionBasedPathForce::getTension(const SimTK::State& s) const {
+    return getCacheVariableValue(s, _tensionCV);
+}
+
+//==============================================================================
+// SCALING
+//==============================================================================
+void ExpressionBasedPathForce::extendPostScale(const SimTK::State& s, 
+        const ScaleSet& scaleSet) {
+    Super::extendPostScale(s, scaleSet);
+
+    AbstractGeometryPath& path = updPath();
+    if (path.getPreScaleLength(s) > 0.0) {
+        double scaleFactor = path.getLength(s) / path.getPreScaleLength(s);
+        upd_resting_length() *= scaleFactor;
+
+        // Clear the pre-scale length that was stored in the 
+        // AbstractGeometryPath.
+        path.setPreScaleLength(s, 0.0);
+    }
+}
+
+//=============================================================================
+// COMPUTATION
+//=============================================================================
+double ExpressionBasedPathForce::computeMomentArm(const SimTK::State& s,
+        const Coordinate& coordinate) const {
+    return getPath().computeMomentArm(s, coordinate);
+}
+
+OpenSim::Array<std::string> ExpressionBasedPathForce::getRecordLabels() const {
+    OpenSim::Array<std::string> labels("");
+    labels.append(fmt::format("{}_tension", getName()));
+    return labels;
+}
+
+OpenSim::Array<double> ExpressionBasedPathForce::getRecordValues(
+        const SimTK::State& state) const {
+    OpenSim::Array<double> values(1);
+    values.append(getTension(state));
+    return values;
+}
+
+//=============================================================================
+// FORCE PRODUCER INTERFACE
+//=============================================================================
+void ExpressionBasedPathForce::implProduceForces(const SimTK::State& s, 
+        ForceConsumer& forceConsumer) const {
+
+    std::map<std::string, double> vars;
+    vars["s"] = getStretch(s);
+    vars["ldot"] = getLengtheningSpeed(s);
+
+    double tension = _tensionProg.evaluate(vars);
+    setCacheVariableValue(s, _tensionCV, tension);
+
+    getPath().produceForces(s, tension, forceConsumer);
+}

--- a/OpenSim/Simulation/Model/ExpressionBasedPathForce.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedPathForce.h
@@ -1,7 +1,7 @@
-#ifndef OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_
-#define OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_
+#ifndef OPENSIM_EXPRESSION_BASED_PATH_FORCE_H_
+#define OPENSIM_EXPRESSION_BASED_PATH_FORCE_H_
 /* -------------------------------------------------------------------------- *
- *                   OpenSim:  ExpressionBasedPathSpring.h                    *
+ *                   OpenSim:  ExpressionBasedPathForce.h                     *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -27,40 +27,52 @@
 #include <OpenSim/Simulation/Model/ForceProducer.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
 
+#include <lepton/ExpressionProgram.h>
 namespace OpenSim {
 
 class ScaleSet;
 
 /**
- * A massless, spring-based path Force whose force magnitude is determined by a 
+ * A massless, path-based Force whose force magnitude is determined by a 
  * user-defined expression, with the path stretch (`s = l-l0`) and the path 
  * speed (`ldot`) as variables, where `l` is the path length and `l0` is the 
- * rest length. The path of the ExpressionBasedPathSpring is determined by an 
+ * rest length. The path of the ExpressionBasedPathForce is determined by an 
  * object derived from AbstractGeometryPath. 
  *
  * "s" and "ldot" are the variables names expected by the expression parser.
  * Common C math library functions such as: exp(), pow(), sqrt(), sin(), ...
  * are permitted. See Lepton/Operation.h for a complete list.
  *
+ * By default, the ExpressionBasedPathForce will not apply tension when the 
+ * path stretch is negative (i.e., when the path is shorter than its resting 
+ * length). This behavior can be modified by setting the `clamp_stretch`
+ * property via `setClampStretch()`. Clamping the path stretch creates a 
+ * discontinuity in the force profile, which may not be desired during gradient
+ * based optimization. 
+ *
  * For example: string expression = "-1.5*exp(10*(d-0.25)^2)*(1 + 2.0*ddot)"
- *              provides a model of a path spring with non-linear stiffness 
+ *              provides a model of a path force with non-linear stiffness 
  *              and damping.
  */
-class OSIMSIMULATION_API ExpressionBasedPathSpring : public ForceProducer {
-OpenSim_DECLARE_CONCRETE_OBJECT(ExpressionBasedPathSpring, ForceProducer);
+class OSIMSIMULATION_API ExpressionBasedPathForce : public ForceProducer {
+OpenSim_DECLARE_CONCRETE_OBJECT(ExpressionBasedPathForce, ForceProducer);
 public:
 //=============================================================================
 // PROPERTIES
 //=============================================================================
     OpenSim_DECLARE_PROPERTY(resting_length, double,
-        "The resting length (m) of the ExpressionBasedPathSpring. Default: 0.");
+        "The resting length (m) of the ExpressionBasedPathForce. Default: 0.");
     OpenSim_DECLARE_PROPERTY(expression, std::string,
-        "Expression of the path spring magnitude as a function of "
+        "Expression of the path force magnitude as a function of "
         "the path stretch (s) and the path speed (ldot). "
         "Note, expression cannot have any whitespace separating characters.");
     OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
         "The path defines the length and lengthening speed of the "
-        "ExpressionBasedPathSpring");
+        "ExpressionBasedPathForce");
+    OpenSim_DECLARE_PROPERTY(clamp_stretch, bool,
+        "Clamp the stretch to be non-negative. Default: true. "
+        "If true, the force will not apply tension when the path is "
+        "shorter than its resting length.");
 
 //=============================================================================
 // OUTPUTS
@@ -79,18 +91,26 @@ public:
 //==============================================================================
     
     /** Default constructor. */
-    ExpressionBasedPathSpring();
+    ExpressionBasedPathForce();
 
     /** Convenience constructor.
-     * @param name          name of this %ExpressionBasedPathSpring Object
-     * @param restLength    the spring's resting length
-     * @param expression    the expression used to compute spring tension */
-     ExpressionBasedPathSpring(const std::string& name, 
-        double restLength, double stiffness, double dissipation);
+     * @param name          name of this %ExpressionBasedPathForce Object
+     * @param restLength    the force's resting length
+     * @param expression    the expression used to compute path tension */
+    ExpressionBasedPathForce(const std::string& name, 
+            double restLength, const std::string& expression);
 
+    /** Convenience constructor.
+     * @param name          name of this %ExpressionBasedPathForce Object
+     * @param restLength    the force's resting length
+     * @param expression    the expression used to compute force tension 
+     * @param clampStretch  if true, the force will not apply tension when the
+     *                      path is shorter than its resting length */
+    ExpressionBasedPathForce(const std::string& name, 
+            double restLength, const std::string& expression, bool clampStretch);
 
     /** 
-     * The resting length of the path spring. The default value is 0. 
+     * The resting length of the path force. The default value is 0. 
      */
     double getRestingLength() const {   
         return get_resting_length();
@@ -98,6 +118,31 @@ public:
     /// @copydoc getRestingLength()
     void setRestingLength(double restingLength) {
         set_resting_length(restingLength);
+    }
+
+    /** 
+     * The expression that defines the path force tension. 
+     * @note The expression must not contain any whitespace separating 
+     *       characters.
+     */
+    void setExpression(const std::string& expression) {
+        set_expression(expression);
+    }
+    /// @copydoc setExpression()
+    const std::string& getExpression() const {
+        return get_expression();
+    }
+    
+    /** 
+     * If true, the force will not apply tension when the path is shorter than 
+     * its resting length. Default: true.
+     */
+    bool getClampStretch() const {
+        return get_clamp_stretch();
+    }
+    /// @copydoc getClampStretch()
+    void setClampStretch(bool clampStretch) {
+        set_clamp_stretch(clampStretch);
     }
 
     /** 
@@ -134,31 +179,30 @@ public:
     bool hasVisualPath() const override { return getPath().isVisualPath(); };
 
     /** 
-     * Get the length of the ExpressionBasedPathSpring. 
+     * Get the length of the ExpressionBasedPathForce. 
      * 
      * @note Accessible at SimTK::Stage::Position. 
      */
     double getLength(const SimTK::State& s) const;
 
     /** 
-     * Get the stretch in the ExpressionBasedPathSpring. 
+     * Get the stretch in the ExpressionBasedPathForce. 
      * 
      * @note Accessible at SimTK::Stage::Position. 
      */
     double getStretch(const SimTK::State& s) const;
 
     /** 
-     * Get the lengthening speed of the ExpressionBasedPathSpring. 
+     * Get the lengthening speed of the ExpressionBasedPathForce. 
      * 
      * @note Accessible at SimTK::Stage::Velocity. 
      */
     double getLengtheningSpeed(const SimTK::State& s) const;
 
     /** 
-     * Get the tension generated by the ExpressionBasedPathSpring. 
+     * Get the tension generated by the ExpressionBasedPathForce. 
      * 
-     * @note The value of the tension can only be obtained after the system has
-     * been realized to SimTK::Stage::Dynamics. 
+     * @note Accessible at SimTK::Stage::Dynamics. 
      */
     double getTension(const SimTK::State& s) const;
 
@@ -169,8 +213,8 @@ public:
     double computeMomentArm(const SimTK::State& s, 
             const Coordinate& aCoord) const;
 
-=    // SCALE
-    /** Adjust the resting length of the path spring after the model has been
+    // SCALE
+    /** Adjust the resting length of the path force after the model has been
      * scaled. The `resting_length` property is multiplied by the quotient of
      * the current path length and the path length before scaling. 
      */
@@ -180,6 +224,7 @@ public:
 protected:
     // MODEL COMPONENT INTERFACE
     void extendFinalizeFromProperties() override;
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
 
     // FORCE INTERFACE
     OpenSim::Array<std::string> getRecordLabels() const override;
@@ -191,8 +236,11 @@ private:
     void implProduceForces(const SimTK::State&, ForceConsumer&) const override;
 
     void constructProperties();
+
+    Lepton::ExpressionProgram _tensionProg;
+    mutable CacheVariable<double> _tensionCV;
 };
 
 } // namespace OpenSim
 
-#endif // OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_
+#endif // OPENSIM_EXPRESSION_BASED_PATH_FORCE_H_

--- a/OpenSim/Simulation/Model/ExpressionBasedPathSpring.h
+++ b/OpenSim/Simulation/Model/ExpressionBasedPathSpring.h
@@ -1,0 +1,198 @@
+#ifndef OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_
+#define OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_
+/* -------------------------------------------------------------------------- *
+ *                   OpenSim:  ExpressionBasedPathSpring.h                    *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
+#include <OpenSim/Simulation/Model/ForceProducer.h>
+#include <OpenSim/Simulation/Model/GeometryPath.h>
+
+namespace OpenSim {
+
+class ScaleSet;
+
+/**
+ * A massless, spring-based path Force whose force magnitude is determined by a 
+ * user-defined expression, with the path stretch (`s = l-l0`) and the path 
+ * speed (`ldot`) as variables, where `l` is the path length and `l0` is the 
+ * rest length. The path of the ExpressionBasedPathSpring is determined by an 
+ * object derived from AbstractGeometryPath. 
+ *
+ * "s" and "ldot" are the variables names expected by the expression parser.
+ * Common C math library functions such as: exp(), pow(), sqrt(), sin(), ...
+ * are permitted. See Lepton/Operation.h for a complete list.
+ *
+ * For example: string expression = "-1.5*exp(10*(d-0.25)^2)*(1 + 2.0*ddot)"
+ *              provides a model of a path spring with non-linear stiffness 
+ *              and damping.
+ */
+class OSIMSIMULATION_API ExpressionBasedPathSpring : public ForceProducer {
+OpenSim_DECLARE_CONCRETE_OBJECT(ExpressionBasedPathSpring, ForceProducer);
+public:
+//=============================================================================
+// PROPERTIES
+//=============================================================================
+    OpenSim_DECLARE_PROPERTY(resting_length, double,
+        "The resting length (m) of the ExpressionBasedPathSpring. Default: 0.");
+    OpenSim_DECLARE_PROPERTY(expression, std::string,
+        "Expression of the path spring magnitude as a function of "
+        "the path stretch (s) and the path speed (ldot). "
+        "Note, expression cannot have any whitespace separating characters.");
+    OpenSim_DECLARE_PROPERTY(path, AbstractGeometryPath,
+        "The path defines the length and lengthening speed of the "
+        "ExpressionBasedPathSpring");
+
+//=============================================================================
+// OUTPUTS
+//=============================================================================
+    OpenSim_DECLARE_OUTPUT(length, double, getLength,
+        SimTK::Stage::Position);
+    OpenSim_DECLARE_OUTPUT(stretch, double, getStretch,
+        SimTK::Stage::Position);
+    OpenSim_DECLARE_OUTPUT(lengthening_speed, double, getLengtheningSpeed,
+        SimTK::Stage::Velocity);
+    OpenSim_DECLARE_OUTPUT(tension, double, getTension,
+        SimTK::Stage::Dynamics);
+
+//==============================================================================
+// METHODS
+//==============================================================================
+    
+    /** Default constructor. */
+    ExpressionBasedPathSpring();
+
+    /** Convenience constructor.
+     * @param name          name of this %ExpressionBasedPathSpring Object
+     * @param restLength    the spring's resting length
+     * @param expression    the expression used to compute spring tension */
+     ExpressionBasedPathSpring(const std::string& name, 
+        double restLength, double stiffness, double dissipation);
+
+
+    /** 
+     * The resting length of the path spring. The default value is 0. 
+     */
+    double getRestingLength() const {   
+        return get_resting_length();
+    }
+    /// @copydoc getRestingLength()
+    void setRestingLength(double restingLength) {
+        set_resting_length(restingLength);
+    }
+
+    /** 
+     * The path object. 
+     */
+    AbstractGeometryPath& updPath() { return upd_path(); }
+    const AbstractGeometryPath& getPath() const { return get_path(); }
+
+    template <typename PathType>
+    PathType& updPath() {
+        return dynamic_cast<PathType&>(upd_path());
+    }
+    template <typename PathType>
+    const PathType& getPath() const {
+        return dynamic_cast<const PathType&>(get_path());
+    }
+
+    template <typename PathType>
+    PathType* tryUpdPath() {
+        return dynamic_cast<PathType*>(&upd_path());
+    }
+    template <typename PathType>
+    const PathType* tryGetPath() const {
+        return dynamic_cast<const PathType*>(&get_path());
+    }
+
+    GeometryPath& updGeometryPath() {
+        return updPath<GeometryPath>();
+    }
+    const GeometryPath& getGeometryPath() const {
+        return getPath<GeometryPath>();
+    }
+    
+    bool hasVisualPath() const override { return getPath().isVisualPath(); };
+
+    /** 
+     * Get the length of the ExpressionBasedPathSpring. 
+     * 
+     * @note Accessible at SimTK::Stage::Position. 
+     */
+    double getLength(const SimTK::State& s) const;
+
+    /** 
+     * Get the stretch in the ExpressionBasedPathSpring. 
+     * 
+     * @note Accessible at SimTK::Stage::Position. 
+     */
+    double getStretch(const SimTK::State& s) const;
+
+    /** 
+     * Get the lengthening speed of the ExpressionBasedPathSpring. 
+     * 
+     * @note Accessible at SimTK::Stage::Velocity. 
+     */
+    double getLengtheningSpeed(const SimTK::State& s) const;
+
+    /** 
+     * Get the tension generated by the ExpressionBasedPathSpring. 
+     * 
+     * @note The value of the tension can only be obtained after the system has
+     * been realized to SimTK::Stage::Dynamics. 
+     */
+    double getTension(const SimTK::State& s) const;
+
+    // COMPUTATIONS
+    /** 
+     * Compute the moment arm of the path with respect to a given coordinate.
+     */
+    double computeMomentArm(const SimTK::State& s, 
+            const Coordinate& aCoord) const;
+
+=    // SCALE
+    /** Adjust the resting length of the path spring after the model has been
+     * scaled. The `resting_length` property is multiplied by the quotient of
+     * the current path length and the path length before scaling. 
+     */
+    void extendPostScale(const SimTK::State& s,
+                         const ScaleSet& scaleSet) override;
+
+protected:
+    // MODEL COMPONENT INTERFACE
+    void extendFinalizeFromProperties() override;
+
+    // FORCE INTERFACE
+    OpenSim::Array<std::string> getRecordLabels() const override;
+    OpenSim::Array<double> getRecordValues(
+            const SimTK::State& state) const override;
+
+private:
+    // FORCE PRODUCER INTERFACE
+    void implProduceForces(const SimTK::State&, ForceConsumer&) const override;
+
+    void constructProperties();
+};
+
+} // namespace OpenSim
+
+#endif // OPENSIM_EXPRESSION_BASED_PATH_SPRING_H_

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -67,6 +67,7 @@
 #include "Model/PointToPointSpring.h"
 #include "Model/ExpressionBasedPointToPointForce.h"
 #include "Model/PathSpring.h"
+#include "Model/ExpressionBasedPathForce.h"
 #include "Model/BushingForce.h"
 #include "Model/FunctionBasedBushingForce.h"
 #include "Model/ExpressionBasedBushingForce.h"
@@ -267,6 +268,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( PointToPointSpring() );
     Object::registerType( ExpressionBasedPointToPointForce() );
     Object::registerType( PathSpring() );
+    Object::registerType( ExpressionBasedPathForce() );
     Object::registerType( BushingForce() );
     Object::registerType( FunctionBasedBushingForce() );
     Object::registerType( ExpressionBasedBushingForce() );

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -64,6 +64,7 @@
 #include "Model/ExpressionBasedPointToPointForce.h"
 #include "Model/ExpressionBasedCoordinateForce.h"
 #include "Model/PathSpring.h"
+#include "Model/ExpressionBasedPathForce.h"
 #include "Model/BushingForce.h"
 #include "Model/FunctionBasedBushingForce.h"
 #include "Model/ExpressionBasedBushingForce.h"


### PR DESCRIPTION
Fixes issue #4034

### Brief summary of changes
Adds `ExpressionBasedPathForce`, which can be used to create non-linear path springs or other path-based force elements dependent on a user-provided expression. Includes some minor drive-by changes to CMake files based on recently removed sandbox files.

### Testing I've completed
Added a test to `testForces.cpp`. I have not tested the updated bindings.

### Looking for feedback on...

### CHANGELOG.md (choose one)
- updated.
