### PR TITLE
Add class `Scholz2015GeometryPath`

### DIFF
--- a/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
+++ b/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
@@ -1,0 +1,93 @@
+% -------------------------------------------------------------------------- %
+%                OpenSim:  exampleScholz2015GeometryPath.m                   %
+% -------------------------------------------------------------------------- %
+% The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  %
+% See http://opensim.stanford.edu and the NOTICE file for more information.  %
+% OpenSim is developed at Stanford University and supported by the US        %
+% National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    %
+% through the Warrior Web program.                                           %
+%                                                                            %
+% Copyright (c) 2005-2025 Stanford University and the Authors                %
+% Author(s): Nicholas Bianco                                                 %
+%                                                                            %
+% Licensed under the Apache License, Version 2.0 (the 'License') you may     %
+% not use this file except in compliance with the License. You may obtain a  %
+% copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         %
+%                                                                            %
+% Unless required by applicable law or agreed to in writing, software        %
+% distributed under the License is distributed on an 'AS IS' BASIS,          %
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   %
+% See the License for the specific language governing permissions and        %
+% limitations under the License.                                             %
+% -------------------------------------------------------------------------- %
+
+% This example demonstrates the basic elements of creating a geometry-based
+% path using the Scholz2015GeometryPath class. The path is used to define the
+% length and speed of a PathSpring, which applies forces to the bodies of a
+% double pendulum model. The path contains three path points and wraps around
+% a cylindrical obstacle.
+
+function exampleScholz2015GeometryPath()
+
+import org.opensim.modeling.*;
+
+model = ModelFactory.createDoublePendulum();
+model.setUseVisualizer(true);
+
+% Create a PathSpring with a Scholz2015GeometryPath.
+spring = PathSpring();
+spring.setName('path_spring');
+spring.setRestingLength(0.25);
+spring.setDissipation(0.75);
+spring.setStiffness(10.0);
+spring.set_path(Scholz2015GeometryPath());
+model.addComponent(spring);
+
+% Configure the Scholz2015GeometryPath. We will update the path after
+% adding it to the PathSpring, so that the Socket connections in each
+% Station (i.e., path point) remain valid.
+path = Scholz2015GeometryPath.safeDownCast(spring.updPath());
+path.setName('path');
+
+% Add a path point connected to ground. Since this is the first path point,
+% it defines the origin of the path.
+path.appendPathPoint(model.getGround(), Vec3(0.05, 0.05, 0.));
+
+% Append a second path point, creating a straight line segment between the
+% ground and body "b0".
+path.appendPathPoint(model.getBodySet().get('b0'), Vec3(-0.5, 0.1, 0.));
+
+% Create a ContactCylinder to use as a wrapping obstacle to the path. The
+% cylinder has radius 0.15 m and is attached to body "b0".
+obstacle = ContactCylinder(0.15, ...
+    Vec3(-0.2, 0.2, 0.), Vec3(0), ...
+    model.getBodySet().get('b0'));
+model.addComponent(obstacle);
+
+% Before we add the obstacle to the path, we must provide a "contact hint"
+% to initialize the wrapping solver. The contact hint is a point on the
+% surface of the obstacle, expressed in the obstacle's frame. The point
+% does not have to lie on the contact geometry's surface, nor does it have
+% to belong to a valid cable path. The choice of the contact hint will
+% determine which side of the cylinder the path wraps around.
+contact_hint = Vec3(0., 0.15, 0.);
+path.appendObstacle(obstacle, contact_hint);
+
+% At least one path point must follow an obstacle (or list of obstacles)
+% in a Scholz2015GeometryPath. Since this is the last path point we are
+% adding, it defines the insertion of the path.
+path.appendPathPoint(model.getBodySet().get('b1'), Vec3(-0.5, 0.1, 0.));
+
+% Initialize the system.
+state = model.initSystem();
+model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2);
+transform = Transform(Vec3(0.2, -0.8, 3.0));
+model.updVisualizer().updSimbodyVisualizer().setCameraTransform(transform);
+model.updVisualizer().updSimbodyVisualizer().setCameraFieldOfView(0.9);
+
+% Simulate.
+manager = Manager(model);
+manager.initialize(state);
+manager.integrate(20.0);
+
+end

--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -111,6 +111,7 @@
 #include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
 #include <OpenSim/Simulation/Model/FunctionBasedPath.h>
+#include <OpenSim/Simulation/Model/Scholz2015GeometryPath.h>
 #include <OpenSim/Simulation/Model/Ligament.h>
 #include <OpenSim/Simulation/Model/Blankevoort1991Ligament.h>
 

--- a/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
+++ b/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
@@ -1,0 +1,89 @@
+# -------------------------------------------------------------------------- #
+#                OpenSim:  exampleScholz2015GeometryPath.py                  #
+# -------------------------------------------------------------------------- #
+# The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  #
+# See http://opensim.stanford.edu and the NOTICE file for more information.  #
+# OpenSim is developed at Stanford University and supported by the US        #
+# National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    #
+# through the Warrior Web program.                                           #
+#                                                                            #
+# Copyright (c) 2005-2025 Stanford University and the Authors                #
+# Author(s): Nicholas Bianco                                                 #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the 'License') you may     #
+# not use this file except in compliance with the License. You may obtain a  #
+# copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an 'AS IS' BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+# -------------------------------------------------------------------------- #
+
+# This example demonstrates the basic elements of creating a geometry-based
+# path using the Scholz2015GeometryPath class. The path is used to define the
+# length and speed of a PathSpring, which applies forces to the bodies of a
+# double pendulum model. The path contains three path points and wraps around
+# a cylindrical obstacle.
+
+import opensim as osim
+
+model = osim.ModelFactory.createDoublePendulum()
+model.setUseVisualizer(True)
+
+# Create a PathSpring with a Scholz2015GeometryPath.
+spring = osim.PathSpring()
+spring.setName('path_spring')
+spring.setRestingLength(0.25)
+spring.setDissipation(0.75)
+spring.setStiffness(10.0)
+spring.set_path(osim.Scholz2015GeometryPath())
+model.addComponent(spring)
+
+# Configure the Scholz2015GeometryPath. We will update the path after
+# adding it to the PathSpring, so that the Socket connections in each
+# Station (i.e., path point) remain valid.
+path = osim.Scholz2015GeometryPath.safeDownCast(spring.updPath())
+path.setName('path')
+
+# Add a path point connected to ground. Since this is the first path point,
+# it defines the origin of the path.
+path.appendPathPoint(model.getGround(), osim.Vec3(0.05, 0.05, 0.))
+
+# Append a second path point, creating a straight line segment between the
+# ground and body "b0".
+path.appendPathPoint(model.getBodySet().get('b0'), osim.Vec3(-0.5, 0.1, 0.))
+
+# Create a ContactCylinder to use as a wrapping obstacle to the path. The
+# cylinder has radius 0.15 m and is attached to body "b0".
+obstacle = osim.ContactCylinder(0.15,
+    osim.Vec3(-0.2, 0.2, 0.), osim.Vec3(0),
+    model.getBodySet().get('b0'))
+model.addComponent(obstacle)
+
+# Before we add the obstacle to the path, we must provide a "contact hint"
+# to initialize the wrapping solver. The contact hint is a point on the
+# surface of the obstacle, expressed in the obstacle's frame. The point
+# does not have to lie on the contact geometry's surface, nor does it have
+# to belong to a valid cable path. The choice of the contact hint will
+# determine which side of the cylinder the path wraps around.
+contact_hint = osim.Vec3(0., 0.15, 0.)
+path.appendObstacle(obstacle, contact_hint)
+
+# At least one path point must follow an obstacle (or list of obstacles)
+# in a Scholz2015GeometryPath. Since this is the last path point we are
+# adding, it defines the insertion of the path.
+path.appendPathPoint(model.getBodySet().get('b1'), osim.Vec3(-0.5, 0.1, 0.))
+
+# Initialize the system.
+state = model.initSystem()
+model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2)
+transform = osim.Transform(osim.Vec3(0.2, -0.8, 3.0))
+model.updVisualizer().updSimbodyVisualizer().setCameraTransform(transform)
+model.updVisualizer().updSimbodyVisualizer().setCameraFieldOfView(0.9)
+
+# Simulate.
+manager = osim.Manager(model)
+manager.initialize(state)
+manager.integrate(20.0)

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -195,6 +195,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
 %include <OpenSim/Simulation/Model/GeometryPath.h>
 %include <OpenSim/Simulation/Model/FunctionBasedPath.h>
