### PR TITLE
Fix `C3DFileAdapter` error when numMarkers > 255

### DIFF
--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -136,6 +136,12 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                 non_marker_points.push_back(label);
             }
         }
+        // SCALARS
+        if (c3d.parameters().group("POINT").isParameter("SCALARS")) {
+            for (const std::string& label : c3d.parameters().group("POINT").parameter("SCALARS").valuesAsString()) {
+                non_marker_points.push_back(label);
+            }
+        }
         // Store the indices and names of markers only
         std::vector<size_t> marker_indices;
         std::vector<std::string> marker_labels;

--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -106,20 +106,54 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
     if(numMarkers != 0) {
 
         int marker_nrow = numFrames;
-        int marker_ncol = numMarkers;
 
         std::vector<double> marker_times(marker_nrow);
-        SimTK::Matrix_<SimTK::Vec3> marker_matrix(marker_nrow, marker_ncol);
 
-        std::vector<std::string> marker_labels{};
-        for (auto label : c3d.parameters().group("POINT")
-                .parameter("LABELS").valuesAsString()) {
-            marker_labels.push_back(SimTK::Value<std::string>(label));
+        // This returns the name of all points including non markers
+        std::vector<std::string> all_points(c3d.pointNames());
+        std::vector<std::string> non_marker_points;
+        // ANGLES
+        if (c3d.parameters().group("POINT").isParameter("ANGLES")) {
+            for (const std::string& label : c3d.parameters().group("POINT").parameter("ANGLES").valuesAsString()) {
+                non_marker_points.push_back(label);
+            }
         }
+        // FORCES
+        if (c3d.parameters().group("POINT").isParameter("FORCES")) {
+            for (const std::string& label : c3d.parameters().group("POINT").parameter("FORCES").valuesAsString()) {
+                non_marker_points.push_back(label);
+            }
+        }
+        // MOMENTS
+        if (c3d.parameters().group("POINT").isParameter("MOMENTS")) {
+            for (const std::string& label : c3d.parameters().group("POINT").parameter("MOMENTS").valuesAsString()) {
+                non_marker_points.push_back(label);
+            }
+        }
+        // POWERS
+        if (c3d.parameters().group("POINT").isParameter("POWERS")) {
+            for (const std::string& label : c3d.parameters().group("POINT").parameter("POWERS").valuesAsString()) {
+                non_marker_points.push_back(label);
+            }
+        }
+        // Store the indices and names of markers only
+        std::vector<size_t> marker_indices;
+        std::vector<std::string> marker_labels;
+        for (size_t i = 0; i < all_points.size(); ++i) {
+            auto it = std::find(non_marker_points.begin(), non_marker_points.end(), all_points[i]);
+            if (it == non_marker_points.end()) {
+                marker_indices.push_back(i);
+                marker_labels.push_back(all_points[i]);
+            }
+        }
+
+        int marker_ncol = marker_labels.size();
+
+        SimTK::Matrix_<SimTK::Vec3> marker_matrix(marker_nrow, marker_ncol);
 
         double time_step{1.0 / pointFrequency};
         for(int f = 0; f < marker_nrow; ++f) {
-            SimTK::RowVector_<SimTK::Vec3> row{ numMarkers,
+            SimTK::RowVector_<SimTK::Vec3> row{ marker_ncol,
                                                 SimTK::Vec3(SimTK::NaN) };
             int m{0};
             // C3D standard is to read empty values as zero, but sets a
@@ -127,7 +161,8 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
             // values as blank, instead of 0,  when exporting to .trc
             // See: C3D documention 3D Point Residuals
             // Read in value if it is not zero or residual is not -1
-            for(auto pt : c3d.data().frame(f).points().points()) {
+            for (size_t idx : marker_indices) {
+                ezc3d::DataNS::Points3dNS::Point pt = c3d.data().frame(f).points().point(idx);
                 if (!pt.isEmpty() ) {//residual is not -1
                     row[m] = SimTK::Vec3{ static_cast<double>(pt.x()),
                                           static_cast<double>(pt.y()),


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-core/issues/3606

### Brief summary of changes
Following https://github.com/opensim-org/opensim-core/pull/4072
`C3DFileAdapter` now looks for non-marker labels, i.e., `FORCES`, `MOMENTS`, `ANGLES`, `POWERS`, and `SCALARS`, and exclude them from the marker labels and data.

@nickbianco, please let me know your ideas about it.

### CHANGELOG.md
updated
