### PR TITLE
Joint reaction goal prints

### DIFF
--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -154,9 +154,9 @@ void MocoJointReactionGoal::calcIntegrandImpl(
 }
 
 void MocoJointReactionGoal::printDescriptionImpl() const {
-    log_info("        joint path: ", get_joint_path());
-    log_info("        loads frame: ", get_loads_frame());
-    log_info("        expressed: ", get_expressed_in_frame_path());
+    log_info("    joint path: {}", get_joint_path());
+    log_info("        loads frame: {}", get_loads_frame());
+    log_info("        expressed: {}", get_expressed_in_frame_path());
 
     std::vector<std::string> measures(getProperty_reaction_measures().size());
     for (int i = 0; i < (int)measures.size(); i++) {

--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -154,7 +154,7 @@ void MocoJointReactionGoal::calcIntegrandImpl(
 }
 
 void MocoJointReactionGoal::printDescriptionImpl() const {
-    log_info("    joint path: {}", get_joint_path());
+    log_info("        joint path: {}", get_joint_path());
     log_info("        loads frame: {}", get_loads_frame());
     log_info("        expressed: {}", get_expressed_in_frame_path());
 


### PR DESCRIPTION
Fixes issue #<3719>

### Brief summary of changes
Added placeholder in each of the print statements in `MocoJointReactionGoal::printDescriptionImpl()`. This way the outputs are handled properly. 
### Testing I've completed
C++ and python on Mac. Both seem to print out the details for MocoJointReactionGoal now. 
### Looking for feedback on...

### CHANGELOG.md (choose one)
No need to update. Small fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4069)
<!-- Reviewable:end -->
