### PR TITLE
CMake MacOS Runner Fix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -328,8 +328,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew pin cmake
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew install pkgconfig autoconf libtool automake wget pcre doxygen llvm
         brew reinstall gcc
         pip3 install numpy==1.25
         gfortran -v
@@ -455,7 +454,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew install pkgconfig autoconf libtool automake wget pcre doxygen llvm
         brew reinstall gcc
         pip3 install numpy==1.25
         gfortran -v
@@ -582,7 +581,7 @@ jobs:
     - name: Install Homebrew packages
       # Save the gfortran version to a file so we can use it in the cache key.
       run: |
-        brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew install pkgconfig autoconf libtool automake wget pcre doxygen llvm
         brew reinstall gcc
         pip3 install numpy==1.25
         gfortran -v


### PR DESCRIPTION
Fixes MacOS ARM CI failures

### Brief summary of changes

The [macOS runners](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md) contain CMake `3.31.6` in the base image. Overwriting the image version with the brew package version installs CMake v4 which [does not work](https://github.com/opensim-org/opensim-core/issues/4061). 

### Testing I've completed

### Looking for feedback on...

@aymanhab @nickbianco can you take a look?

### CHANGELOG.md (choose one)

- no need to update because it is an internal CI change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4088)
<!-- Reviewable:end -->
