### PR TITLE
Expose the energy dissipation state variable in `BushingForce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ v4.6
   tendon force bounds rather than fiber length bounds. (#4040)
 - Fixed bugs in `PolynomialPathFitter` when too few coordinate samples were provided. (#4039)
 - Exposed the "dissipated energy" state variable allocated by the `SimTK::Force::LinearBushing` that is internal to `BushingForce`. 
-  This changed fixed a bug in Moco, where adding a `BushingForce` led to a segfault due to a mismatch between the size of the 
+  This change fixed a bug in Moco where adding a `BushingForce` led to a segfault due to a mismatch between the size of the 
   auxiliary state vector reserved by Moco and `SimTK::State::getZ()`. (#4054)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ v4.6
 - Fixed a bug where `DeGrooteFregly2016Muscle::getBoundsNormalizedFiberLength()` was returning
   tendon force bounds rather than fiber length bounds. (#4040)
 - Fixed bugs in `PolynomialPathFitter` when too few coordinate samples were provided. (#4039)
+- Exposed the "dissipated energy" state variable allocated by the `SimTK::Force::LinearBushing` that is internal to `BushingForce`. 
+  This changed fixed a bug in Moco, where adding a `BushingForce` led to a segfault due to a mismatch between the size of the 
+  auxiliary state vector reserved by Moco and `SimTK::State::getZ()`. (#4054)
 
 
 v4.5.1

--- a/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
@@ -60,9 +60,6 @@ std::unique_ptr<Model> createSlidingMassModel() {
     actu->setOptimalForce(1);
     model->addComponent(actu);
 
-    auto* force = new BushingForce("bushing", model->getGround(), *body);
-    model->addComponent(force);
-
     body->attachGeometry(new Sphere(0.05));
 
     model->finalizeConnections();

--- a/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
@@ -48,7 +48,6 @@ std::unique_ptr<Model> createSlidingMassModel() {
     model->addComponent(body);
 
     // Allows translation along x.
-    std::cout << "ground name: " << model->getGround().getName() << std::endl;
     auto* joint = new SliderJoint("slider", model->getGround(), *body);
     auto& coord = joint->updCoordinate(SliderJoint::Coord::TranslationX);
     coord.setName("position");

--- a/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
@@ -72,22 +72,6 @@ std::unique_ptr<Model> createSlidingMassModel() {
 
 int main() {
 
-    // Create the model.
-    // ================
-    // std::unique_ptr<Model> model = createSlidingMassModel();
-    // SimTK::State state = model->initSystem();
-    // std::cout << "state.getY() = " << state.getY() << std::endl;
-    // std::cout << "state.getQ() = " << state.getQ() << std::endl;
-    // std::cout << "state.getU() = " << state.getU() << std::endl;
-    // std::cout << "state.getZ() = " << state.getZ() << std::endl;
-
-    // auto stateNames = model->getStateVariableNames();
-    // for (int i = 0; i < stateNames.size(); ++i) {
-    //     const auto& name = stateNames[i];
-    //     std::cout << "state name: " << name << std::endl;
-    // }
-    // std::cout << "num state variables: " << model->getNumStateVariables() << std::endl;
-
     MocoStudy study;
     study.setName("sliding_mass");
 
@@ -111,9 +95,6 @@ int main() {
     // Speed must be within [-50, 50] throughout the motion.
     // Initial and final speed must be 0. Use compact syntax.
     problem.setStateInfo("/slider/position/speed", {-50, 50}, 0, 0);
-
-    problem.setStateInfo("/bushing/dissipated_energy", 
-            {-SimTK::Infinity, SimTK::Infinity});
 
     // Applied force must be between -50 and 50.
     problem.setControlInfo("/actuator", MocoBounds(-50, 50));

--- a/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
+++ b/OpenSim/Examples/Moco/exampleSlidingMass/exampleSlidingMass.cpp
@@ -48,6 +48,7 @@ std::unique_ptr<Model> createSlidingMassModel() {
     model->addComponent(body);
 
     // Allows translation along x.
+    std::cout << "ground name: " << model->getGround().getName() << std::endl;
     auto* joint = new SliderJoint("slider", model->getGround(), *body);
     auto& coord = joint->updCoordinate(SliderJoint::Coord::TranslationX);
     coord.setName("position");
@@ -59,6 +60,9 @@ std::unique_ptr<Model> createSlidingMassModel() {
     actu->setOptimalForce(1);
     model->addComponent(actu);
 
+    auto* force = new BushingForce("bushing", model->getGround(), *body);
+    model->addComponent(force);
+
     body->attachGeometry(new Sphere(0.05));
 
     model->finalizeConnections();
@@ -67,6 +71,22 @@ std::unique_ptr<Model> createSlidingMassModel() {
 }
 
 int main() {
+
+    // Create the model.
+    // ================
+    // std::unique_ptr<Model> model = createSlidingMassModel();
+    // SimTK::State state = model->initSystem();
+    // std::cout << "state.getY() = " << state.getY() << std::endl;
+    // std::cout << "state.getQ() = " << state.getQ() << std::endl;
+    // std::cout << "state.getU() = " << state.getU() << std::endl;
+    // std::cout << "state.getZ() = " << state.getZ() << std::endl;
+
+    // auto stateNames = model->getStateVariableNames();
+    // for (int i = 0; i < stateNames.size(); ++i) {
+    //     const auto& name = stateNames[i];
+    //     std::cout << "state name: " << name << std::endl;
+    // }
+    // std::cout << "num state variables: " << model->getNumStateVariables() << std::endl;
 
     MocoStudy study;
     study.setName("sliding_mass");
@@ -91,6 +111,9 @@ int main() {
     // Speed must be within [-50, 50] throughout the motion.
     // Initial and final speed must be 0. Use compact syntax.
     problem.setStateInfo("/slider/position/speed", {-50, 50}, 0, 0);
+
+    problem.setStateInfo("/bushing/dissipated_energy", 
+            {-SimTK::Infinity, SimTK::Infinity});
 
     // Applied force must be between -50 and 50.
     problem.setControlInfo("/actuator", MocoBounds(-50, 50));

--- a/OpenSim/Simulation/Model/BushingForce.cpp
+++ b/OpenSim/Simulation/Model/BushingForce.cpp
@@ -306,6 +306,11 @@ getRecordValues(const SimTK::State& state) const
 //-----------------------------------------------------------------------------
 // BushingForce::DissipatedEnergyStateVariable
 //-----------------------------------------------------------------------------
+const BushingForce& 
+BushingForce::DissipatedEnergyStateVariable::getBushingForce() const {
+    return static_cast<const BushingForce&>(getOwner());
+}
+
 double BushingForce::DissipatedEnergyStateVariable::getValue(
         const SimTK::State& state) const {
     return getBushingForce().getDissipatedEnergy(state);

--- a/OpenSim/Simulation/Model/BushingForce.h
+++ b/OpenSim/Simulation/Model/BushingForce.h
@@ -66,6 +66,13 @@ public:
         "Damping parameters resisting angular deviation rate. (Nm/(rad/s))");
     OpenSim_DECLARE_PROPERTY(translational_damping, SimTK::Vec3,
         "Damping parameters resisting relative translational velocity. (N/(m/s))");
+
+//==============================================================================
+// OUTPUTS
+//==============================================================================
+    OpenSim_DECLARE_OUTPUT(statebounds_dissipated_energy, SimTK::Vec2,
+        getBoundsDissipatedEnergy, SimTK::Stage::Model);   
+
 //==============================================================================
 // PUBLIC METHODS
 //==============================================================================
@@ -202,6 +209,15 @@ public:
 
     double getPowerDissipation(const SimTK::State& state) const;
 
+    /// The first element of the Vec2 is the lower bound, and the second is the
+    /// upper bound.
+    /// This function is intended primarily for the model Output 
+    /// 'statebounds_dissipated_energy'. We don't need the state, but the 
+    /// state parameter is a requirement of Output functions.
+    SimTK::Vec2 getBoundsDissipatedEnergy(const SimTK::State&) const {
+         return {0, SimTK::Infinity}; 
+    }
+
     //--------------------------------------------------------------------------
     // Reporting
     //--------------------------------------------------------------------------
@@ -227,9 +243,7 @@ private:
                     int index) : 
                 StateVariable(name, owner, subSysIndex, index, false) {}
 
-        const BushingForce& getBushingForce() const {
-            return static_cast<const BushingForce&>(getOwner());
-        }
+        const BushingForce& getBushingForce() const;
         double getValue(const SimTK::State& state) const override;
         void setValue(SimTK::State& state, double value) const override;
         double getDerivative(const SimTK::State& state) const override;

--- a/OpenSim/Simulation/Model/BushingForce.h
+++ b/OpenSim/Simulation/Model/BushingForce.h
@@ -242,7 +242,7 @@ public:
      * parameter is a requirement of Output functions.
      */
     SimTK::Vec2 getBoundsDissipatedEnergy(const SimTK::State&) const {
-         return {-SimTK::Infinity, SimTK::Infinity}; 
+         return {0, SimTK::Infinity}; 
     }
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/BushingForce.h
+++ b/OpenSim/Simulation/Model/BushingForce.h
@@ -38,15 +38,19 @@ namespace OpenSim {
 //==============================================================================
 /**
  * A class implementing a Bushing Force.
+ *
  * A Bushing Force is the force proportional to the deviation of two frames.
  * One can think of the Bushing as being composed of 3 linear and 3 torsional
  * spring-dampers, which act along or about the bushing frames. Orientations
  * are measured as x-y-z body-fixed Euler rotations, which are treated as
  * though they were uncoupled. Damping is proportional to the deflection rate of 
- * change (e.g. Euler angle derivatives) which is NOT the angular velocity between
- * the two frames. That makes this bushing model suitable only for relatively
- * small relative orientation deviations between the frames.
- * The underlying Force in Simbody is a SimtK::Force::LinearBushing.
+ * change (e.g. Euler angle derivatives) which is NOT the angular velocity 
+ * between the two frames. That makes this bushing model suitable only for 
+ * relatively small relative orientation deviations between the frames.
+ *
+ * The underlying Force in Simbody is a SimtK::Force::LinearBushing. This 
+ * implementation exposes the state variable for the dissipated energy of the 
+ * bushing force allocated internally by Simbody.
  *
  * @author Ajay Seth
  */
@@ -214,7 +218,6 @@ public:
      */
     double getDissipatedEnergy(const SimTK::State& state) const;
     
-
     /** 
      * Set the accumulated dissipated energy to an arbitrary value, in joules.
      * 
@@ -257,10 +260,9 @@ private:
     //--------------------------------------------------------------------------
     // Implement ModelComponent interface.
     //--------------------------------------------------------------------------
-
     // Create a SimTK::Force::LinearBushing which implements this BushingForce.
     void extendAddToSystemAfterSubcomponents(
-        SimTK::MultibodySystem& system) const override;
+            SimTK::MultibodySystem& system) const override;
 
     /** 
      * Get the underlying SimTK::Force::LinearBushing force.

--- a/OpenSim/Simulation/Model/BushingForce.h
+++ b/OpenSim/Simulation/Model/BushingForce.h
@@ -215,12 +215,13 @@ public:
     double getDissipatedEnergy(const SimTK::State& state) const;
     
 
-    /** Set the accumulated dissipated energy to an arbitrary value, in joules.
-      * 
-      * Typically this is used only to reset the dissipated energy to zero, but 
-      * non-zero values can be useful if you are trying to match some existing 
-      * data or continuing a simulation.
-      */
+    /** 
+     * Set the accumulated dissipated energy to an arbitrary value, in joules.
+     * 
+     * Typically this is used only to reset the dissipated energy to zero, but 
+     * non-zero values can be useful if you are trying to match some existing 
+     * data or continuing a simulation.
+     */
     void setDissipatedEnergy(SimTK::State& state, double value) const;
 
     /** 
@@ -229,13 +230,16 @@ public:
      */
     double getPowerDissipation(const SimTK::State& state) const;
 
-    /// The first element of the Vec2 is the lower bound, and the second is the
-    /// upper bound.
-    /// This function is intended primarily for the model Output 
-    /// 'statebounds_dissipated_energy'. We don't need the state, but the 
-    /// state parameter is a requirement of Output functions.
+    /** 
+     * The first element of the Vec2 is the lower bound, and the second is the
+     * upper bound.
+     * 
+     * This function is intended primarily for the model Output 
+     * 'statebounds_dissipated_energy'. We don't need the state, but the state 
+     * parameter is a requirement of Output functions.
+     */
     SimTK::Vec2 getBoundsDissipatedEnergy(const SimTK::State&) const {
-         return {0, SimTK::Infinity}; 
+         return {-SimTK::Infinity, SimTK::Infinity}; 
     }
 
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -740,11 +740,12 @@ TEST_CASE("testBushingForce") {
             Catch::Matchers::WithinAbs(0.0, 1e-9));
 
     // Update the energy dissipation to be non-zero.
-    Real energyDissipation = SimTK::Test::randReal();
+    Random::Uniform rand(0, 1);
+    Real energyDissipation = rand.getValue();
     osim_state.updZ()[0] = energyDissipation;
     CHECK_THAT(bushingForce.getDissipatedEnergy(osim_state), 
             Catch::Matchers::WithinAbs(energyDissipation, 1e-9));
-    energyDissipation = SimTK::Test::randReal();
+    energyDissipation = rand.getValue();
     bushingForce.setDissipatedEnergy(osim_state, energyDissipation);
     CHECK_THAT(bushingForce.getDissipatedEnergy(osim_state), 
             Catch::Matchers::WithinAbs(energyDissipation, 1e-9));


### PR DESCRIPTION
Fixes issue #4042

### Brief summary of changes
This change exposes the "dissipated energy" state variable allocated by the `SimTK::Force::LinearBushing` that is internal to `BushingForce`. This fixes the bug in #4042, which occurred because the size of the auxiliary state vector reserved by Moco did not match `SimTK::State::getZ()`. This happened because Moco reserves state vectors based on the number of state variables reported by each `Component`, but `BushingForce` did not report the "dissipated energy" state as part of the system, even though a slot for it is reserved in the `SimTK::State`.

For convenience, I added the `Output` "statebounds_dissipated_energy", which Moco will use to automatically set the bounds on the energy dissipation state variable (i.e., so users do not have to call `setStateInfo`).

### Testing I've completed
Added tests to `testMocoInterface.cpp` and `testForces.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4054)
<!-- Reviewable:end -->
