### PR TITLE
Bump spdlog to v1.9.0

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -204,7 +204,7 @@ endif()
 AddDependency(NAME       spdlog
               DEFAULT    ON
               GIT_URL    https://github.com/gabime/spdlog.git
-              GIT_TAG    v1.4.1
+              GIT_TAG    v1.9.0
               CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
                          -DSPDLOG_BUILD_TESTS:BOOL=OFF
                          -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF


### PR DESCRIPTION
Fixes issue #4066

### Brief summary of changes

Bumps the `spdlog` dependency to version `1.9.0`, which bundles [a more recent version of `fmt` (v7.1.3)](https://github.com/gabime/spdlog/releases/tag/v1.8.2) and includes [support for `fmt` v8.x](https://github.com/gabime/spdlog/releases/tag/v1.9.0). This version also fixes a warning observed in #4066 when building with C++20 resulting in a deprecated implicit copy assignment operator warning.

### Testing I've completed

Built locally on M3 MacBook with:
- AppleClang 17.0.0
- macOS SDK 15.4

### Looking for feedback on...
Will this lead to any unforeseen issues in downstream libraries or cause backwards compatibility issues?

### CHANGELOG.md (choose one)

- updated.