### PR TITLE
Fix logging for spdlog when imported by consuming libraries

### DIFF
--- a/OpenSim/Common/Assertion.cpp
+++ b/OpenSim/Common/Assertion.cpp
@@ -24,6 +24,7 @@
 #include "Assertion.h"
 
 #include <OpenSim/Common/Exception.h>
+#include <OpenSim/Common/Object.h>
 
 void OpenSim::OnAssertionError(
     char const* failingCode,

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -3525,10 +3525,10 @@ public:
                 foundCs.push_back(&comp);
                 // TODO Revisit why the exact match isn't found when
                 // when what appears to be the complete path.
-                log_debug("{} Found '{}' as a match for: Component '{}' of "
-                          "type {}, but it is not on the specified path.",
-                          msg, compAbsPath.toString(),
-                          comp.getConcreteClassName());
+                log_debug("{} Found '{}' as a match for: Component '{}', "
+                          "but it is not on the specified path.",
+                        msg, compAbsPath.toString(),
+                        comp.getConcreteClassName());
                 //throw Exception(details, __FILE__, __LINE__);
             }
         }

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -201,12 +201,10 @@ public:
     OPENSIM_THROW_IF) and also provide a message that is formatted
     using fmt::format() syntax. */
     template <typename... Args>
-    Exception(const std::string& file,
-              size_t line,
-              const std::string& func,
-              spdlog::string_view_t fmt,
-              const Args&... args)
-            : Exception{file, line, func, fmt::format(fmt, args...)} {}
+    Exception(const std::string& file, size_t line, const std::string& func,
+            spdlog::format_string_t<Args...> fmt, Args&&... args)
+            : Exception{file, line, func,
+                      fmt::format(fmt, std::forward<Args>(args)...)} {}
 
     /** The message created by this constructor will contain the class name and
     instance name of the provided Object, and also accepts a message formatted
@@ -214,13 +212,11 @@ public:
     Use OPENSIM_THROW_FRMOBJ and OPENSIM_THROW_IF_FRMOBJ macros at throw sites.
     */
     template <typename... Args>
-    Exception(const std::string& file,
-              size_t line,
-              const std::string& func,
-              const Object& obj,
-              spdlog::string_view_t fmt,
-              const Args&... args)
-            : Exception{file, line, func, obj, fmt::format(fmt, args...)} {}
+    Exception(const std::string& file, size_t line, const std::string& func,
+            const Object& obj, spdlog::format_string_t<Args...> fmt,
+            Args&&... args)
+            : Exception{file, line, func, obj,
+                      fmt::format(fmt, std::forward<Args>(args)...)} {}
 
     virtual ~Exception() throw() {}
 
@@ -323,7 +319,10 @@ public:
 
 class ComponentNotFound : public Exception {
 public:
-    using Exception::Exception;
+    ComponentNotFound(
+            const std::string& file, size_t line, const std::string& func)
+            : Exception(file, line, func) {}
+
     ComponentNotFound(const std::string& file,
         size_t line,
         const std::string& func,

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -197,6 +197,7 @@ public:
         const Component& component,
         const std::string& msg);
 
+#ifndef SWIG
     /** Use this when you want to throw an Exception (with OPENSIM_THROW or
     OPENSIM_THROW_IF) and also provide a message that is formatted
     using fmt::format() syntax. */
@@ -217,6 +218,7 @@ public:
             Args&&... args)
             : Exception{file, line, func, obj,
                       fmt::format(fmt, std::forward<Args>(args)...)} {}
+#endif
 
     virtual ~Exception() throw() {}
 

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -24,11 +24,13 @@
 
 #include "osimCommonDLL.h"              // for OSIMCOMMON_API
 #include <memory>                       // for shared_ptr
-#include <spdlog/common.h>              // for string_view_t
+#include <spdlog/common.h>              // for spdlog::format_string_t
 #include <spdlog/fmt/bundled/base.h>    // for formatter
 #include <spdlog/fmt/bundled/ostream.h> // for ostream_formatter
 #include <spdlog/logger.h>              // for logger
 #include <string>                       // for basic_string, string
+#include <string_view>                  // for std::string_view
+#include <utility>                      // for std::forward
 
 #ifndef SWIG
 #include <SimTKcommon/SmallMatrix.h>             // for Vec3
@@ -123,44 +125,44 @@ public:
     /// @{
 
     template <typename... Args>
