### PR TITLE
Remove logging calls from core headers

### DIFF
--- a/OpenSim/Actuators/ModelOperators.cpp
+++ b/OpenSim/Actuators/ModelOperators.cpp
@@ -1,0 +1,26 @@
+#include "ModelOperators.h"
+
+#include <OpenSim/Common/GCVSplineSet.h>
+
+using namespace OpenSim;
+
+void ModOpPrescribeCoordinateValues::operate(
+        Model& model, const std::string&) const {
+    model.finalizeFromProperties();
+    TimeSeriesTable table = get_coordinate_values().process();
+    GCVSplineSet statesSpline(table);
+
+    for (const std::string& pathString : table.getColumnLabels()) {
+        ComponentPath path = ComponentPath(pathString);
+        if (path.getNumPathLevels() < 3) { continue; }
+        std::string jointPath = path.getParentPath().getParentPath().toString();
+        if (!model.hasComponent<Joint>(jointPath)) {
+            log_warn("Found column label '{}', but it does not match a "
+                     "joint coordinate value in the model.", pathString);
+            continue;
+        }
+        Coordinate& q = model.updComponent<Joint>(jointPath).updCoordinate();
+        q.setPrescribedFunction(statesSpline.get(pathString));
+        q.setDefaultIsPrescribed(true);
+    }
+}

--- a/OpenSim/Actuators/ModelOperators.h
+++ b/OpenSim/Actuators/ModelOperators.h
@@ -20,7 +20,6 @@
 
 #include "ModelProcessor.h"
 #include <OpenSim/Actuators/ModelFactory.h>
-#include <OpenSim/Common/GCVSplineSet.h>
 #include <OpenSim/Simulation/Model/ExternalLoads.h>
 #include "OpenSim/Simulation/TableProcessor.h"
 
@@ -285,27 +284,7 @@ public:
     ModOpPrescribeCoordinateValues(TableProcessor table) {
         constructProperty_coordinate_values(table);
     }
-    void operate(Model& model, const std::string&) const override {
-        model.finalizeFromProperties();
-        TimeSeriesTable table = get_coordinate_values().process();
-        GCVSplineSet statesSpline(table);
-
-        for (const std::string& pathString: table.getColumnLabels()) {
-            ComponentPath path = ComponentPath(pathString);
-            if (path.getNumPathLevels() < 3) {
-                continue;
-            }
-            std::string jointPath = path.getParentPath().getParentPath().toString();
-            if (!model.hasComponent<Joint>(jointPath)) {
-                log_warn("Found column label '{}', but it does not match a "
-                         "joint coordinate value in the model.", pathString);
-                continue;
-            }
-            Coordinate& q = model.updComponent<Joint>(jointPath).updCoordinate();
-            q.setPrescribedFunction(statesSpline.get(pathString));
-            q.setDefaultIsPrescribed(true);
-        }
-    }
+    void operate(Model& model, const std::string&) const override;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Analyses/ProbeReporter.cpp
+++ b/OpenSim/Analyses/ProbeReporter.cpp
@@ -255,6 +255,21 @@ int ProbeReporter::record(const SimTK::State& s)
 
     return 0;
 }
