### PR TITLE
`CMake` symlink test data files

### DIFF
--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -390,9 +390,15 @@ function(OpenSimAddTests)
 
         # Copy data files to build directory.
         foreach(data_file ${OSIMADDTESTS_DATAFILES})
-            # This command re-copies the data files if they are modified;
-            # custom commands don't do this.
-            file(COPY "${data_file}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+            # This command symlinks the data files
+            # from the source directories into the running directory.
+            # This preserves changes to source files.
+            get_filename_component(FILENAME ${data_file} NAME)
+            add_custom_command(
+                TARGET ${TEST_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E create_symlink
+                    "${data_file}" 
+                    "${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}")
         endforeach()
 
         #if(UNIX)


### PR DESCRIPTION
The CMake test data file copy has never worked properly for me and I usually need to manually copy files around.

### Brief summary of changes

Symlink the test data files to the target directory. This has the advantage of avoiding excessive copying and preserving changes made to the source files. As of CMake 3.13 (released in 2018) `-E create_symlink` is supported on all platforms and OpenSim uses version 3.15.

### Testing I've completed

- Ran locally
- CI success indicates the files are linked properly

### Looking for feedback on...


### CHANGELOG.md (choose one)

- no need to update because it is an internal change to configure CMake tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4076)
<!-- Reviewable:end -->