+%include <OpenSim/Simulation/Model/Scholz2015GeometryPath.h>
 %include <OpenSim/Simulation/Model/Ligament.h>
 %include <OpenSim/Simulation/Model/Blankevoort1991Ligament.h>
 %include <OpenSim/Simulation/Model/PathActuator.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ v4.6
 - Removed the following deprecated methods from `ContactGeometry`: `getLocation()`, `setLocation()`, `getOrientation()`, `setOrientation()`, `getBody()`, and `setBody()`. (#4115)
 - Fixed `OpenSim::Marker::generateDecorations` to account for markers that are attached to bodies via other frames (#4144).
 - Added the scripting-friendly accessors `SpatialTransform::setTransformAxis()` and `CustomJoint::setSpatialTransform()`. (#4168)
+- Added `Scholz2015GeometryPath`, a geometry-based path wrapping algorithm based on the publication "A fast multi-obstacle muscle wrapping method using natural geodesic variations" by
+Scholz et al. (2015). This class encapsulates `SimTK::CableSpan`, the Simbody implementation of the core wrapping algorithm, and provides support for using this method to define the
+geometry for path-based OpenSim components (e.g., `Muscle`, `PathSpring`, etc.). This class can be used as a replacement for `GeometryPath`, providing improved computational
+performance and stability in wrapping solutions.
 
 
 v4.5.2

--- a/OpenSim/Examples/CMakeLists.txt
+++ b/OpenSim/Examples/CMakeLists.txt
@@ -23,8 +23,9 @@ if(BUILD_API_EXAMPLES)
     add_subdirectory(DataTable)
     add_subdirectory(DataAdapter)
     add_subdirectory(Moco)
+    add_subdirectory(Wrapping)
 
-elseif()
+else()
 
     add_subdirectory(ControllerExample)
     add_subdirectory(ExampleLuxoMuscle)
@@ -39,7 +40,7 @@ endif()
 
 # We do not install the BuildDynamicWalker example, because it is assigned to
 # students as homework. The solution to the BuildDynamicWalker example is in
-# OpenSim/Examples/BuildDynamicWalker, and is tested in 
+# OpenSim/Examples/BuildDynamicWalker, and is tested in
 # OpenSim/Tests/BuildDynamicWalker.
 
 install(DIRECTORY Plugins DESTINATION "${OPENSIM_INSTALL_CPPEXDIR}")

--- a/OpenSim/Examples/Wrapping/CMakeLists.txt
+++ b/OpenSim/Examples/Wrapping/CMakeLists.txt
@@ -1,0 +1,1 @@
+OpenSimAddExampleCXX(NAME exampleScholz2015GeometryPath SUBDIR Wrapping)

--- a/OpenSim/Examples/Wrapping/exampleScholz2015GeometryPath.cpp
+++ b/OpenSim/Examples/Wrapping/exampleScholz2015GeometryPath.cpp
@@ -1,0 +1,97 @@
+/* -------------------------------------------------------------------------- *
+ *                OpenSim:  exampleScholz2015GeometryPath.cpp                 *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/// This example demonstrates the basic elements of creating a geometry-based
+/// path using the Scholz2015GeometryPath class. The path is used to define the
+/// length and speed of a PathSpring, which applies forces to the bodies of a
+/// double pendulum model. The path contains three path points and wraps around
+/// a cylindrical obstacle.
+
+#include <OpenSim/OpenSim.h>
+
+using namespace OpenSim;
+
+int main() {
+
+    Model model = ModelFactory::createDoublePendulum();
+    model.setUseVisualizer(true);
+
+    // Create a PathSpring with a Scholz2015GeometryPath.
+    auto* spring = new PathSpring();
+    spring->setName("path_spring");
+    spring->setRestingLength(0.25);
+    spring->setDissipation(0.75);
+    spring->setStiffness(10.0);
+    spring->set_path(Scholz2015GeometryPath());
+    model.addComponent(spring);
+
+    // Configure the Scholz2015GeometryPath. We will update the path after
+    // adding it to the PathSpring, so that the Socket connections in each
+    // Station (i.e., path point) remain valid.
+    Scholz2015GeometryPath& path = spring->updPath<Scholz2015GeometryPath>();
+    path.setName("path");
+
+    // Add a path point connected to ground. Since this is the first path point,
+    // it defines the origin of the path.
+    path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+
+    // Append a second path point, creating a straight line segment between the
+    // ground and body "b0".
+    path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.5, 0.1, 0.));
+
+    // Create a ContactCylinder to use as a wrapping obstacle to the path. The
+    // cylinder has radius 0.15 m and is attached to body "b0".
+    auto* obstacle = new ContactCylinder(0.15,
+            SimTK::Vec3(-0.2, 0.2, 0.), SimTK::Vec3(0),
+            model.getComponent<Body>("/bodyset/b0"));
+    model.addComponent(obstacle);
+
+    // Before we add the obstacle to the path, we must provide a "contact hint"
+    // to initialize the wrapping solver. The contact hint is a point on the
+    // surface of the obstacle, expressed in the obstacle's frame. The point
+    // does not have to lie on the contact geometry's surface, nor does it have
+    // to belong to a valid cable path. The choice of the contact hint will
+    // determine which side of the cylinder the path wraps around.
+    SimTK::Vec3 contact_hint(0., 0.15, 0.);
+    path.appendObstacle(*obstacle, contact_hint);
+
+    // At least one path point must follow an obstacle (or list of obstacles)
+    // in a Scholz2015GeometryPath. Since this is the last path point we are
+    // adding, it defines the insertion of the path.
+    path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+            SimTK::Vec3(-0.5, 0.1, 0.));
+
+    // Initialize the system.
+    SimTK::State state = model.initSystem();
+    model.updVisualizer().updSimbodyVisualizer().setBackgroundType(
+            SimTK::Visualizer::SolidColor);
+    model.updVisualizer().updSimbodyVisualizer().setCameraTransform(
+            SimTK::Vec3(0.2, -0.8, 3.0));
+    model.updVisualizer().updSimbodyVisualizer().setCameraFieldOfView(0.9);
+
+    // Simulate.
+    Manager manager(model);
+    manager.initialize(state);
+    manager.integrate(20.0);
+}

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -127,8 +127,8 @@ public:
             ForceConsumer& forceConsumer) const = 0;
 
     /**
-     *  Add in the equivalent body and generalized forces to be applied to the
-     *  multibody system resulting from a tension along the AbstractGeometryPath.
+     * Add in the equivalent body and generalized forces to be applied to the
+     * multibody system resulting from a tension along the AbstractGeometryPath.
      *
      * Note: this internally uses `produceForces`
      *

--- a/OpenSim/Simulation/Model/ContactGeometry.cpp
+++ b/OpenSim/Simulation/Model/ContactGeometry.cpp
@@ -49,8 +49,7 @@ ContactGeometry::ContactGeometry(const SimTK::Vec3& location,
     set_orientation(orientation);
 }
 
-void ContactGeometry::setNull()
-{
+void ContactGeometry::setNull() {
     setAuthors("Peter Eastman");
 }
 
@@ -155,7 +154,7 @@ void ContactGeometry::generateDecorationsImpl(
 // OBJECT INTERFACE
 //=============================================================================
 void ContactGeometry::updateFromXMLNode(SimTK::Xml::Element& node,
-                                        int versionNumber) {
+        int versionNumber) {
     if (versionNumber < XMLDocument::getLatestVersion()) {
         if (versionNumber < 30505) {
             SimTK::Xml::element_iterator bodyElement =

--- a/OpenSim/Simulation/Model/ContactGeometry.h
+++ b/OpenSim/Simulation/Model/ContactGeometry.h
@@ -172,6 +172,7 @@ private:
     void setNull();
     void constructProperties();
 
+    friend class Scholz2015GeometryPath;
 };
 
 /**

--- a/OpenSim/Simulation/Model/ContactHalfSpace.cpp
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.cpp
@@ -25,7 +25,7 @@
 
 #include <OpenSim/Common/ModelDisplayHints.h>
 
-namespace OpenSim {
+using namespace OpenSim;
 
 ContactHalfSpace::ContactHalfSpace() :
     ContactGeometry()
@@ -40,7 +40,7 @@ ContactHalfSpace::ContactHalfSpace(const SimTK::Vec3& location,
     setNull();
 }
 
-ContactHalfSpace::ContactHalfSpace(const SimTK::Vec3& location, 
+ContactHalfSpace::ContactHalfSpace(const SimTK::Vec3& location,
     const SimTK::Vec3& orientation, const PhysicalFrame& frame,
     const std::string& name) :
         ContactHalfSpace(location, orientation, frame)
@@ -59,7 +59,7 @@ SimTK::ContactGeometry ContactHalfSpace::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::HalfSpace();
 }
 
-void ContactHalfSpace::generateDecorationsImpl(bool fixed, 
+void ContactHalfSpace::generateDecorationsImpl(bool fixed,
     const ModelDisplayHints& hints,
     const SimTK::State& s,
     SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const
@@ -87,13 +87,10 @@ void ContactHalfSpace::generateDecorationsImpl(bool fixed,
                     // decorative geometry is within the contact geomtry, we
                     // must offset by half the thickness of the brick.
                     .setTransform(X_BP * SimTK::Transform(SimTK::Vec3(
-                                                 brickHalfThickness, 0, 0)))
+                                                brickHalfThickness, 0, 0)))
                     .setScale(1)
                     .setRepresentation(get_Appearance().get_representation())
                     .setBodyId(getFrame().getMobilizedBodyIndex())
                     .setColor(get_Appearance().get_color())
                     .setOpacity(get_Appearance().get_opacity()));
 }
-
-
-} // end of namespace OpenSim

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -684,11 +684,13 @@ void Model::createMultibodySystem()
     _matter.reset();
     _forceSubsystem.reset();
     _contactSubsystem.reset();
+    _cableSubsystem.reset();
     // create system
     _system.reset(new SimTK::MultibodySystem);
     _matter.reset(new SimTK::SimbodyMatterSubsystem(*_system));
     _forceSubsystem.reset(new SimTK::GeneralForceSubsystem(*_system));
     _contactSubsystem.reset(new SimTK::GeneralContactSubsystem(*_system));
+    _cableSubsystem.reset(new SimTK::CableSubsystem(*_system));
 
     // create gravity force, a direction is needed even if magnitude=0 for
     // PotentialEnergy purposes.

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -537,6 +537,15 @@ public:
     {
         return getGravityForce().getBodyForces(state);
     }
+
+    /** Get read-only access to the internal Simbody CableSubsystem
+    allocated by this %Model. **/
+    const SimTK::CableSubsystem& getCableSubsystem() const
+    {   return *_cableSubsystem; }
+    /** (Advanced) Get writable access to the internal Simbody
+    CableSubsystem allocated by this %Model. **/
+    SimTK::CableSubsystem& updCableSubsystem()
+    {   return *_cableSubsystem; }
     /**@}**/
 
     /**@name  Realize the Simbody System and State to Computational Stage
@@ -1291,6 +1300,8 @@ private:
         _forceSubsystem;
     SimTK::ResetOnCopy<std::unique_ptr<SimTK::GeneralContactSubsystem>>
         _contactSubsystem;
+    SimTK::ResetOnCopy<std::unique_ptr<SimTK::CableSubsystem>>
+        _cableSubsystem;
 
     // We place this after the subsystems so that during copy construction and
     // copy assignment, the subsystem handles are copied first. If the system

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -1,0 +1,372 @@
+/* -------------------------------------------------------------------------- *
+ *                   OpenSim:  Scholz2015GeometryPath.cpp                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ * Contributor(s): Pepijn van den Bos, Andreas Scholz                         *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "Scholz2015GeometryPath.h"
+
+#include <OpenSim/Simulation/Model/ForceConsumer.h>
+#include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
+#include <OpenSim/Simulation/Model/Model.h>
+
+using namespace OpenSim;
+
+//=============================================================================
+// SCHOLZ 2015 GEOMETRY PATH POINT
+//=============================================================================
+Scholz2015GeometryPathPoint::Scholz2015GeometryPathPoint() {
+    constructProperty_PathPoint(PathPoint());
+}
+
+const PathPoint& Scholz2015GeometryPathPoint::getPathPoint() const {
+    return get_PathPoint();
+}
+
+//=============================================================================
+// SCHOLZ 2015 GEOMETRY PATH OBSTACLE
+//=============================================================================
+Scholz2015GeometryPathObstacle::Scholz2015GeometryPathObstacle() {
+    constructProperty_contact_hint(SimTK::Vec3(SimTK::NaN));
+}
+
+const ContactGeometry&
+Scholz2015GeometryPathObstacle::getContactGeometry() const {
+    return getSocket<ContactGeometry>("contact_geometry").getConnectee();
+}
+
+const SimTK::Vec3& Scholz2015GeometryPathObstacle::getContactHint() const {
+    return get_contact_hint();
+}
+
+//=============================================================================
+// CONSTRUCTION
+//=============================================================================
+Scholz2015GeometryPath::Scholz2015GeometryPath() : AbstractGeometryPath() {
+    constructProperties();
+}
+
+//=============================================================================
+// PATH CONFIGURATION
+//=============================================================================
+void Scholz2015GeometryPath::appendPathPoint(const PhysicalFrame& frame,
+        const SimTK::Vec3& location) {
+
+    // Construct a new path point.
+    append_path_elements(Scholz2015GeometryPathPoint());
+    auto& point = updElement<Scholz2015GeometryPathPoint>(
+            getProperty_path_elements().size() - 1);
+    point.setName("path_point_" + std::to_string(getNumPathPoints() - 1));
+
+    // Set the path point's PathPoint.
+    PathPoint& pathPoint = point.upd_PathPoint();
+    pathPoint.set_location(location);
+    pathPoint.setParentFrame(frame);
+
+    // Call finalizeFromProperties() to ensure that the path point is recognized
+    // as a subcomponent.
+    finalizeFromProperties();
+}
+
+const PathPoint& Scholz2015GeometryPath::getOrigin() const {
+    OPENSIM_THROW_IF_FRMOBJ(getNumPathPoints() == 0, Exception,
+            "Tried retrieving the origin point, but the path contains no path "
+            "points.");
+
+    const auto* point = tryGetElement<Scholz2015GeometryPathPoint>(0);
+    OPENSIM_THROW_IF_FRMOBJ(point == nullptr, Exception,
+            "Tried retrieving the origin point, but the first element in the "
+            "path is not a path point.");
+
+    return point->getPathPoint();
+}
+
+const PathPoint& Scholz2015GeometryPath::getInsertion() const {
+    OPENSIM_THROW_IF_FRMOBJ(getNumPathPoints() < 2, Exception,
+            "Tried retrieving the insertion point, but the path contains less "
+            "than two path points.");
+
+    const auto* point = tryGetElement<Scholz2015GeometryPathPoint>(
+            getProperty_path_elements().size() - 1);
+    OPENSIM_THROW_IF_FRMOBJ(point == nullptr, Exception,
+            "Tried retrieving the insertion point, but the last element in the "
+            "path is not a path point.");
+
+    return point->getPathPoint();
+}
+
+const PathPoint& Scholz2015GeometryPath::getPathPoint(
+        int pathPointIndex) const {
+    OPENSIM_THROW_IF_FRMOBJ(
+            pathPointIndex < 0 || pathPointIndex >= getNumPathPoints(),
+            Exception,
+            "Index {} is out of range. There are {} path points in the path.",
+            pathPointIndex, getNumPathPoints());
+
+    int count = 0;
+    for (int i = 0; i < getNumPathElements(); ++i) {
+        if (const auto* point = tryGetElement<Scholz2015GeometryPathPoint>(i)) {
+            if (count == pathPointIndex) {
+                return point->getPathPoint();
+            }
+            ++count;
+        }
+    }
+
+    // We should never reach this point.
+    OPENSIM_THROW_FRMOBJ(Exception,
+            "Path point index {} could not be found.", pathPointIndex);
+}
+
+void Scholz2015GeometryPath::appendObstacle(
+        const ContactGeometry& contactGeometry,
+        const SimTK::Vec3& contactHint) {
+
+    // Construct a new obstacle.
+    append_path_elements(Scholz2015GeometryPathObstacle());
+    auto& obstacle = updElement<Scholz2015GeometryPathObstacle>(
+            getProperty_path_elements().size() - 1);
+    obstacle.setName("obstacle_" + std::to_string(getNumObstacles() - 1));
+
+    // Set the obstacle's ContactGeometry and contact hint.
+    obstacle.connectSocket_contact_geometry(contactGeometry);
+    obstacle.set_contact_hint(contactHint);
+}
+
+const ContactGeometry& Scholz2015GeometryPath::getContactGeometry(
+        int obstacleIndex) const {
+    const Scholz2015GeometryPathObstacle* obstacle = getObstacle(obstacleIndex);
+    return obstacle->getContactGeometry();
+}
+
+const SimTK::Vec3& Scholz2015GeometryPath::getContactHint(
+        int obstacleIndex) const {
+    const Scholz2015GeometryPathObstacle* obstacle = getObstacle(obstacleIndex);
+    return obstacle->getContactHint();
+}
+
+int Scholz2015GeometryPath::getNumPathPoints() const {
+    int count = 0;
+    for (int i = 0; i < getNumPathElements(); ++i) {
+        if (tryGetElement<Scholz2015GeometryPathPoint>(i) != nullptr) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int Scholz2015GeometryPath::getNumObstacles() const {
+    int count = 0;
+    for (int i = 0; i < getNumPathElements(); ++i) {
+        if (tryGetElement<Scholz2015GeometryPathObstacle>(i) != nullptr) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int Scholz2015GeometryPath::getNumPathElements() const {
+    return getProperty_path_elements().size();
+}
+
+//=============================================================================
+// ABSTRACT PATH INTERFACE
+//=============================================================================
+double Scholz2015GeometryPath::getLength(const SimTK::State& s) const {
+    return getCableSpan().calcLength(s);
+}
+
+double Scholz2015GeometryPath::getLengtheningSpeed(
+        const SimTK::State& s) const {
+    return getCableSpan().calcLengthDot(s);
+}
+
+double Scholz2015GeometryPath::computeMomentArm(const SimTK::State& s,
+        const Coordinate& coord) const {
+
+    if (!_maSolver) {
+        const_cast<Self*>(this)->_maSolver.reset(
+            new MomentArmSolver(getModel()));
+    }
+
+    return _maSolver->solve(s, coord,  *this);
+}
+
+void Scholz2015GeometryPath::produceForces(const SimTK::State& state,
+        double tension, ForceConsumer& forceConsumer) const {
+
+    if (tension < 0.) {
+        return;
+    }
+
+    const SimTK::CableSpan& cable = getCableSpan();
+    const PathPoint& origin = getOrigin();
+    const PathPoint& insertion = getInsertion();
+    SimTK::SpatialVec unitBodyForce;
+
+    // Force applied at path origin point.
+    {
+        cable.calcOriginUnitForce(state, unitBodyForce);
+        forceConsumer.consumeBodySpatialVec(state, origin.getParentFrame(),
+                tension * unitBodyForce);
+    }
+
+    // Forces applied to each obstacle body.
+    for (const auto& [ix, eltIx] : _obstacleIndexes) {
+        if (!cable.isInContactWithObstacle(state, ix)) {
+            continue;
+        }
+
+        cable.calcCurveSegmentUnitForce(state, ix, unitBodyForce);
+        const auto& obstacle =
+                getElement<Scholz2015GeometryPathObstacle>(eltIx);
+        const auto& frame = obstacle.getContactGeometry().getFrame();
+        forceConsumer.consumeBodySpatialVec(state, frame,
+                tension * unitBodyForce);
+    }
+
+    // Forces applied to each via point.
+    for (const auto& [ix, eltIx] : _viaPointIndexes) {
+        cable.calcViaPointUnitForce(state, ix, unitBodyForce);
+        const auto& point = getElement<Scholz2015GeometryPathPoint>(eltIx);
+        const auto& frame = point.getPathPoint().getParentFrame();
+        forceConsumer.consumeBodySpatialVec(state, frame,
+                tension * unitBodyForce);
+    }
+
+    // Force applied at path insertion point.
+    {
+        cable.calcTerminationUnitForce(state, unitBodyForce);
+        forceConsumer.consumeBodySpatialVec(
+            state, insertion.getParentFrame(), unitBodyForce * tension);
+    }
+}
+
+//=============================================================================
+// MODEL COMPONENT INTERFACE
+//=============================================================================
+void Scholz2015GeometryPath::extendConnectToModel(Model& model) {
+    Super::extendConnectToModel(model);
+
+    OPENSIM_THROW_IF_FRMOBJ(getNumPathPoints() < 2, Exception,
+            "Expected at least two path points before finalizing the path, but "
+            "{} path point(s) were found. Use addPathPoint() to add a path "
+            "point to the path.", getNumPathPoints());
+    OPENSIM_THROW_IF_FRMOBJ(
+            tryGetElement<Scholz2015GeometryPathPoint>(0) == nullptr,
+            Exception, "Expected the first element of the path to be a path "
+            "point, but it is an obstacle.");
+    OPENSIM_THROW_IF_FRMOBJ(
+            tryGetElement<Scholz2015GeometryPathPoint>(
+                    getNumPathElements() - 1) == nullptr,
+            Exception, "Expected the last element of the path to be a path "
+            "point, but it is an obstacle.");
+}
+
+void Scholz2015GeometryPath::extendAddToSystem(
+        SimTK::MultibodySystem& system) const {
+    Super::extendAddToSystem(system);
+
+    const PathPoint& origin = getOrigin();
+    const PathPoint& insertion = getInsertion();
+    SimTK::CableSubsystem& cables = system.updCableSubsystem();
+    SimTK::CableSpan cable(cables,
+        origin.getParentFrame().getMobilizedBodyIndex(),
+        origin.get_location(),
+        insertion.getParentFrame().getMobilizedBodyIndex(),
+        insertion.get_location());
+
+    for (int ielt = 1; ielt < getProperty_path_elements().size() - 1; ++ielt) {
+        if (const auto* point =
+                    tryGetElement<Scholz2015GeometryPathPoint>(ielt)) {
+            SimTK::CableSpanViaPointIndex ix = cable.addViaPoint(
+                point->getPathPoint().getParentFrame().getMobilizedBodyIndex(),
+                point->getPathPoint().get_location());
+            _viaPointIndexes.emplace_back(std::make_pair(ix, ielt));
+        } else if (const auto* obstacle =
+                    tryGetElement<Scholz2015GeometryPathObstacle>(ielt)) {
+            SimTK::CableSpanObstacleIndex ix = cable.addObstacle(
+                obstacle->getContactGeometry().getFrame()
+                                              .getMobilizedBodyIndex(),
+                obstacle->getContactGeometry().getTransform(),
+                obstacle->getContactGeometry().getSimTKContactGeometryPtr(),
+                obstacle->getContactHint());
+            _obstacleIndexes.emplace_back(std::make_tuple(ix, ielt));
+        }
+    }
+
+    cable.setSmoothnessTolerance(1e-5);
+    cable.setCurveSegmentAccuracy(1e-10);
+    cable.setSolverMaxIterations(50);
+    cable.setAlgorithm(SimTK::CableSpanAlgorithm::Scholz2015);
+    _index = cable.getIndex();
+}
+
+void Scholz2015GeometryPath::generateDecorations(bool fixed,
+        const ModelDisplayHints&, const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const {
+    if (fixed) { return; }
+
+    getCableSpan().calcDecorativePathPoints(s,
+        [&](SimTK::Vec3 x_G)
+        {
+            geoms.push_back(SimTK::DecorativeSphere(0.005).setTransform(x_G)
+                    .setColor(SimTK::Blue));
+        });
+}
+
+//=============================================================================
+// CONVENIENCE METHODS
+//=============================================================================
+void Scholz2015GeometryPath::constructProperties() {
+    constructProperty_path_elements();
+}
+
+const Scholz2015GeometryPathObstacle* Scholz2015GeometryPath::getObstacle(
+        int obstacleIndex) const {
+    OPENSIM_THROW_IF_FRMOBJ(
+            obstacleIndex < 0 || obstacleIndex >= getNumObstacles(), Exception,
+            "Index {} is out of range. There are {} obstacles in the path.",
+            obstacleIndex, getNumObstacles());
+
+    int count = 0;
+    for (int i = 0; i < getNumPathElements(); ++i) {
+        if (const auto* obstacle =
+                tryGetElement<Scholz2015GeometryPathObstacle>(i)) {
+            if (count == obstacleIndex) {
+                return obstacle;
+            }
+            ++count;
+        }
+    }
+
+    // We should never reach this point.
+    OPENSIM_THROW_FRMOBJ(Exception,
+            "Obstacle index {} could not be found.", obstacleIndex);
+}
+
+const SimTK::CableSpan& Scholz2015GeometryPath::getCableSpan() const {
+    return getModel().getMultibodySystem().getCableSubsystem().getCable(_index);
+}
+
+SimTK::CableSpan& Scholz2015GeometryPath::updCableSpan() {
+    return getModel().updMultibodySystem().updCableSubsystem().updCable(_index);
+}

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -1,0 +1,496 @@
+#ifndef OPENSIM_SCHOLZ_2015_GEOMETRY_PATH_H
+#define OPENSIM_SCHOLZ_2015_GEOMETRY_PATH_H
+/* -------------------------------------------------------------------------- *
+ *                   OpenSim:  Scholz2015GeometryPath.h                       *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ * Contributor(s): Pepijn van den Bos, Andreas Scholz                         *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Simulation/Model/AbstractGeometryPath.h>
+
+#include <OpenSim/Simulation/Model/ContactGeometry.h>
+#include <OpenSim/Simulation/Model/PathPoint.h>
+#include <OpenSim/Simulation/MomentArmSolver.h>
+
+#include <simbody/internal/CableSpan.h>
+namespace OpenSim {
+
+/**
+ * \section Scholz2015GeometryPathPoint
+ * An abstract class representing an element in a `Scholz2015GeometryPath`.
+ *
+ * Concrete implementations of this class should represent geometric elements
+ * in a path (e.g., path points and obstacles). Path elements of a
+ * `Scholz2015GeometryPath` are stored as an ordered list in the `path_elements`
+ * property.
+ *
+ * @see Scholz2015GeometryPathPoint
+ * @see Scholz2015GeometryPathObstacle
+ * @see Scholz2015GeometryPath
+ */
+class OSIMSIMULATION_API Scholz2015GeometryPathElement : public Component {
+OpenSim_DECLARE_ABSTRACT_OBJECT(Scholz2015GeometryPathElement, Component);
+};
+
+/**
+ * \section Scholz2015GeometryPathPoint
+ * A class representing a point in a `Scholz2015GeometryPath`.
+ *
+ * This class stores a `PathPoint`, which defines a fixed point on a
+ * `PhysicalFrame` in the model. Users should not create instances of this class
+ * directly. Instead, use the `appendPathPoint()` method of
+ * `Scholz2015GeometryPath` to append path points.
+ *
+ * @see Scholz2015GeometryPath
+ */
+class OSIMSIMULATION_API Scholz2015GeometryPathPoint :
+        public Scholz2015GeometryPathElement {
+OpenSim_DECLARE_CONCRETE_OBJECT(Scholz2015GeometryPathPoint,
+        Scholz2015GeometryPathElement);
+public:
+//=============================================================================
+// SOCKETS
+//=============================================================================
+    OpenSim_DECLARE_UNNAMED_PROPERTY(PathPoint,
+            "A point fixed to a PhysicalFrame that the path must pass through.");
+
+//=============================================================================
+// METHODS
+//=============================================================================
+    // CONSTRUCTOR(S)
+    Scholz2015GeometryPathPoint();
+
+    // ACCESSOR(S)
+    /**
+     * Get the underlying `PathPoint`.
+     */
+    const PathPoint& getPathPoint() const;
+};
+
+/**
+ * \section Scholz2015GeometryPathObstacle
+ * A class representing an obstacle in a `Scholz2015GeometryPath`.
+ *
+ * A path obstacle consists of a `Socket` connected to a `ContactGeometry` and
+ * an initial guess for the wrapping solver via the `contact_hint` property. The
+ * `ContactGeometry` is used internally to provide an equivalent
+ * `SimTK::ContactGeometry` which is needed by `SimTK::CableSpan` to define a
+ * wrapping surface. The contact hint is a `SimTK::Vec3` defining a
+ * point on the surface, in the surface coordinates, which `SimTK::CableSpan`
+ * uses to shoot a zero-length geodesic to initialize the wrapping solver. The
+ * contact hint need not lie on the surface, nor does it need to belong to a
+ * valid (i.e., converged) wrapping path.
+ *
+ * Users should not create instances of this class directly. Instead, use the
+ * `appendObstacle()` method of `Scholz2015GeometryPath` to append obstacles.
+ *
+ * @see Scholz2015GeometryPath
+ */
+class OSIMSIMULATION_API Scholz2015GeometryPathObstacle :
+        public Scholz2015GeometryPathElement {
+OpenSim_DECLARE_CONCRETE_OBJECT(Scholz2015GeometryPathObstacle,
+        Scholz2015GeometryPathElement);
+public:
+//=============================================================================
+// SOCKETS
+//=============================================================================
+    OpenSim_DECLARE_SOCKET(contact_geometry, ContactGeometry,
+            "The contact geometry representing the obstacle.");
+
+//=============================================================================
+// PROPERTIES
+//=============================================================================
+    OpenSim_DECLARE_PROPERTY(contact_hint, SimTK::Vec3,
+            "The contact hint for the obstacle.");
+
+//=============================================================================
+// METHODS
+//=============================================================================
+    // CONSTRUCTOR(S)
+    Scholz2015GeometryPathObstacle();
+
+    // ACCESSOR(S)
+    /**
+     * Get the ContactGeometry associated with this obstacle.
+     */
+    const ContactGeometry& getContactGeometry() const;
+
+    /**
+     * Get the contact hint for the obstacle.
+     */
+    const SimTK::Vec3& getContactHint() const;
+};
+
+//=============================================================================
+//                       SCHOLZ 2015 GEOMETRY PATH
+//=============================================================================
+
+/**
+ * \section Scholz2015GeometryPath
+ * A concrete class representing a geometric path object defined by a list of
+ * path points and wrapping obstacles.
+ *
+ * The path consists of straight line segments and curved line segments: a
+ * curved segment over each obstacle, and straight segments connecting path
+ * points to obstacles. If no obstacle lies between two path points, the points
+ * will be connected by a straight line segment. The path is computed as a
+ * geodesic to provide a shortest path over the surface. During a simulation,
+ * the cable can slide freely over the obstacle surfaces. It can lose contact
+ * with a surface and miss that obstacle in a straight line. Similarly the cable
+ * can touchdown on the obstacle if the surface obstructs the straight line
+ * segment again.
+ *
+ * The path is computed as an optimization problem using the previous optimal
+ * path as the warm start. This is done by computing natural geodesic
+ * corrections for each curve segment to compute the locally shortest path,
+ * as described in the following publication:
+ *
+ *     Scholz, A., Sherman, M., Stavness, I. et al (2015). A fast multi-obstacle
+ *     muscle wrapping method using natural geodesic variations. Multibody
+ *     System Dynamics 36, 195–219.
+ *
+ * The overall path is locally the shortest, allowing winding over an obstacle
+ * multiple times, without flipping to the other side.
+ *
+ * This class encapsulates `SimTK::CableSpan`, the Simbody implementation of
+ * this algorithm. For the full details concerning this class, see the Simbody
+ * API documentation.
+ *
+ * ## Constructing a Scholz2015GeometryPath
+ *
+ * The simplest valid path consists of two path points: an origin and an
+ * insertion point:
+ *
+ * \code{.cpp}
+ * Model model = ModelFactory::createDoublePendulum();
+ * Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+ * path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * model.addComponent(path);
+ * \endcode
+ *
+ * Typically, a Scholz2015GeometryPath will be used to define the geometry of
+ * path-based force generating elements, e.g., `PathSpring`, `PathActuator`,
+ * `Muscle`, etc. This example shows how to create a `PathSpring` and set the
+ * 'path' property to a Scholz2015GeometryPath:
+ *
+ * \code{.cpp}
+ * auto* spring = new PathSpring();
+ * spring->setName("path_spring");
+ * spring->setRestingLength(0.25);
+ * spring->setDissipation(0.75);
+ * spring->setStiffness(10.0);
+ * spring->set_path(Scholz2015GeometryPath());
+ * model.addComponent(spring);
+ *
+ * auto& path = spring->updPath<Scholz2015GeometryPath>();
+ * path.setName("path");
+ * path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+ *         SimTK::Vec3(-0.25, 0.1, 0));
+ * \endcode
+ *
+ * @note We append path points *after* the `Scholz2015GeometryPath` has been
+ * added to the `PathSpring`, so that the connections for each `PathPoint`'s
+ * parent frame `Socket` remain valid. If we instead called `set_path()` after
+ * each `PathPoint` was appended, the `Socket` connections would be broken when
+ * the `Scholz2015GeometryPath` is copied into the `PathSpring`.
+ *
+ * ## Appending Wrap Obstacles
+ *
+ * Wrap obstacles are defined by `ContactGeometry` objects which encapsulate
+ * a wrapping geometry, the `PhysicalFrame` that the geometry is attached to,
+ * and the location and orientation of the geometry in that frame. The following
+ * concrete implementations of `ContactGeometry` are recommended for use with
+ * `Scholz2015GeometryPath`:
+ * - `ContactSphere`
+ * - `ContactCylinder`
+ * - `ContactEllipsoid`
+ * - `ContactTorus`
+ *
+ * Use `appendObstacle()` to append a `ContactGeometry` wrapping obstacle to
+ * path, along with a "contact hint" that is used to initialize the wrapping
+ * solver:
+ *
+ * \code{.cpp}
+ * auto* obstacle = new ContactCylinder(0.15,
+ *         SimTK::Vec3(-0.2, 0.2, 0), SimTK::Vec3(0),
+ *         model.getComponent<Body>("/bodyset/b0"));
+ * model.addComponent(obstacle);
+ * path.appendObstacle(*obstacle, SimTK::Vec3(0., 0.15, 0.));
+ * \endcode
+ *
+ * The contact hint is a `SimTK::Vec3` defining a point on the surface in local
+ * surface frame coordinates. The point will be used to provide an initial guess
+ * when solving for the path. As such, it does not have to lie on the contact
+ * geometry's surface, nor does it have to belong to a valid cable path. For
+ * obstacles with symmetry, the choice of the contact hint will determine which
+ * side of the obstacle the path will wrap around.
+ *
+ * A `Scholz2015GeometryPath` must begin and end with a path point. Since we
+ * appended an obstacle, we must append an additional path point to "close" the
+ * path:
+ *
+ * \code{.cpp}
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * \endcode
+ *
+ * ## Path Ordering
+ *
+ * The order in which obstacles and path points are appended to the path is
+ * important. For example, consider the path we constructed above:
+ *
+ * \code{.cpp}
+ * path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * path.appendObstacle(*obstacle, SimTK::Vec3(0., 0.15, 0.));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * \endcode
+ *
+ * Using the order of calls above, we have explicitly defined a cylinder
+ * obstacle to apply only to the portion of the path between the second and
+ * third path points.
+ *
+ * By changing the order of the `appendObstacle()` and `appendPathPoint()`
+ * calls, we could define a different path where a cylinder obstacle is applied
+ * to the portion of the path between the first and second path points:
+ *
+ * \code{.cpp}
+ * path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+ * path.appendObstacle(*obstacle, SimTK::Vec3(0., 0.15, 0.));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+ *         SimTK::Vec3(-0.5, 0.1, 0.));
+ * \endcode
+ *
+ * The location of the cylinder obstacle in this new path would likely need to
+ * be updated to a new location that is consistent with the portion of the path
+ * between the first and second path points to produce the desired wrapping
+ * behavior. Note also that both of the path examples above are valid, since
+ * each begins and ends with a path point.
+ *
+ * @see Scholz2015GeometryPathPoint
+ * @see Scholz2015GeometryPathObstacle
+ */
+class OSIMSIMULATION_API Scholz2015GeometryPath : public AbstractGeometryPath {
+OpenSim_DECLARE_CONCRETE_OBJECT(Scholz2015GeometryPath, AbstractGeometryPath);
+
+public:
+//=============================================================================
+// METHODS
+//=============================================================================
+
+    /** Default constructor. */
+    Scholz2015GeometryPath();
+
+    //** @name Path configuration */
+    // @{
+    /**
+     * Append a path point to the path.
+     */
+    void appendPathPoint(const PhysicalFrame& frame,
+            const SimTK::Vec3& location);
+
+    /**
+     * Get the origin `PathPoint` of the path (i.e., the first path point).
+     */
+    const PathPoint& getOrigin() const;
+
+    /**
+     * Get the insertion `PathPoint` of the path (i.e., the last path point).
+     */
+    const PathPoint& getInsertion() const;
+
+    /**
+     * Get the `PathPoint` at the specified index.
+     *
+     * The argument `pathPointIndex` is the index to the list of path points in
+     * the path, not all path elements (e.g., obstacles). For example, if the
+     * path consists of two path points and one obstacle, the valid indices are
+     * 0 and 1.
+     *
+     * @note Avoid repeated calls to this method in performance-critical
+     * code, as it may involve searching through the path elements.
+     */
+    const PathPoint& getPathPoint(int pathPointIndex) const;
+
+    /**
+     * Add an obstacle to the path.
+     *
+     * The contact hint is a `SimTK::Vec3` defining a point on the surface, in
+     * the surface coordinates, used to initialize the wrapping solver. The
+     * contact hint need not lie on the surface, nor does it need to belong to a
+     * valid wrapping path.
+     *
+     * @param contactGeometry  the ContactGeometry representing the obstacle.
+     * @param contactHint      the point on the contact geometry surface, in
+     *                         surface coordinates, that is used to initialize
+     *                         the wrapping solver.
+     *
+     * @see Scholz2015GeometryPathObstacle
+     */
+    void appendObstacle(const ContactGeometry& contactGeometry,
+            const SimTK::Vec3& contactHint);
+
+    /**
+     * Get the `ContactGeometry` associated with the obstacle at the specified
+     * index.
+     *
+     * The argument `obstacleIndex` is the index to the list of obstacles in
+     * the path, not all path elements (e.g., path points). For example, if the
+     * path consists of two path points and one obstacle, the only valid index
+     * is 0.
+     *
+     * @note Avoid repeated calls to this method in performance-critical
+     * code, as it may involve searching through the path elements.
+     */
+    const ContactGeometry& getContactGeometry(int obstacleIndex) const;
+
+    /**
+     * Get the contact hint associated with the obstacle at the specified
+     * index.
+     *
+     * The argument `obstacleIndex` is the index to the list of obstacles in
+     * the path, not all path elements (e.g., path points). For example, if the
+     * path consists of two path points and one obstacle, the only valid index
+     * is 0.
+     *
+     * @note Avoid repeated calls to this method in performance-critical
+     * code, as it may involve searching through the path elements.
+     */
+    const SimTK::Vec3& getContactHint(int obstacleIndex) const;
+
+    /**
+     * Get the number of path points in the path.
+     */
+    int getNumPathPoints() const;
+
+    /**
+     * Get the number of obstacles in the path.
+     */
+    int getNumObstacles() const;
+
+    /**
+     * Get the total number of path elements (path points and obstacles) in the
+     * path.
+     */
+    int getNumPathElements() const;
+
+    // @}
+
+    //** @name `AbstractGeometryPath` interface */
+    // @{
+    double getLength(const SimTK::State& s) const override;
+    double getLengtheningSpeed(const SimTK::State& s) const override;
+    double computeMomentArm(const SimTK::State& s,
+            const Coordinate& coord) const override;
+    bool isVisualPath() const override { return true; }
+    // @}
+
+    //** @name `ForceProducer` interface */
+    // @{
+    void produceForces(const SimTK::State& s, double tension,
+            ForceConsumer& consumer) const override;
+    // @}
+
+private:
+    // PROPERTIES
+    OpenSim_DECLARE_LIST_PROPERTY(path_elements, Scholz2015GeometryPathElement,
+        "The list of elements (path points or obstacles) defining the path.");
+
+    // MODEL COMPONENT INTERFACE
+    void extendConnectToModel(Model& model) override;
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+            const SimTK::State& s,
+            SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const override;
+
+    // CONVENIENCE METHODS
+    void constructProperties();
+
+    // Get the obstacle at the specified index.
+    // The argument `obstacleIndex` is the index to the list of obstacles in
+    // the path, not all path elements (e.g., path points). For example, if the
+    // path consists of two path points and one obstacle, the only valid index
+    // is 0.
+    const Scholz2015GeometryPathObstacle* getObstacle(int obstacleIndex) const;
+
+    // Get a non-modifiable reference to a path element based on the element
+    // index and type. Use this if you certain of the element type; otherwise,
+    // use tryGetElement().
+    template <typename ElementType>
+    const ElementType& getElement(int index) const {
+        OPENSIM_ASSERT_ALWAYS(index >= 0 && index < getNumPathElements());
+        return dynamic_cast<const ElementType&>(get_path_elements(index));
+    }
+
+    // Get a modifiable reference to a path element based on the element index
+    // and type. Use this if you certain of the element type; otherwise, use
+    // tryUpdElement().
+    template <typename ElementType>
+    ElementType& updElement(int index) {
+        OPENSIM_ASSERT_ALWAYS(index >= 0 && index < getNumPathElements());
+        return dynamic_cast<ElementType&>(upd_path_elements(index));
+    }
+
+    // Attempt to get a non-modifiable pointer to a path element based on the
+    // element index and type. Returns nullptr if the element is not of the
+    // requested type.
+    template <typename ElementType>
+    const ElementType* tryGetElement(int index) const {
+        OPENSIM_ASSERT_ALWAYS(index >= 0 && index < getNumPathElements());
+        return dynamic_cast<const ElementType*>(&get_path_elements(index));
+    }
+
+    // Attempt to get a modifiable pointer to a path element based on the
+    // element index and type. Returns nullptr if the element is not of the
+    // requested type.
+    template <typename ElementType>
+    ElementType* tryUpdElement(int index) {
+        OPENSIM_ASSERT_ALWAYS(index >= 0 && index < getNumPathElements());
+        return dynamic_cast<ElementType*>(&upd_path_elements(index));
+    }
+
+    // Internal mutable access to the underlying SimTK::CableSpan.
+    const SimTK::CableSpan& getCableSpan() const;
+    SimTK::CableSpan& updCableSpan();
+
+    // MEMBER VARIABLES
+    mutable SimTK::ResetOnCopy<SimTK::CableSpanIndex> _index;
+    using ObstacleIndexes = std::vector<std::tuple<
+            SimTK::CableSpanObstacleIndex, int>>;
+    mutable SimTK::ResetOnCopy<ObstacleIndexes> _obstacleIndexes;
+    using ViaPointIndexes = std::vector<std::pair<
+            SimTK::CableSpanViaPointIndex, int>>;
+    mutable SimTK::ResetOnCopy<ViaPointIndexes> _viaPointIndexes;
+
+    SimTK::ResetOnCopy<std::unique_ptr<MomentArmSolver> > _maSolver;
+};
+
+
+} // namespace OpenSim
+
+#endif // OPENSIM_SCHOLZ_2015_GEOMETRY_PATH_H

--- a/OpenSim/Simulation/MomentArmSolver.cpp
+++ b/OpenSim/Simulation/MomentArmSolver.cpp
@@ -58,7 +58,7 @@ Refer to Moment-arm Theory document by Michael Sherman for details.
 
 **********************************************************************************/
 double MomentArmSolver::solve(const SimTK::State& state,
-        const Coordinate& aCoord, const GeometryPath& path) const {
+        const Coordinate& aCoord, const AbstractGeometryPath& path) const {
     //Local modifiable copy of the state
     SimTK::State& s_ma = _stateCopy;
     s_ma.updQ() = state.getQ();

--- a/OpenSim/Simulation/MomentArmSolver.h
+++ b/OpenSim/Simulation/MomentArmSolver.h
@@ -28,7 +28,7 @@
 
 namespace OpenSim {
 
-class GeometryPath;
+class AbstractGeometryPath;
 class PointForceDirection;
 class Coordinate;
 
@@ -63,14 +63,16 @@ public:
     virtual ~MomentArmSolver() {}
 
     /** Solve for the effective moment-arm about the all coordinates (q) based 
-        on the geometric distribution of forces described by a GeometryPath. 
+        on the geometric distribution of forces described by an 
+        AbstractGeometryPath. 
     @param  state               current state of the model
     @param  coordinate          Coordinate about which we want the moment-arm
-    @param  path                GeometryPath for which to calculate a moment-arm
+    @param  path                AbstractGeometryPath for which to calculate a 
+                                moment-arm
     @return ma                  resulting moment-arm as a double
     */
     double solve(const SimTK::State& state, const Coordinate &coordinate,
-        const GeometryPath &path) const;
+        const AbstractGeometryPath &path) const;
 
     /** Solve for the effective moment-arm about the specified coordinate based 
         on the geometric distribution of forces described by the list of 

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -62,6 +62,7 @@
 #include "Model/MovingPathPoint.h"
 #include "Model/GeometryPath.h"
 #include "Model/FunctionBasedPath.h"
+#include "Model/Scholz2015GeometryPath.h"
 #include "Model/PrescribedForce.h"
 #include "Model/ExternalForce.h"
 #include "Model/PointToPointSpring.h"
@@ -198,6 +199,9 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( Arrow());
     Object::registerType( GeometryPath());
     Object::registerType( FunctionBasedPath());
+    Object::registerType( Scholz2015GeometryPathObstacle());
+    Object::registerType( Scholz2015GeometryPathPoint());
+    Object::registerType( Scholz2015GeometryPath());
 
     Object::registerType( ControlSet() );
     Object::registerType( ControlConstant() );

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -58,6 +58,7 @@
 #include "Model/MovingPathPoint.h"
 #include "Model/GeometryPath.h"
 #include "Model/FunctionBasedPath.h"
+#include "Model/Scholz2015GeometryPath.h"
 #include "Model/PrescribedForce.h"
 #include "Model/PointToPointSpring.h"
 #include "Model/ExpressionBasedPointToPointForce.h"

--- a/OpenSim/Tests/Wrapping/CMakeLists.txt
+++ b/OpenSim/Tests/Wrapping/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_PROGS
         testWrapObject.cpp
         testWrapCylinder.cpp
         testGeometryPathWrapping.cpp
+        testScholz2015GeometryPath.cpp
 )
 file(GLOB TEST_FILES *.osim *.xml *.sto *.mot)
 

--- a/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
+++ b/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
@@ -1,0 +1,905 @@
+/* -------------------------------------------------------------------------- *
+ *                  OpenSim:  testScholz2015GeometryPath.cpp                  *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Actuators/ModelFactory.h>
+#include <OpenSim/Common/Constant.h>
+#include <OpenSim/Simulation/Control/PrescribedController.h>
+#include <OpenSim/Simulation/Manager/Manager.h>
+#include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/Model/PathSpring.h>
+#include <OpenSim/Simulation/Model/Scholz2015GeometryPath.h>
+#include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
+
+#include <OpenSim/Simulation/VisualizerUtilities.h>
+
+#include <catch2/catch_all.hpp>
+
+using namespace OpenSim;
+
+TEST_CASE("Interface") {
+    Model model = ModelFactory::createDoublePendulum();
+
+    Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+    path->setName("path");
+    model.addComponent(path);
+
+    SECTION("No path points") {
+        // Adding a component calls finalizeFromProperties() internally.
+        CHECK_THROWS_WITH(model.initSystem(),
+            Catch::Matchers::ContainsSubstring(
+                "Expected at least two path points before finalizing the path, "
+                "but 0 path point(s) were found."));
+    }
+
+    // Add the first path point. This defines the origin of the path.
+    path->appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+
+    SECTION("Only one path point") {
+        CHECK_THROWS_WITH(model.initSystem(),
+            Catch::Matchers::ContainsSubstring(
+                "Expected at least two path points before finalizing the path, "
+                "but 1 path point(s) were found."));
+    }
+
+    // Append a second path point, creating a straight line segment between the
+    // first and second path points.
+    path->appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.75, 0.1, 0.));
+
+    // Append a ContactCylinder wrapping obstacle to the path.
+    auto* obstacle = new ContactCylinder(0.1,
+        SimTK::Vec3(-0.5, 0.1, 0.), SimTK::Vec3(0),
+        model.getComponent<Body>("/bodyset/b0"));
+    model.addComponent(obstacle);
+    path->appendObstacle(*obstacle, SimTK::Vec3(0., 0.1, 0.));
+
+    SECTION("Path not closed") {
+        CHECK_THROWS_WITH(model.initSystem(),
+            Catch::Matchers::ContainsSubstring(
+               "Expected the last element of the path to be a path "
+               "point, but it is an obstacle."));
+    }
+
+    // Add additional path points.
+    path->appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+            SimTK::Vec3(-0.25, 0.1, 0.));
+
+    SECTION("Valid path") {
+        CHECK_NOTHROW(model.initSystem());
+    }
+
+    SECTION("Path configuration") {
+        CHECK(path->getNumPathPoints() == 3);
+        CHECK(path->getNumObstacles() == 1);
+        CHECK(path->getNumPathElements() == 4);
+    }
+
+    SECTION("Accessing path points") {
+        CHECK_NOTHROW(path->getPathPoint(0));
+        CHECK_NOTHROW(path->getPathPoint(1));
+        CHECK_NOTHROW(path->getPathPoint(2));
+        CHECK_THROWS_WITH(path->getPathPoint(3),
+            Catch::Matchers::ContainsSubstring(
+                "Index 3 is out of range."));
+    }
+
+    SECTION("Accessing obstacles") {
+        CHECK_NOTHROW(path->getContactGeometry(0));
+        CHECK_THROWS_WITH(path->getContactGeometry(1),
+            Catch::Matchers::ContainsSubstring(
+                "Index 1 is out of range."));
+        CHECK_NOTHROW(path->getContactHint(0));
+        CHECK_THROWS_WITH(path->getContactHint(1),
+            Catch::Matchers::ContainsSubstring(
+                "Index 1 is out of range."));
+    }
+
+    SECTION("Serialization and deserialization") {
+        model.finalizeConnections();
+        std::string fileName = "testScholz2015GeometryPath.osim";
+        model.print(fileName);
+
+        Model model2(fileName);
+        CHECK(model == model2);
+    }
+}
+
+TEST_CASE("Suspended pendulum") {
+
+    // Create a single pendulum model.
+    Model model = ModelFactory::createPendulum();
+
+    // Add a path spring that will wrap over each ContactGeometry, suspending
+    // the pendulum. We use a relatively large dissipation coefficient to ensure
+    // that the pendulum comes to rest quickly.
+    const double stiffness = 25.0;
+    const double dissipation = 5.0;
+    auto* actu = new PathSpring();
+    actu->setName("path_spring");
+    actu->setRestingLength(0.0);
+    actu->setDissipation(dissipation);
+    actu->setStiffness(stiffness);
+    actu->set_path(Scholz2015GeometryPath());
+    model.addComponent(actu);
+
+    // Set the path's origin and insertion.
+    Scholz2015GeometryPath& path = actu->updPath<Scholz2015GeometryPath>();
+    path.appendPathPoint(model.getGround(), SimTK::Vec3(-0.1, 0, 0));
+
+    // Check that pendulum is at rest with the expected length.
+    const double expectedLength = 0.81268778;
+    const double expectedSpeed = 0.0;
+    const double expectedTension = stiffness * expectedLength +
+            dissipation * expectedSpeed;
+    auto simulateHangingPendulum = [&](Model& model) {
+        SimTK::State state = model.initSystem();
+        Manager manager(model);
+        manager.initialize(state);
+        state = manager.integrate(20.0);
+
+        model.realizeVelocity(state);
+        CHECK_THAT(path.getLength(state),
+            Catch::Matchers::WithinRel(expectedLength, 1e-3));
+        CHECK_THAT(path.getLengtheningSpeed(state),
+            Catch::Matchers::WithinAbs(0.0, 1e-3));
+        CHECK_THAT(state.getU()[0],
+            Catch::Matchers::WithinAbs(0.0, 1e-3));
+        CHECK_THAT(actu->getTension(state),
+            Catch::Matchers::WithinRel(expectedTension, 1e-3));
+    };
+
+    // Simulate the "suspended" pendulum over each contact geometry. The
+    // geometries are configured such that each test will result in the same
+    // final path length.
+
+    SECTION("ContactCylinder") {
+        auto* obstacle = new ContactCylinder(0.1,
+            SimTK::Vec3(0.25, 0, 0), SimTK::Vec3(0), model.getGround());
+        model.addComponent(obstacle);
+        path.appendObstacle(*obstacle, SimTK::Vec3(0.0, 0.1, 0.0));
+        path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.5, 0.1, 0));
+        simulateHangingPendulum(model);
+    }
+
+    SECTION("ContactEllipsoid") {
+        auto* obstacle = new ContactEllipsoid(SimTK::Vec3(0.1, 0.1, 0.3),
+            SimTK::Vec3(0.25, 0, 0), SimTK::Vec3(0), model.getGround());
+        model.addComponent(obstacle);
+        path.appendObstacle(*obstacle, SimTK::Vec3(0.0, 0.1, 0.0));
+        path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.5, 0.1, 0));
+        simulateHangingPendulum(model);
+    }
+
+    SECTION("ContactSphere") {
+        auto* obstacle = new ContactSphere(0.1,
+            SimTK::Vec3(0.25, 0, 0), model.getGround());
+        model.addComponent(obstacle);
+        path.appendObstacle(*obstacle, SimTK::Vec3(0.0, 0.1, 0.0));
+        path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.5, 0.1, 0));
+        simulateHangingPendulum(model);
+    }
+
+    SECTION("ContactTorus") {
+        auto* obstacle = new ContactTorus(0.4, 0.1,
+            SimTK::Vec3(0.25, 0.4, 0),
+            SimTK::Vec3(0, 0.5*SimTK::Pi, 0),
+            model.getGround());
+        model.addComponent(obstacle);
+        path.appendObstacle(*obstacle, SimTK::Vec3(0.0, -0.3, 0.0));
+        path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.5, 0.1, 0));
+        simulateHangingPendulum(model);
+    }
+}
+
+TEST_CASE("Moment arms") {
+
+    const SimTK::Real radius = 0.2;
+    const SimTK::Real offset = 0.5;
+
+    // Construct a double pendulum model.
+    Model model = ModelFactory::createDoublePendulum();
+
+    // Configure the Scholz2015GeometryPath.
+    Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+    path->setName("path");
+    path->appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-offset, 0., 0.));
+    // Add a ContactCylinder along the axis definiing the PinJoint between
+    // body 'b0' and body 'b1'.
+    auto* obstacle = new ContactCylinder(radius,
+        SimTK::Vec3(0., 0., 0.), SimTK::Vec3(0),
+        model.getComponent<Body>("/bodyset/b0"));
+    model.addComponent(obstacle);
+    path->appendObstacle(*obstacle, SimTK::Vec3(0., radius, 0.));
+    path->appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
+            SimTK::Vec3(-offset, 0., 0.));
+
+    // Add the path to the model.
+    model.addComponent(path);
+
+    // The model is in the default configuration with both bodies aligned along
+    // their x-axes. Check that the computed moment arm is equal to the cylinder
+    // radius.
+    SECTION("Zero degrees") {
+        SimTK::State state = model.initSystem();
+        model.realizePosition(state);
+        const Coordinate& coord = model.getCoordinateSet().get("q1");
+        CHECK_THAT(path->computeMomentArm(state, coord),
+                Catch::Matchers::WithinRel(radius, 1e-6));
+    }
+
+    // The model is now posed with the second body rotated 90 degrees relative
+    // to the first body. The path should be lifted off the cylinder, no matter
+    // what cylinder radius is used in the range defined above.
+    SECTION("90 degrees") {
+        model.updCoordinateSet().get("q1").setDefaultValue(SimTK::Pi/2.);
+        SimTK::State state = model.initSystem();
+        model.realizePosition(state);
+        const Coordinate& coord = model.getCoordinateSet().get("q1");
+
+        SimTK::Real pathLength = std::sqrt(2*offset*offset);
+        CHECK_THAT(path->getLength(state),
+                Catch::Matchers::WithinRel(pathLength, 1e-6));
+
+        SimTK::Real momentArm =
+            std::sqrt(offset*offset - 0.25*pathLength*pathLength);
+        CHECK_THAT(path->computeMomentArm(state, coord),
+                Catch::Matchers::WithinRel(momentArm, 1e-6));
+    }
+
+    // The model is now posed with the second body rotated 180 degrees relative
+    // to the first body, such that the two bodies are fully overlapping. In
+    // this configuration, the path length should be zero and the moment arm
+    // should be equal to the offset used for the origin and insertion points.
+    SECTION("180 degrees") {
+        model.updCoordinateSet().get("q1").setDefaultValue(SimTK::Pi);
+        SimTK::State state = model.initSystem();
+        model.realizePosition(state);
+        const Coordinate& coord = model.getCoordinateSet().get("q1");
+
+        CHECK_THAT(path->getLength(state),
+                Catch::Matchers::WithinAbs(0.0, 1e-6));
+        CHECK_THAT(path->computeMomentArm(state, coord),
+                Catch::Matchers::WithinRel(offset, 1e-6));
+    }
+}
+
+// Test a simple Scholz2015GeometryPath with a known solution. The path wraps
+// over the following obstacles, in order: torus, ellipsoid, torus, cylinder.
+// We wrap the cable conveniently over the obstacles such that each curve
+// segment becomes a circular-arc shape. This allows us to check the results by
+// hand.
+//
+// This test is based on "testSimpleCable" in Simbody's TestCableSpan.cpp.
+TEST_CASE("Simple path") {
+
+    // Default mass properties.
+    const SimTK::Real mass = 1.0;
+    const SimTK::Vec3 com(0);
+    const SimTK::Inertia inertia(1);
+
+    // Create a model and add path-related bodies.
+    Model model;
+    auto* originBody = new Body("origin", mass, com, inertia);
+    auto* insertionBody = new Body("insertion", mass, com, inertia);
+    auto* torusBody = new Body("torus_body", mass, com, inertia);
+    auto* ellipsoidBody = new Body("ellipsoid_body", mass, com, inertia);
+    model.addBody(originBody);
+    model.addBody(insertionBody);
+    model.addBody(torusBody);
+    model.addBody(ellipsoidBody);
+
+    model.addJoint(new FreeJoint("origin_joint",
+            model.getGround(), SimTK::Vec3(0.), SimTK::Vec3(0.),
+            *originBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("insertion_joint",
+            model.getGround(), SimTK::Vec3(-4., 0., 0.), SimTK::Vec3(0.),
+            *insertionBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("torus_joint",
+            model.getGround(), SimTK::Vec3(0., 10., 0.), SimTK::Vec3(0.),
+            *torusBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("ellipsoid_joint",
+            *torusBody, SimTK::Vec3(4., -10., 0.), SimTK::Vec3(0.),
+            *ellipsoidBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+
+    // Create a PathActuator with a Scholz2015GeometryPath.
+    auto* actu = new PathActuator();
+    actu->setName("path_actuator");
+    actu->setOptimalForce(1.0);
+    actu->set_path(Scholz2015GeometryPath());
+    model.addComponent(actu);
+
+    // Add a prescribed controller for the actuator.
+    auto* controller = new PrescribedController();
+    controller->setName("controller");
+    model.addController(controller);
+
+    // Configure the path.
+    Scholz2015GeometryPath& path = actu->updPath<Scholz2015GeometryPath>();
+    path.appendPathPoint(*originBody, SimTK::Vec3(0.));
+
+    // Add the first torus obstacle.
+    auto* torus1 = new ContactTorus(10., 1.,
+        SimTK::Vec3(1., 1., 0.), SimTK::Vec3(0., 0.5*SimTK::Pi, 0.),
+        *torusBody);
+    torus1->setName("torus1");
+    model.addComponent(torus1);
+    path.appendObstacle(*torus1, SimTK::Vec3(0., -9., 0.));
+
+    // Add the ellipsoid obstacle.
+    auto* ellipsoid = new ContactEllipsoid(SimTK::Vec3(1., 1., 6.),
+        SimTK::Vec3(0.5, 1., 0.), SimTK::Vec3(0), *ellipsoidBody);
+    ellipsoid->setName("ellipsoid");
+    model.addComponent(ellipsoid);
+    path.appendObstacle(*ellipsoid, SimTK::Vec3(1., 1., 0.5));
+
+    // Add the second torus obstacle.
+    auto* torus2 = new ContactTorus(10., 1.5,
+        SimTK::Vec3(4., -12., 0.), SimTK::Vec3(0., 0.5*SimTK::Pi, 0.),
+        model.getGround());
+    torus2->setName("torus2");
+    model.addComponent(torus2);
+    path.appendObstacle(*torus2, SimTK::Vec3(0., 1., 0.));
+
+    // Add the cylinder obstacle.
+    auto* cylinder = new ContactCylinder(2.,
+        SimTK::Vec3(-2., -1.5, 0.), SimTK::Vec3(0), model.getGround());
+    cylinder->setName("cylinder");
+    model.addComponent(cylinder);
+    path.appendObstacle(*cylinder, SimTK::Vec3(0., -1., 0.));
+
+    // Add the insertion path point.
+    path.appendPathPoint(*insertionBody, SimTK::Vec3(0.));
+
+    // Initialize the system and state.
+    SimTK::State state = model.initSystem();
+    model.realizePosition(state);
+
+    SECTION("Configuration and smoothness") {
+        CHECK(path.getNumObstacles() == 4);
+        CHECK(path.getNumPathPoints() == 2);
+    }
+
+    SECTION("Path length") {
+        // Note that the length deviates because the path is solved up to angle
+        // tolerance, not length tolerance.
+        const SimTK::Real lengthTolerance = 1e-5;
+
+        // Sum all straight line segment lengths + curve line segment lengths.
+        const SimTK::Real sumStraightLineSegmentLengths =
+                1. + 3.5 + 3. + 6. + 1.5;
+        const SimTK::Real sumCurveLineSegmentLengths =
+                0.5 * SimTK::Pi * (1. + 1. + 1.5 + 2.);
+        const SimTK::Real expectedTotalPathLength =
+                sumStraightLineSegmentLengths + sumCurveLineSegmentLengths;
+        const SimTK::Real gotTotalPathLength = path.getLength(state);
+        CHECK_THAT(gotTotalPathLength, Catch::Matchers::WithinRel(
+                expectedTotalPathLength, lengthTolerance));
+    }
+
+    SECTION("Body forces exerted by the path") {
+        SimTK::Vector_<SimTK::SpatialVec> expectedBodyForces(
+                5, {{0., 0., 0.}, {0., 0., 0.}});
+        // Ground body - Sphere and cylinder are connected to it.
+        expectedBodyForces[0] = SimTK::SpatialVec{{0., 0., 1.5}, {0., 2., 0.}};
+        // Cable origin body.
+        expectedBodyForces[1] = SimTK::SpatialVec{{0., 0., 0.}, {0., 1., 0.}};
+        // Cable termination body.
+        expectedBodyForces[2] = SimTK::SpatialVec{{0., 0., 0.}, {0., -1., 0.}};
+        // Torus body.
+        expectedBodyForces[3] = SimTK::SpatialVec{{0., 0., 8.}, {1., -1., 0.}};
+        // Ellipsoid body.
+        expectedBodyForces[4] =
+                SimTK::SpatialVec{{0., 0., 0.5}, {-1., -1., 0.}};
+
+        // Apply a constant tension and check that the expected body forces are
+        // correct.
+        const SimTK::Real tension = SimTK::Pi;
+        controller->addActuator(*actu);
+        controller->prescribeControlForActuator(
+                "path_actuator", Constant(tension));
+        model.finalizeConnections();
+        model.realizeDynamics(state);
+
+        // Subtract out the gravitational forces to get only the forces due to
+        // the cable tension.
+        SimTK::Vector_<SimTK::SpatialVec> bodyForces =
+                model.getRigidBodyForces(state) -
+                model.getGravityBodyForces(state);
+        for (int i = 0; i < bodyForces.size(); ++i) {
+            CHECK_THAT((expectedBodyForces[i] * tension - bodyForces[i]).norm(),
+                Catch::Matchers::WithinAbs(0., 1e-5));
+        }
+    }
+}
+
+// Simple Scholz2015GeometryPath comprised of via points with a known solution.
+//
+// This test is based on "testViaPoints" in Simbody's TestCableSpan.cpp.
+TEST_CASE("Via points") {
+
+    // Default mass properties.
+    const SimTK::Real mass = 1.0;
+    const SimTK::Vec3 com(0);
+    const SimTK::Inertia inertia(1);
+
+    // Create a model and add path-related bodies.
+    Model model;
+    auto* originBody = new Body("origin", mass, com, inertia);
+    auto* insertionBody = new Body("insertion", mass, com, inertia);
+    auto* viaPoint1Body = new Body("via_point_1", mass, com, inertia);
+    auto* viaPoint2Body = new Body("via_point_2", mass, com, inertia);
+    auto* viaPoint3Body = new Body("via_point_3", mass, com, inertia);
+    model.addBody(originBody);
+    model.addBody(insertionBody);
+    model.addBody(viaPoint1Body);
+    model.addBody(viaPoint2Body);
+    model.addBody(viaPoint3Body);
+
+    model.addJoint(new FreeJoint("origin_joint",
+            model.getGround(), SimTK::Vec3(0.), SimTK::Vec3(0.),
+            *originBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("insertion_joint",
+            model.getGround(), SimTK::Vec3(-4., 0., 0.), SimTK::Vec3(0.),
+            *insertionBody, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("via_point_1_joint",
+            model.getGround(), SimTK::Vec3(0., 1., 0.), SimTK::Vec3(0.),
+            *viaPoint1Body, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("via_point_2_joint",
+            model.getGround(), SimTK::Vec3(0., 1., 2.), SimTK::Vec3(0.),
+            *viaPoint2Body, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+    model.addJoint(new FreeJoint("via_point_3_joint",
+            model.getGround(), SimTK::Vec3(-4., 1., 2.), SimTK::Vec3(0.),
+            *viaPoint3Body, SimTK::Vec3(0.), SimTK::Vec3(0.)));
+
+    // Create a PathActuator with a Scholz2015GeometryPath.
+    auto* actu = new PathActuator();
+    actu->setName("path_actuator");
+    actu->setOptimalForce(1.0);
+    actu->set_path(Scholz2015GeometryPath());
+    model.addComponent(actu);
+
+    // Add a prescribed controller for the actuator.
+    auto* controller = new PrescribedController();
+    controller->setName("controller");
+    model.addController(controller);
+
+    // Configure the path.
+    Scholz2015GeometryPath& path = actu->updPath<Scholz2015GeometryPath>();
+    path.appendPathPoint(*originBody, SimTK::Vec3(0.));
+    path.appendPathPoint(*viaPoint1Body, SimTK::Vec3(0.));
+    path.appendPathPoint(*viaPoint2Body, SimTK::Vec3(0.));
+    path.appendPathPoint(*viaPoint3Body, SimTK::Vec3(0.));
+    path.appendPathPoint(*insertionBody, SimTK::Vec3(0.));
+
+    // Initialize the system and state.
+    SimTK::State state = model.initSystem();
+    model.realizePosition(state);
+
+    SECTION("Configuration and smoothness") {
+        CHECK(path.getNumObstacles() == 0);
+        CHECK(path.getNumPathPoints() == 5);
+    }
+
+    SECTION("Path length") {
+        // Sum all straight line segment lengths.
+        const SimTK::Real lengthTolerance = 1e-5;
+        const SimTK::Real expectedTotalCableLength =
+                1. + 2. + 4. + std::sqrt(5.);
+        const SimTK::Real gotTotalCableLength = path.getLength(state);
+        CHECK_THAT(gotTotalCableLength, Catch::Matchers::WithinRel(
+                expectedTotalCableLength, lengthTolerance));
+    }
+
+    SECTION("Body forces exerted by the path") {
+        SimTK::Vector_<SimTK::SpatialVec> expectedBodyForces(
+                6, {{0., 0., 0.}, {0., 0., 0.}});
+        // Ground body.
+        expectedBodyForces[0] = SimTK::SpatialVec{{0., 0., 0}, {0., 0., 0.}};
+        // Cable origin body.
+        expectedBodyForces[1] = SimTK::SpatialVec{{0., 0., 0.}, {0., 1., 0.}};
+        // Cable termination body.
+        expectedBodyForces[2] = SimTK::SpatialVec{{0., 0., 0.},
+                {0., 1./std::sqrt(5.), 2./std::sqrt(5.)}};
+        // First via point.
+        expectedBodyForces[3] = SimTK::SpatialVec{{0., 0., 0.}, {0., -1., 1.}};
+        // Second via point.
+        expectedBodyForces[4] = SimTK::SpatialVec{{0., 0., 0.}, {-1., 0, -1.}};
+        // Third via point.
+        expectedBodyForces[5] = SimTK::SpatialVec{{0., 0., 0.},
+                {1., -1./std::sqrt(5.), -2./std::sqrt(5.)}};
+
+        // Apply a constant tension and check that the expected body forces are
+        // correct.
+        const SimTK::Real tension = SimTK::Pi;
+        controller->addActuator(*actu);
+        controller->prescribeControlForActuator(
+                "path_actuator", Constant(tension));
+        model.finalizeConnections();
+        model.realizeDynamics(state);
+
+        // Subtract out the gravitational forces to get only the forces due to
+        // the cable tension.
+        SimTK::Vector_<SimTK::SpatialVec> bodyForces =
+                model.getRigidBodyForces(state) -
+                model.getGravityBodyForces(state);
+        for (int i = 0; i < bodyForces.size(); ++i) {
+            CHECK_THAT((expectedBodyForces[i] * tension - bodyForces[i]).norm(),
+                Catch::Matchers::WithinAbs(0., 1e-5));
+        }
+    }
+}
+
+
+// Simulate a Scholz2015GeometryPath over all supported surfaces and a via
+// point, testing that we get the correct path kinematics. The path wraps over
+// the following obstacles, in order: torus, ellipsoid, via point, sphere,
+// cylinder, torus.
+//
+// This test is based on "testAllSurfaceKinds" in Simbody's TestCableSpan.cpp.
+TEST_CASE("Path with all surfaces and a via point") {
+    // Create an empty model.
+    Model model;
+
+    // Origin body and joint.
+    auto* originBody = new Body("origin_body", 1.0, SimTK::Vec3(0),
+        SimTK::Inertia(1.0));
+    model.addComponent(originBody);
+    auto* originJoint = new FreeJoint("origin_joint",
+        model.getGround(), SimTK::Vec3(-8., 0.1, 0.), SimTK::Vec3(0),
+        *originBody, SimTK::Vec3(0), SimTK::Vec3(0));
+    model.addComponent(originJoint);
+
+    // Via point body and joint.
+    auto* viaPointBody = new Body("via_point_body", 1.0, SimTK::Vec3(0),
+        SimTK::Inertia(1.0));
+    model.addComponent(viaPointBody);
+    auto* viaPointJoint = new FreeJoint("via_point_joint",
+        model.getGround(), SimTK::Vec3(0., 0.9, 0.5), SimTK::Vec3(0),
+        *viaPointBody, SimTK::Vec3(0), SimTK::Vec3(0));
+    model.addComponent(viaPointJoint);
+
+    // Insertion body and joint.
+    auto* insertionBody = new Body("insertion_body", 1.0, SimTK::Vec3(0),
+        SimTK::Inertia(1.0));
+    model.addComponent(insertionBody);
+    auto* insertionJoint = new FreeJoint("insertion_joint",
+        model.getGround(), SimTK::Vec3(20., 1.0, -1.), SimTK::Vec3(0),
+        *insertionBody, SimTK::Vec3(0), SimTK::Vec3(0));
+    model.addComponent(insertionJoint);
+
+    // Create the path object.
+    Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+    path->appendPathPoint(*originBody, SimTK::Vec3(0.));
+
+    // Add the first torus obstacle.
+    auto* torus1 = new ContactTorus(1., 0.2,
+        SimTK::Vec3(-4., 0., 0.), SimTK::Vec3(0., 0.5*SimTK::Pi, 0.),
+        model.getGround());
+    torus1->setName("torus1");
+    model.addComponent(torus1);
+    path->appendObstacle(*torus1, SimTK::Vec3(0.1, 0.2, 0.));
+
+    // Add the ellipsoid obstacle.
+    auto* ellipsoid = new ContactEllipsoid(SimTK::Vec3(1.5, 2.6, 1.),
+        SimTK::Vec3(-2., 0., 0.), SimTK::Vec3(0), model.getGround());
+    ellipsoid->setName("ellipsoid");
+    model.addComponent(ellipsoid);
+    path->appendObstacle(*ellipsoid, SimTK::Vec3(0., 0., 1.1));
+
+    // Add the via point.
+    path->appendPathPoint(*viaPointBody, SimTK::Vec3(0.));
+
+    // Add the sphere obstacle.
+    auto* sphere = new ContactSphere(1.,
+        SimTK::Vec3(2., 0., 0.), model.getGround());
+    sphere->setName("sphere");
+    model.addComponent(sphere);
+    path->appendObstacle(*sphere, SimTK::Vec3(0.1, 1.1, 0.));
+
+    // Add the cylinder obstacle.
+    auto* cylinder = new ContactCylinder(1.,
+        SimTK::Vec3(5., 0., 0.), SimTK::Vec3(0.5*SimTK::Pi, 0., 0.),
+        model.getGround());
+    cylinder->setName("cylinder");
+    model.addComponent(cylinder);
+    path->appendObstacle(*cylinder, SimTK::Vec3(0., -1., 0.));
+
+    // Add the second torus obstacle.
+    auto* torus2 = new ContactTorus(1., 0.2,
+        SimTK::Vec3(14., 0., 0.), SimTK::Vec3(0., 0.5*SimTK::Pi, 0.),
+        model.getGround());
+    torus2->setName("torus2");
+    model.addComponent(torus2);
+    path->appendObstacle(*torus2, SimTK::Vec3(0.1, 0.2, 0.));
+
+    // Add the insertion path point.
+    path->appendPathPoint(*insertionBody, SimTK::Vec3(0.));
+
+    // Add the path to the model.
+    model.addComponent(path);
+
+    // Initialize the system and state.
+    SimTK::State state = model.initSystem();
+    model.realizePosition(state);
+
+    // Use this to assert cable length time derivative.
+    SimTK::Real prevCableLength = SimTK::NaN;
+
+    auto setJointKinematics =
+            [&](FreeJoint& joint, SimTK::Vec3 q, SimTK::Vec3 u)
+    {
+        auto& x_coord = joint.updCoordinate(FreeJoint::Coord::TranslationX);
+        x_coord.setValue(state, q[0]);
+        x_coord.setSpeedValue(state, u[0]);
+
+        auto& y_coord = joint.updCoordinate(FreeJoint::Coord::TranslationY);
+        y_coord.setValue(state, q[1]);
+        y_coord.setSpeedValue(state, u[1]);
+
+        auto& z_coord = joint.updCoordinate(FreeJoint::Coord::TranslationZ);
+        z_coord.setValue(state, q[2]);
+        z_coord.setSpeedValue(state, u[2]);
+    };
+
+    // Let the path end and via points be parameterized by an angle, and draw
+    // the path for different angles.
+    const SimTK::Real dAngle = 1e-4;
+    const SimTK::Real finalAngle = 0.5 * SimTK::Pi;
+    for (SimTK::Real angle = 0.; angle < finalAngle; angle += dAngle) {
+
+        // Move the cable origin.
+        setJointKinematics(*originJoint,
+                SimTK::Vec3(1.1 * sin(angle),
+                            5. * sin(angle * 1.5),
+                            5. * sin(angle * 2.)),
+                SimTK::Vec3(1.1 * cos(angle),
+                            5. * 1.5 * cos(angle * 1.5),
+                            5. * 2. * cos(angle * 2.)));
+
+        // Move the via point.
+        setJointKinematics(*viaPointJoint,
+                SimTK::Vec3(0., 0.5 * cos(angle), 0.),
+                SimTK::Vec3(0., 0.5 * -sin(angle), 0.));
+
+        // Move the cable insertion.
+        setJointKinematics(*insertionJoint,
+                SimTK::Vec3(0.1 * sin(angle),
+                            4. * sin(angle * 0.7),
+                            10. * sin(angle * 1.3)),
+                SimTK::Vec3(0.1 * cos(angle),
+                            4. * 0.7 * cos(angle * 0.7),
+                            10. * 1.3 * cos(angle * 1.3)));
+
+        // Compute the path.
+        model.realizeVelocity(state);
+        const SimTK::Real cableLength = path->getLength(state);
+
+        // Assert length derivative using the change in length.
+        if (!SimTK::isNaN(prevCableLength)) {
+            const SimTK::Real tolerance = 5e-3;
+            const SimTK::Real expectedCableLengtheningSpeed =
+                    (cableLength - prevCableLength) / dAngle;
+            const SimTK::Real gotCableLengtheningSpeed =
+                    path->getLengtheningSpeed(state);
+            CHECK_THAT(gotCableLengtheningSpeed,
+                Catch::Matchers::WithinAbs(expectedCableLengtheningSpeed,
+                    tolerance));
+        }
+
+        // Total path length should be longer than direct distance between the
+        // path endpoints.
+        const SimTK::Real distanceBetweenEndPoints =
+            (insertionBody->getPositionInGround(state) -
+             originBody->getPositionInGround(state))
+                .norm();
+        CHECK(cableLength > distanceBetweenEndPoints);
+
+        prevCableLength = cableLength;
+    }
+}
+
+// Simulate touchdown and liftoff events in a Scholz2015GeometryPath. A simple
+// touchdown and liftoff case on torus, ellipsoid, sphere, and cylinder wrapping
+// obstacles. A path is spanned over each obstacle individually, so there are 4
+// paths, each with one obstacle.
+//
+// This test is based on "testTouchdownAndLiftoff" in Simbody's
+// TestCableSpan.cpp.
+TEST_CASE("Touchdown and liftoff") {
+    // Create an empty model.
+    Model model;
+
+    // Helper for creating a path with a single obstacle at a certain offset
+    // location.
+    SimTK::Vec3 originShift(-2., 0., 0.);
+    SimTK::Vec3 terminationShift(2., 0., 0.);
+    auto createPath = [&](
+        const std::string& name, const ContactGeometry& obstacle,
+        const SimTK::Vec3& sceneOffset) {
+
+        auto* originBody = new Body(
+            fmt::format("{}_origin_body", name), 1.0, SimTK::Vec3(0),
+            SimTK::Inertia(1.0));
+        model.addComponent(originBody);
+        auto* originJoint = new FreeJoint(fmt::format("{}_origin_joint", name),
+            model.getGround(), sceneOffset + originShift, SimTK::Vec3(0),
+            *originBody, SimTK::Vec3(0), SimTK::Vec3(0));
+        model.addComponent(originJoint);
+
+        // Termination body and joint.
+        auto* terminationBody = new Body(
+            fmt::format("{}_termination_body", name), 1.0, SimTK::Vec3(0),
+            SimTK::Inertia(1.0));
+        model.addComponent(terminationBody);
+        auto* terminationJoint = new FreeJoint(
+            fmt::format("{}_termination_joint", name),
+            model.getGround(), sceneOffset + terminationShift, SimTK::Vec3(0),
+            *terminationBody, SimTK::Vec3(0), SimTK::Vec3(0));
+        model.addComponent(terminationJoint);
+
+        // Create the path object.
+        Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+        path->setName(fmt::format("{}_path", name));
+        path->appendPathPoint(*originBody, SimTK::Vec3(0.));
+        path->appendObstacle(obstacle, SimTK::Vec3(SimTK::NaN));
+        path->appendPathPoint(*terminationBody, SimTK::Vec3(0.));
+
+        // Add the path to the model.
+        model.addComponent(path);
+    };
+
+    // Create a path with a torus obstacle.
+    SimTK::Vec3 sceneOffset(0., 2., 0.);
+    auto* torus = new ContactTorus(2., 0.25,
+        SimTK::Vec3(0., 1.75, 0.) + sceneOffset,
+        SimTK::Vec3(0., 0.5*SimTK::Pi, 0.),
+        model.getGround());
+    torus->setName("torus");
+    model.addComponent(torus);
+    createPath("torus", *torus, sceneOffset);
+
+    // Create a path with an ellipsoid obstacle.
+    sceneOffset = SimTK::Vec3(0., 0., 0.);
+    auto* ellipsoid = new ContactEllipsoid(SimTK::Vec3(1., 0.5, 0.75),
+        SimTK::Vec3(0., -0.5, 0.) + sceneOffset,
+        SimTK::Vec3(0., 0., 0.),
+        model.getGround());
+    ellipsoid->setName("ellipsoid");
+    model.addComponent(ellipsoid);
+    createPath("ellipsoid", *ellipsoid, sceneOffset);
+
+    // Create a path with a sphere obstacle.
+    sceneOffset = SimTK::Vec3(0., -2., 0.);
+    auto* sphere = new ContactSphere(1.5,
+        SimTK::Vec3(0., -1.5, 0.) + sceneOffset,
+        model.getGround());
+    sphere->setName("sphere");
+    model.addComponent(sphere);
+    createPath("sphere", *sphere, sceneOffset);
+
+    // Create a path with a cylinder obstacle.
+    sceneOffset = SimTK::Vec3(0., -6., 0.);
+    auto* cylinder = new ContactCylinder(2.,
+        SimTK::Vec3(0., -2., 0.) + sceneOffset,
+        SimTK::Vec3(0),
+        model.getGround());
+    cylinder->setName("cylinder");
+    model.addComponent(cylinder);
+    createPath("cylinder", *cylinder, sceneOffset);
+
+    // Initialize the system and state.
+    SimTK::State state = model.initSystem();
+    const SimTK::SimbodyMatterSubsystem& matter = model.getMatterSubsystem();
+    const SimTK::CableSubsystem& cables = model.getCableSubsystem();
+    CHECK(cables.getNumCables() == 4);
+
+    // Simulate touchdown and liftoff events.
+    for (SimTK::Real angle = 1e-2; angle < 4. * SimTK::Pi; angle += 0.02) {
+        // Move the cable end points.
+        const SimTK::Real yCoord = 0.1 * sin(angle);
+        for (SimTK::CableSpanIndex cableIx(0); cableIx < cables.getNumCables();
+             ++cableIx) {
+            matter
+                .getMobilizedBody(cables.getCable(cableIx).getOriginBodyIndex())
+                .setQToFitTranslation(state, SimTK::Vec3(0., yCoord, 0.));
+            matter
+                .getMobilizedBody(
+                    cables.getCable(cableIx).getTerminationBodyIndex())
+                .setQToFitTranslation(state, SimTK::Vec3(0., yCoord, 0.));
+        }
+
+        model.realizePosition(state);
+
+        // All obstacles are positioned such that for negative yCoord of the
+        // endpoints, the cable touches down on the obstacle.
+        for (SimTK::CableSpanIndex cableIx(0); cableIx < cables.getNumCables();
+             ++cableIx) {
+            cables.getCable(cableIx).calcLength(state);
+            const bool gotContactStatus =
+                cables.getCable(cableIx).isInContactWithObstacle(
+                    state,
+                    SimTK::CableSpanObstacleIndex(0));
+            const bool expectedContactStatus = yCoord < 0.;
+            CHECK(gotContactStatus == expectedContactStatus);
+        }
+    }
+}
+
+TEST_CASE("Path tension") {
+    Model model = ModelFactory::createDoublePendulum();
+
+    Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+    path->setName("path");
+    model.addComponent(path);
+    path->appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));
+    path->appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
+            SimTK::Vec3(-0.75, 0.1, 0.));
+
+    SimTK::State state = model.initSystem();
+    model.realizePosition(state);
+
+    SimTK::Vector_<SimTK::SpatialVec> bodyForces(3, SimTK::SpatialVec(0));
+    SimTK::Vector mobilityForces(3, 0.0);
+
+    SECTION("Unit tension") {
+        const SimTK::Real tension = 1.0;
+        path->addInEquivalentForces(state, tension, bodyForces, mobilityForces);
+        CHECK(bodyForces[0].norm() > 0.0);
+        CHECK(bodyForces[1].norm() > 0.0);
+        CHECK(bodyForces[2].norm() == 0.0);
+        CHECK(mobilityForces.norm() == 0.0);
+    }
+
+    SECTION("Zero tension") {
+        const SimTK::Real tension = 0.0;
+        path->addInEquivalentForces(state, tension, bodyForces, mobilityForces);
+        for (int i = 0; i < bodyForces.size(); ++i) {
+            CHECK(bodyForces[i].norm() == 0.0);
+        }
+        CHECK(mobilityForces.norm() == 0.0);
+    }
+
+    SECTION("Negative tension") {
+        const SimTK::Real tension = -1.0;
+        path->addInEquivalentForces(state, tension, bodyForces, mobilityForces);
+        for (int i = 0; i < bodyForces.size(); ++i) {
+            CHECK(bodyForces[i].norm() == 0.0);
+        }
+        CHECK(mobilityForces.norm() == 0.0);
+    }
+
+    SECTION("NaN tension") {
+        const SimTK::Real tension = SimTK::NaN;
+        path->addInEquivalentForces(state, tension, bodyForces, mobilityForces);
+        CHECK(SimTK::isNaN(bodyForces[0].norm()));
+        CHECK(SimTK::isNaN(bodyForces[1].norm()));
+        CHECK(!SimTK::isNaN(bodyForces[2].norm()));
+        CHECK(mobilityForces.norm() == 0.0);
+    }
+}

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -93,7 +93,7 @@ int main()
         for (int i=0; i< availableComponentTypes.getSize(); i++){
             Object* clone = availableComponentTypes[i]->clone();
             Object* randClone;
-    
+
             if (auto* path = dynamic_cast<FunctionBasedPath*>(clone)){
                 // FunctionBasedPath requires that its properties follow specific
                 // requirements. For example, `length_function` must have the same
@@ -112,9 +112,9 @@ int main()
                 // leads to a segfault due to invalid Property indexes when
                 // Joints try to access Coordinates.
                 // randomize(coord);
-                // Array<double> defaultRange(-10.0, 2); 
-                // defaultRange[1] = 10.0; 
-                // coord->set_range(defaultRange); 
+                // Array<double> defaultRange(-10.0, 2);
+                // defaultRange[1] = 10.0;
+                // coord->set_range(defaultRange);
                 // randClone = coord;
                 continue;
             } else if (auto* wrap = dynamic_cast<WrapTorus*>(clone)) {
@@ -155,12 +155,12 @@ int main()
                 muscle->set_min_control(0.01);
                 randClone = muscle;
             } else if (dynamic_cast<DeGrooteFregly2016Muscle*>(clone)) {
-                // TODO: we can't randomize DeGrooteFregly2016Muscle, since 
-                // changing the the optimal_force property inherited by 
+                // TODO: we can't randomize DeGrooteFregly2016Muscle, since
+                // changing the the optimal_force property inherited by
                 // PathActuator leads to an invalid configuration.
                 continue;
             } else if (dynamic_cast<ControlSetController*>(clone)) {
-                // TODO: randomizing ControlSetController fails because it is 
+                // TODO: randomizing ControlSetController fails because it is
                 // unable to load nonexistent file 'ABCXYZ'.
                 continue;
             } else if (dynamic_cast<StationDefinedFrame*>(clone)) {
@@ -168,7 +168,7 @@ int main()
                 // exception message "failed to match original model".
                 continue;
             } else if (dynamic_cast<ExponentialContactForce*>(clone)) {
-                // TODO: randomizing ExponentialContactForce sporadically fails 
+                // TODO: randomizing ExponentialContactForce sporadically fails
                 // with exception message "failed to match original model".
                 continue;
             } else {

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -185,7 +185,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    69a1328806f3ec3a99678615a28741002323d2d0
+              GIT_TAG    77bf63c030e4c30112952602abe120afedbdb1e6
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})

--- a/doc/OpenSimExamples.dox
+++ b/doc/OpenSimExamples.dox
@@ -1,0 +1,17 @@
+namespace OpenSim {
+/**
+
+@example exampleScholz2015GeometryPath.m
+This example demonstrates the basic elements of creating a geometry-based
+path using the Scholz2015GeometryPath class.
+
+@example exampleScholz2015GeometryPath.py
+This example demonstrates the basic elements of creating a geometry-based
+path using the Scholz2015GeometryPath class.
+
+@example exampleScholz2015GeometryPath.cpp
+This example demonstrates the basic elements of creating a geometry-based
+path using the Scholz2015GeometryPath class.
+
+*/
+} // namespace OpenSim

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -966,9 +966,12 @@ EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           = "@PROJECT_SOURCE_DIR@/OpenSim/Tests/README/testREADME.cpp" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/Moco" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/PolynomialPathFitter" \
+                         "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/Wrapping" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/Moco" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/PolynomialPathFitter" \
-                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Moco"
+                         "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/Wrapping" \
+                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Moco" \
+                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Wrapping"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and


### PR DESCRIPTION
Fixes issue #4113

### Overview

Scholz2015GeometryPath is a geometry-based path wrapping algorithm based on the publication "A fast multi-obstacle muscle wrapping method using natural geodesic variations" by Scholz et al. (2015). This class encapsulates `SimTK::CableSpan`, the Simbody implementation of the core wrapping algorithm, and provides support for using this method to define the geometry for path-based OpenSim components (e.g., `Muscle`, `PathSpring`, etc.). This class can be used as a replacement for `GeometryPath`, providing improved computational performance and stability in wrapping solutions.

Below is a simple example that includes most of `Scholz2015GeometryPath`'s features. `Scholz2015GeometryPath` defines the path of a `PathSpring` component, which applies forces to a double pendulum model.

```c++
#include <OpenSim/OpenSim.h>

using namespace OpenSim;

int main() {

    Model model = ModelFactory::createDoublePendulum();
    model.setUseVisualizer(true);

    // Create a PathSpring with a Scholz2015GeometryPath.
    auto* spring = new PathSpring();
    spring->setName("path_spring");
    spring->setRestingLength(0.25);
    spring->setDissipation(0.75);
    spring->setStiffness(10.0);
    spring->set_path(Scholz2015GeometryPath());
    model.addComponent(spring);

    // Configure the Scholz2015GeometryPath. We will update the path after
    // adding it to the PathSpring, so that the Socket connections in each
    // Station (i.e., path point) remain valid.
    Scholz2015GeometryPath& path = spring->updPath<Scholz2015GeometryPath>();
    path.setName("path");

    // Add a path point connected to ground. Since this is the first path point,
    // it defines the origin of the path.
    path.appendPathPoint(model.getGround(), SimTK::Vec3(0.05, 0.05, 0.));

    // Add a second path point, creating a straight line segment between the
    // ground and body "b0".
    path.appendPathPoint(model.getComponent<Body>("/bodyset/b0"),
            SimTK::Vec3(-0.5, 0.1, 0.));

    // Create a ContactCylinder to use as a wrapping obstacle to the path. The
    // cylinder has radius 0.15 m and is attached to body "b0".
    auto* obstacle = new ContactCylinder(0.15,
            SimTK::Vec3(-0.2, 0.2, 0.), SimTK::Vec3(0),
            model.getComponent<Body>("/bodyset/b0"));
    model.addComponent(obstacle);

    // Before we add the obstacle to the path, we must provide a "contact hint"
    // to initialize the wrapping solver. The contact hint is a point on the
    // surface of the obstacle, expressed in the obstacle's frame. The point
    // does not have to lie on the contact geometry's surface, nor does it have
    // to belong to a valid cable path. The choice of the contact hint will
    // determine which side of the cylinder the path wraps around.
    SimTK::Vec3 contact_hint(0., 0.15, 0.);
    path.appendObstacle(*obstacle, contact_hint);

    // At least one path point must follow an obstacle (or list of obstacles)
    // in a Scholz2015GeometryPath. Since this is the last path point we are
    // adding, it defines the insertion of the path.
    path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
            SimTK::Vec3(-0.5, 0.1, 0.));

    // Use the "minimum length" algorithm, which solves for a path that
    // minimizes the total length of the path.
    path.setAlgorithm("MinimumLength");

    // Initialize the system.
    SimTK::State state = model.initSystem();
    model.updVisualizer().updSimbodyVisualizer().setBackgroundType(
            SimTK::Visualizer::SolidColor);
    model.updVisualizer().updSimbodyVisualizer().setCameraTransform(
            SimTK::Vec3(0.2, -0.8, 3.0));
    model.updVisualizer().updSimbodyVisualizer().setCameraFieldOfView(0.9);

    // Simulate.
    Manager manager(model);
    manager.initialize(state);
    manager.integrate(20.0);
}
```

Running this example produces the following motion. The double pendulum model responds to the spring forces applied by the `PathSpring` and the motion damps out over time due to the non-zero dissipation parameter.

https://github.com/user-attachments/assets/43489a50-eb9d-4a1f-b0e1-b4bb911f1047

### Brief summary of changes

- Added the class `Scholz2015GeometryPath` which derives from `AbstractGeometryPath`. The helper classes `Scholz2015GeometryPathPoint` and `Scholz2015GeometryPathObstacle` help internally maintain the organization of path wrapping obstacles and via points during serialization and deserialization.
- `Scholz2015GeometryPathPoint` stores a `Station` defining a point on a `PhysicalFrame` in the model which the path must pass through.
- `Scholz2015GeometryPathObstacle` stores a `Socket` to a `ContactGeometry` and a contact hint. The `ContactGeometry` reference is used internally to generate a shared pointer to a `SimTK::ContactGeometry`, which `SimTK::CableSpan` needs to define wrapping obstacles.
- `Scholz2015GeometryPathPoint` and `Scholz2015GeometryPathObstacle` both derive from `Scholz2015GeometryPathElement`. This allows us to store an ordered list of path points and obstacles in the `path_elements` property (i.e., the path elements will appear in the same order in XML as added by the user in the API).
- Updates `Model` to include a unique pointer to `SimTK::CableSubsystem`, the Simbody subsystem to which all `SimTK::CableSpan` objects belong.
- Adds `exampleScholz2015GeometryPath.cpp`, which is the same as the example in the Overview section above.  Python and MATLAB versions of this example are also included.
- `MomentArmSolver` is updated to support any `AbstractGeometryPath`, allowing moment arm calculations for `Scholz2015GeometryPath`.
- Various formatting and whitespace "drive-by" changes are applied.

### Testing I've completed
Several tests for `Scholz2015GeometryPath` have been added via `testScholz2015GeometryPath.cpp`.  Here is an example of a set of regression tests where a pendulum is suspended by a `Scholz2015GeometryPath` element hanging over a wrap element. Similar to the example above, the path is connected to a `PathSpring`, so we test that we receive the expected path length and tension after the motion damps out.

https://github.com/user-attachments/assets/f9e365bd-bfa3-4b6a-b2c1-cbe0820bd203

The C++, Python, and Matlab examples have been tested locally on my Arm64 Mac. 

### Looking for feedback on...

API design, test coverage, and anything that might improve both the user and developer experience with `Scholz2015GeometryPath`.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4156)
<!-- Reviewable:end -->
