### PR TITLE
Fix bugs in `PolynomialPathFitter` related to the number of input coordinate samples

### DIFF
--- a/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
+++ b/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
@@ -63,8 +63,8 @@ for i = times.size():-1:1
     end
 end
 
-% Add columns for the toe joints. Use a sine function to generate the 
-% coordinate values.An amplitude of 0.5 keeps the values within the coordinate 
+% Add columns for the toe joints. Use a sine function to generate the
+% coordinate values.An amplitude of 0.5 keeps the values within the coordinate
 % range of the MTP joints in the model.
 amplitude = 0.5;
 angular_frequency = 10.0; % rad/s
@@ -74,8 +74,7 @@ mtp_values = Vector(values.getNumRows(), 0.0);
 time = Vector(1, 0.0);
 for i = 0:values.getNumRows()-1
     time.set(0, times.get(i));
-    mtp_value = sine.calcValue(time);
-    mtp_values.set(i, mtp_value);
+    mtp_values.set(i, sine.calcValue(time));
 end
 
 values.appendColumn('/jointset/mtp_r/mtp_angle_r/value', mtp_values);

--- a/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
+++ b/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
@@ -51,10 +51,10 @@ fitter.setModel(ModelProcessor(model));
 % The fitter will randomly sample around the coordinate values provided in the
 % table to generate model configurations for which to compute path lengths and
 % moment arms. In general, it is up to the user to decide how many sample points
-% are needed to adequately cover the range of motion of the model's coordinates. 
+% are needed to adequately cover the range of motion of the model's coordinates.
 % In this case, the table has many more rows than are needed for the fitter to
-% generate a good fit, so we will remove some of the rows to speed up the fitting 
-% process. 
+% generate a good fit, so we will remove some of the rows to speed up the fitting
+% process.
 values = TimeSeriesTable('coordinates.sto');
 times = values.getIndependentColumn();
 for i = times.size():-1:1

--- a/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
+++ b/Bindings/Java/Matlab/examples/PolynomialPathFitter/examplePolynomialPathFitter.m
@@ -64,7 +64,7 @@ for i = times.size():-1:1
 end
 
 % Add columns for the toe joints. Use a sine function to generate the
-% coordinate values.An amplitude of 0.5 keeps the values within the coordinate
+% coordinate values. An amplitude of 0.5 keeps the values within the coordinate
 % range of the MTP joints in the model.
 amplitude = 0.5;
 angular_frequency = 10.0; % rad/s

--- a/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
+++ b/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
@@ -61,8 +61,8 @@ for i in range(len(times)):
     if i % 10 != 0:
         values.removeRow(times[i])
 
-# Add columns for the toe joints. Use a sine function to generate the 
-# coordinate values.An amplitude of 0.5 keeps the values within the coordinate 
+# Add columns for the toe joints. Use a sine function to generate the
+# coordinate values.An amplitude of 0.5 keeps the values within the coordinate
 # range of the MTP joints in the model.
 amplitude = 0.5
 angular_frequency = 10.0 # rad/s

--- a/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
+++ b/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
@@ -62,7 +62,7 @@ for i in range(len(times)):
         values.removeRow(times[i])
 
 # Add columns for the toe joints. Use a sine function to generate the
-# coordinate values.An amplitude of 0.5 keeps the values within the coordinate
+# coordinate values. An amplitude of 0.5 keeps the values within the coordinate
 # range of the MTP joints in the model.
 amplitude = 0.5
 angular_frequency = 10.0 # rad/s

--- a/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
+++ b/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
@@ -51,10 +51,10 @@ fitter.setModel(osim.ModelProcessor(model))
 # The fitter will randomly sample around the coordinate values provided in the
 # table to generate model configurations for which to compute path lengths and
 # moment arms. In general, it is up to the user to decide how many sample points
-# are needed to adequately cover the range of motion of the model's coordinates. 
+# are needed to adequately cover the range of motion of the model's coordinates.
 # In this case, the table has many more rows than are needed for the fitter to
-# generate a good fit, so we will remove some of the rows to speed up the fitting 
-# process. 
+# generate a good fit, so we will remove some of the rows to speed up the fitting
+# process.
 values = osim.TimeSeriesTable('coordinates.sto')
 times = values.getIndependentColumn()
 for i in range(len(times)):

--- a/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
+++ b/Bindings/Python/examples/PolynomialPathFitter/examplePolynomialPathFitter.py
@@ -50,15 +50,33 @@ fitter.setModel(osim.ModelProcessor(model))
 #
 # The fitter will randomly sample around the coordinate values provided in the
 # table to generate model configurations for which to compute path lengths and
-# moment arms. This table has many more rows than are needed for the fitter to
-# generate a good fit, so we will remove some of the rows to speed up the
-# fitting process.
+# moment arms. In general, it is up to the user to decide how many sample points
+# are needed to adequately cover the range of motion of the model's coordinates. 
+# In this case, the table has many more rows than are needed for the fitter to
+# generate a good fit, so we will remove some of the rows to speed up the fitting 
+# process. 
 values = osim.TimeSeriesTable('coordinates.sto')
 times = values.getIndependentColumn()
 for i in range(len(times)):
     if i % 10 != 0:
         values.removeRow(times[i])
 