-    static void critical(spdlog::string_view_t fmt, const Args&... args) {
+    static void critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Critical)) {
-            getDefaultLogger().critical(fmt, args...);
+            getDefaultLogger().critical(fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
-    static void error(spdlog::string_view_t fmt, const Args&... args) {
+    static void error(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Error)) {
-            getDefaultLogger().error(fmt, args...);
+            getDefaultLogger().error(fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
-    static void warn(spdlog::string_view_t fmt, const Args&... args) {
+    static void warn(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Warn)) {
-            getDefaultLogger().warn(fmt, args...);
+            getDefaultLogger().warn(fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
-    static void info(spdlog::string_view_t fmt, const Args&... args) {
+    static void info(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Info)) {
-            getDefaultLogger().info(fmt, args...);
+            getDefaultLogger().info(fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
-    static void debug(spdlog::string_view_t fmt, const Args&... args) {
+    static void debug(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Debug)) {
-            getDefaultLogger().debug(fmt, args...);
+            getDefaultLogger().debug(fmt, std::forward<Args>(args)...);
         }
     }
 
     template <typename... Args>
-    static void trace(spdlog::string_view_t fmt, const Args&... args) {
+    static void trace(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Trace)) {
-            getDefaultLogger().trace(fmt, args...);
+            getDefaultLogger().trace(fmt, std::forward<Args>(args)...);
         }
     }
 
@@ -172,8 +174,9 @@ public:
     /// Besides such use cases, this function should be used sparingly to
     /// give users control over what gets logged.
     template <typename... Args>
-    static void cout(spdlog::string_view_t fmt, const Args&... args) {
-        getCoutLogger().log(getCoutLogger().level(), fmt, args...);
+    static void cout(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+        getCoutLogger().log(
+                getCoutLogger().level(), fmt, std::forward<Args>(args)...);
     }
 
     /// @}
@@ -212,46 +215,77 @@ private:
 
 /// @related Logger
 template <typename... Args>
-void log_critical(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::critical(fmt, args...);
+void log_critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::critical(fmt, std::forward<Args>(args)...);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_error(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::error(fmt, args...);
+void log_error(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::error(fmt, std::forward<Args>(args)...);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_warn(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::warn(fmt, args...);
+void log_warn(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::warn(fmt, std::forward<Args>(args)...);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_info(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::info(fmt, args...);
+void log_info(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::info(fmt, std::forward<Args>(args)...);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_debug(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::debug(fmt, args...);
+void log_debug(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::debug(fmt, std::forward<Args>(args)...);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_trace(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::trace(fmt, args...);
+void log_trace(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::trace(fmt, std::forward<Args>(args)...);
 }
 
 /// @copydoc Logger::cout()
 /// @related Logger
 template <typename... Args>
-void log_cout(spdlog::string_view_t fmt, const Args&... args) {
-    Logger::cout(fmt, args...);
+void log_cout(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+    Logger::cout(fmt, std::forward<Args>(args)...);
 }
+
+// Overloads for logging a single raw string message.
+
+/// @related Logger
+inline void log_critical(std::string_view msg) {
+    OpenSim::Logger::critical("{}", msg);
+}
+
+/// @related Logger
+inline void log_error(std::string_view msg) {
+    OpenSim::Logger::error("{}", msg);
+}
+
+/// @related Logger
+inline void log_warn(std::string_view msg) { OpenSim::Logger::warn("{}", msg); }
+
+/// @related Logger
+inline void log_info(std::string_view msg) { OpenSim::Logger::info("{}", msg); }
+
+/// @related Logger
+inline void log_debug(std::string_view msg) {
+    OpenSim::Logger::debug("{}", msg);
+}
+
+/// @related Logger
+inline void log_trace(std::string_view msg) {
+    OpenSim::Logger::trace("{}", msg);
+}
+
+/// @related Logger
+inline void log_cout(std::string_view msg) { OpenSim::Logger::cout("{}", msg); }
 
 /// @}
 

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -123,7 +123,7 @@ public:
     /// @name Commands to log messages
     /// Use these functions instead of using spdlog directly.
     /// @{
-
+#ifndef SWIG
     template <typename... Args>
     static void critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
         if (shouldLog(Level::Critical)) {
@@ -178,7 +178,7 @@ public:
         getCoutLogger().log(
                 getCoutLogger().level(), fmt, std::forward<Args>(args)...);
     }
-
+#endif
     /// @}
 
     /// Log messages to a file at the level getLevel().
@@ -212,7 +212,7 @@ private:
 
 /// @name Logging functions
 /// @{
-
+#ifndef SWIG
 /// @related Logger
 template <typename... Args>
 void log_critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
@@ -286,8 +286,7 @@ inline void log_trace(std::string_view msg) {
 
 /// @related Logger
 inline void log_cout(std::string_view msg) { OpenSim::Logger::cout("{}", msg); }
-
-/// @}
+#endif
 
 } // namespace OpenSim
 

--- a/OpenSim/Simulation/Control/ControlSetController.cpp
+++ b/OpenSim/Simulation/Control/ControlSetController.cpp
@@ -21,15 +21,15 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/*   
- * Author: Jack Middleton 
+/*
+ * Author: Jack Middleton
  */
-
 
 //=============================================================================
 // INCLUDES
 //=============================================================================
 #include "ControlSetController.h"
+
 #include "ControlLinear.h"
 #include "ControlSet.h"
 #include "Controller.h"
@@ -54,18 +54,14 @@ using namespace OpenSim;
 /**
  * Destructor.
  */
-ControlSetController::~ControlSetController()
-{
-    delete _controlSet;
-}
+ControlSetController::~ControlSetController() { delete _controlSet; }
 //_____________________________________________________________________________
 /**
  * Default constructor
  */
 
-ControlSetController::ControlSetController() :
-    Controller(),
-    _controlsFileName(_controlsFileNameProp.getValueStr() ) {
+ControlSetController::ControlSetController()
+        : Controller(), _controlsFileName(_controlsFileNameProp.getValueStr()) {
     setNull();
 }
 
@@ -73,59 +69,50 @@ ControlSetController::ControlSetController() :
 /**
  * Copy constructor.
  */
-ControlSetController::ControlSetController(const ControlSetController &aController) :
-    Controller(aController),
-   _controlsFileName(_controlsFileNameProp.getValueStr())
-{
+ControlSetController::ControlSetController(
+        const ControlSetController& aController)
+        : Controller(aController),
+          _controlsFileName(_controlsFileNameProp.getValueStr()) {
     setNull();
     copyData(aController);
 }
-
 
 //_____________________________________________________________________________
 /**
  * Set NULL values for all member variables.
  */
-void ControlSetController::setNull()
-{
+void ControlSetController::setNull() {
     setupProperties();
 
     _model = NULL;
     _controlSet = NULL;
-
-
 }
 //_____________________________________________________________________________
 /**
- * Set name of ControlSet file 
+ * Set name of ControlSet file
  */
 //_____________________________________________________________________________
 /**
  * Connect properties to local pointers.
  */
-void ControlSetController::
-setControlSetFileName( const std::string&  controlSetFileName )
-{
-   _controlsFileName = controlSetFileName;
+void ControlSetController::setControlSetFileName(
+        const std::string& controlSetFileName) {
+    _controlsFileName = controlSetFileName;
 }
-void ControlSetController::
-setupProperties()
-{
-    std::string comment = "A Storage (.sto) or an XML control nodes file containing the controls for this controlSet.";
+void ControlSetController::setupProperties() {
+    std::string comment = "A Storage (.sto) or an XML control nodes file "
+                          "containing the controls for this controlSet.";
     _controlsFileNameProp.setComment(comment);
     _controlsFileNameProp.setName("controls_file");
-    _propertySet.append( &_controlsFileNameProp );
-
+    _propertySet.append(&_controlsFileNameProp);
 }
 //_____________________________________________________________________________
 /**
  * Copy the member variables of the specified controller.
  */
-void ControlSetController::copyData(const ControlSetController &aController)
-{   
+void ControlSetController::copyData(const ControlSetController& aController) {
     _controlsFileName = aController._controlsFileName;
 }
-
 
 //=============================================================================
 // OPERATORS
@@ -137,18 +124,16 @@ void ControlSetController::copyData(const ControlSetController &aController)
 /**
  * Assignment operator.
  */
-ControlSetController& ControlSetController::
-operator=(const ControlSetController &aController)
-{
+ControlSetController& ControlSetController::operator=(
+        const ControlSetController& aController) {
     // BASE CLASS
     Object::operator=(aController);
 
     // DATA
     copyData(aController);
 
-    return(*this);
+    return (*this);
 }
-
 
 //=============================================================================
 // GET AND SET
@@ -158,27 +143,30 @@ operator=(const ControlSetController &aController)
 // CONTROL
 //=============================================================================
 
-// compute the control value for all actuators this Controller is responsible for
-void ControlSetController::computeControls(const SimTK::State& s, SimTK::Vector& controls)  const
-{
-    SimTK_ASSERT( _controlSet , "ControlSetController::computeControls controlSet is NULL");
+// compute the control value for all actuators this Controller is responsible
+// for
+void ControlSetController::computeControls(
+        const SimTK::State& s, SimTK::Vector& controls) const {
+    SimTK_ASSERT(_controlSet,
+            "ControlSetController::computeControls controlSet is NULL");
 
     std::string actName;
     int index = -1;
 
     const auto& socket = getSocket<Actuator>("actuators");
     const int na = static_cast<int>(socket.getNumConnectees());
-    for(int i = 0; i < na; ++i){
+    for (int i = 0; i < na; ++i) {
         const auto& actu = socket.getConnectee(i);
         actName = actu.getName();
         index = _controlSet->getIndex(actName);
-        if(index < 0){
+        if (index < 0) {
             actName = actName + ".excitation";
             index = _controlSet->getIndex(actName);
         }
 
-        if(index >= 0){
-            SimTK::Vector actControls(1, _controlSet->get(index).getControlValue(s.getTime()));
+        if (index >= 0) {
+            SimTK::Vector actControls(
+                    1, _controlSet->get(index).getControlValue(s.getTime()));
             actu.addInControls(actControls, controls);
         }
     }
@@ -186,36 +174,38 @@ void ControlSetController::computeControls(const SimTK::State& s, SimTK::Vector&
 
 double ControlSetController::getFirstTime() const {
     Array<int> controlList;
-   SimTK_ASSERT( _controlSet , "ControlSetController::getFirstTime controlSet is NULL");
+    SimTK_ASSERT(_controlSet,
+            "ControlSetController::getFirstTime controlSet is NULL");
 
-    _controlSet->getControlList( "ControlLinear" , controlList );
-    
-    if( controlList.getSize() < 1 ) {
-       return( -SimTK::Infinity );
+    _controlSet->getControlList("ControlLinear", controlList);
+
+    if (controlList.getSize() < 1) {
+        return (-SimTK::Infinity);
     } else {
-       ControlLinear& control = (ControlLinear&)_controlSet->get(controlList[0]);
-       return( control.getFirstTime() );
+        ControlLinear& control =
+                (ControlLinear&)_controlSet->get(controlList[0]);
+        return (control.getFirstTime());
     }
 }
 
 double ControlSetController::getLastTime() const {
     Array<int> controlList;
-    _controlSet->getControlList( "ControlLinear" , controlList );
-    
-    if(controlList.getSize() < 1 ) {
-       return( SimTK::Infinity );
+    _controlSet->getControlList("ControlLinear", controlList);
+
+    if (controlList.getSize() < 1) {
+        return (SimTK::Infinity);
     } else {
-       ControlLinear& control = (ControlLinear&)_controlSet->get(controlList[0]);
-       return( control.getLastTime() );
+        ControlLinear& control =
+                (ControlLinear&)_controlSet->get(controlList[0]);
+        return (control.getLastTime());
     }
 }
 
-void ControlSetController::extendFinalizeFromProperties()
-{
+void ControlSetController::extendFinalizeFromProperties() {
     Super::extendFinalizeFromProperties();
 
     bool hasFile = !_controlsFileName.empty() &&
-                    _controlsFileName.compare("Unassigned");
+                   _controlsFileName.compare("Unassigned");
 
     // The result of default constructing and adding  this to a model
     if (_controlSet == nullptr &&  !hasFile) {
@@ -239,14 +229,14 @@ void ControlSetController::extendFinalizeFromProperties()
         // Should only catch an "UnaccessibleFileException" since we would want
         // to know if the file was corrupt or in the wrong format
         catch (const Exception& e) {
-            std::string msg = "ControlSetController::extendFinalizeFromProperties ";
-            msg += "Unable to load control set file '" + _controlsFileName + "'.";
-            msg += "\nDetails: " + std::string(e.getMessage());
-            //throw Exception(msg);
-            //TODO: Should throw a specific "UnaccessibleControlFileException"
-            //testSerializeOpenSimObjects should not expect to just add garbage filled
-            //objects (components) to a model and expect to serialize- must be changed!
-            log_error(msg);
+            // throw Exception(msg);
+            // TODO: Should throw a specific "UnaccessibleControlFileException"
+            // testSerializeOpenSimObjects should not expect to just add garbage
+            // filled objects (components) to a model and expect to serialize-
+            // must be changed!
+            log_error("ControlSetController::extendFinalizeFromProperties: "
+                      "Unable to load control set file '{}'.\nDetails: {}",
+                    _controlsFileName, e.getMessage());
         }
     }
 
@@ -282,7 +272,7 @@ void ControlSetController::extendConnectToModel(Model& model) {
                 log_cout("ControlSetController::extendConnectToModel "
                          "Actuator '{}' already connected to "
                          "ControlSetController '{}'.",
-                         actName, getName());
+                        actName, getName());
                 isConnected = true;
                 break;
             }
@@ -294,7 +284,8 @@ void ControlSetController::extendConnectToModel(Model& model) {
                 if (actu.getName() == actName) {
                     log_cout("ControlSetController::extendConnectToModel "
                              "Connecting ControlSetController '{}' to Actuator "
-                             "'{}'.", getName(), actu.getName());
+                             "'{}'.",
+                            getName(), actu.getName());
                     addActuator(actu);
                     isConnected = true;
                     break;
@@ -309,4 +300,3 @@ void ControlSetController::extendConnectToModel(Model& model) {
             actName, _controlSet->getName());
     }
 }
-

--- a/OpenSim/Simulation/Model/ExternalLoads.cpp
+++ b/OpenSim/Simulation/Model/ExternalLoads.cpp
@@ -434,13 +434,13 @@ void ExternalLoads::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNum
             if(!ifstream(_dataFileName.c_str(), ios_base::in).good()) {
             string msg =
                     "Object: Could not open file " + _dataFileName+ "IO. It may not exist or you don't have permission to read it.";
-                log_error(msg);
-                // Try switching to directory of setup file before aborting
-                if(getDocument()) {
-                    savedCwd = IO::getCwd();
-                    IO::chDir(IO::getParentDirectory(getDocument()->getFileName()));
-                    changeWorkingDir=true;
-                }
+            log_error(msg);
+            // Try switching to directory of setup file before aborting
+            if (getDocument()) {
+                savedCwd = IO::getCwd();
+                IO::chDir(IO::getParentDirectory(getDocument()->getFileName()));
+                changeWorkingDir = true;
+            }
                 if(!ifstream(_dataFileName.c_str(), ios_base::in).good()) {
                     if(changeWorkingDir) IO::chDir(savedCwd);
             throw Exception(msg,__FILE__,__LINE__);

--- a/OpenSim/Simulation/Model/Ground.cpp
+++ b/OpenSim/Simulation/Model/Ground.cpp
@@ -1,25 +1,25 @@
 /* --------------------------------------------------------------------------*
-*                             OpenSim:  Ground.cpp                           *
-* -------------------------------------------------------------------------- *
-* The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
-* See http://opensim.stanford.edu and the NOTICE file for more information.  *
-* OpenSim is developed at Stanford University and supported by the US        *
-* National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
-* through the Warrior Web program.                                           *
-*                                                                            *
-* Copyright (c) 2005-2017 Stanford University and the Authors                *
-* Author(s): Ajay Seth                                                       *
-*                                                                            *
-* Licensed under the Apache License, Version 2.0 (the "License"); you may    *
-* not use this file except in compliance with the License. You may obtain a  *
-* copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
-*                                                                            *
-* Unless required by applicable law or agreed to in writing, software        *
-* distributed under the License is distributed on an "AS IS" BASIS,          *
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
-* See the License for the specific language governing permissions and        *
-* limitations under the License.                                             *
-* -------------------------------------------------------------------------- */
+ *                             OpenSim:  Ground.cpp                           *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Author(s): Ajay Seth                                                       *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
 
 //=============================================================================
 // INCLUDES
@@ -32,17 +32,16 @@
 using namespace std;
 using namespace OpenSim;
 
-const char* Ground::GroundNameString{ "ground" };
+const char* Ground::GroundNameString{"ground"};
 
 //=============================================================================
 // CONSTRUCTOR(S)
 //=============================================================================
 //_____________________________________________________________________________
 /*
-* Default constructor.
-*/
-Ground::Ground() : PhysicalFrame()
-{
+ * Default constructor.
+ */
+Ground::Ground() : PhysicalFrame() {
     setName(GroundNameString);
     setAuthors("Ajay Seth");
 }
@@ -52,34 +51,30 @@ void Ground::extendFinalizeFromProperties() {
     Super::extendFinalizeFromProperties();
     // Ground is always named "ground"
     if (getName() != GroundNameString) {
-        std::string msg = getConcreteClassName() + " '" + getName() + "' ";
         setName(GroundNameString);
-        msg += "was renamed and is being reset to '" + getName() + "'.";
-        log_info(msg);
+        log_info("'{}' was renamed and is being reset to '{}'.",
+                getConcreteClassName(), getName());
     }
 }
 
 /*
-* Implementation of Frame interface by Ground.
-*/
-SimTK::Transform Ground::calcTransformInGround(const SimTK::State& s) const
-{
+ * Implementation of Frame interface by Ground.
+ */
+SimTK::Transform Ground::calcTransformInGround(const SimTK::State& s) const {
     return SimTK::Transform();
 }
 
-SimTK::SpatialVec Ground::calcVelocityInGround(const SimTK::State& s) const
-{
+SimTK::SpatialVec Ground::calcVelocityInGround(const SimTK::State& s) const {
     return SimTK::SpatialVec(0);
 }
 
 /** The spatial acceleration {alpha; a} for this Frame in ground */
-SimTK::SpatialVec Ground::calcAccelerationInGround(const SimTK::State& s) const
-{
+SimTK::SpatialVec Ground::calcAccelerationInGround(
+        const SimTK::State& s) const {
     return SimTK::SpatialVec(0);
 }
 
-void Ground::extendAddToSystem(SimTK::MultibodySystem& system) const
-{
+void Ground::extendAddToSystem(SimTK::MultibodySystem& system) const {
     Super::extendAddToSystem(system);
     setMobilizedBodyIndex(SimTK::GroundIndex);
 }

--- a/OpenSim/Simulation/Model/ModelComponentSet.h
+++ b/OpenSim/Simulation/Model/ModelComponentSet.h
@@ -24,10 +24,11 @@
  * -------------------------------------------------------------------------- */
 
 // INCLUDES
-#include <OpenSim/Simulation/osimSimulationDLL.h>
+#include "ModelComponent.h"
+
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Common/Set.h>
-#include "ModelComponent.h"
+#include <OpenSim/Simulation/osimSimulationDLL.h>
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -50,12 +51,12 @@ class Model;
  * @tparam  T   This must be a concrete class derived from ModelComponent.
  */
 
-template<typename T>
-using SetTModelComponent = Set<T, ModelComponent>;
+template <typename T> using SetTModelComponent = Set<T, ModelComponent>;
 
-template <class T=ModelComponent>
+template <class T = ModelComponent>
 class ModelComponentSet : public Set<T, ModelComponent> {
-    OpenSim_DECLARE_CONCRETE_OBJECT_T(ModelComponentSet, T, SetTModelComponent<T>);
+    OpenSim_DECLARE_CONCRETE_OBJECT_T(
+            ModelComponentSet, T, SetTModelComponent<T>);
 
 //============================================================================
 // METHODS
@@ -71,12 +72,10 @@ public:
         // the class name, which is also the default for the unnamed property.
         const std::string& name = this->getName();
         if (name != IO::Lowercase(getConcreteClassName())) {
-            std::string msg = getConcreteClassName() + " '" + name + "' ";
-            this->setName(IO::Lowercase(getConcreteClassName()));
-
-            msg += "was renamed and is being reset to '" + name
-                + "'.";
-            log_info(msg);
+            const std::string new_name = IO::Lowercase(getConcreteClassName());
+            this->setName(new_name);
+            log_info("'{}' was renamed and is being set to '{}'.",
+                    getConcreteClassName(), new_name);
         }
     }
 
@@ -88,4 +87,3 @@ public:
 } // end of namespace OpenSim
 
 #endif // OPENSIM_MODEL_COMPONENT_SET_H
-


### PR DESCRIPTION
Fixes issue #4066

Related:
https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/1099

For reference:
https://github.com/opensim-org/opensim-core/pull/4094 and https://github.com/opensim-org/opensim-core/pull/4157

### Brief summary of changes

With the current spdlog configuration this nasty error https://github.com/opensim-org/opensim-core/issues/4066#issuecomment-3306012803 is produced. After looking into it further, it seems to do with the compile time format string checking that the new `spdlog` + `fmt` lib is doing. This fixes the logging headers using `std::forward<Args>` so that downstream libraries can consume OpenSim without nasty compile errors.

### Testing I've completed

- Test suite
- Works with my consuming downstream project

### Looking for feedback on...
@nickbianco and @adamkewley  can you take a look?

### CHANGELOG.md (choose one)

- already updated for previous update of spdlog

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4158)
<!-- Reviewable:end -->
