### PR TITLE
Add CMake Flag to build Metis with CMake v4

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -258,7 +258,7 @@ else()
         ExternalProject_Add(metis
             # URL    http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/metis-5.1.0.tar.gz
             URL    https://sourceforge.net/projects/myosin/files/metis-5.1.0.tar.gz/download
-            CONFIGURE_COMMAND cd <SOURCE_DIR> && ${CMAKE_MAKE_PROGRAM} shared=1 config "prefix=${CMAKE_INSTALL_PREFIX}/ipopt" BUILDDIR=bdir
+            CONFIGURE_COMMAND cd <SOURCE_DIR> && ${CMAKE_MAKE_PROGRAM} CMAKE_POLICY_VERSION_MINIMUM=4.0 shared=1 config "prefix=${CMAKE_INSTALL_PREFIX}/ipopt" BUILDDIR=bdir
             BUILD_COMMAND cd <SOURCE_DIR>/bdir && ${CMAKE_MAKE_PROGRAM}
             INSTALL_DIR       "${CMAKE_INSTALL_PREFIX}/ipopt"
             INSTALL_COMMAND cd <SOURCE_DIR>/bdir && ${CMAKE_MAKE_PROGRAM} install)


### PR DESCRIPTION
Fixes issue #4061

### Brief summary of changes

Related to https://github.com/opensim-org/opensim-core/issues/4061. 
Adds `CMAKE_POLICY_VERSION_MINIMUM=4.0` for `Metis` to enable building with CMake v4

### Testing I've completed

### Looking for feedback on...

@nickbianco can you take a look

### CHANGELOG.md (choose one)

- no need to update because internal build change