+
+void ProbeReporter::disableIntegrationOnlyProbes() {
+    ProbeSet& probes = _model->updProbeSet();
+    int nP = probes.getSize();
+
+    for(int i=0 ; i<nP ; i++) {
+        Probe& nextProbe = (Probe&)probes[i];
+        if (nextProbe.getOperation()=="integrate" || nextProbe.getOperation()=="min" || nextProbe.getOperation()=="max"){
+            nextProbe.setEnabled(false);
+            log_warn("Disabling probe {} as invalid for non-integration "
+                     "context.",
+                    nextProbe.getName());
+        }
+    }
+}
 //_____________________________________________________________________________
 /**
  * This method is called at the beginning of an analysis so that any

--- a/OpenSim/Analyses/ProbeReporter.h
+++ b/OpenSim/Analyses/ProbeReporter.h
@@ -150,20 +150,7 @@ protected:
     virtual int
         record(const SimTK::State& s );
 public:
-    void disableIntegrationOnlyProbes() {
-        ProbeSet& probes = _model->updProbeSet();
-        int nP = probes.getSize();
-
-        for(int i=0 ; i<nP ; i++) {
-            Probe& nextProbe = (Probe&)probes[i];
-            if (nextProbe.getOperation()=="integrate" || nextProbe.getOperation()=="min" || nextProbe.getOperation()=="max"){
-                nextProbe.setEnabled(false);
-                log_warn("Disabling probe {} as invalid for non-integration "
-                         "context.",
-                        nextProbe.getName());
-            }
-        }
-    }
+    void disableIntegrationOnlyProbes();
     //--------------------------------------------------------------------------
     // IO
     //--------------------------------------------------------------------------

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1081,10 +1081,10 @@ void Object::checkPropertyValueIsInSet(
     for (int i = 0; i < p.size(); ++i) {
         const auto& value = p.getValue(i);
         if (set.find(value) == set.end()) {
-            std::string str = fmt::format("{}", fmt::join(set, ", "));
-            OPENSIM_THROW_FRMOBJ(Exception,
-                    "Property '{}' has invalid value {}; expected one of the "
-                    "following: {}.", p.getName(), value, str);
+            std::ostringstream msg;
+            msg << "Property '" << p.getName() << "' has invalid value "
+                << value;
+            OPENSIM_THROW_FRMOBJ(Exception, msg.str());
         }
     }
 }
@@ -1104,11 +1104,10 @@ void Object::checkPropertyValueIsInRangeOrSet(const Property<T>& p,
     for (int i = 0; i < p.size(); ++i) {
         const auto& value = p.getValue(i);
         if ((value < lower || value > upper) && set.find(value) == set.end()) {
-            std::string str = fmt::format("{}", fmt::join(set, ", "));
             OPENSIM_THROW_FRMOBJ(Exception,
                     "Property '{}' has invalid value {}; expected value to be "
-                    "in range [{}, {}], or one of the following: {}.",
-                    p.getName(), value, lower, upper, str);
+                    "in range [{}, {}].",
+                    p.getName(), value, lower, upper);
         }
     }
 }

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -1405,16 +1405,11 @@ ObjectProperty<T>::readFromXMLElement
         const Object* registeredObj = 
             Object::getDefaultInstanceOfType(objTypeTag);
 
-        if (!registeredObj) {
-            log_error("Encountered unrecognized Object typename {} while reading property {}. There is no registered Object of this type. Ignoring.", objTypeTag, this->getName());
+        // Check that the object type found is derived from T.
+        if (!registeredObj || !dynamic_cast<const T*>(registeredObj)) {
             continue;
         }
 
-        // Check that the object type found is derived from T.
-        if (!dynamic_cast<const T*>(registeredObj)) {
-            log_error("Object type {} wrong for {} property {}. Ignoring.", objTypeTag, objectClassName, this->getName());
-            continue;                        
-        }
         ++objectsFound;
 
         if (objectsFound > this->getMaxListSize())
@@ -1428,21 +1423,6 @@ ObjectProperty<T>::readFromXMLElement
         T* objectT = dynamic_cast<T*>(object);
         OPENSIM_ASSERT(objectT); // should have worked by construction
         adoptAndAppendValueVirtual(objectT); // don't copy
-    }
-
-    if (objectsFound < this->getMinListSize()) {
-        log_error("Got {} object values for Property {} but the minimum is {}. Continuing anyway.",
-            objectsFound ,
-            this->getName() ,
-            this->getMinListSize()
-        );
-    }
-    if (objectsFound > this->getMaxListSize()) {
-        log_error("Got {} object values for Property {} but the maximum is {}. Ignoring the rest.",
-            objectsFound,
-            this->getName(),
-            this->getMaxListSize()
-        );
     }
 }
 

--- a/OpenSim/Common/Property.h
+++ b/OpenSim/Common/Property.h
@@ -909,33 +909,11 @@ public:
         SimTK::Array_<T, int> valuesBackup = values;
         bool shouldRollback = false;
 
-        if (!readSimplePropertyFromStream(valstream)) {
-            log_warn("Failed to read '{}': property '{}' with input '{}': the data has been ignored",
-                SimTK::NiceTypeName<T>::name(),
-                this->getName(),
-                valstream.str().substr(0, 50)  // limit displayed length
-            );
-            shouldRollback = true;
-        }
-        if (values.size() < this->getMinListSize()) {
-            log_warn("Failed to read '{}': property '{}' with input '{}': does not contain enough values (minimum: {}, got: {}): the data (all fields) have been ignored",
-                SimTK::NiceTypeName<T>::name(),
-                this->getName(),
-                valstream.str().substr(0,50),  // limit displayed length
-                this->getMinListSize(),
-                values.size()
-            );
+        if (!readSimplePropertyFromStream(valstream) || values.size() < this->getMinListSize()) {
+
             shouldRollback = true;
         }
         if (values.size() > this->getMaxListSize()) {
-            log_warn("Truncated '{}': property '{}' with input '{}': contains too many values (maximum: {}, got: {}): the data has been truncated",
-                SimTK::NiceTypeName<T>::name(),
-                this->getName(),
-                valstream.str().substr(0,50),  // limit displayed length
-                this->getMaxListSize(),
-                values.size()
-            );
-
             values.resize(this->getMaxListSize());  // truncate
         }
 

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -25,6 +25,7 @@
 // INCLUDE
 #include <OpenSim/Common/Component.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
+#include <iostream>
 
 namespace OpenSim {
 
@@ -236,12 +237,6 @@ protected:
         }
         if (!labels.empty()) {
             const_cast<Self*>(this)->_outputTable.setColumnLabels(labels);
-        } else {
-            std::cout << "Warning: No outputs were connected to '"
-                      << this->getName() << "' of type "
-                      << getConcreteClassName() << ". You can connect outputs "
-                      "by calling addToReport()." << std::endl;
-
         }
     }
 
@@ -287,7 +282,7 @@ private:
 
         // Periodically display column headers.
         if (_printCount % 40 == 0) {
-            log_cout("[{}]", this->getName());
+            std::cout << "[" << this->getName() << "]" << std::endl;
 
             // Split labels over multiple lines.
             // Round up to the nearest multiple of _width to determine the
@@ -313,14 +308,14 @@ private:
                         + outName;
                     msg += fmt::format("{}| ", lbl.substr(_width*row, _width));
                 }
-                log_cout(msg);
+                std::cout << msg << std::endl;
             }
 
             // Horizontal rule.
             std::string msg;
             for (auto idx = 0u; idx <= input.getNumConnectees(); ++idx)
                 msg += std::string(_width, '-') + "| ";
-            log_cout(msg);
+            std::cout << msg << std::endl;
         }
 
         // TODO set width based on number of significant digits.
@@ -333,7 +328,7 @@ private:
             // using `nSigFigs`: {:>{_width}.{nSigFigs}g}
             msg += fmt::format("{:>{}.{}g}| ", value, _width, nSigFigs);
         }
-        log_cout(msg);
+        std::cout << msg << std::endl;
 
         const_cast<ConsoleReporter_<T>*>(this)->_printCount++;
     }

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -288,28 +288,34 @@ private:
             // Round up to the nearest multiple of _width to determine the
             // number of header rows.
             const int numHeaderRows = (lengthOfLongestLabel -1) / _width + 1;
+            
+        // Display labels in chunks of size _width.
+        for (int row = 0; row < numHeaderRows; ++row)
+        {
+            std::ostringstream oss;
 
-            // Display labels in chunks of size _width.
-            for (int row = 0; row < numHeaderRows; ++row)
-            {
-                std::string msg;
+            // Time column.
+            if (row == numHeaderRows - 1)
+                oss << std::setw(_width) << std::right << "time" << "| ";
+            else
+                oss << std::setw(_width) << std::right << "" << "| ";
 
-                // Time column.
-                if (row == numHeaderRows-1)
-                    msg += fmt::format("{:>{}}| ", "time", _width);
-                else
-                    msg += fmt::format("{:>{}}| ", "", _width);
+            // Data columns.
+            for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
+                const auto& outName = input.getLabel(idx);
 
-                // Data columns.
-                for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
-                    const auto& outName = input.getLabel(idx);
-                    const std::string lbl =
-                        std::string(numHeaderRows*_width - outName.size(), ' ')
-                        + outName;
-                    msg += fmt::format("{}| ", lbl.substr(_width*row, _width));
-                }
-                std::cout << msg << std::endl;
+                // Create padded label string.
+                const std::string lbl =
+                    std::string(numHeaderRows * _width - outName.size(), ' ') + outName;
+
+                // Extract the slice for the current row.
+                const std::string chunk = lbl.substr(_width * row, _width);
+
+                oss << chunk << "| ";
             }
+
+            std::cout << oss.str() << std::endl;
+        }
 
             // Horizontal rule.
             std::string msg;
@@ -318,17 +324,27 @@ private:
             std::cout << msg << std::endl;
         }
 
-        // TODO set width based on number of significant digits.
-        std::string msg;
-        msg += fmt::format("{:>{}}| ", state.getTime(), _width);
+        std::ostringstream oss;
+
+        // Print time, right-justified in a column of width _width
+        oss << std::setw(_width) << std::right << state.getTime() << "| ";
+
         for (const auto& chan : input.getChannels()) {
             const auto& value = chan->getValue(state);
-            const auto& nSigFigs = chan->getOutput().getNumberOfSignificantDigits();
-            // Print `value` right-justified in a column with width `_width`,
-            // using `nSigFigs`: {:>{_width}.{nSigFigs}g}
-            msg += fmt::format("{:>{}.{}g}| ", value, _width, nSigFigs);
+            const auto nSigFigs = chan->getOutput().getNumberOfSignificantDigits();
+
+            // Configure the stream for significant digits formatting
+            std::ostringstream valStream;
+            valStream << std::setw(_width)
+                    << std::right
+                    << std::setprecision(nSigFigs)
+                    << std::defaultfloat 
+                    << value;
+
+            oss << valStream.str() << "| ";
         }
-        std::cout << msg << std::endl;
+
+        std::cout << oss.str() << std::endl;
 
         const_cast<ConsoleReporter_<T>*>(this)->_printCount++;
     }

--- a/OpenSim/Common/VectorFunctionUncoupledNxN.h
+++ b/OpenSim/Common/VectorFunctionUncoupledNxN.h
@@ -97,17 +97,10 @@ public:
     // EVALUATE
     //--------------------------------------------------------------------------
     virtual void evaluate( const SimTK::State& s, const double *aX, double *rF) {
-        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
-                  "const SimTK::State&, const double*, double*)");
     }
     virtual void evaluate( const SimTK::State& s, const Array<double> &aX, Array<double> &rF){
-        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
-                  "const SimTK::State&, const Array<double>, Array<double>)");
     }
     virtual void evaluate( const SimTK::State& s, const Array<double> &aX, Array<double> &rF, const Array<int> &aDerivWRT){
-        log_error("VectorFunctionUncoupledNxN UNIMPLEMENTED: evaluate( "
-                     "const SimTK::State&, const Array<double>&a, "
-                     "Array<double>&, const Array<int>&)");
     }
 
 //=============================================================================

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -517,10 +517,9 @@ private:
     void checkMode(const std::string& mode) const {
         OPENSIM_THROW_IF_FRMOBJ(mode != "cost" && mode != "endpoint_constraint",
                 Exception,
-                fmt::format(
                         "Expected mode to be 'cost' or 'endpoint_constraint' "
                         "but got {}.",
-                        mode));
+                        mode);
     }
 
     mutable SimTK::ReferencePtr<const Model> m_model;

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -73,10 +73,6 @@ public:
         if (name != IO::Lowercase(getConcreteClassName())) {
             std::string msg = getConcreteClassName() + " '" + name + "' ";
             this->setName(IO::Lowercase(getConcreteClassName()));
-
-            msg += "was renamed and is being reset to '" + name
-                + "'.";
-            log_info(msg);
         }
     }
 

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -286,12 +286,7 @@ TimeSeriesTable_<T> analyze(Model model, const TimeSeriesTable& statesTable,
                         thisOutputPath, std::regex(outputPathArg))) {
                     // Make sure the output type agrees with the template.
                     if (dynamic_cast<const Output<T>*>(&output)) {
-                        log_debug("Adding output {} of type {}.",
-                                output.getPathName(), output.getTypeName());
                         reporter->addToReport(output);
-                    } else {
-                        log_warn("Ignoring output {} of type {}.",
-                                output.getPathName(), output.getTypeName());
                     }
                 }
             }

--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -22,8 +22,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <OpenSim/Common/LogSink.h>
-#include <OpenSim/Common/Logger.h>
 #include <OpenSim/Common/Reporter.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/Model/Model.h>
@@ -57,15 +55,17 @@ void testConsoleReporterLabels() {
     state.setTime(0.0);
     manager.initialize(state);
 
-    // Create a sink to obtain the ConsoleReporter output.
-    auto sink = std::make_shared<StringLogSink>();
-    Logger::addSink(sink);
+    // Redirect std::cout to obtain the ConsoleReporter output.
+    std::streambuf* oldCoutBuf = std::cout.rdbuf();
+    std::ostringstream oss;
+    std::cout.rdbuf(oss.rdbuf());
+
     manager.integrate(1.0);
 
     // Restore original destination for cout and display ConsoleReporter output.
-    Logger::removeSink(sink);
-    const std::string output = sink->getString();
-    cout << output << endl;
+    std::cout.rdbuf(oldCoutBuf);
+    const std::string output = oss.str();
+    std::cout << output << std::endl;
 
     // Check column headings reported by ConsoleReporter, which should be
     // "time", then "value", then "height". The amount of whitespace appearing

--- a/OpenSim/Tools/VectorFunctionForActuators.h
+++ b/OpenSim/Tools/VectorFunctionForActuators.h
@@ -121,20 +121,13 @@ public:
     //--------------------------------------------------------------------------
 
     void calcValue( const double *aX, double *rF, int aSize) override {
-        log_warn("Unimplemented evaluate method."); 
-//      exit(0);
     }
     void calcValue( const Array<double> &aX, Array<double> &rF) override {
-        log_warn("Unimplemented evaluate method."); 
-//      exit(0);
     }
     virtual void calcValue( const Array<double> &aX, Array<double> &rF, const Array<int> &aDerivWRT) {
-        log_warn("Unimplemented evaluate method."); 
-//      exit(0);
     }
     void calcDerivative(const Array<double> &aX,Array<double> &rY,
         const Array<int> &aDerivWRT) override {
-        log_warn("Unimplemented calcDerivative method."); 
     }
 
     void evaluate(const SimTK::State& s, const double *aX, double *rF) override;


### PR DESCRIPTION
Fixes issue #4066

Also related to the [dependency tree issue](https://github.com/opensim-org/opensim-core/issues/3933).

### Brief summary of changes
Removed logging and `fmt` calls from core headers.
This was simple for non-template classes because they could be moved to `.cpp` files.
For the template headers, right now I have just removed the few log statements that snuck in.


### Testing I've completed

### Looking for feedback on...

@nickbianco can you take a look?

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4094)
<!-- Reviewable:end -->