+# Add columns for the toe joints. Use a sine function to generate the 
+# coordinate values.An amplitude of 0.5 keeps the values within the coordinate 
+# range of the MTP joints in the model.
+amplitude = 0.5
+angular_frequency = 10.0 # rad/s
+phase = 0.0
+sine = osim.Sine(amplitude, angular_frequency, phase)
+mtp_values = osim.Vector(values.getNumRows(), 0.0)
+times = values.getIndependentColumn()
+time = osim.Vector(1, 0.0)
+for i in range(values.getNumRows()):
+    time.set(0, times[i])
+    mtp_values.set(i, sine.calcValue(time))
+
+values.appendColumn('/jointset/mtp_r/mtp_angle_r/value', mtp_values)
+values.appendColumn('/jointset/mtp_l/mtp_angle_l/value', mtp_values)
 fitter.setCoordinateValues(osim.TableProcessor(values))
 
 # Configure optional settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ v4.6
 - Support using swig version 4.2 to generate Java & Python bindings. (#4028)
 - Added `ExpressionBasedPathForce`, which can be used to create non-linear path springs or 
   other path-based force elements dependent on a user-provided expression. (#4035)
-
+- Fixed bugs in `PolynomialPathFitter` when too few coordinate samples were provided. (#4039)
 
 
 v4.5.1

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -170,6 +170,12 @@ void PolynomialPathFitter::run() {
             "Expected 'num_parallel_threads' to be between 1 and {}, but "
             "received {}.", std::thread::hardware_concurrency(),
             get_num_parallel_threads())
+    OPENSIM_THROW_IF_FRMOBJ(
+            static_cast<int>(values.getNumRows()) < get_num_parallel_threads(), 
+            Exception, "Expected the number of time points in the coordinate "
+            "values table to be greater than 'num_parallel_threads', but "
+            "received {} and {}, respectively.", 
+            values.getNumRows(), get_num_parallel_threads())
     log_info("Number of parallel threads = {}", get_num_parallel_threads());
 
     // Number of samples per frame.
@@ -662,7 +668,8 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     int timeIdx = 0;
     const auto& times = values.getIndependentColumn();
     TimeSeriesTable valuesSampled;
-    double dt = (times[1] - times[0]) / (get_num_samples_per_frame() + 2);
+    double dt = (times.size() < 2) ? 0.01 : 
+            (times[1] - times[0]) / (get_num_samples_per_frame() + 2);
     for (int i = 0; i < get_num_parallel_threads(); ++i) {
         int numTimeIndexes = outputs[i].nrow() / get_num_samples_per_frame();
         for (int j = 0; j < numTimeIndexes; ++j) {

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -151,9 +151,9 @@ private:
  * for the fitting process, or if the fit for a particular path did not meet the
  * specified tolerances.
  *
- * In general, it is up to the user to decide how many sample points are needed 
- * to adequately cover the range of motion of the model's coordinates. As the 
- * complexity of a muscle path increases, more sample points over a larger 
+ * In general, it is up to the user to decide how many sample points are needed
+ * to adequately cover the range of motion of the model's coordinates. As the
+ * complexity of a muscle path increases, more sample points over a larger
  * dimension of coordinate values are needed to achieve a good fit. Users may
  * consider manually creating the coordinates value table to ensure that the
  * sampling covers the fulle range of motion for the model.

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -151,6 +151,13 @@ private:
  * for the fitting process, or if the fit for a particular path did not meet the
  * specified tolerances.
  *
+ * In general, it is up to the user to decide how many sample points are needed 
+ * to adequately cover the range of motion of the model's coordinates. As the 
+ * complexity of a muscle path increases, more sample points over a larger 
+ * dimension of coordinate values are needed to achieve a good fit. Users may
+ * consider manually creating the coordinates value table to ensure that the
+ * sampling covers the fulle range of motion for the model.
+ *
  * It is highly recommended to use the files printed to the output directory to
  * evaluate the quality of the fitted paths (see `setOutputDirectory()` for more
  * details). Depending on the quality of the original model, it may not be

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -156,7 +156,7 @@ private:
  * complexity of a muscle path increases, more sample points over a larger
  * dimension of coordinate values are needed to achieve a good fit. Users may
  * consider manually creating the coordinates value table to ensure that the
- * sampling covers the fulle range of motion for the model.
+ * sampling covers the full range of motion for the model.
  *
  * It is highly recommended to use the files printed to the output directory to
  * evaluate the quality of the fitted paths (see `setOutputDirectory()` for more


### PR DESCRIPTION
Fixes issue #4038 

### Brief summary of changes
This change fixes two bugs in `PolynomialPathFitter`:
- When calculating the time step used to create the "sampled" coordinates table, we previously did not take into account that the table could only contain only one row. A time step of 0.01 is now used if only one row is present.
- If the number of threads used was greater than the number of rows in the table, a segfault would occur during a logging call as described in #4038.

### Testing I've completed
Added a unit test to `testPolynomialPathFitter`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4039)
<!-- Reviewable:end -->
