### PR TITLE
Fix ExampleHopperDevice example

### DIFF
--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice.cpp
@@ -44,7 +44,7 @@ static const double REPORTING_INTERVAL{ 0.2 };
 static const double FINAL_TIME{ 5.0 };
 
 static const std::string testbedAttachment1{"ground"};
-static const std::string testbedAttachment2{"load"};
+static const std::string testbedAttachment2{"bodyset/load"};
 
 //TODO: Provide the name of the coordinate corresponding to the hopper's height.
 //      Hint: the hopper's pelvis is attached to ground with a vertical slider
@@ -95,7 +95,7 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
 
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
-    const std::string patellaPath("thigh/patellaFrame/patella");
+    const std::string patellaPath("/bodyset/thigh/patellaFrame/wrapobjectset/patella");
     if (model.hasComponent<WrapCylinder>(patellaPath)) {
         auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
         auto& wrapObject = model.updComponent<WrapCylinder>(patellaPath);

--- a/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
+++ b/OpenSim/Examples/ExampleHopperDevice/exampleHopperDevice_answers.cpp
@@ -127,7 +127,7 @@ void connectDeviceToModel(OpenSim::Device& device, OpenSim::Model& model,
 
     // Configure the device to wrap over the patella (if one exists; there is no
     // patella in the testbed).
-    const std::string patellaPath("thigh/patellaFrame/patella");
+    const std::string patellaPath("/bodyset/thigh/patellaFrame/wrapobjectset/patella");
     if (model.hasComponent<WrapCylinder>(patellaPath)) {
         auto& cable = model.updComponent<PathActuator>("device/cableAtoB");
         auto& wrapObject = model.updComponent<WrapCylinder>(patellaPath);


### PR DESCRIPTION
Fixes ExampleHopperDevice example

### Brief summary of changes

I just went through the `ExampleHopperDevice` example and it was very informative.
I noticed a couple of issues with the patella wrapping and testbed setup which have been fixed.

### Testing I've completed

Completed tutorial locally

### Looking for feedback on...

@nickbianco can you take a look?

### CHANGELOG.md (choose one)

- no need to update because small example change
