### PR TITLE
Don't call LoadOpenSimLibrary("osimActuators") in tests

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -47,7 +47,6 @@
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/FunctionAdapter.h>
 #include <OpenSim/Common/LinearFunction.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
 #include <OpenSim/Common/SimmSpline.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/Model/BodySet.h>
@@ -69,6 +68,7 @@
 #include <OpenSim/Simulation/SimbodyEngine/WeldConstraint.h>
 #include <OpenSim/Simulation/SimbodyEngine/WeldJoint.h>
 #include <OpenSim/Simulation/Test/SimulationComponentsForTesting.h>
+#include <OpenSim/Actuators/PointActuator.h>
 
 #include <memory>
 #include <catch2/catch_all.hpp>
@@ -2059,9 +2059,12 @@ TEST_CASE("testEquivalentBodyForceFromGeneralizedForce") {
             "==="
          << endl;
 
-    // Need to load osim actuators because the following model has
-    // Actuators that will fail to register and the model will not load.
-    LoadOpenSimLibrary("osimActuators");
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
 
     Model gaitModel("testJointConstraints.osim");
 

--- a/OpenSim/Simulation/Test/testInitState.cpp
+++ b/OpenSim/Simulation/Test/testInitState.cpp
@@ -24,7 +24,7 @@
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/Control/ControlSetController.h>
 #include <OpenSim/Simulation/Model/Model.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
+#include <OpenSim/Actuators/PointActuator.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <catch2/catch_all.hpp>
 
@@ -41,7 +41,14 @@ using namespace std;
 TEST_CASE("testStates")
 {
     using namespace SimTK;
-    LoadOpenSimLibrary("osimActuators");
+
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
+
     //==========================================================================
     // Setup OpenSim model
     std::string modelFile = "arm26.osim";

--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -25,7 +25,7 @@
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
 #include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
+#include <OpenSim/Actuators/PointActuator.h>
 
 #include <memory>
 
@@ -37,7 +37,12 @@ void testModelTopologyErrors();
 void testDoesNotSegfaultWithUnusualConnections();
 
 int main() {
-    LoadOpenSimLibrary("osimActuators");
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
 
     SimTK_START_TEST("testModelInterface");
         SimTK_SUBTEST(testModelFinalizePropertiesAndConnections);

--- a/OpenSim/Simulation/Test/testMomentArms.cpp
+++ b/OpenSim/Simulation/Test/testMomentArms.cpp
@@ -37,7 +37,6 @@
 #include <OpenSim/Simulation/osimSimulation.h>
 #include <OpenSim/Actuators/Thelen2003Muscle.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
 
 #include "SimulationComponentsForTesting.h"
 
@@ -59,7 +58,6 @@ void testMomentArmsAcrossCompoundJoint();
 int main()
 {
     clock_t startTime = clock();
-    LoadOpenSimLibrary("osimActuators");
     Object::registerType(CompoundJoint());
 
     try {

--- a/OpenSim/Simulation/Test/testSimulationUtilities.cpp
+++ b/OpenSim/Simulation/Test/testSimulationUtilities.cpp
@@ -25,7 +25,7 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
+#include <OpenSim/Actuators/PointActuator.h>
 
 using namespace OpenSim;
 using namespace std;
@@ -33,7 +33,12 @@ using namespace std;
 void testUpdatePre40KinematicsFor40MotionType();
 
 int main() {
-    LoadOpenSimLibrary("osimActuators");
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
 
     SimTK_START_TEST("testSimulationUtilities");
         SimTK_SUBTEST(testUpdatePre40KinematicsFor40MotionType);

--- a/OpenSim/Simulation/Test/testStatesTrajectory.cpp
+++ b/OpenSim/Simulation/Test/testStatesTrajectory.cpp
@@ -23,7 +23,7 @@
 
 #include <OpenSim/Simulation/osimSimulation.h>
 #include <OpenSim/Common/Constant.h>
-#include <OpenSim/Common/LoadOpenSimLibrary.h>
+#include <OpenSim/Actuators/PointActuator.h>
 #include <random>
 #include <cstdio>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
@@ -776,10 +776,13 @@ void testExport() {
 
 int main() {
     SimTK_START_TEST("testStatesTrajectory");
-        // actuators library is not loaded automatically (unless using clang).
-        #if !defined(__clang__)
-            LoadOpenSimLibrary("osimActuators");
-        #endif
+
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
 
         // Make sure the states Storage file doesn't already exist; we'll
         // generate it later and we don't want to use a stale one by accident.


### PR DESCRIPTION
Potential fix for issue #4139

### (Not-so-)Brief summary of changes

Based on comments and commits these calls exist because the osimActuators shared library "is not automatically loaded on anything other than clang". The reason for this is that the tests in question do not actually reference anything in osimActuators directly (e.g., call any of its functions) so the linker sees this and decides there's no need to record the dependency in the executable. And thus osimActuators is not loaded when the executable is run.

If we instead just call one of its functions the linker will record the dependency in the test executable and the osimActuators library will get loaded automatically.

Given that the only reason we need osimActuators is because the data files these tests load contain objects defined in and registered by that library, perhaps the most appropriate function to call would be `RegisterTypes_osimActuators()`. That works but then we end up registering the osimActuators types twice (first time being when the library is loaded). So I went with just default-instantiating what looks like one of the most common Actuator classes given that we're loading Actuators from the data files.

I think there are probably linker-specific methods to make this work but it seems like the above is probably going to be simpler.

### Testing I've completed

Ran tests locally on Linux. Only 5 Moco tests failed, but this is true even for the `main` branch.

### Looking for feedback on...

The method is still a bit of a hack so any suggestions are welcome but I think it's definitely better than calling `LoadOpenSimLibrary()`.

### CHANGELOG.md

- no need to update because these are not user-visible changes.
