### PR TITLE
Trim trailing whitespace characters in Model.h/.cpp

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -205,11 +205,11 @@ Model::Model(const string &aFileName) :
     _workingState(),
     _useVisualizer(false),
     _allControllersEnabled(true)
-{   
+{
     constructProperties();
     setNull();
     updateFromXMLDocument();
-    // Check is done below because only Model files have migration issues, version is not available until 
+    // Check is done below because only Model files have migration issues, version is not available until
     // updateFromXMLDocument is called. Fixes core issue #2395
     OPENSIM_THROW_IF(getDocument()->getDocumentVersion() < 10901,
         Exception,
@@ -264,11 +264,11 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
         // Version has to be 1.6 or later, otherwise assert
         if (versionNumber == 10600){
             // Get node for DynamicsEngine
-            SimTK::Xml::element_iterator engIter = 
+            SimTK::Xml::element_iterator engIter =
                 aNode.element_begin("DynamicsEngine");
             //Get node for SimbodyEngine
             if (engIter != aNode.element_end()){
-                SimTK::Xml::element_iterator simbodyEngIter = 
+                SimTK::Xml::element_iterator simbodyEngIter =
                     engIter->element_begin("SimbodyEngine");
                 // Move all Children of simbodyEngineNode to be children of _node
                 // we'll keep inserting before enginesNode then remove it;
@@ -303,15 +303,15 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                     SimTK::Xml::Element newGroundElement("Ground");
                     newGroundElement.setAttributeValue("name", "ground");
 
-                    SimTK::Xml::element_iterator geometryIter = 
+                    SimTK::Xml::element_iterator geometryIter =
                         bodyIter->element_begin("geometry");
                     if (geometryIter != bodyIter->element_end()) {
                         SimTK::Xml::Element cloneOfGeomety = geometryIter->clone();
-                        newGroundElement.insertNodeAfter(newGroundElement.node_end(), 
+                        newGroundElement.insertNodeAfter(newGroundElement.node_end(),
                             cloneOfGeomety);
                     }
 
-                    SimTK::Xml::element_iterator visObjIter = 
+                    SimTK::Xml::element_iterator visObjIter =
                         bodyIter->element_begin("VisibleObject");
                     if (visObjIter != bodyIter->element_end()) {
                         SimTK::Xml::Element cloneOfVisObj = visObjIter->clone();
@@ -319,7 +319,7 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                             cloneOfVisObj);
                     }
 
-                    SimTK::Xml::element_iterator wrapSetIter = 
+                    SimTK::Xml::element_iterator wrapSetIter =
                         bodyIter->element_begin("WrapObjectSet");
                     if (wrapSetIter != bodyIter->element_end()) {
                         SimTK::Xml::Element cloneOfWrapSet = wrapSetIter->clone();
@@ -343,10 +343,10 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                     bodyIter->element_begin("Joint");
                 if (joint_node->element_begin() != joint_node->element_end()){
                     SimTK::Xml::Element detach_joint_node = joint_node->clone();
-                    SimTK::Xml::element_iterator concreteJointNode = 
+                    SimTK::Xml::element_iterator concreteJointNode =
                         detach_joint_node.element_begin();
                     detach_joint_node.removeNode(concreteJointNode);
-                    SimTK::Xml::element_iterator parentBodyElement = 
+                    SimTK::Xml::element_iterator parentBodyElement =
                         concreteJointNode->element_begin("parent_body");
                     SimTK::String parent_name = "ground";
                     parentBodyElement->getValueAs<SimTK::String>(parent_name);
@@ -358,13 +358,13 @@ void Model::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
                     std::string parent_frame = parent_name;
                     if (!parent_frame.empty())
                         parent_frame = "../" + parent_frame;
-                    XMLDocument::addConnector(*concreteJointNode, 
+                    XMLDocument::addConnector(*concreteJointNode,
                         "Connector_PhysicalFrame_", "parent_frame",
                         parent_frame);
                     std::string child_frame = body_name;
                     if (!child_frame.empty())
                         child_frame = "../" + child_frame;
-                    XMLDocument::addConnector(*concreteJointNode, 
+                    XMLDocument::addConnector(*concreteJointNode,
                         "Connector_PhysicalFrame_", "child_frame",
                         child_frame);
                     concreteJointNode->eraseNode(parentBodyElement);
@@ -443,7 +443,7 @@ void Model::constructProperties()
     constructProperty_credits("Frank Anderson, Peter Loan, Ayman Habib, Ajay Seth, Michael Sherman");
 
     constructProperty_publications("List of publications related to model...");
-    
+
     constructProperty_length_units("meters");
     _lengthUnits = Units::Meters;
 
@@ -520,18 +520,18 @@ void Model::buildSystem() {
 //------------------------------------------------------------------------------
 // Requires that buildSystem() has already been called.
 SimTK::State& Model::initializeState() {
-    if (!hasSystem()) 
+    if (!hasSystem())
         throw Exception("Model::initializeState(): call buildSystem() first.");
 
     // This tells Simbody to finalize the System.
     getMultibodySystem().invalidateSystemTopologyCache();
     getMultibodySystem().realizeTopology();
 
-    // Set the model's operating state (internal member variable) to the 
+    // Set the model's operating state (internal member variable) to the
     // default state that is stored inside the System.
     _workingState = getMultibodySystem().getDefaultState();
 
-    // Set the Simbody modeling option that tells any joints that use 
+    // Set the Simbody modeling option that tells any joints that use
     // quaternions to use Euler angles instead.
     _matter->setUseEulerAngles(_workingState, true);
 
@@ -541,8 +541,8 @@ SimTK::State& Model::initializeState() {
     // Invoke the ModelComponent interface for initializing the state.
     initStateFromProperties(_workingState);
 
-    // Realize instance variables that may have been set above. This 
-    // means floating point parameters such as mass properties and 
+    // Realize instance variables that may have been set above. This
+    // means floating point parameters such as mass properties and
     // geometry placements are frozen.
     getMultibodySystem().realize(_workingState, SimTK::Stage::Instance);
 
@@ -585,7 +585,7 @@ const SimTK::State& Model::getWorkingState() const
 
 void Model::assemble(SimTK::State& s, const Coordinate *coord, double weight)
 {
-    
+
     bool constrained = false;
     const CoordinateSet &coords = getCoordinateSet();
     for(int i=0; i<coords.getSize(); ++i){
@@ -646,7 +646,7 @@ void Model::assemble(SimTK::State& s, const Coordinate *coord, double weight)
                 _assemblySolver->assemble(s);
             }
             catch (const std::exception& ex){
-                log_error("Model unable to assemble with relaxed constraints: {}", 
+                log_error("Model unable to assemble with relaxed constraints: {}",
                     ex.what());
             }
         }
@@ -701,7 +701,7 @@ void Model::createMultibodySystem()
 }
 
 
-std::vector<SimTK::ReferencePtr<const Coordinate>> 
+std::vector<SimTK::ReferencePtr<const Coordinate>>
     Model::getCoordinatesInMultibodyTreeOrder() const
 {
     OPENSIM_THROW_IF_FRMOBJ(!isValidSystem(), Exception,
@@ -710,8 +710,8 @@ std::vector<SimTK::ReferencePtr<const Coordinate>>
     int nc = getNumCoordinates();
     auto coordinates = getComponentList<Coordinate>();
 
-    std::vector<SimTK::ReferencePtr<const Coordinate>> 
-        coordinatesInTreeOrder(nc, 
+    std::vector<SimTK::ReferencePtr<const Coordinate>>
+        coordinatesInTreeOrder(nc,
             SimTK::ReferencePtr<const Coordinate>(*coordinates.begin()));
 
     // We have a valid MultibodySystem underlying the Coordinates
@@ -763,7 +763,7 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
 
     auto coordinates = getComponentList<Coordinate>();
     for (auto& coord : coordinates) {
-        const Coordinate::MotionType oldMotionType = 
+        const Coordinate::MotionType oldMotionType =
             coord.getUserSpecifiedMotionTypePriorTo40();
         const Coordinate::MotionType motionType = coord.getMotionType();
 
@@ -779,7 +779,7 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
     // and how to resolve future issues.
     if (message.size()) {
         message = "\nModel '" + getName() + "' has inconsistencies:\n" + message;
-        message += 
+        message +=
             "You must update any motion files you generated in versions prior to 4.0. You can:\n"
             "  (1) Run the updatePre40KinematicsFilesFor40MotionType() utility (in the scripting shell) OR\n"
             "  (2) Re-run the Inverse Kinematics Tool with the updated model in 4.0.\n"
@@ -796,7 +796,7 @@ void Model::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-    // wipe-out the existing System 
+    // wipe-out the existing System
     _matter.reset();
     _forceSubsystem.reset();
     _contactSubsystem.reset();
@@ -858,7 +858,7 @@ void Model::createMultibodyTree()
         joints.push_back(SimTK::ReferencePtr<Joint>(&joint));
     }
 
-    // Complete multibody tree description by indicating how (mobilized) 
+    // Complete multibody tree description by indicating how (mobilized)
     // "bodies" are connected by joints.
     for (auto& joint : joints) {
         std::string name = joint->getAbsolutePathString();
@@ -869,7 +869,7 @@ void Model::createMultibodyTree()
         // to determine their underlying base (physical) frames.
         joint->finalizeConnections(*this);
 
-        // Verify that the underlying frames are also connected so we can 
+        // Verify that the underlying frames are also connected so we can
         // traverse to the base frame and get its name. This allows the
         // (offset) frames to satisfy the sockets of Joint to be added
         // to a Body, for example, and not just joint itself.
@@ -903,7 +903,7 @@ void Model::extendConnectToModel(Model &model)
                 model.getName());
         // if part of another Model, that Model is in charge
         // of creating a valid Multibody tree that includes
-        // Components of this Model. 
+        // Components of this Model.
         return;
     }
 
@@ -921,17 +921,17 @@ void Model::extendConnectToModel(Model &model)
     Ground& ground = updGround();
     setNextSubcomponentInSystem(ground);
 
-    // The JointSet of the Model is only being manipulated for consistency with 
+    // The JointSet of the Model is only being manipulated for consistency with
     // Tool expectations. TODO fix Tools and remove
     JointSet& joints = upd_JointSet();
 
     bool isMemoryOwner = joints.getMemoryOwner();
-    //Temporarily set owner ship to false so we 
+    //Temporarily set owner ship to false so we
     //can swap to rearrange order of the joints
     joints.setMemoryOwner(false);
 
     // Run through all the mobilizers in the multibody tree, adding
-    // a joint in the correct sequence. Also add massless bodies, 
+    // a joint in the correct sequence. Also add massless bodies,
     // loop closure constraints, etc... to form the valid tree.
     for (int m = 0; m < _multibodyTree.getNumMobilizers(); ++m) {
         // Get a mobilizer from the tree, then extract its corresponding
@@ -952,7 +952,7 @@ void Model::extendConnectToModel(Model &model)
                 outb = outbMaster->addSlave();
                 useJoint->setSlaveBodyForChild(*outb);
                 SimTK::Transform o(SimTK::Vec3(0));
-                //Now add the constraints that weld the slave to the master at the 
+                //Now add the constraints that weld the slave to the master at the
                 // body origin
                 std::string pathName = outb->getAbsolutePathString();
                 WeldConstraint* weld = new WeldConstraint(outb->getName()+"_weld",
@@ -968,7 +968,7 @@ void Model::extendConnectToModel(Model &model)
             // create and add the base joint to enable these dofs
             Body* child = MultibodyGraphMakerPtrCast<Body>(mob.getOutboardBodyRef());
             log_warn("Body '{}' not connected by a Joint."
-                "A FreeJoint will be added to connect it to ground.", 
+                "A FreeJoint will be added to connect it to ground.",
                 child->getName());
             Ground* ground = MultibodyGraphMakerPtrCast<Ground>(mob.getInboardBodyRef());
 
@@ -978,7 +978,7 @@ void Model::extendConnectToModel(Model &model)
             free->isReversed = mob.isReversedFromJoint();
             // TODO: Joints are currently required to be in the JointSet
             // When the reordering of Joints is eliminated (see following else block)
-            // this limitation can be removed and the free joint adopted as in 
+            // this limitation can be removed and the free joint adopted as in
             // internal subcomponent (similar to the weld constraint above)
             addJoint(free);
             setNextSubcomponentInSystem(*free);
@@ -1088,7 +1088,7 @@ void Model::extendAddToSystem(SimTK::MultibodySystem& system) const
 
     Model *mutableThis = const_cast<Model *>(this);
 
-    //Analyses are not Components so add them after legit 
+    //Analyses are not Components so add them after legit
     //Components have been wired-up correctly.
     mutableThis->updAnalysisSet().setModel(*mutableThis);
 
@@ -1223,7 +1223,7 @@ void Model::setup()
 
 //_____________________________________________________________________________
 /* Perform some clean up functions that are normally done from the destructor
- * however this gives the GUI a way to proactively do the cleaning without 
+ * however this gives the GUI a way to proactively do the cleaning without
  * waiting for garbage collection to do the actual cleanup.
  */
 void Model::cleanup()
@@ -1259,7 +1259,7 @@ void Model::extendSetPropertiesFromState(const SimTK::State& state)
 }
 
 void Model::generateDecorations
-       (bool                                        fixed, 
+       (bool                                        fixed,
         const ModelDisplayHints&                    hints,
         const SimTK::State&                         state,
         SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
@@ -1293,7 +1293,7 @@ void Model::equilibrateMuscles(SimTK::State& state) {
                     errorMsg = e.what();
                     failed = true;
                 }
-                // just because one muscle failed to equilibrate doesn't mean 
+                // just because one muscle failed to equilibrate doesn't mean
                 // it isn't still useful to have remaining muscles equilibrate
                 // in an analysis, for example, we might not be reporting about
                 // all muscles, so continue with the rest.
@@ -1302,7 +1302,7 @@ void Model::equilibrateMuscles(SimTK::State& state) {
         }
     }
 
-    if(failed) // Notify the caller of the failure to equilibrate 
+    if(failed) // Notify the caller of the failure to equilibrate
         throw Exception("Model::equilibrateMuscles() "+errorMsg, __FILE__, __LINE__);
 }
 
@@ -1817,7 +1817,7 @@ void Model::createAssemblySolver(const SimTK::State& s)
     SimTK::Array_<CoordinateReference> coordsToTrack;
 
     for(int i=0; i<getNumCoordinates(); ++i){
-        // Iff a coordinate is dependent on other coordinates for its value, 
+        // Iff a coordinate is dependent on other coordinates for its value,
         // do not give it a reference/goal.
         if(!_coordinateSet[i].isDependent(s)){
             Constant reference(_coordinateSet[i].getValue(s));
@@ -1836,7 +1836,7 @@ void Model::createAssemblySolver(const SimTK::State& s)
 
 void Model::updateAssemblyConditions(SimTK::State& s)
 {
-    createAssemblySolver(s);    
+    createAssemblySolver(s);
 }
 //--------------------------------------------------------------------------
 // MARKERS
@@ -1940,7 +1940,7 @@ Ground& Model::updGround()
 int Model::getNumControls() const
 {
     if(!_system){
-        throw Exception("Model::getNumControls() requires an initialized Model./n" 
+        throw Exception("Model::getNumControls() requires an initialized Model./n"
             "Prior Model::initSystem() required.");
     }
 
@@ -1951,7 +1951,7 @@ int Model::getNumControls() const
  * Throws an exception if called before Model::initSystem() */
 SimTK::Vector& Model::updControls(const SimTK::State& s) const {
     if( (!_system) || (!_modelControlsIndex.isValid()) ){
-        throw Exception("Model::updControls() requires an initialized Model./n" 
+        throw Exception("Model::updControls() requires an initialized Model./n"
             "Prior call to Model::initSystem() is required.");
     }
 
@@ -1966,7 +1966,7 @@ SimTK::Vector& Model::updControls(const SimTK::State& s) const {
 void Model::markControlsAsValid(const SimTK::State& s) const
 {
     if( (!_system) || (!_modelControlsIndex.isValid()) ){
-        throw Exception("Model::markControlsAsValid() requires an initialized Model./n" 
+        throw Exception("Model::markControlsAsValid() requires an initialized Model./n"
             "Prior call to Model::initSystem() is required.");
     }
 
@@ -1980,7 +1980,7 @@ void Model::markControlsAsValid(const SimTK::State& s) const
 void Model::markControlsAsInvalid(const SimTK::State& s) const
 {
     if( (!_system) || (!_modelControlsIndex.isValid()) ){
-        throw Exception("Model::markControlsAsInvalid() requires an initialized Model./n" 
+        throw Exception("Model::markControlsAsInvalid() requires an initialized Model./n"
             "Prior call to Model::initSystem() is required.");
     }
 
@@ -1992,9 +1992,9 @@ void Model::markControlsAsInvalid(const SimTK::State& s) const
 }
 
 void Model::setControls(const SimTK::State& s, const SimTK::Vector& controls) const
-{   
+{
     if( (!_system) || (!_modelControlsIndex.isValid()) ){
-        throw Exception("Model::setControls() requires an initialized Model./n" 
+        throw Exception("Model::setControls() requires an initialized Model./n"
             "Prior call to Model::initSystem() is required.");
     }
 
@@ -2014,7 +2014,7 @@ void Model::setControls(const SimTK::State& s, const SimTK::Vector& controls) co
 /** Const access to controls does not invalidate dynamics */
 const SimTK::Vector& Model::getControls(const SimTK::State& s) const {
     if( (!_system) || (!_modelControlsIndex.isValid()) ){
-        throw Exception("Model::getControls() requires an initialized Model./n" 
+        throw Exception("Model::getControls() requires an initialized Model./n"
             "Prior call to Model::initSystem() is required.");
     }
 
@@ -2091,7 +2091,7 @@ void Model::formStateStorage(const Storage& originalStorage,
     // make sure same size, otherwise warn
     if (originalStorage.getSmallestNumberOfStates() != rStateNames.getSize() && warnUnspecifiedStates){
         log_warn("Number of columns does not match in formStateStorage. Found {}"
-            " Expected  {}.", 
+            " Expected  {}.",
             originalStorage.getSmallestNumberOfStates(), rStateNames.getSize());
     }
 
@@ -2115,12 +2115,12 @@ void Model::formStateStorage(const Storage& originalStorage,
         }
     }
     // Now cycle through each state (row of Storage) and form the Model consistent
-    // order for the state values 
+    // order for the state values
     double assignedValue = SimTK::NaN;
     for (int row =0; row< originalStorage.getSize(); row++){
         StateVector* originalVec = originalStorage.getStateVector(row);
         StateVector stateVec{originalVec->getTime()};
-        stateVec.getData().setSize(numStates); 
+        stateVec.getData().setSize(numStates);
         for(int column=0; column< numStates; column++) {
             if (mapColumns[column] != -1)
                 originalVec->getDataValue(mapColumns[column], assignedValue);
@@ -2203,19 +2203,19 @@ void Model::overrideAllActuators( SimTK::State& s, bool flag) {
 }
 
 const Object& Model::getObjectByTypeAndName(const std::string& typeString, const std::string& nameString) {
-    if (typeString=="Body") 
+    if (typeString=="Body")
         return getBodySet().get(nameString);
     else if (typeString == "Joint")
         return getJointSet().get(nameString);
-    else if (typeString=="Force") 
+    else if (typeString=="Force")
         return getForceSet().get(nameString);
     else if (typeString=="Constraint")
         return getConstraintSet().get(nameString);
-    else if (typeString=="Coordinate") 
+    else if (typeString=="Coordinate")
         return getCoordinateSet().get(nameString);
-    else if (typeString=="Marker") 
+    else if (typeString=="Marker")
         return getMarkerSet().get(nameString);
-    else if (typeString=="Controller") 
+    else if (typeString=="Controller")
         return getControllerSet().get(nameString);
     else if (typeString == "Probe")
         return getProbeSet().get(nameString);

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -99,7 +99,7 @@ public:
         const std::string& frameName) :
         Exception(file, line, func, obj) {
         std::string msg =
-            "PhysicalOffsetFrames are not permitted to form loops.\n'" + 
+            "PhysicalOffsetFrames are not permitted to form loops.\n'" +
             frameName + "' already part of a branch of PhysicalOffsetFrames.";
         addMessage(msg);
     }
@@ -115,7 +115,7 @@ public:
         const std::string& childName,
         const std::string& baseName) :
         Exception(file, line, func) {
-        std::string msg = "Joint '" + thisName + 
+        std::string msg = "Joint '" + thisName +
             "' cannot connect parent frame '" +
             parentName + "' to child frame '" + childName + "'.\n" +
             "Parent and child frames have the same base frame '" +
@@ -134,12 +134,12 @@ You can read this in from an XML file or create it programmatically, and
 modify it via the API.
 
 A Model contains ModelComponents, and is itself a ModelComponent so must
-satisfy the ModelComponent interface, as well as the Object interface from 
-which ModelComponent derives. This allows a Model to allocate "global" 
+satisfy the ModelComponent interface, as well as the Object interface from
+which ModelComponent derives. This allows a Model to allocate "global"
 resources using ModelComponent resource-allocation facilities.
 
 Computation using a Model is done by creating a computational representation
-of the Model, called a System (SimTK::System), using Simbody. Creation of the 
+of the Model, called a System (SimTK::System), using Simbody. Creation of the
 System is initiated by a call to the Model's initSystem() method. The System and
 related objects are maintained in a runtime section of the Model object. You
 can also ask a Model to provide visualization using the setUseVisualizer()
@@ -161,7 +161,7 @@ OpenSim_OBJECT_NONTEMPLATE_DEFS(Model, ModelComponent);
 public:
 //==============================================================================
 // PROPERTIES
-//==============================================================================    
+//==============================================================================
     OpenSim_DECLARE_PROPERTY(credits, std::string,
         "Credits (e.g., model author names) associated with the model.");
 
@@ -173,45 +173,45 @@ public:
 
     OpenSim_DECLARE_PROPERTY(force_units, std::string,
         "Units for all forces.");
-        
+
     OpenSim_DECLARE_PROPERTY(assembly_accuracy, double,
     "Specify how accurate the resulting configuration of a model assembly "
     "should be. This translates to the number of significant digits in the "
     "resulting coordinate values. Therefore, if you require initial conditions "
     "accurate to four significant digits, use a minimum of 1e-4 as the accuracy."
-    "The default setting is 1e-9 as to satisfy the most stringent requirements by " 
+    "The default setting is 1e-9 as to satisfy the most stringent requirements by "
     "default. NOTE: Failure for a model to satisfy the assembly accuracy often "
-    "indicates inconsistency in the constraints. For example, the feet are welded " 
+    "indicates inconsistency in the constraints. For example, the feet are welded "
     "at locations measured to five significant digits while the model lacks dofs "
     "to change stance width, in which case it cannot achieve 1e-9 accuracy." );
 
     OpenSim_DECLARE_PROPERTY(gravity, SimTK::Vec3,
         "Acceleration due to gravity, expressed in ground.");
-    
+
     OpenSim_DECLARE_PROPERTY(ground, Ground,
         "The model's ground reference frame.");
-    
+
     OpenSim_DECLARE_UNNAMED_PROPERTY(BodySet,
         "List of bodies that make up this model.");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(JointSet,
         "List of joints that connect the bodies.");
-    
+
     OpenSim_DECLARE_UNNAMED_PROPERTY(ConstraintSet,
         "Constraints in the model.");
-    
+
     OpenSim_DECLARE_UNNAMED_PROPERTY(MarkerSet,
         "Markers in the model.");
-    
+
     OpenSim_DECLARE_UNNAMED_PROPERTY(ForceSet,
         "Forces in the model (includes Actuators).");
 
-    OpenSim_DECLARE_UNNAMED_PROPERTY(ControllerSet, 
-        "Controllers that provide the control inputs for Actuators.");  
+    OpenSim_DECLARE_UNNAMED_PROPERTY(ControllerSet,
+        "Controllers that provide the control inputs for Actuators.");
 
     OpenSim_DECLARE_UNNAMED_PROPERTY(ContactGeometrySet,
         "Geometry to be used in contact forces.");
-    
+
     OpenSim_DECLARE_UNNAMED_PROPERTY(ProbeSet,
         "Probes in the model.");
 
@@ -261,17 +261,17 @@ public:
     and a set of default properties. */
     Model();
 
-    /** Constructor from an OpenSim XML model file. 
+    /** Constructor from an OpenSim XML model file.
     NOTE: The Model is read in (deserialized) from the model file, which means
     the properties of the Model and its components are filled in from values in
     the file. In order to evaluate the validity of the properties (e.g. Inertia
     tensors, availability of Mesh files, ...) and to identify properties as
-    subcomponents of the Model, one must invoke Model::finalizeFromProperties() 
+    subcomponents of the Model, one must invoke Model::finalizeFromProperties()
     first. Model::initSystem() invokes finalizeFromProperties() on its way to
     creating the System and initializing the State.
 
     @param filename     Name of a file containing an OpenSim model in XML
-                        format; suffix is typically ".osim". 
+                        format; suffix is typically ".osim".
     **/
     explicit Model(const std::string& filename) SWIG_DECLARE_EXCEPTION;
 
@@ -292,17 +292,17 @@ public:
     void setup() SWIG_DECLARE_EXCEPTION;
 
     /**
-     * Perform some clean up functions that are normally done 
-     * from the destructor however this gives the GUI a way to 
+     * Perform some clean up functions that are normally done
+     * from the destructor however this gives the GUI a way to
      * proactively do the cleaning without waiting for garbage
      * collection to do the actual cleanup.
      */
     void cleanup();
 
-    /** Model clone() override that invokes finalizeFromProperties() 
+    /** Model clone() override that invokes finalizeFromProperties()
         on a default copy constructed Model, prior to returning the Model. */
     Model* clone() const override;
-    
+
     const std::string& getConcreteClassName() const override
     {   return getClassName(); }
 
@@ -311,12 +311,12 @@ public:
     //--------------------------------------------------------------------------
     /** @name                     Visualization
     Methods in this group affect visualization of this Model, which may be
-    through the OpenSim GUI or through the use of a ModelVisualizer which can 
+    through the OpenSim GUI or through the use of a ModelVisualizer which can
     provide limited run-time display and user interaction capability for an
-    OpenSim API-based program. If you enable visualization at the API level, 
-    the %Model will create a ModelVisualizer that you can use to control 
-    display and user interaction. In turn, the ModelVisualizer makes use of a 
-    Simbody SimTK::Visualizer; for advanced features you can ask the 
+    OpenSim API-based program. If you enable visualization at the API level,
+    the %Model will create a ModelVisualizer that you can use to control
+    display and user interaction. In turn, the ModelVisualizer makes use of a
+    Simbody SimTK::Visualizer; for advanced features you can ask the
     ModelVisualizer to give you direct access to the SimTK::Visualizer; consult
     Simbody documentation for more details. **/
     /**@{**/
@@ -329,13 +329,13 @@ public:
     /** Get writable access to the ModelDisplayHints object stored with this
     %Model. The GUI or ModelVisualizer can update these as a result of user
     requests, or an OpenSim API program can set them programmatically. **/
-    ModelDisplayHints& updDisplayHints() { 
+    ModelDisplayHints& updDisplayHints() {
         return upd_ModelVisualPreferences().upd_ModelDisplayHints(); }
 
     /** Request or suppress visualization of this %Model. This flag is checked
     during initSystem() and if set causes the %Model to allocate a
     ModelVisualizer that provides visualization and interaction with the %Model
-    as it is executing. The default is no visualization. 
+    as it is executing. The default is no visualization.
     @see getModelVisualizer() **/
     void setUseVisualizer(bool visualize) {_useVisualizer=visualize;}
     /** Return the current setting of the "use visualizer" flag, which will
@@ -349,7 +349,7 @@ public:
     unpleasant exception. **/
     bool hasVisualizer() const {return _modelViz != nullptr;}
 
-    /** Obtain read-only access to the ModelVisualizer. This will throw an 
+    /** Obtain read-only access to the ModelVisualizer. This will throw an
     exception if visualization was not requested or initSystem() not yet
     called.
     @return A const reference to the allocated ModelVisualizer. **/
@@ -358,15 +358,15 @@ public:
             throw Exception("Model::getVisualizer(): no visualizer present.");
         return *_modelViz;
     }
-    /** Obtain writable access to the ModelVisualizer. This will throw an 
+    /** Obtain writable access to the ModelVisualizer. This will throw an
     exception if visualization was not requested or initSystem() not yet
-    called. Writable access to the ModelVisualizer requires that you have 
+    called. Writable access to the ModelVisualizer requires that you have
     writable access to this containing Model.
     @return A non-const reference to the allocated ModelVisualizer. **/
     ModelVisualizer& updVisualizer() {
         if (!hasVisualizer())
             throw Exception("Model::updVisualizer(): no visualizer present.");
-        return *_modelViz; 
+        return *_modelViz;
     }
     /**@}**/
 
@@ -374,30 +374,30 @@ public:
     interconnect the components and then create the Simbody
     MultibodySystem needed to represent the %Model computationally. The
     extendConnectToModel() method of each contained ModelComponent will be invoked,
-    and then their addToSystem() methods are invoked.   
-    The resulting MultibodySystem is maintained internally by the %Model. After 
-    this call, you may obtain a writable reference to the System using 
-    updMultibodySystem() which you can use to make any additions you want. Then 
-    when the System is complete, call initializeState() to finalize it and 
+    and then their addToSystem() methods are invoked.
+    The resulting MultibodySystem is maintained internally by the %Model. After
+    this call, you may obtain a writable reference to the System using
+    updMultibodySystem() which you can use to make any additions you want. Then
+    when the System is complete, call initializeState() to finalize it and
     obtain an initial State. **/
     void buildSystem();
 
     /** After buildSystem() has been called, and any additional modifications
-    to the Simbody MultibodySystem have been made, call this method to finalize 
-    the MultibodySystem (by calling its realizeTopology() method), obtain an 
-    initial state, and assemble it so that position constraints are 
+    to the Simbody MultibodySystem have been made, call this method to finalize
+    the MultibodySystem (by calling its realizeTopology() method), obtain an
+    initial state, and assemble it so that position constraints are
     satisfied. The initStateFromProperties() method of each contained
     ModelComponent will be invoked. A reference to the writable internally-
-    maintained model State is returned (note that this does not affect the 
+    maintained model State is returned (note that this does not affect the
     system's default state (which is part of the model and hence read only).
     The model's state can be reset to the system's default state at any time
     by re-executing initializeState(). **/
     SimTK::State& initializeState();
 
-    
-    /** Convenience method that invokes buildSystem() and then 
+
+    /** Convenience method that invokes buildSystem() and then
     initializeState(). This returns a reference to the writable internally-
-    maintained model State. Note that this does not affect the 
+    maintained model State. Note that this does not affect the
     system's default state (which is part of the model and hence read-only). **/
     SimTK::State& initSystem() SWIG_DECLARE_EXCEPTION {
         buildSystem();
@@ -406,7 +406,7 @@ public:
 
 
     /** Convenience method that returns a reference to the model's 'working'
-    state. This is just returning the reference that was returned by 
+    state. This is just returning the reference that was returned by
     initSystem() and initializeState() -- note that either of these methods
     must be called prior to getWorkingState(), otherwise an empty state will
     be returned. **/
@@ -415,9 +415,9 @@ public:
 
     /**
      * This is called after the Model is fully created but before starting a simulation.
-     * It ONLY initializes the computational system used to simulate the model and 
-     * addToSystem() has been called already. This method should only be used if 
-     * if additional SimTK::System components are being added using the SimTK API 
+     * It ONLY initializes the computational system used to simulate the model and
+     * addToSystem() has been called already. This method should only be used if
+     * if additional SimTK::System components are being added using the SimTK API
      * and the programmer is certain that the model's system has been created.
      */
     void initStateWithoutRecreatingSystem(SimTK::State& state) const { initStateFromProperties(state); };
@@ -429,7 +429,7 @@ public:
      */
     void invalidateSystem();
 
-    /** Check that the underlying computational system representing the model is valid. 
+    /** Check that the underlying computational system representing the model is valid.
         That is, is the system ready for performing calculations. */
     bool isValidSystem() const;
 
@@ -438,16 +438,16 @@ public:
      * with values populated from originalStorage. Use the default state value if
      * a state is unspecified in the originalStorage. If warnUnspecifiedStates is
      * true then a warning is printed that includes the default value used for
-     * the state value unspecified in originalStorage. The input originalStorage 
+     * the state value unspecified in originalStorage. The input originalStorage
      * must be in meters or radians for Coordinate values and their speeds
      * (m/s, rad/s) otherwise an Exception is thrown.
      */
-    void formStateStorage(const Storage& originalStorage, 
+    void formStateStorage(const Storage& originalStorage,
                           Storage& statesStorage,
                           bool warnUnspecifiedStates = true) const;
 
     void formQStorage(const Storage& originalStorage, Storage& qStorage);
-    
+
     /**
      * Update the AssemblySolver to the latest coordinate locking/constraints
      */
@@ -469,58 +469,58 @@ public:
     /**@name       Access to the Simbody System and components
 
     Methods in this section provide advanced users access to the underlying
-    Simbody System and associated subcomponents that are constructed and 
+    Simbody System and associated subcomponents that are constructed and
     maintained by this %Model. Note that these are not available until after
     initSystem() has been invoked on this %Model. Be very careful if you
     call any of the upd() methods since modifying a System after the %Model
-    creates it can require reinitialization. 
+    creates it can require reinitialization.
     @see initStateWithoutRecreatingSystem() **/
     /**@{**/
 
     /** Get read-only access to the internal Simbody MultibodySystem that was
-    created by this %Model at the last initSystem() call. **/    
+    created by this %Model at the last initSystem() call. **/
     const SimTK::MultibodySystem& getMultibodySystem() const {return getSystem(); }
-    /** (Advanced) Get writable access to the internal Simbody MultibodySystem 
+    /** (Advanced) Get writable access to the internal Simbody MultibodySystem
     that was created by this %Model at the last initSystem() call. Be careful
-    if you make modifications to the System because that will invalidate 
-    initialization already performed by the Model. 
-    @see initStateWithoutRecreatingSystem() **/    
+    if you make modifications to the System because that will invalidate
+    initialization already performed by the Model.
+    @see initStateWithoutRecreatingSystem() **/
     SimTK::MultibodySystem& updMultibodySystem() const {return updSystem(); }
 
     /** Get read-only access to the internal DefaultSystemSubsystem allocated
     by this %Model's Simbody MultibodySystem. **/
-    const SimTK::DefaultSystemSubsystem& getDefaultSubsystem() const 
+    const SimTK::DefaultSystemSubsystem& getDefaultSubsystem() const
     {   return getMultibodySystem().getDefaultSubsystem(); }
-    /** (Advanced) Get writable access to the internal DefaultSystemSubsystem 
+    /** (Advanced) Get writable access to the internal DefaultSystemSubsystem
     allocated by this %Model's Simbody MultibodySystem. **/
-    SimTK::DefaultSystemSubsystem& updDefaultSubsystem() 
+    SimTK::DefaultSystemSubsystem& updDefaultSubsystem()
     {   return updMultibodySystem().updDefaultSubsystem(); }
 
     /** Get read-only access to the internal SimbodyMatterSubsystem allocated
     by this %Model. **/
-    const SimTK::SimbodyMatterSubsystem& getMatterSubsystem() const 
+    const SimTK::SimbodyMatterSubsystem& getMatterSubsystem() const
     {   return _system->getMatterSubsystem(); }
-    /** (Advanced) Get writable access to the internal SimbodyMatterSubsystem 
+    /** (Advanced) Get writable access to the internal SimbodyMatterSubsystem
     allocated by this %Model. **/
-    SimTK::SimbodyMatterSubsystem& updMatterSubsystem() 
+    SimTK::SimbodyMatterSubsystem& updMatterSubsystem()
     {   return _system->updMatterSubsystem(); }
 
-    /** Get read-only access to the Simbody Force::Gravity element that was 
+    /** Get read-only access to the Simbody Force::Gravity element that was
     allocated by this %Model. **/
-    const SimTK::Force::Gravity& getGravityForce() const 
+    const SimTK::Force::Gravity& getGravityForce() const
     {   return *_gravityForce; }
-    /** (Advanced) Get writable access to the Simbody Force::Gravity element 
+    /** (Advanced) Get writable access to the Simbody Force::Gravity element
     that was allocated by this %Model. **/
-    SimTK::Force::Gravity& updGravityForce() 
+    SimTK::Force::Gravity& updGravityForce()
     {   return *_gravityForce; }
 
-    /** Get read-only access to the internal Simbody GeneralForceSubsystem 
+    /** Get read-only access to the internal Simbody GeneralForceSubsystem
     allocated by this %Model. **/
-    const SimTK::GeneralForceSubsystem& getForceSubsystem() const 
+    const SimTK::GeneralForceSubsystem& getForceSubsystem() const
     {   return *_forceSubsystem; }
-    /** (Advanced) Get writable access to the internal Simbody 
+    /** (Advanced) Get writable access to the internal Simbody
     GeneralForceSubsystem allocated by this %Model. **/
-    SimTK::GeneralForceSubsystem& updForceSubsystem() 
+    SimTK::GeneralForceSubsystem& updForceSubsystem()
     {   return *_forceSubsystem; }
     /** (Advanced) Get read only access to internal Simbody RigidBodyForces at Dynamics stage **/
     const SimTK::Vector_<SimTK::SpatialVec>& getRigidBodyForces(const SimTK::State& state)
@@ -583,7 +583,7 @@ public:
      * using Component::addComponent().
      * In contrast, components added using addComponent() are not stored in the
      * model's %Sets but live in a flat components list (which is also serialized).
-     * Component provides access via getComponentList<%SpecificType> or 
+     * Component provides access via getComponentList<%SpecificType> or
      * getComponent<%SpecificType> to get any subcomponent, including those that
      * are contained in Model's %Sets. In this case, either a Body or a Joint has
      * the pathname "/toes" but both cannot share the same name and will throw
@@ -609,57 +609,57 @@ public:
     /** remove passed in Probe from model **/
     void removeProbe(Probe *probe);
 
-    /** 
-     * Get the XML file name used to construct the model. 
+    /**
+     * Get the XML file name used to construct the model.
      *
-     * @return XML file name string.    
+     * @return XML file name string.
      */
     const std::string& getInputFileName() const { return _fileName; }
 
-    /** 
+    /**
      * %Set the XML file name used to construct the model.
      *
      * @param fileName The XML file name.
      */
     void setInputFileName(const std::string& fileName) { _fileName = fileName; }
 
-    /** 
-     * Get the credits (e.g., model author names) associated with the model. 
+    /**
+     * Get the credits (e.g., model author names) associated with the model.
      *
      * @return Credits string.
      */
     const std::string& getCredits() const { return get_credits(); }
 
-    /** 
+    /**
      * %Set the credits (e.g., model author names) associated with the model.
      *
      * @param aCredits The string of credits.
      */
     void setAuthors(const std::string& aCredits) { upd_credits() = aCredits; }
 
-    /** 
-     * Get the publications associated with the model. 
+    /**
+     * Get the publications associated with the model.
      *
      * @return Publications string.
      */
     const std::string& getPublications() const { return get_publications(); }
-    
-    /** 
-     * %Set the publications associated with the model. 
+
+    /**
+     * %Set the publications associated with the model.
      *
      * @param aPublications The string of publications.
      */
     void setPublications(const std::string& aPublications) { upd_publications() = aPublications; }
 
-    /** 
-     * Get the length units associated with the model. 
+    /**
+     * Get the length units associated with the model.
      *
      * @return Length units.
      */
     const Units& getLengthUnits() const { return _lengthUnits; }
-    
-    /** 
-     * Get the force units associated with the model. 
+
+    /**
+     * Get the force units associated with the model.
      *
      * @return Force units
      */
@@ -671,7 +671,7 @@ public:
      * @return The XYZ gravity vector in the global frame.
      */
     SimTK::Vec3 getGravity() const;
-    
+
     /**
      * %Set the gravity vector in the global frame.
      *
@@ -756,9 +756,9 @@ public:
      * Get the subst of misc ModelComponents in the model
      * @return The set of misc ModelComponents
      */
-    const ComponentSet& getMiscModelComponentSet() const 
+    const ComponentSet& getMiscModelComponentSet() const
     {   return get_ComponentSet(); };
-    ComponentSet& updMiscModelComponentSet() 
+    ComponentSet& updMiscModelComponentSet()
     {   return upd_ComponentSet(); };
 
     /**
@@ -775,7 +775,7 @@ public:
      */
     int getNumControls() const;
 
-    /** Writable access to the default values for controls. These values are used for 
+    /** Writable access to the default values for controls. These values are used for
         control value during a simulation unless updated, for example, by a Controller */
     SimTK::Vector& updDefaultControls() const { return _defaultControls; }
     void setDefaultControls(const SimTK::Vector& controls) const
@@ -793,23 +793,23 @@ public:
      * @return      writable controls Vector
      */
     SimTK::Vector& updControls(const SimTK::State& s) const;
-    
+
     /**
      * Mark controls as valid after an update at a given state.
      * Indicates that controls are valid for use at the dynamics stage.
      * If the stage is Velocity or lower the controls will remain invalid.
-     * @param[in]   s         System state in which the controls are updated 
+     * @param[in]   s         System state in which the controls are updated
      */
     void markControlsAsValid(const SimTK::State& s) const;
 
     /**
      * Mark controls as invalid after an update at a given state.
      * Indicates that controls are not valid for use at the dynamics stage.
-     * @param[in]   s         System state in which the controls are updated 
+     * @param[in]   s         System state in which the controls are updated
      */
     void markControlsAsInvalid(const SimTK::State& s) const;
 
-    /** 
+    /**
      * Alternatively, set the controls on the model at a given state.
      * Note, this method will invalidate the dynamics of the model,
      * but will mark the controls as valid. (E.g. controllers will not be invoked)
@@ -822,11 +822,11 @@ public:
     const SimTK::Vector& getControls(const SimTK::State &s) const;
 
     /** Compute the controls for the model.
-    Calls down to the Controllers to make their contributions to the controls. 
-    
+    Calls down to the Controllers to make their contributions to the controls.
+
     @param[in]   state       System state from which Controllers should draw
                              when computing their control outputs.
-    @param[out]  controls    The complete vector of controls into which 
+    @param[out]  controls    The complete vector of controls into which
                              individual controller contributions should be
                              added. **/
     void computeControls(const SimTK::State& state, SimTK::Vector& controls) const;
@@ -921,22 +921,22 @@ public:
     }
 
     /** Calulate the sum of body and mobility forces in the system applied by
-     * the Force%s at the supplied indexes. 
-     * 
-     * @param[in]   state            The system SimTK::State at which to 
+     * the Force%s at the supplied indexes.
+     *
+     * @param[in]   state            The system SimTK::State at which to
      *                               calculate forces.
-     * @param[in]   forceIndexes     The indexes (SimTK::ForceIndex) of the 
-     *                               forces in the system for which to calculate 
+     * @param[in]   forceIndexes     The indexes (SimTK::ForceIndex) of the
+     *                               forces in the system for which to calculate
      *                               forces.
      * @param[out]  bodyForces       The sum of the body forces applied by the
      *                               forces at the supplied indexes.
      * @param[out]  mobilityForces   The sum of the mobility forces applied by
      *                               the forces at the supplied indexes.
-     * 
+     *
      * @pre Requires that the system has been realized to Stage::Dynamics.
      * */
     void calcForceContributionsSum(const SimTK::State& state,
-            const SimTK::Array_<SimTK::ForceIndex>& forceIndexes,  
+            const SimTK::Array_<SimTK::ForceIndex>& forceIndexes,
             SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
             SimTK::Vector& mobilityForces) const {
         getForceSubsystem().calcForceContributionsSum(
@@ -953,22 +953,22 @@ public:
     //--------------------------------------------------------------------------
     // COORDINATES
     //--------------------------------------------------------------------------
-    CoordinateSet& updCoordinateSet() { 
-       return _coordinateSet; 
+    CoordinateSet& updCoordinateSet() {
+       return _coordinateSet;
     }
-    const CoordinateSet& getCoordinateSet() const { 
-       return _coordinateSet; 
+    const CoordinateSet& getCoordinateSet() const {
+       return _coordinateSet;
     }
 
     /** Obtain a list of Model's Coordinates in the order they appear in the
-        MultibodySystem after Model::initSystem() has been called. 
+        MultibodySystem after Model::initSystem() has been called.
         Coordinates in the CoordinateSet do not have a predefined order. In
-        some instances it is helpful to get the coordinates in order of 
-        generalized coordinates in the Multibody Tree as defined in the 
+        some instances it is helpful to get the coordinates in order of
+        generalized coordinates in the Multibody Tree as defined in the
         underlying MultibodySystem. For example, computing the generalized
         forces from the System, yields a vector of generalized forces
-        in order of the Multibody Tree and now that can be attributed to 
-        corresponding generalized Coordinates of the Model. 
+        in order of the Multibody Tree and now that can be attributed to
+        corresponding generalized Coordinates of the Model.
         Throws if the MultibodySystem is not valid. */
     std::vector<SimTK::ReferencePtr<const OpenSim::Coordinate>>
         getCoordinatesInMultibodyTreeOrder() const;
@@ -982,14 +982,14 @@ public:
         return namesArray;
     }
     /** Get a warning message if any Coordinates have a MotionType that is NOT
-        consistent with its previous user-specified value that existed in 
+        consistent with its previous user-specified value that existed in
         Model files prior to OpenSim 4.0 */
     std::string getWarningMesssageForMotionTypeInconsistency() const;
 
     BodySet& updBodySet() { return upd_BodySet(); }
     const BodySet& getBodySet() const { return get_BodySet(); }
 
-    JointSet& updJointSet(); 
+    JointSet& updJointSet();
     const JointSet& getJointSet() const;
 
     AnalysisSet& updAnalysisSet() {return _analysisSet; }
@@ -1026,7 +1026,7 @@ public:
     */
     void updateMarkerSet(MarkerSet& newMarkerSet);
     int deleteUnusedMarkers(const Array<std::string>& aMarkerNames);
- 
+
     /**
      * Add an Analysis to the %Model.
      *
@@ -1048,7 +1048,7 @@ public:
 
     //--------------------------------------------------------------------------
     // DERIVATIVES
-    //--------------------------------------------------------------------------    
+    //--------------------------------------------------------------------------
     //--------------------------------------------------------------------------
     // OPERATIONS
     //--------------------------------------------------------------------------
@@ -1100,14 +1100,14 @@ public:
                            std::ostream& aOStream = std::cout) const;
 
     /**
-     * Model relinquishes ownership of all components such as: Bodies, Constraints, Forces, 
+     * Model relinquishes ownership of all components such as: Bodies, Constraints, Forces,
      * ContactGeometry and so on. That means the freeing of the memory of these objects is up
      * to the caller. This only affects components stored in the Model's Sets,
      * and does not affect those added via Component::addComponent().
      */
     void disownAllComponents();
     /**
-     * Convenience function to turn on/off overriding the force for all actuators 
+     * Convenience function to turn on/off overriding the force for all actuators
      */
     void overrideAllActuators( SimTK::State& s, bool flag);
 
@@ -1133,7 +1133,7 @@ public:
     /**@name            Implementation of Object interface
 
     These methods are %Model's implementation of virtual methods defined in
-    the Object class from which %Model derives (indirectly through 
+    the Object class from which %Model derives (indirectly through
     ModelComponent). **/
     /**@{**/
 
@@ -1148,7 +1148,7 @@ public:
     }
 
     /** Override of the default implementation to account for versioning. */
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, 
+    void updateFromXMLNode(SimTK::Xml::Element& aNode,
                            int versionNumber = -1) override;
     /**@}**/
 
@@ -1161,12 +1161,12 @@ public:
     void extendFinalizeFromProperties() override;
 
     void extendConnectToModel(Model& model)  override;
-    void extendAddToSystem(SimTK::MultibodySystem& system) const override; 
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
     void extendInitStateFromProperties(SimTK::State& state) const override;
     /**@}**/
 
     /**
-     * Given a State, set all default values for this Model to match those 
+     * Given a State, set all default values for this Model to match those
      * found in the State.
      */
     void extendSetPropertiesFromState(const SimTK::State& state) override;
@@ -1178,13 +1178,13 @@ public:
     the ModelComponent class from which %Model derives. **/
     /**@{**/
     void generateDecorations
-       (bool                                        fixed, 
+       (bool                                        fixed,
         const ModelDisplayHints&                    hints,
         const SimTK::State&                         state,
-        SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const 
+        SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
                                                                 override;
     /**@}**/
-    
+
     //--------------------------------------------------------------------------
 
 private:
@@ -1203,14 +1203,14 @@ private:
     void createAssemblySolver(const SimTK::State& s);
 
     // To provide access to private _modelComponents member.
-    friend class Component; 
+    friend class Component;
 
 //==============================================================================
 // DATA MEMBERS
 //==============================================================================
 private:
     //--------------------------------------------------------------------------
-    //                              MODELING 
+    //                              MODELING
     //--------------------------------------------------------------------------
     // These data members are concerned with the structure and contents of the
     // model and must be given values prior to initiating computation.
@@ -1219,7 +1219,7 @@ private:
     // set to "Unassigned".
     std::string _fileName;
 
-    // Private place to save some deserialization/error checking info in case 
+    // Private place to save some deserialization/error checking info in case
     // needed later.
     std::string _validationLog;
 
@@ -1228,7 +1228,7 @@ private:
     Units _lengthUnits;
     //Units for forces
     Units _forceUnits;
-   
+
     // Other Model data structures that are derived from the properties
     // or added programmatically.
 
@@ -1264,7 +1264,7 @@ private:
     std::vector<std::reference_wrapper<const Controller>> _enabledControllers{};
 
     //--------------------------------------------------------------------------
-    //                              RUN TIME 
+    //                              RUN TIME
     //--------------------------------------------------------------------------
 
     // If this flag is set when initSystem() is called, we'll allocate
@@ -1284,7 +1284,7 @@ private:
     // us to manage the heap memory for the handles.
 
     SimTK::ResetOnCopy<std::unique_ptr<SimTK::SimbodyMatterSubsystem>>
-        _matter;     
+        _matter;
     SimTK::ResetOnCopy<std::unique_ptr<SimTK::Force::Gravity>>
         _gravityForce;
     SimTK::ResetOnCopy<std::unique_ptr<SimTK::GeneralForceSubsystem>>
@@ -1316,7 +1316,7 @@ private:
     // current user interface (GUI or ModelVisualizer) or programmatically.
     ModelDisplayHints   _displayHints;
 
-    // If visualization has been requested at the API level, we'll allocate 
+    // If visualization has been requested at the API level, we'll allocate
     // a ModelVisualizer. The Model owns this object, but it should not be
     // copied.
     SimTK::ResetOnCopy<std::unique_ptr<ModelVisualizer>> _modelViz;


### PR DESCRIPTION
### Brief summary of changes
Trims all whitespace characters in Model.h and Model.cpp. I recently discovered this while working on other changes, nuking them here so they don't muddy future PRs.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...whitespace changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4153)
<!-- Reviewable:end -->
