### PR TITLE
Fix bug in `DeGrooteFregly2016Muscle::getBoundsNormalizedFiberLength()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,8 @@ v4.6
 - Support using swig version 4.2 to generate Java & Python bindings. (#4028)
 - Added `ExpressionBasedPathForce`, which can be used to create non-linear path springs or 
   other path-based force elements dependent on a user-provided expression. (#4035)
-
+- Fixed a bug where `DeGrooteFregly2016Muscle::getBoundsNormalizedFiberLength()` was returning
+  tendon force bounds rather than fiber length bounds. (#4040)
 
 
 v4.5.1

--- a/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
+++ b/OpenSim/Actuators/DeGrooteFregly2016Muscle.h
@@ -383,7 +383,7 @@ public:
     /// bounds cannot be enforced directly. It is upon the user to ensure the
     /// muscle fiber is operating within the specified domain.
     SimTK::Vec2 getBoundsNormalizedFiberLength() const {
-        return {getMinNormalizedTendonForce(), getMaxNormalizedTendonForce()};
+        return {getMinNormalizedFiberLength(), getMaxNormalizedFiberLength()};
     }
     /// @}
 


### PR DESCRIPTION
Fixes issue #4032

### Brief summary of changes
Fixed a bug where `DeGrooteFregly2016Muscle::getBoundsNormalizedFiberLength()` was returning tendon force bounds rather than fiber length bounds.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4040)
<!-- Reviewable:end -->
