### PR TITLE
Update Jupyter tutorial links to point to `opensim-org/opensim-core` notebooks

### DIFF
--- a/Bindings/Python/tutorials/Tutorial 1 - Introduction to OpenSim.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 1 - Introduction to OpenSim.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ]

--- a/Bindings/Python/tutorials/Tutorial 2 - Creating and Simulating a simple arm Model.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 2 - Creating and Simulating a simple arm Model.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%202%20-%20Creating%20and%20Simulating%20a%20simple%20arm%20Model.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%202%20-%20Creating%20and%20Simulating%20a%20simple%20arm%20Model.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]
@@ -67,7 +67,7 @@
     "id": "mmmTuEI4HQJG"
    },
    "source": [
-    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb))."
+    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb))."
    ]
   },
   {

--- a/Bindings/Python/tutorials/Tutorial 3 - Loading and Modifying OpenSim Models.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 3 - Loading and Modifying OpenSim Models.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%203%20-%20Loading%20and%20Modifying%20OpenSim%20Models.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%203%20-%20Loading%20and%20Modifying%20OpenSim%20Models.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]
@@ -73,7 +73,7 @@
     "id": "mmmTuEI4HQJG"
    },
    "source": [
-    "First, set up the environment by executing the following cell (see [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more details)."
+    "First, set up the environment by executing the following cell (see [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more details)."
    ]
   },
   {

--- a/Bindings/Python/tutorials/Tutorial 4 - Musculoskeletal models, Motion Files and MuscleAnalysis.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 4 - Musculoskeletal models, Motion Files and MuscleAnalysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%204%20-%20Musculoskeletal%20models%2C%20Motion%20Files%20and%20MuscleAnalysis.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%204%20-%20Musculoskeletal%20models%2C%20Motion%20Files%20and%20MuscleAnalysis.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]
@@ -101,7 +101,7 @@
     "id": "mmmTuEI4HQJG"
    },
    "source": [
-    "First, set up the environment by executing the following cell (see [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
+    "First, set up the environment by executing the following cell (see [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
    ]
   },
   {

--- a/Bindings/Python/tutorials/Tutorial 5 - Scaling, Inverse Kinematics, and Inverse Dynamics.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 5 - Scaling, Inverse Kinematics, and Inverse Dynamics.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%205%20-%20Scaling%2C%20Inverse%20Kinematics%2C%20and%20Inverse%20Dynamics.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%205%20-%20Scaling%2C%20Inverse%20Kinematics%2C%20and%20Inverse%20Dynamics.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]
@@ -100,7 +100,7 @@
     "id": "mmmTuEI4HQJG"
    },
    "source": [
-    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim in Colab](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
+    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim in Colab](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
    ]
   },
   {

--- a/Bindings/Python/tutorials/Tutorial 6 - Static Optimization.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 6 - Static Optimization.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%206%20-%20Static%20Optimization.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%206%20-%20Static%20Optimization.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]
@@ -85,11 +85,11 @@
     "\n",
     "User Guide | Prerequisite Tutorials | Other Resources\n",
     "--------------------|------------------------|------------------\n",
