### PR TITLE
Update patch number for OpenSim 4.5.2 API release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ request related to the change, then we may provide the commit.
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [OpenSim Core GitHub repo](https://github.com/opensim-org/opensim-core).
 
-v4.6
-====
+v4.5.2
+======
 - The performance of `getStateVariableValue`, `getStateVariableDerivativeValue`, and `getModelingOption` was improved in
   the case where provided string is just the name of the value, rather than a path to it (#3782)
 - Fixed bugs in `MocoStepTimeAsymmetryGoal::printDescriptionImpl()` where there were missing or incorrect values printed. (#3842)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ include(FeatureSummary)
 # ----------------
 set(OPENSIM_MAJOR_VERSION 4)
 set(OPENSIM_MINOR_VERSION 5)
-set(OPENSIM_PATCH_VERSION 1)
+set(OPENSIM_PATCH_VERSION 2)
 
 # Don't include the patch version if it is 0.
 set(PATCH_VERSION_STRING)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -3,7 +3,7 @@
 # OpenSim does not use this file directly.
 
 # We require a version of CMake that supports Visual Studio 2015.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 
 project(OpenSimDependencies)
 


### PR DESCRIPTION
### Brief summary of changes

Updates the patch version for the upcoming OpenSim 4.5.2 API. I've also updated the changelog to be consistent.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4055)
<!-- Reviewable:end -->
