### PR TITLE
Enable Moco solve by default

### DIFF
--- a/Bindings/Java/tests/TestMocoSlidingMass.java
+++ b/Bindings/Java/tests/TestMocoSlidingMass.java
@@ -80,19 +80,18 @@ class TestMocoSlidingMass {
 
     // Configure the solver.
     // =====================
-    if (MocoCasADiSolver.isAvailable()) {
-      MocoCasADiSolver ms = study.initCasADiSolver();
-      ms.set_num_mesh_intervals(50);
 
-      // Now that we've finished setting up the tool, print it to a file.
-      study.print("sliding_mass.omoco");
+    MocoCasADiSolver ms = study.initCasADiSolver();
+    ms.set_num_mesh_intervals(50);
 
-      // Solve the problem.
-      // ==================
-      MocoSolution solution = study.solve();
+    // Now that we've finished setting up the tool, print it to a file.
+    study.print("sliding_mass.omoco");
 
-      solution.write("sliding_mass_solution.sto");
-    }
+    // Solve the problem.
+    // ==================
+    MocoSolution solution = study.solve();
+
+    solution.write("sliding_mass_solution.sto");
   }
   
   public static void testMarkersReference() throws Exception {


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Always test Moco casadi solver.  If a user doesn't build it, the test should fail. The code was checking if the solver is available. Note that this runs the casadi solver on all platforms but doesn't prove that distribution is relocatable or can run on a different machine since RPath can still point to folders outside the installation.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal.
- 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4087)
<!-- Reviewable:end -->