-    "[Static Optimization](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090088/Static+Optimization) | [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb)          | [[1]](https://doi.org/10.1115/1.4029304)  \n",
-    "[Inverse Kinematics](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090037/Inverse+Kinematics)  | [Tutorial 2 : Creating and Simulating a Simple Arm Model ](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%202%20-%20Creating%20and%20Simulating%20a%20simple%20arm%20Model.ipynb)         | [[2]](https://doi.org/10.1109/TBME.2007.901024)  \n",
-    "[Residual Reduction Algorithm](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53089669/Residual+Reduction+Algorithm)  | [Tutorial 3: Loading and Modifying OpenSim Models](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%203%20-%20Loading%20and%20Modifying%20OpenSim%20Models.ipynb)        |               \n",
-    "[Inverse Dynamics](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090074/Inverse+Dynamics)  | [Tutorial 4: Musculoskeletal Models, Motion Files, and MuscleAnalysis](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%204%20-%20Musculoskeletal%20models%2C%20Motion%20Files%20and%20MuscleAnalysis.ipynb)           |      |  \n",
-    "[Scaling](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090000/Scaling)       | [Tutorial 5: Scaling, Inverse Kinematics, and Inverse Dynamics](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%205%20-%20Scaling%2C%20Inverse%20Kinematics%2C%20and%20Inverse%20Dynamics.ipynb)           |                    "
+    "[Static Optimization](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090088/Static+Optimization) | [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb)          | [[1]](https://doi.org/10.1115/1.4029304)  \n",
+    "[Inverse Kinematics](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090037/Inverse+Kinematics)  | [Tutorial 2 : Creating and Simulating a Simple Arm Model ](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%202%20-%20Creating%20and%20Simulating%20a%20simple%20arm%20Model.ipynb)         | [[2]](https://doi.org/10.1109/TBME.2007.901024)  \n",
+    "[Residual Reduction Algorithm](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53089669/Residual+Reduction+Algorithm)  | [Tutorial 3: Loading and Modifying OpenSim Models](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%203%20-%20Loading%20and%20Modifying%20OpenSim%20Models.ipynb)        |               \n",
+    "[Inverse Dynamics](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090074/Inverse+Dynamics)  | [Tutorial 4: Musculoskeletal Models, Motion Files, and MuscleAnalysis](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%204%20-%20Musculoskeletal%20models%2C%20Motion%20Files%20and%20MuscleAnalysis.ipynb)           |      |  \n",
+    "[Scaling](https://opensimconfluence.atlassian.net/wiki/spaces/OpenSim/pages/53090000/Scaling)       | [Tutorial 5: Scaling, Inverse Kinematics, and Inverse Dynamics](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%205%20-%20Scaling%2C%20Inverse%20Kinematics%2C%20and%20Inverse%20Dynamics.ipynb)           |                    "
    ]
   },
   {
@@ -126,7 +126,7 @@
     "id": "mmmTuEI4HQJG"
    },
    "source": [
-    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
+    "First, set up the environment by executing the following cell (See [Tutorial 1: Introduction to OpenSim](https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%201%20-%20Introduction%20to%20OpenSim.ipynb) for more information)."
    ]
   },
   {

--- a/Bindings/Python/tutorials/Tutorial 7 - Introduction to OpenSim Moco.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 7 - Introduction to OpenSim Moco.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%207%20-%20Introduction%20to%20OpenSim%20Moco.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%207%20-%20Introduction%20to%20OpenSim%20Moco.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ]

--- a/Bindings/Python/tutorials/Tutorial 8 - Creating Muscle-driven Simulations with OpenSim Moco.ipynb
+++ b/Bindings/Python/tutorials/Tutorial 8 - Creating Muscle-driven Simulations with OpenSim Moco.ipynb
@@ -6,7 +6,7 @@
         "id": "view-in-github"
       },
       "source": [
-        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/python_examples/Bindings/Python/tutorials/Tutorial%208%20-%20Creating%20Muscle-driven%20Simulations%20with%20OpenSim%20Moco.ipynb\">\n",
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/opensim-org/opensim-core/blob/main/Bindings/Python/tutorials/Tutorial%208%20-%20Creating%20Muscle-driven%20Simulations%20with%20OpenSim%20Moco.ipynb\">\n",
         "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
         "</a>"
       ]


### PR DESCRIPTION
Brief follow-up PR to #4124.

### Brief summary of changes

Updated "Open in Colab" links to point to Jupyter notebooks in `opensim-org/opensim-core`.

### Testing I've completed

Tested the links on branch `python_example_links` of my fork `nickbianco/opensim-core`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4129)
<!-- Reviewable:end -->
