### PR TITLE
Fix OpenSim::Marker::generateDecorations to account for custom parent frames (#4144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ v4.6
 - Added a suite of Jupyter notebooks containing OpenSim API Python tutorials. (#4124)
 - Added new concrete implementations of `ContactGeometry`: `ContactCylinder`, `ContactEllipsoid`, and `ContactTorus`. (#4115)
 - Removed the following deprecated methods from `ContactGeometry`: `getLocation()`, `setLocation()`, `getOrientation()`, `setOrientation()`, `getBody()`, and `setBody()`. (#4115)
+- Fixed `OpenSim::Marker::generateDecorations` to account for markers that are attached to bodies via other frames (#4144).
 
 
 v4.5.2

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -170,13 +170,10 @@ void Marker::generateDecorations(bool fixed, const ModelDisplayHints& hints, con
     // @TODO default color, size, shape should be obtained from hints
     const Vec3 color = hints.get_marker_color();
     const OpenSim::PhysicalFrame& frame = getParentFrame();
-    //const Frame& bf = frame.findBaseFrame();
-    //SimTK::Transform bTrans = frame.findTransformInBaseFrame();
-    //const Vec3& p_BM = bTrans*get_location();
     appendToThis.push_back(
         SimTK::DecorativeSphere(.01).setBodyId(frame.getMobilizedBodyIndex())
         .setColor(color).setOpacity(1.0)
-        .setTransform(get_location())
+        .setTransform(frame.findTransformInBaseFrame() * get_location())
         .setScaleFactors(Vec3(1)));
     
 }


### PR DESCRIPTION
Fixes issue #4144. Downsteam: https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/1101

### Brief summary of changes

- Updates math in `OpenSim::Marker::generateDecorations` to handle the case where the marker is defined in a non-body frame (e.g. in a `PhysicalOffsetFrame` or `StationDefinedFrame`).

### Testing I've completed

- Visually looked in OSC. Could add a test for `generateDecorations` but it's an awful lot of work for something so simple

### Looking for feedback on...

- Vibe

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4145)
<!-- Reviewable:end -->
