### PR TITLE
Refactor `ForceConsumer::impl*()` methods to accept `SimTK` indexes directly

### DIFF
--- a/OpenSim/Simulation/Model/ForceApplier.cpp
+++ b/OpenSim/Simulation/Model/ForceApplier.cpp
@@ -7,13 +7,14 @@
 
 void OpenSim::ForceApplier::implConsumeGeneralizedForce(
     const SimTK::State& state,
-    const Coordinate& coord,
+    SimTK::MobilizedBodyIndex mobodIndex,
+    SimTK::MobilizerUIndex uIndex,
     double force)
 {
     _matter->addInMobilityForce(
         state,
-        SimTK::MobilizedBodyIndex(coord.getBodyIndex()),
-        SimTK::MobilizerUIndex(coord.getMobilizerQIndex()),
+        mobodIndex,
+        uIndex,
         force,
         *_generalizedForces
     );
@@ -21,24 +22,23 @@ void OpenSim::ForceApplier::implConsumeGeneralizedForce(
 
 void OpenSim::ForceApplier::implConsumeBodySpatialVec(
     const SimTK::State& state,
-    const PhysicalFrame& body,
+    SimTK::MobilizedBodyIndex mobodIndex,
     const SimTK::SpatialVec& spatialVec)
 {
-    const auto mobilizedBodyIndex = body.getMobilizedBodyIndex();
-    OPENSIM_ASSERT_ALWAYS(0 <= mobilizedBodyIndex && mobilizedBodyIndex < _bodyForces->size() && "the provided mobilized body index is out-of-bounds");
-    (*_bodyForces)[mobilizedBodyIndex] += spatialVec;
+    OPENSIM_ASSERT_ALWAYS(0 <= mobodIndex && mobodIndex < _bodyForces->size() && "the provided mobilized body index is out-of-bounds");
+    (*_bodyForces)[mobodIndex] += spatialVec;
 }
 
 void OpenSim::ForceApplier::implConsumePointForce(
     const SimTK::State& state,
-    const PhysicalFrame& frame,
+    SimTK::MobilizedBodyIndex mobodIndex,
     const SimTK::Vec3& point,
     const SimTK::Vec3& force)
 {
     _matter->addInStationForce(
         state,
-        frame.getMobilizedBodyIndex(),
-        frame.findTransformInBaseFrame() * point,
+        mobodIndex,
+        point,
         force,
         *_bodyForces
     );

--- a/OpenSim/Simulation/Model/ForceApplier.h
+++ b/OpenSim/Simulation/Model/ForceApplier.h
@@ -43,6 +43,7 @@ namespace OpenSim
  * - Converts any point forces into body forces
  * - Applies body forces to a `SimTK::Vector_<SimTK::SpatialVec>`
  * - Applies generalized (mobility) forces to a `SimTK::Vector`
+ * - Applies a vector of body forces to the system's `SimTK::Vector_<SimTK::SpatialVec>`
  *
  * The `ForceApplier` is primarily used as an internal class for adapting
  * the `OpenSim::ForceConsumer`'s API contract ("undefined virtual
@@ -73,9 +74,9 @@ public:
 
 private:
 
-    void implConsumeGeneralizedForce(const SimTK::State&, const Coordinate&, double) final;
-    void implConsumeBodySpatialVec(const SimTK::State&, const PhysicalFrame&, const SimTK::SpatialVec&) final;
-    void implConsumePointForce(const SimTK::State&, const PhysicalFrame&, const SimTK::Vec3&, const SimTK::Vec3&) final;
+    void implConsumeGeneralizedForce(const SimTK::State&, SimTK::MobilizedBodyIndex, SimTK::MobilizerUIndex, double) final;
+    void implConsumeBodySpatialVec(const SimTK::State&, SimTK::MobilizedBodyIndex, const SimTK::SpatialVec&) final;
+    void implConsumePointForce(const SimTK::State&, SimTK::MobilizedBodyIndex, const SimTK::Vec3&, const SimTK::Vec3&) final;
 
     const SimTK::SimbodyMatterSubsystem* _matter;
     SimTK::Vector_<SimTK::SpatialVec>* _bodyForces;

--- a/OpenSim/Simulation/Model/TwoFrameLinker.h
+++ b/OpenSim/Simulation/Model/TwoFrameLinker.h
@@ -596,10 +596,10 @@ void TwoFrameLinker<C, F>::addInPhysicalForcesFromInternal(
     private:
         void implConsumeBodySpatialVec(
             const SimTK::State& state,
-            const PhysicalFrame& body,
+            SimTK::MobilizedBodyIndex mobodIndex,
             const SimTK::SpatialVec& spatialVec) final
         {
-            (*_physicalForces)[body.getMobilizedBodyIndex()] += spatialVec;
+            (*_physicalForces)[mobodIndex] += spatialVec;
         }
 
         SimTK::Vector_<SimTK::SpatialVec>* _physicalForces;

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -222,7 +222,7 @@ public:
 
     /** @name Advanced Access to underlying Simbody system resources */
     /**@{**/
-    int getMobilizerQIndex() const { return _mobilizerQIndex; };
+    SimTK::MobilizerQIndex getMobilizerQIndex() const { return _mobilizerQIndex; };
     SimTK::MobilizedBodyIndex getBodyIndex() const { return _bodyIndex; };
     /**@}**/
 

--- a/OpenSim/Simulation/Test/testForceProducer.cpp
+++ b/OpenSim/Simulation/Test/testForceProducer.cpp
@@ -90,17 +90,17 @@ namespace
 
     private:
 
-        void implConsumeGeneralizedForce(const SimTK::State&, const Coordinate&, double) final
+        void implConsumeGeneralizedForce(const SimTK::State&, SimTK::MobilizedBodyIndex, SimTK::MobilizerUIndex, double) final
         {
             ++_numGeneralizedForcesConsumed;
         }
 
-        void implConsumeBodySpatialVec(const SimTK::State&, const PhysicalFrame&, const SimTK::SpatialVec&) final
+        void implConsumeBodySpatialVec(const SimTK::State&, SimTK::MobilizedBodyIndex, const SimTK::SpatialVec&) final
         {
             ++_numBodySpatialVectorsConsumed;
         }
 
-        void implConsumePointForce(const SimTK::State&, const PhysicalFrame&, const SimTK::Vec3&, const SimTK::Vec3&) final
+        void implConsumePointForce(const SimTK::State&, SimTK::MobilizedBodyIndex, const SimTK::Vec3&, const SimTK::Vec3&) final
         {
             ++_numPointForcesConsumed;
         }


### PR DESCRIPTION
### Brief summary of changes
This change refactors the `impl*()` methods in `ForceConsumer` to accept directly `SimTK::MobilizedBodyIndex` and `SimTK::MobilizerUIndex`,  supporting future `consume*()` methods that, for example, accept a `SimTK::MobilizedBodyIndex` instead of a `PhysicalFrame` as argument.  While the contract `ForceConsumer`s must satisfy has changed, the user-facing API of `ForceConsumer` remains the same. 

This change is motivated by upcoming changes to support `SimTK::CableSpan` in OpenSim. Specifically, it would allow iterating over cable indexes (e.g., `SimTK::CableSpanObstacleIndex`) to simplify computations:

```c++
// Forces applied to each obstacle body.
for (const auto& index : _obstacleIndexes) {
    if (!cable.isInContactWithObstacle(state, index)) {
        continue;
    }

    cable.calcCurveSegmentUnitForce(state, index, unitBodyForce);
    forceConsumer.consumeBodySpatialVec(state,
            cable.getObstacleMobilizedBodyIndex(index),
            tension * unitBodyForce);
}
```


### Testing I've completed

Ran existing test suite.

### Looking for feedback on...

Will future concrete implementations of `ForceConsumer` require more information provided by the `impl*()` virtual method arguments?

### CHANGELOG.md (choose one)

- no need to update because...internal change.
