### PR TITLE
Fix issue with large marker labels

### DIFF
--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -112,8 +112,7 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         SimTK::Matrix_<SimTK::Vec3> marker_matrix(marker_nrow, marker_ncol);
 
         std::vector<std::string> marker_labels{};
-        for (auto label : c3d.parameters().group("POINT")
-                .parameter("LABELS").valuesAsString()) {
+        for (auto label : c3d.pointNames()) {
             marker_labels.push_back(SimTK::Value<std::string>(label));
         }
 


### PR DESCRIPTION
Closing https://github.com/opensim-org/opensim-core/issues/3606

`c3d.pointNames()` reads all labels.

### Testing I've completed
Worked in my test.

### CHANGELOG.md (choose one)

- if accepted.
