### PR TITLE
Handle setting controls file to blank in tools more intuitively

### DIFF
--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -728,7 +728,7 @@ std::string AbstractTool::getControlsFileName() const
  */
 void AbstractTool::setControlsFileName(const std::string& controlsFilename)
 {
-    if (controlsFilename=="" || controlsFilename=="Unassigned") return;
+    bool disableControlSetController = (controlsFilename=="" || controlsFilename=="Unassigned");
 
     int numControllers = _controllerSet.getSize();
 
@@ -738,8 +738,11 @@ void AbstractTool::setControlsFileName(const std::string& controlsFilename)
             continue;
         OpenSim::ControlSetController& dController = (OpenSim::ControlSetController&)_controllerSet[i];
         dController.setControlSetFileName(controlsFilename);
+        if (disableControlSetController) 
+            dController.setEnabled(false);
         return;
     }
+    if (disableControlSetController) return;
     // Create a new controlsetController and add it to the tool
     ControlSetController* csc = new ControlSetController();
     csc->setControlSetFileName(controlsFilename);


### PR DESCRIPTION
Fixes issue #1840 in opensim-gui

### Brief summary of changes
setting ControlsFile to "" was being ignored making it impossible to revert setting controls file in Analyze tool GUI

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4058)
<!-- Reviewable:end -->
