### PR TITLE
Clarify path logging line in GenericModelMaker

### DIFF
--- a/OpenSim/Tools/GenericModelMaker.cpp
+++ b/OpenSim/Tools/GenericModelMaker.cpp
@@ -165,10 +165,9 @@ Model* GenericModelMaker::processModel(const string& aPathToSubject) const
         model->initSystem();
 
         if (!_markerSetFileNameProp.getValueIsDefault() && _markerSetFileName !="Unassigned") {
-            log_info("Loading marker set from '{}'.", 
-                aPathToSubject + _markerSetFileName);
             std::string markerSetPath = 
                 SimTK::Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(aPathToSubject, _markerSetFileName);
+            log_info("Loading marker set from '{}'.", markerSetPath);
             MarkerSet *markerSet = new MarkerSet(markerSetPath);
             model->updateMarkerSet(*markerSet);
         }


### PR DESCRIPTION
### Brief summary of changes

This clarifies the path logging line in the GenericModelMaker. When I was trying to use absolute paths with the tool, I initially suspected there was something wrong with the path handling. It was challenging to debug and I eventually determined the absolute path handling was done correctly in SimTK but the logging output wasn't correct so I was getting an output like this:
```
Loading marker set from '/home/alexbeat/data/kg-all-trials-v1/16//home/alexbeat/AlexDev/opensim-domu/build/bin/kg_Scale_MarkerSet.xml'.
```
This fixes the logging output so that it outputs the exact path that will be in use after the call to `SimTK::Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory`, which aids in proper inspect and debugging of path handling. 

### Testing I've completed

Compiled and ran locally

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it is a single line change to logging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4045)
<!-- Reviewable:end -->
