### PR TITLE
Make `CustomJoint`, `SpatialTransform`, and `TransformAxis` scripting-friendly and improve formatting and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ v4.6
 - Added new concrete implementations of `ContactGeometry`: `ContactCylinder`, `ContactEllipsoid`, and `ContactTorus`. (#4115)
 - Removed the following deprecated methods from `ContactGeometry`: `getLocation()`, `setLocation()`, `getOrientation()`, `setOrientation()`, `getBody()`, and `setBody()`. (#4115)
 - Fixed `OpenSim::Marker::generateDecorations` to account for markers that are attached to bodies via other frames (#4144).
+- Added the scripting-friendly accessors `SpatialTransform::setTransformAxis()` and `CustomJoint::setSpatialTransform()`. (#4168)
 
 
 v4.5.2

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.cpp
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
  * Author(s): Frank C. Anderson, Peter Loan, Ajay Seth                        *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -21,9 +21,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-//=============================================================================
-// INCLUDES
-//=============================================================================
 #include "CustomJoint.h"
 #include "SpatialTransform.h"
 #include <OpenSim/Simulation/Model/Model.h>
@@ -32,76 +29,102 @@
 #include <OpenSim/Common/LinearFunction.h>
 #include "simbody/internal/MobilizedBody_FunctionBased.h"
 
-
-//=============================================================================
-// STATICS
-//=============================================================================
-using namespace std;
 using namespace OpenSim;
 
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
 //=============================================================================
-//_____________________________________________________________________________
-/* Default Constructor */
-CustomJoint::CustomJoint()
-{
+CustomJoint::CustomJoint() {
     constructProperties();
 }
 
-
-/**
- * Constructor with specified SpatialTransform.
- */
-CustomJoint::CustomJoint(const std::string&    name,
-                         const PhysicalFrame&  parent,
-                         const PhysicalFrame&  child,
-                         SpatialTransform&     spatialTransform) :
-                         Super(name, parent, child)
-{
+CustomJoint::CustomJoint(const std::string& name,
+        const PhysicalFrame& parent,
+        const PhysicalFrame& child,
+        const SpatialTransform& spatialTransform) :
+        Super(name, parent, child) {
     constructProperties();
     set_SpatialTransform(spatialTransform);
 }
 
-CustomJoint::CustomJoint(const std::string&    name,
-                         const PhysicalFrame&  parent,
-                         const SimTK::Vec3&    locationInParent,
-                         const SimTK::Vec3&    orientationInParent,
-                         const PhysicalFrame&  child,
-                         const SimTK::Vec3&    locationInChild,
-                         const SimTK::Vec3&    orientationInChild,
-                         SpatialTransform&     spatialTransform) :
-    Super(name, parent, locationInParent, orientationInParent,
-          child, locationInChild, orientationInChild)
-{
+CustomJoint::CustomJoint(const std::string& name,
+        const PhysicalFrame& parent,
+        const SimTK::Vec3& locationInParent,
+        const SimTK::Vec3& orientationInParent,
+        const PhysicalFrame& child,
+        const SimTK::Vec3& locationInChild,
+        const SimTK::Vec3& orientationInChild,
+        const SpatialTransform& spatialTransform) :
+        Super(name, parent, locationInParent, orientationInParent,
+                child, locationInChild, orientationInChild) {
     constructProperties();
     set_SpatialTransform(spatialTransform);
 }
 
-//_____________________________________________________________________________
-/**
- * Connect properties to local pointers.
- */
-void CustomJoint::constructProperties()
-{
-    setAuthors("Frank C. Anderson, Ajay Seth");
-    constructProperty_SpatialTransform(SpatialTransform());
+//=============================================================================
+// ACCESSOR(S)
+//=============================================================================
+const SpatialTransform& CustomJoint::getSpatialTransform() const {
+    return get_SpatialTransform();
 }
 
-/*
- * Perform some set up functions that happen after the
- * object has been deserialized or copied.
- */
-void CustomJoint::extendFinalizeFromProperties()
-{
+SpatialTransform& CustomJoint::updSpatialTransform() {
+    return upd_SpatialTransform();
+}
+
+void CustomJoint::setSpatialTransform(const SpatialTransform& transform) {
+    set_SpatialTransform(transform);
+}
+
+const Coordinate& CustomJoint::getCoordinate(unsigned idx) const {
+    OPENSIM_THROW_IF(numCoordinates() == 0,
+                     JointHasNoCoordinates);
+    OPENSIM_THROW_IF((int)idx > numCoordinates()-1,
+                     InvalidCall,
+                     "Index passed to getCoordinate() exceeds the largest "
+                     "index available");
+
+    return get_coordinates(idx);
+}
+
+Coordinate& CustomJoint::updCoordinate(unsigned idx) {
+    OPENSIM_THROW_IF(numCoordinates() == 0,
+                     JointHasNoCoordinates);
+    OPENSIM_THROW_IF((int)idx > numCoordinates()-1,
+                     InvalidCall,
+                     "Index passed to updCoordinate() exceeds the largest "
+                     "index available");
+
+    return upd_coordinates(idx);
+}
+
+//=============================================================================
+// MODEL COMPONENT INTERFACE
+//=============================================================================
+void CustomJoint::extendScale(const SimTK::State& s, const ScaleSet& scaleSet) {
+    Super::extendScale(s, scaleSet);
+
+    // Get scale factors (if an entry for the parent Frame's base Body exists).
+    const SimTK::Vec3& scaleFactors =
+            getScaleFactors(scaleSet, getParentFrame());
+    if (scaleFactors == ModelComponent::InvalidScaleFactors)
+        return;
+
+    //TODO: Need to scale transforms appropriately, given an arbitrary axis.
+    updSpatialTransform().scale(scaleFactors);
+}
+
+void CustomJoint::extendFinalizeFromProperties() {
     Super::extendFinalizeFromProperties();
 
-    //CustomJoint can only construct the coordinates once SpatialTransform is specified 
+    // CustomJoint can only construct the coordinates once the SpatialTransform
+    // is specified.
     constructCoordinates();
 
-    // Axes should be independent otherwise Simbody throws an exception in extendAddToSystem
+    // Axes should be independent otherwise Simbody throws an exception in
+    // extendAddToSystem.
     double tol = 1e-5;
-    // Verify that none of the rotation axes are collinear
+    // Verify that none of the rotation axes are collinear.
     const std::vector<SimTK::Vec3> axes = getSpatialTransform().getAxes();
     for (int startIndex = 0; startIndex <= 3; startIndex += 3) {
         if (((axes[startIndex + 0] % axes[startIndex + 1]).norm() < tol) ||
@@ -118,25 +141,203 @@ void CustomJoint::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
     // SpatialTransform "connect" methods are poorly named. This
-    // establishing the SpatialTransform and its Transform axes as 
+    // establishing the SpatialTransform and its Transform axes as
     // sub objects (not updated to Components) of the CustomJoint and this
     // should be done here.
     /* Set up spatial transform for this custom joint. */
     updSpatialTransform().connectToJoint(*this);
 }
 
-void CustomJoint::extendScale(const SimTK::State& s, const ScaleSet& scaleSet)
+
+void CustomJoint::extendAddToSystem(SimTK::MultibodySystem& system) const
 {
-    Super::extendScale(s, scaleSet);
+    Super::extendAddToSystem(system);
 
-    // Get scale factors (if an entry for the parent Frame's base Body exists).
-    const SimTK::Vec3& scaleFactors =
-            getScaleFactors(scaleSet, getParentFrame());
-    if (scaleFactors == ModelComponent::InvalidScaleFactors)
-        return;
+    SimTK::MobilizedBody inb;
+    SimTK::Body outb;
+    SimTK::Transform inbX = getParentFrame().findTransformInBaseFrame();
+    SimTK::Transform outbX = getChildFrame().findTransformInBaseFrame();
+    const OpenSim::PhysicalFrame* mobilized = &getChildFrame();
+    // if the joint is reversed then flip the underlying tree representation
+    // of inboard and outboard bodies, although the joint direction will be
+    // preserved, the inboard must exist first.
+    if (isReversed){
+        inb = getChildFrame().getMobilizedBody();
+        inbX = getChildFrame().findTransformInBaseFrame();
 
-    //TODO: Need to scale transforms appropriately, given an arbitrary axis.
-    updSpatialTransform().scale(scaleFactors);
+        outb = getParentInternalRigidBody();
+        outbX = getParentFrame().findTransformInBaseFrame();
+
+        mobilized = &getParentFrame();
+    }
+    else{
+        inb = getParentFrame().getMobilizedBody();
+        outb = getChildInternalRigidBody();
+    }
+
+    const Array<std::string>& coordNames =
+            getSpatialTransform().getCoordinateNames();
+
+    // Some initializations
+    // Note: should check that all coordinates are used.
+    const int numCoords = numCoordinates();
+    std::vector<std::vector<int> > coordinateIndices =
+        getSpatialTransform().getCoordinateIndices();
+    std::vector<const SimTK::Function*> functions =
+        getSpatialTransform().getFunctions();
+    std::vector<SimTK::Vec3> axes = getSpatialTransform().getAxes();
+
+    SimTK_ASSERT1(numCoords == coordNames.getSize(),
+        "%s list of coordinates does not match number of mobilities.",
+        getConcreteClassName().c_str());
+
+    SimTK_ASSERT1(numCoords > 0,
+        "%s must have 1 or more mobilities (dofs).",
+                  getConcreteClassName().c_str());
+
+    SimTK_ASSERT1(numCoords <= 6,
+        "%s cannot exceed 6 mobilities (dofs).",
+        getConcreteClassName().c_str());
+    OPENSIM_ASSERT_FRMOBJ(functions.size() == 6);
+
+    SimTK_ASSERT2(numCoords <= 6,
+        "%s::%s must specify functions for complete spatial (6 axes) motion.",
+        getConcreteClassName().c_str(),
+                  getSpatialTransform().getConcreteClassName().c_str());
+    OPENSIM_ASSERT_FRMOBJ(coordinateIndices.size() == 6);
+
+    SimTK_ASSERT2(axes.size() == 6,
+        "%s::%s must specify 6 independent axes to span spatial motion.",
+        getConcreteClassName().c_str(),
+        getSpatialTransform().getConcreteClassName().c_str());
+
+    SimTK::MobilizedBody::Direction dir =
+        SimTK::MobilizedBody::Direction(isReversed);
+
+    SimTK::MobilizedBody::FunctionBased
+        simtkBody(inb, inbX,
+                  outb, outbX,
+                    numCoords, functions,
+                  coordinateIndices, axes, dir);
+
+    assignSystemIndicesToBodyAndCoordinates(simtkBody, mobilized, numCoords, 0);
+}
+
+//=============================================================================
+// OBJECT INTERFACE
+//=============================================================================
+void CustomJoint::updateFromXMLNode(SimTK::Xml::Element& aNode,
+        int versionNumber) {
+    int documentVersion = versionNumber;
+    if ( documentVersion < XMLDocument::getLatestVersion()){
+        log_debug("Updating CustomJoint to latest format...");
+        // Version before refactoring spatialTransform
+        if (documentVersion<10901){
+            // replace TransformAxisSet with SpatialTransform
+            /////renameChildNode("TransformAxisSet", "SpatialTransform");
+            // Check how many TransformAxes are defined
+            SimTK::Xml::element_iterator spatialTransformNode =
+                aNode.element_begin("TransformAxisSet");
+            if (spatialTransformNode == aNode.element_end()) return;
+
+            SimTK::Xml::element_iterator axesSetNode =
+                spatialTransformNode->element_begin("objects");
+            /////if (axesSetNode != NULL)
+            /////   spatialTransformNode->removeChild(axesSetNode);
+            /////DOMElement*grpNode = XMLNode::GetFirstChildElementByTagName(spatialTransformNode,"groups");
+            /////if (grpNode != NULL)
+            /////   spatialTransformNode->removeChild(grpNode);
+            // (0, 1, 2 rotations & 3, 4, 5 translations then remove the is_rotation node)
+            SimTK::Array_<SimTK::Xml::Element> list =
+                axesSetNode->getAllElements();
+            unsigned int listLength = list.size();
+            //int objectsFound = 0;
+            Array<int> translationIndices(-1, 0);
+            Array<int>  rotationIndices(-1, 0);
+            int nextAxis = 0;
+            std::vector<TransformAxis *> axes;
+            // Add children for all six axes here
+            //////_node->removeChild(SpatialTransformNode);
+
+            // Create a blank Spatial Transform and use it to populate the
+            // XML structure
+            for(int i=0; i<6; i++)
+                updSpatialTransform()[i].setFunction(new OpenSim::Constant(0));
+
+            Array<OpenSim::TransformAxis*> oldAxes;
+            for(unsigned int j=0;j<listLength;j++) {
+                // getChildNodes() returns all types of DOMNodes including
+                // comments, text, etc., but we only want
+                // to process element nodes
+                SimTK::Xml::Element objElmt = list[j];
+                std::string objectType = objElmt.getElementTag();
+                // (sherm) this is cleaning up old TransformAxis here but
+                // that should really be done in TransformAxis instead.
+                if (objectType == "TransformAxis"){
+                    OpenSim::TransformAxis* readAxis =
+                        new OpenSim::TransformAxis(objElmt);
+                    OPENSIM_ASSERT_FRMOBJ(nextAxis <=5);
+                    bool isRotation = false;
+                    SimTK::Xml::element_iterator rotationNode =
+                        objElmt.element_begin("is_rotation");
+                    if (rotationNode != objElmt.element_end()){
+                        SimTK::String sValue =
+                            rotationNode->getValueAs<SimTK::String>();
+                        bool value = (sValue.toLower() == "true");
+                                isRotation = value;
+                        objElmt.eraseNode(rotationNode);
+                            }
+                    SimTK::Xml::element_iterator coordinateNode =
+                        objElmt.element_begin("coordinate");
+                    SimTK::String coordinateName =
+                        coordinateNode->getValueAs<SimTK::String>();
+                    Array<std::string> names("");
+                    names.append(coordinateName);
+                    readAxis->setCoordinateNames(names);
+                    SimTK::Xml::element_iterator axisNode =
+                        objElmt.element_begin("axis");
+
+                    SimTK::Vec3 axisVec= axisNode->getValueAs<SimTK::Vec3>();
+                    readAxis->setAxis(axisVec);
+                    if (isRotation){
+                        rotationIndices.append(nextAxis);
+                    }
+                    else {
+                        translationIndices.append(nextAxis);
+                    }
+                    axes.push_back(readAxis);
+                    nextAxis++;
+                }
+            }
+            OPENSIM_ASSERT_FRMOBJ(rotationIndices.getSize() <=3);
+            OPENSIM_ASSERT_FRMOBJ(translationIndices.getSize() <=3);
+            //XMLNode::RemoveChildren(SpatialTransformAxesNode);
+            int nRotations = rotationIndices.getSize();
+            int nTranslations = translationIndices.getSize();
+            // Now copy coordinateName, Axis, Function into proper slot
+            for (int i=0; i<nRotations; i++){
+                updSpatialTransform()[i] = *axes[rotationIndices[i]];
+            }
+            updSpatialTransform().constructIndependentAxes(nRotations, 0);
+            // Add Translations from old list then pad with default ones,
+            // make sure no singularity.
+            for (int i=0; i<nTranslations; i++){
+                updSpatialTransform()[i+3] = *axes[translationIndices[i]];
+            }
+            updSpatialTransform().constructIndependentAxes(nTranslations, 3);
+        }
+    }
+
+    // Delegate to superclass now.
+    Super::updateFromXMLNode(aNode, versionNumber);
+}
+
+//=============================================================================
+// CONVENIENCE METHODS
+//=============================================================================
+void CustomJoint::constructProperties() {
+    setAuthors("Frank C. Anderson, Ajay Seth");
+    constructProperty_SpatialTransform(SpatialTransform());
 }
 
 void CustomJoint::constructCoordinates()
@@ -156,12 +357,12 @@ void CustomJoint::constructCoordinates()
         // in XML)
         int coordIndex = getProperty_coordinates().findIndexForName(coordName);
         if (coordIndex < 0) {
-            coordIndex =
-                    constructCoordinate(Coordinate::MotionType::Undefined, i);
-        } else { 
-            // Coordinate was defined in XML, make sure the order in spatialTransform
-            // matches the order in the XML file/property
-            coordinatesInTransformOrder = coordinatesInTransformOrder && 
+            coordIndex = constructCoordinate(
+                    Coordinate::MotionType::Undefined, i);
+        } else {
+            // Coordinate was defined in XML, make sure the order in
+            // spatialTransform matches the order in the XML file/property
+            coordinatesInTransformOrder = coordinatesInTransformOrder &&
                     coordIndex == i;
             coordIndices.push_back(coordIndex);
         }
@@ -188,9 +389,9 @@ void CustomJoint::constructCoordinates()
                     {
                         // coordinate is pure axis displacement
                         if (j < 3)
-                            // coordinate about rotational axis 
+                            // coordinate about rotational axis
                             mt = Coordinate::MotionType::Rotational;
-                        else // otherwise translational axis 
+                        else // otherwise translational axis
                             mt = Coordinate::MotionType::Translational;
                     } else {
                         // scaled (slope != +/-1) or nonlinear relationship
@@ -237,195 +438,7 @@ void CustomJoint::constructCoordinates()
                      .empty())
                 updProperty_coordinates()[ix].set_prescribed_function(
                         *(newCoord.get_prescribed_function().clone()));
-            
+
         }
     }
-}
-
-//=============================================================================
-// Simbody Model building.
-//=============================================================================
-//_____________________________________________________________________________
-void CustomJoint::extendAddToSystem(SimTK::MultibodySystem& system) const
-{
-    Super::extendAddToSystem(system);
-
-    SimTK::MobilizedBody inb;
-    SimTK::Body outb;
-    SimTK::Transform inbX = getParentFrame().findTransformInBaseFrame();
-    SimTK::Transform outbX = getChildFrame().findTransformInBaseFrame();
-    const OpenSim::PhysicalFrame* mobilized = &getChildFrame();
-    // if the joint is reversed then flip the underlying tree representation
-    // of inboard and outboard bodies, although the joint direction will be 
-    // preserved, the inboard must exist first.
-    if (isReversed){
-        inb = getChildFrame().getMobilizedBody();
-        inbX = getChildFrame().findTransformInBaseFrame();
-
-        outb = getParentInternalRigidBody();
-        outbX = getParentFrame().findTransformInBaseFrame();
-
-        mobilized = &getParentFrame();
-    }
-    else{
-        inb = getParentFrame().getMobilizedBody();
-        outb = getChildInternalRigidBody();
-    }
-
-    const Array<std::string>& coordNames = getSpatialTransform().getCoordinateNames();
-
-    // Some initializations
-    const int numCoords = numCoordinates();  // Note- should check that all coordinates are used.
-    std::vector<std::vector<int> > coordinateIndices =
-        getSpatialTransform().getCoordinateIndices();
-    std::vector<const SimTK::Function*> functions =
-        getSpatialTransform().getFunctions();
-    std::vector<SimTK::Vec3> axes = getSpatialTransform().getAxes();
-
-    SimTK_ASSERT1(numCoords == coordNames.getSize(),
-        "%s list of coordinates does not match number of mobilities.",
-        getConcreteClassName().c_str());
-
-    SimTK_ASSERT1(numCoords > 0,
-        "%s must have 1 or more mobilities (dofs).",
-                  getConcreteClassName().c_str());
-
-    SimTK_ASSERT1(numCoords <= 6,
-        "%s cannot exceed 6 mobilities (dofs).",
-        getConcreteClassName().c_str());
-    OPENSIM_ASSERT_FRMOBJ(functions.size() == 6);
-
-    SimTK_ASSERT2(numCoords <= 6,
-        "%s::%s must specify functions for complete spatial (6 axes) motion.",
-        getConcreteClassName().c_str(),
-                  getSpatialTransform().getConcreteClassName().c_str());
-    OPENSIM_ASSERT_FRMOBJ(coordinateIndices.size() == 6);
-
-    SimTK_ASSERT2(axes.size() == 6,
-        "%s::%s must specify 6 independent axes to span spatial motion.",
-        getConcreteClassName().c_str(), getSpatialTransform().getConcreteClassName().c_str());
-
-    SimTK::MobilizedBody::Direction dir =
-        SimTK::MobilizedBody::Direction(isReversed);
-
-    SimTK::MobilizedBody::FunctionBased
-        simtkBody(inb, inbX, 
-                  outb, outbX, 
-                    numCoords, functions,
-                  coordinateIndices, axes, dir);
-
-    assignSystemIndicesToBodyAndCoordinates(simtkBody, mobilized, numCoords, 0);
-}
-
-//=============================================================================
-// Utilities for versioning
-//=============================================================================
-//_____________________________________________________________________________
-
-/** Override of the default implementation to account for versioning. */
-void CustomJoint::
-updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
-{
-    int documentVersion = versionNumber;
-    if ( documentVersion < XMLDocument::getLatestVersion()){
-        log_debug("Updating CustomJoint to latest format...");
-        // Version before refactoring spatialTransform
-        if (documentVersion<10901){
-            // replace TransformAxisSet with SpatialTransform
-            /////renameChildNode("TransformAxisSet", "SpatialTransform");
-            // Check how many TransformAxes are defined
-            SimTK::Xml::element_iterator spatialTransformNode = 
-                aNode.element_begin("TransformAxisSet");
-            if (spatialTransformNode == aNode.element_end()) return;
-
-            SimTK::Xml::element_iterator axesSetNode = 
-                spatialTransformNode->element_begin("objects");
-            /////if (axesSetNode != NULL)
-            /////   spatialTransformNode->removeChild(axesSetNode);
-            /////DOMElement*grpNode = XMLNode::GetFirstChildElementByTagName(spatialTransformNode,"groups");
-            /////if (grpNode != NULL)
-            /////   spatialTransformNode->removeChild(grpNode);
-            // (0, 1, 2 rotations & 3, 4, 5 translations then remove the is_rotation node)
-            SimTK::Array_<SimTK::Xml::Element> list = 
-                axesSetNode->getAllElements();
-            unsigned int listLength = list.size();
-            //int objectsFound = 0;
-            Array<int> translationIndices(-1, 0);
-            Array<int>  rotationIndices(-1, 0);
-            int nextAxis = 0;
-            std::vector<TransformAxis *> axes;
-            // Add children for all six axes here
-            //////_node->removeChild(SpatialTransformNode);
-            
-            // Create a blank Spatial Transform and use it to populate the 
-            // XML structure
-            for(int i=0; i<6; i++)
-                updSpatialTransform()[i].setFunction(new OpenSim::Constant(0));
-            
-            Array<OpenSim::TransformAxis*> oldAxes;
-            for(unsigned int j=0;j<listLength;j++) {
-                // getChildNodes() returns all types of DOMNodes including 
-                // comments, text, etc., but we only want
-                // to process element nodes
-                SimTK::Xml::Element objElmt = list[j];
-                string objectType = objElmt.getElementTag();
-                // (sherm) this is cleaning up old TransformAxis here but
-                // that should really be done in TransformAxis instead.
-                if (objectType == "TransformAxis"){
-                    OpenSim::TransformAxis* readAxis = 
-                        new OpenSim::TransformAxis(objElmt);
-                    OPENSIM_ASSERT_FRMOBJ(nextAxis <=5);
-                    bool isRotation = false;
-                    SimTK::Xml::element_iterator rotationNode = 
-                        objElmt.element_begin("is_rotation");
-                    if (rotationNode != objElmt.element_end()){
-                        SimTK::String sValue = 
-                            rotationNode->getValueAs<SimTK::String>();
-                        bool value = (sValue.toLower() == "true");
-                                isRotation = value;
-                        objElmt.eraseNode(rotationNode);
-                            }
-                    SimTK::Xml::element_iterator coordinateNode = 
-                        objElmt.element_begin("coordinate");
-                    SimTK::String coordinateName = 
-                        coordinateNode->getValueAs<SimTK::String>();
-                    Array<std::string> names("");
-                    names.append(coordinateName);
-                    readAxis->setCoordinateNames(names);
-                    SimTK::Xml::element_iterator axisNode = 
-                        objElmt.element_begin("axis");
-                    
-                    SimTK::Vec3 axisVec= axisNode->getValueAs<SimTK::Vec3>();
-                    readAxis->setAxis(axisVec);
-                    if (isRotation){
-                        rotationIndices.append(nextAxis);
-                    }
-                    else {
-                        translationIndices.append(nextAxis);
-                    }
-                    axes.push_back(readAxis);
-                    nextAxis++;
-                }
-            }
-            OPENSIM_ASSERT_FRMOBJ(rotationIndices.getSize() <=3);
-            OPENSIM_ASSERT_FRMOBJ(translationIndices.getSize() <=3);
-            //XMLNode::RemoveChildren(SpatialTransformAxesNode);
-            int nRotations = rotationIndices.getSize();
-            int nTranslations = translationIndices.getSize();
-            // Now copy coordinateName, Axis, Function into proper slot
-            for (int i=0; i<nRotations; i++){
-                updSpatialTransform()[i] = *axes[rotationIndices[i]];
-            }
-            updSpatialTransform().constructIndependentAxes(nRotations, 0);
-            // Add Translations from old list then pad with default ones, 
-            // make sure no singularity.
-            for (int i=0; i<nTranslations; i++){
-                updSpatialTransform()[i+3] = *axes[translationIndices[i]];
-            }
-            updSpatialTransform().constructIndependentAxes(nTranslations, 3);
-        }
-    }
-
-    // Delegate to superclass now.
-    Super::updateFromXMLNode(aNode, versionNumber);
 }

--- a/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/CustomJoint.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
  * Author(s): Frank C. Anderson, Ajay Seth                                    *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -23,127 +23,136 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include "Joint.h"
 
 namespace OpenSim {
 
 class SpatialTransform;
 
-//==============================================================================
-//                              CUSTOM JOINT
-//==============================================================================
 /**
-A class implementing a custom joint.  The underlying implementation in Simbody 
-is a SimTK::MobilizedBody::FunctionBased. Custom joints offer a generic joint
-representation, which can be used to model both conventional (pins, slider,
-universal, etc.) as well as more complex biomechanical joints. The behavior of
-a custom joint is specified by its SpatialTransform. A SpatialTransform is com-
-prised of 6 TransformAxes (3 rotations and 3 translations) that define the
-spatial position of Child in Parent as a function of coordinates. Each transform
-axis has a function of joint coordinates that describes the motion about or along
-the transform axis. The order of the spatial transform is fixed with rotations
-first followed by translations. Subsequently, coupled motion (i.e., describing
-motion of two degrees of freedom as a function of one coordinate) is handled by
-transform axis functions that depend on the same coordinate(s).
-
-@author Ajay Seth, Frank C. Anderson
+ * A class implementing a custom joint.
+ *
+ * The underlying implementation in Simbody is a
+ * `SimTK::MobilizedBody::FunctionBased`. `CustomJoint`s offer a generic joint
+ * representation, which can be used to model both conventional (pins, slider,
+ * universal, etc.) as well as more complex biomechanical joints.
+ *
+ * The behavior of a `CustomJoint` is specified by its `SpatialTransform`. A
+ * `SpatialTransform` is comprised of 6 `TransformAxis` objects (3 rotations and
+ * 3 translations) that define the spatial position of the child body in the
+ * parent body frame as a function of the joint's coordinates. Each transform
+ * axis has a `Function` of joint coordinates that describes the motion about or
+ * along the `TransformAxis`. The order of the `SpatialTransform` is fixed with
+ * rotations first followed by translations. Subsequently, coupled motion (i.e.,
+ * describing motion of two degrees of freedom as a function of one coordinate)
+ * is handled by `TransformAxis` functions that depend on the same
+ * coordinate(s).
+ *
+ * @author Ajay Seth, Frank C. Anderson
 */
 class OSIMSIMULATION_API CustomJoint : public Joint {
 OpenSim_DECLARE_CONCRETE_OBJECT(CustomJoint, Joint);
-
 public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-
-    /** Spatial transform defining how the child body moves with respect
-    to the parent body as a function of the generalized coordinates.
-    Motion over 6 (independent) spatial axes must be defined. */
     OpenSim_DECLARE_UNNAMED_PROPERTY(SpatialTransform,
-        "Defines how the child body moves with respect to the parent as "
-        "a function of the generalized coordinates.");
+        "The spatial transform defining how the child body moves with respect"
+        "to the parent as a function of the generalized coordinates.");
 
 //==============================================================================
-// PUBLIC METHODS
+// METHODS
 //==============================================================================
-    // CONSTRUCTION
-    /** Default Constructor */
+    /**
+     * Default constructor.
+     */
     CustomJoint();
 
-    /** Construct joint with supplied coordinates and transform axes */
-    CustomJoint(const std::string&    name,
-                const PhysicalFrame&  parent,
-                const PhysicalFrame&  child,
-                SpatialTransform&     spatialTransform);
+    /**
+     * Construct joint with supplied coordinates and transform axes.
+     */
+    CustomJoint(const std::string& name,
+            const PhysicalFrame& parent,
+            const PhysicalFrame& child,
+            const SpatialTransform& spatialTransform);
 
-    /** Joint constructor with explicit parent and child offsets in terms of
-        their location and orientation. */
-    CustomJoint(const std::string&    name,
-                const PhysicalFrame&  parent,
-                const SimTK::Vec3&    locationInParent,
-                const SimTK::Vec3&    orientationInParent,
-                const PhysicalFrame&  child,
-                const SimTK::Vec3&    locationInChild,
-                const SimTK::Vec3&    orientationInChild,
-                SpatialTransform&     spatialTransform);
+    /**
+     * Joint constructor with explicit parent and child offsets in terms of
+     * their location and orientation.
+     */
+    CustomJoint(const std::string& name,
+            const PhysicalFrame& parent,
+            const SimTK::Vec3& locationInParent,
+            const SimTK::Vec3& orientationInParent,
+            const PhysicalFrame& child,
+            const SimTK::Vec3& locationInChild,
+            const SimTK::Vec3& orientationInChild,
+            const SpatialTransform& spatialTransform);
 
-    // default destructor, copy constructor, copy assignment
 
-    // Get and Set Transforms
-    const SpatialTransform& getSpatialTransform() const
-    {   return get_SpatialTransform(); }
-    SpatialTransform& updSpatialTransform()
-    {   return upd_SpatialTransform(); }
+    //** @name Accessors */
+    // @{
+    /**
+     * Get the `SpatialTransform` defining the joint motion.
+     */
+    const SpatialTransform& getSpatialTransform() const;
 
-    /** Exposes getCoordinate() method defined in base class (overloaded below).
-        @see Joint */
+    /**
+     * Update the `SpatialTransform` defining the joint motion.
+     */
+    SpatialTransform& updSpatialTransform();
+
+    /**
+     * Set the `SpatialTransform` defining the joint motion.
+     */
+    void setSpatialTransform(const SpatialTransform& transform);
+
+    /**
+     * Exposes getCoordinate() method defined in base class (overloaded below).
+     * @see Joint
+     */
     using Joint::getCoordinate;
 
-    /** Exposes updCoordinate() method defined in base class (overloaded below).
-        @see Joint */
+    /**
+     * Exposes updCoordinate() method defined in base class (overloaded below).
+     * @see Joint
+     */
     using Joint::updCoordinate;
 
-    /** Get a const reference to a Coordinate associated with this Joint. */
-    const Coordinate& getCoordinate(unsigned idx) const {
-        OPENSIM_THROW_IF(numCoordinates() == 0,
-                         JointHasNoCoordinates);
-        OPENSIM_THROW_IF((int)idx > numCoordinates()-1,
-                         InvalidCall,
-                         "Index passed to getCoordinate() exceeds the largest "
-                         "index available");
+    /**
+     * Get a const reference to a Coordinate associated with this Joint.
+     */
+    const Coordinate& getCoordinate(unsigned idx) const;
 
-        return get_coordinates(idx);
-    }
+    /**
+     * Get a writable reference to a Coordinate associated with this Joint.
+     */
+    Coordinate& updCoordinate(unsigned idx);
 
-    /** Get a writable reference to a Coordinate associated with this Joint. */
-    Coordinate& updCoordinate(unsigned idx) {
-        OPENSIM_THROW_IF(numCoordinates() == 0,
-                         JointHasNoCoordinates);
-        OPENSIM_THROW_IF(idx >= static_cast<unsigned>(numCoordinates()),
-                         InvalidCall,
-                         "Index passed to updCoordinate() exceeds the largest "
-                         "index available");
+    // @}
 
-        return upd_coordinates(idx);
-    }
-
-    // SCALE
+    //** @name ModelComponent interface */
+    // @{
     void extendScale(const SimTK::State& s, const ScaleSet& scaleSet) override;
+    // @}
 
-    /** Override of the default implementation to account for versioning. */
-    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1)
-        override;
+    //** @name Object interface */
+    // @{
+    void updateFromXMLNode(SimTK::Xml::Element& aNode,
+            int versionNumber=-1) override;
+    // @}
 
 private:
-    // ModelComponent extension interface
+    // MODEL COMPONENT INTERFACE
     void extendFinalizeFromProperties() override;
     void extendConnectToModel(Model& aModel) override;
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
 
+    // CONVENIENCE METHODS
     void constructProperties();
 
-    // Construct coordinates according to the SpatialTransform of the CustomJoint
+    // Construct coordinates according to the SpatialTransform of the
+    // CustomJoint.
     void constructCoordinates();
 
     template <typename T>
@@ -151,21 +160,18 @@ private:
         const SimTK::Transform& inboardTransform,
         const SimTK::Body& outboard,
         const SimTK::Transform& outboardTransform,
-        int& startingCoorinateIndex) const {};
+        int startingCoorinateIndex) const {};
 
-//==============================================================================
-};  // END of class CustomJoint
-//==============================================================================
-//==============================================================================
+};  // class CustomJoint
+
+// Template specialization for `SimTK::MobilizedBody::FunctionBased`.
 template <>
 SimTK::MobilizedBody::FunctionBased
-    CustomJoint::createMobilizedBody<SimTK::MobilizedBody::FunctionBased>(
-                            SimTK::MobilizedBody& inboard,
-                            const SimTK::Transform& inboardTransform,
-                            const SimTK::Body& outboard,
-                            const SimTK::Transform& outboardTransform,
-                            int& startingCoorinateIndex) const;
+CustomJoint::createMobilizedBody<SimTK::MobilizedBody::FunctionBased>(
+        SimTK::MobilizedBody& inboard, const SimTK::Transform& inboardTransform,
+        const SimTK::Body& outboard, const SimTK::Transform& outboardTransform,
+        int startingCoordinateIndex) const;
 
-} // end of namespace OpenSim
+} // namespace OpenSim
 
 #endif // OPENSIM_CUSTOM_JOINT_H_

--- a/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SpatialTransform.cpp
@@ -20,59 +20,45 @@
  * See the License for the specific language governing permissions and        *
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
+
 #include "SpatialTransform.h"
+#include "CustomJoint.h"
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/MultiplierFunction.h>
 #include <OpenSim/Common/LinearFunction.h>
 
-using namespace std;
+
 using namespace OpenSim;
-using namespace SimTK;
-
 
 //=============================================================================
-// DESTRUCTOR AND CONSTRUCTORS
+// CONSTRUCTOR(S)
 //=============================================================================
-
-//_____________________________________________________________________________
-/*
- * Default constructor of a SpatialTransform.
- */
-SpatialTransform::SpatialTransform()
-{
-    setNull();
+SpatialTransform::SpatialTransform() {
+    setAuthors("Ajay Seth");
     constructProperties();
 }
 
-//=============================================================================
-// CONSTRUCTION METHODS
-//=============================================================================
-/**
- * Set the data members of this SpatialTransform to their null values.
- */
-void SpatialTransform::setNull()
-{
-    setAuthors("Ajay Seth");
-}
-
-//_____________________________________________________________________________
-/**
- * Initialize properties.
- */
 void SpatialTransform::constructProperties()
 {
-    constructProperty_rotation1(TransformAxis(Array<string>(), Vec3(1,0,0)));
-    constructProperty_rotation2(TransformAxis(Array<string>(), Vec3(0,1,0)));
-    constructProperty_rotation3(TransformAxis(Array<string>(), Vec3(0,0,1)));
-    constructProperty_translation1(TransformAxis(Array<string>(), Vec3(1,0,0)));
-    constructProperty_translation2(TransformAxis(Array<string>(), Vec3(0,1,0)));
-    constructProperty_translation3(TransformAxis(Array<string>(), Vec3(0,0,1)));
+    constructProperty_rotation1(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(1, 0, 0)));
+    constructProperty_rotation2(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(0, 1, 0)));
+    constructProperty_rotation3(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(0, 0, 1)));
+    constructProperty_translation1(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(1, 0, 0)));
+    constructProperty_translation2(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(0, 1, 0)));
+    constructProperty_translation3(
+            TransformAxis(Array<std::string>(), SimTK::Vec3(0, 0, 1)));
 }
 
-
-const TransformAxis& SpatialTransform::getTransformAxis(int whichAxis) const
-{
-     switch(whichAxis){
+//=============================================================================
+// ACCESSOR(S)
+//=============================================================================
+const TransformAxis& SpatialTransform::getTransformAxis(int whichAxis) const {
+     switch (whichAxis) {
         case 0: return get_rotation1();
         case 1: return get_rotation2();
         case 2: return get_rotation3();
@@ -80,13 +66,14 @@ const TransformAxis& SpatialTransform::getTransformAxis(int whichAxis) const
         case 4: return get_translation2();
         case 5: return get_translation3();
         default:
-            throw Exception("SpatialTransform: Attempting to access beyond 6 axes.");
+            OPENSIM_THROW_FRMOBJ(Exception, "Invalid axis index {}. Please "
+                    "specify an index between 0 and 5, as there are only six "
+                    "TransformAxis objects in a SpatialTransform.", whichAxis);
      }
 }
 
-TransformAxis& SpatialTransform::updTransformAxis(int whichAxis)
-{
-     switch(whichAxis){
+TransformAxis& SpatialTransform::updTransformAxis(int whichAxis) {
+     switch (whichAxis) {
         case 0: return upd_rotation1();
         case 1: return upd_rotation2();
         case 2: return upd_rotation3();
@@ -94,97 +81,97 @@ TransformAxis& SpatialTransform::updTransformAxis(int whichAxis)
         case 4: return upd_translation2();
         case 5: return upd_translation3();
         default:
-            throw Exception("SpatialTransform: Attempting to access beyond 6 axes.");
+            OPENSIM_THROW_FRMOBJ(Exception, "Invalid axis index {}. Please "
+                    "specify an index between 0 and 5, as there are only six "
+                    "TransformAxis objects in a SpatialTransform.", whichAxis);
      }
 }
 
-// SETUP
-void SpatialTransform::connectToJoint(CustomJoint& owningJoint)
-{
-    // define default function for TransformAxes that have none specified
-    for(int i=0; i < NumTransformAxes; ++i) {
-        TransformAxis& transform = updTransformAxis(i);
-
-        // check if it has a function
-        if(!transform.hasFunction()){
-            // does it have a coordinate?
-            if(transform.getCoordinateNames().size() == 1)
-                transform.setFunction(new LinearFunction());
-            else if(transform.getCoordinateNames().size() > 1)
-                throw Exception("TransformAxis: an appropriate multi-coordinate function was not supplied");
-            else
-                transform.setFunction(new Constant());
-        }
-
-        // Ask the transform axis to connect itself to the joint.
-        transform.connectToJoint(*((Joint*)(&owningJoint)));
-    }
+void SpatialTransform::setTransformAxis(int whichAxis,
+            const TransformAxis& axis) {
+     switch (whichAxis) {
+        case 0: set_rotation1(axis); break;
+        case 1: set_rotation2(axis); break;
+        case 2: set_rotation3(axis); break;
+        case 3: set_translation1(axis); break;
+        case 4: set_translation2(axis); break;
+        case 5: set_translation3(axis); break;
+        default:
+            OPENSIM_THROW_FRMOBJ(Exception, "Invalid axis index {}. Please "
+                    "specify an index between 0 and 5, as there are only six "
+                    "TransformAxis objects in a SpatialTransform.", whichAxis);
+     }
 }
 
-// Spatial Transform specific methods
-OpenSim::Array<string> SpatialTransform::getCoordinateNames() const
-{
-    OpenSim::Array<string> coordinateNames;
+const TransformAxis& SpatialTransform::operator[](int whichAxis) const{
+    return getTransformAxis(whichAxis);
+}
 
-    for(int i=0; i < NumTransformAxes; i++){
+TransformAxis& SpatialTransform::operator[](int whichAxis) {
+    return updTransformAxis(whichAxis);
+}
+
+std::vector<std::vector<int>> SpatialTransform::getCoordinateIndices() const {
+    std::vector<std::vector<int>> coordIndices(6);
+    Array<std::string> coordinateNames = getCoordinateNames();
+    for (int i = 0; i < NumTransformAxes; i++) {
         const TransformAxis& transform = getTransformAxis(i);
-        for(int j = 0; j < transform.getCoordinateNames().size(); j++){
-            string name = transform.getCoordinateNames()[j];
-            if(coordinateNames.findIndex(name) < 0)
+        // Get the number of coordinates that dictate motion along this axis.
+        int ncoords = transform.getCoordinateNames().size();
+        std::vector<int> findex(ncoords);
+        for (int j = 0; j < ncoords; j++) {
+            int ind = coordinateNames.findIndex(
+                    transform.getCoordinateNames()[j]);
+            if (ind > -1) {
+                findex[j] = ind;
+            }
+        }
+        coordIndices[i] = findex;
+    }
+    return coordIndices;
+}
+
+Array<std::string> SpatialTransform::getCoordinateNames() const {
+    Array<std::string> coordinateNames;
+    for (int i = 0; i < NumTransformAxes; i++) {
+        const TransformAxis& transform = getTransformAxis(i);
+        for (int j = 0; j < transform.getCoordinateNames().size(); j++) {
+            std::string name = transform.getCoordinateNames()[j];
+            if (coordinateNames.findIndex(name) < 0)
                 coordinateNames.append(name);
         }
     }
     return coordinateNames;
 }
 
-std::vector<std::vector<int> > SpatialTransform::getCoordinateIndices() const
-{
-    std::vector<std::vector<int> > coordIndices(6);
-    Array<string> coordinateNames = getCoordinateNames();
-
-    for(int i=0; i < NumTransformAxes; i++){
-        const TransformAxis& transform = getTransformAxis(i);
-        // Get the number of coordinates that dictate motion along this axis
-        int ncoords = transform.getCoordinateNames().size();
-        std::vector<int> findex(ncoords);
-        for(int j=0; j< ncoords; j++){
-            int ind = coordinateNames.findIndex(transform.getCoordinateNames()[j]);
-            if (ind > -1)
-                findex[j] = ind;
-        }
-        coordIndices[i] = findex;   
-    }
-    
-    return coordIndices;
-}
-std::vector<const SimTK::Function*> SpatialTransform::getFunctions() const
-{
+std::vector<const SimTK::Function*> SpatialTransform::getFunctions() const {
     std::vector<const SimTK::Function*> functions(NumTransformAxes);
     for(int i=0; i < NumTransformAxes; i++){
         functions[i] = getTransformAxis(i).getFunction().createSimTKFunction();
     }
     return functions;
 }
-std::vector<SimTK::Vec3> SpatialTransform::getAxes() const
-{
+
+std::vector<SimTK::Vec3> SpatialTransform::getAxes() const {
     std::vector<SimTK::Vec3> axes(NumTransformAxes);
     for(int i=0; i<NumTransformAxes; i++){
         axes[i] = getTransformAxis(i).getAxis();
     }
-
     return axes;
 }
 
-
-void SpatialTransform::scale(const SimTK::Vec3 scaleFactors)
-{
+//=============================================================================
+// SCALING
+//=============================================================================
+void SpatialTransform::scale(const SimTK::Vec3 scaleFactors) {
     // Scale the spatial transform functions of translations only
     for (int i = 3; i < NumTransformAxes; i++) {
         TransformAxis& transform = updTransformAxis(i);
         if (transform.hasFunction()) {
             Function& function = transform.updFunction();
-            // If the function is a linear function with coefficients of 1.0 and 0.0, do
-            // not scale it because this transform axis represents a degree of freedom.
+            // If the function is a linear function with coefficients of 1.0 and
+            // 0.0, do not scale it because this transform axis represents a
+            // degree of freedom.
             LinearFunction* lf = dynamic_cast<LinearFunction*>(&function);
             if (lf) {
                 const Array<double> coefficients = lf->getCoefficients();
@@ -193,17 +180,18 @@ void SpatialTransform::scale(const SimTK::Vec3 scaleFactors)
             }
             SimTK::Vec3 axis;
             transform.getAxis(axis);
-            // we want weighted aggregate of scale factors but to ignore the sign
-            // ignoring sign due to issue #3991 resulting -ve scale factor
+            // we want weighted aggregate of scale factors but to ignore the
+            // sign ignoring sign due to issue #3991 resulting -ve scale
+            // factor
             double scaleFactor = ~axis.abs() * scaleFactors;
-            // If the function is already a MultiplierFunction, just update its scale factor.
-            // Otherwise, make a MultiplierFunction from it and make the transform axis use
-            // the new MultiplierFunction.
-            MultiplierFunction* mf = dynamic_cast<MultiplierFunction*>(&function);
+            // If the function is already a MultiplierFunction, just update its
+            // scale factor. Otherwise, make a MultiplierFunction from it and
+            // make the transform axis use the new MultiplierFunction.
+            MultiplierFunction* mf =
+                    dynamic_cast<MultiplierFunction*>(&function);
             if (mf) {
                 mf->setScale(mf->getScale() * scaleFactor);
-            } 
-            else {
+            } else {
                 mf = new MultiplierFunction();
                 mf->setScale(scaleFactor);
                 // Make a copy of the original function and delete the original
@@ -214,29 +202,56 @@ void SpatialTransform::scale(const SimTK::Vec3 scaleFactors)
         }
     }
 }
-/**
- * constructIndependentAxes checks if the TransformAxis at indices startIndex, 
- * startIndex+1, startIndex+2 
- * are independent and fixes them otherwise. It assumes that the first nAxes are ok
- */
+
+//=============================================================================
+// CUSTOM JOINT METHODS
+//=============================================================================
+void SpatialTransform::connectToJoint(CustomJoint& owningJoint) {
+    // define default function for TransformAxes that have none specified
+    for (int i = 0; i < NumTransformAxes; ++i) {
+        TransformAxis& transform = updTransformAxis(i);
+        // check if it has a function
+        if (!transform.hasFunction()) {
+            // does it have a coordinate?
+            if (transform.getCoordinateNames().size() == 1) {
+                transform.setFunction(new LinearFunction());
+            } else if (transform.getCoordinateNames().size() > 1) {
+                OPENSIM_THROW_FRMOBJ(Exception,
+                    "CustomJoint {} TransformAxis {} has multiple coordinates "
+                    "but no function specified. Please specify an appropriate "
+                    "multi-coordinate function.",
+                    owningJoint.getName(), transform.getName());
+            } else {
+                transform.setFunction(new Constant());
+            }
+        }
+        // Ask the transform axis to connect itself to the joint.
+        transform.connectToJoint(*((Joint*)(&owningJoint)));
+    }
+}
+
+// This method checks if the TransformAxis at indexes startIndex, startIndex+1,
+// startIndex+2 are independent and fixes them otherwise. It assumes that the
+// first nAxes are OK.
 void SpatialTransform::constructIndependentAxes(int nAxes, int startIndex)
 {
     if (nAxes == 3 || nAxes==0) return;     // Nothing to do
-    Vec3 v1 = getTransformAxis(0+startIndex).getAxis();
-    Vec3 v2 = getTransformAxis(1+startIndex).getAxis();
-    Vec3 v3 = getTransformAxis(2+startIndex).getAxis();
+    SimTK::Vec3 v1 = getTransformAxis(0+startIndex).getAxis();
+    SimTK::Vec3 v2 = getTransformAxis(1+startIndex).getAxis();
+    SimTK::Vec3 v3 = getTransformAxis(2+startIndex).getAxis();
     if (nAxes ==2){ // Easy, make third axis the cross of the first 2.
         SimTK::Vec3 cross= (v1 % v2);
         cross.normalize();
         updTransformAxis(2+startIndex).setAxis(cross);
-    }
-    else {  // only v1 was specified, check if v2 is collinear if so, exchange v2, v3
+    } else {
+        // only v1 was specified, check if v2 is collinear if so, exchange v2,
+        // v3
         if (fabs(fabs(~v1 * v2) -1) < 1e-4){
             updTransformAxis(1+startIndex).setAxis(v3);
         }
         v2 = getTransformAxis(1+startIndex).getAxis();
         SimTK::Vec3 cross= (v2 % v1);
         cross.normalize();
-        updTransformAxis(2+startIndex).setAxis(cross);  
+        updTransformAxis(2+startIndex).setAxis(cross);
     }
 }

--- a/OpenSim/Simulation/SimbodyEngine/SpatialTransform.h
+++ b/OpenSim/Simulation/SimbodyEngine/SpatialTransform.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
  * Author(s): Ajay Seth                                                       *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -30,96 +30,147 @@ namespace OpenSim {
 class TransformAxis;
 class CustomJoint;
 
-//==============================================================================
-//                           SPATIAL TRANSFORM
-//==============================================================================
 /**
- * A class encapsulating the spatial transformation between two bodies that 
+ * A class encapsulating the spatial transformation between two bodies that
  * defines the behavior of a custom joint.
  *
  * @authors Ajay Seth
  */
-
 class OSIMSIMULATION_API SpatialTransform : public Object {
 OpenSim_DECLARE_CONCRETE_OBJECT(SpatialTransform, Object);
 public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-    /** Define the individual transform axes (6) that specify the spatial 
-    transform; each is a TransformAxis object. **/
+    /**
+     * Define the six individual transform axes that specify the spatial
+     * transform (rotational and translational). Each is a TransformAxis
+     * object.
+     */
     OpenSim_DECLARE_PROPERTY(rotation1, TransformAxis,
-        "3 Axes for rotations are listed first.");
+        "The first TransformAxis defining a rotation about an axis with "
+        "to a set of generalized coordinates.");
     OpenSim_DECLARE_PROPERTY(rotation2, TransformAxis,
-        "");
+        "The second TransformAxis defining a rotation about an axis with "
+        "to a set of generalized coordinates.");
     OpenSim_DECLARE_PROPERTY(rotation3, TransformAxis,
-        "");
+        "The third TransformAxis defining a rotation about an axis with "
+        "to a set of generalized coordinates.");
     OpenSim_DECLARE_PROPERTY(translation1, TransformAxis,
-        "3 Axes for translations are listed next.");
+        "The first TransformAxis defining a translation along an axis with "
+        "to a set of generalized coordinates.");
     OpenSim_DECLARE_PROPERTY(translation2, TransformAxis,
-        "");
+        "The second TransformAxis defining a translation along an axis with "
+        "to a set of generalized coordinates.");
     OpenSim_DECLARE_PROPERTY(translation3, TransformAxis,
-        "");
+        "The third TransformAxis defining a translation along an axis with "
+        "to a set of generalized coordinates.");
 
 //==============================================================================
-// PUBLIC METHODS
+// METHODS
 //==============================================================================
+    /**
+     * Default constructor.
+     */
     SpatialTransform();
 
-    // default destructor, copy constructor, copy assignment
+    //** @name Accessors */
+    // @{
+
+    /**
+     * Get one TransformAxis from an index in [0, 5], where rotation is first
+     * (0, 1, 2), followed by translation (3, 4, 5). An exception is thrown if
+     * the index is out of range.
+     */
+    const TransformAxis& getTransformAxis(int whichAxis) const;
+
+    /**
+     * Get a writable reference to one TransformAxis from an index in [0, 5],
+     * where rotation is first (0, 1, 2), followed by translation (3, 4, 5). An
+     * exception is thrown if the index is out of range.
+     */
+    TransformAxis& updTransformAxis(int whichAxis);
+
+    /**
+     * Set the TransformAxis at the specified index [0, 5]. An exception is
+     * thrown if the index is out of range.
+     */
+    void setTransformAxis(int whichAxis, const TransformAxis& axis);
+
+    #ifndef SWIG
+    /// @copydoc getTransformAxis()
+    const TransformAxis& operator[](int whichAxis) const;
+
+    /// @copydoc updTransformAxis()
+    TransformAxis& operator[](int whichAxis);
+
+    /**
+     * Construct a list of the coordinate indexes that dictate the motion of
+     * each TransformAxis in this SpatialTransform.
+     *
+     * The outer vector is of size 6 (one entry per TransformAxis) and each
+     * inner vector contains the indices of the coordinates (in the Model's
+     * CoordinateSet) that affect motion along/about that axis. Therefore,
+     * accessing the 3 coordinate of the first TransformAxis would be:
+     *
+     * @code{.cpp}
+     * int coordinateIndex = getCoordinateIndices()[0][2];
+     * @endcode
+     */
+    std::vector<std::vector<int>> getCoordinateIndices() const;
+    #endif
+
+    /**
+     * Construct a list of all unique coordinate names used by any of the
+     * contained TransformAxis objects.
+     **/
+    Array<std::string> getCoordinateNames() const;
+
+    /**
+     * Create a new SimTK::Function corresponding to each axis.
+     *
+     * @note These are heap allocated; it is up to the caller to delete them.
+     */
+    std::vector<const SimTK::Function*> getFunctions() const;
+
+    /**
+     * Get the axis direction associated with each TransformAxis.
+     */
+    std::vector<SimTK::Vec3> getAxes() const;
+
+    /// @}
+
+    //** @name Scaling */
+    // @{
+
+    /**
+     * Scale the spatial transform functions of translations only.
+     */
+    void scale(const SimTK::Vec3 scaleFactors);
+
+    // @}
+
+    //** @name CustomJoint methods */
+    // @{
 
     /** This tells the SpatialTransform the CustomJoint to which it belongs;
     this is not copied on copy construction or assignment. **/
     void connectToJoint(CustomJoint& owningJoint);
 
+
     /** Make sure axes are not parallel. **/
     void constructIndependentAxes(int nAxes, int startIndex);
 
-    // Spatial Transform specific methods
-
-    /** Construct a list of all unique coordinate names used by any of the
-    contained TransformAxis objects. **/
-    OpenSim::Array<std::string> getCoordinateNames() const;
-    /** For each axis, construct a list of the coordinate indices that dictate
-    motion along that axis. **/
-#ifndef SWIG
-    std::vector<std::vector<int> > getCoordinateIndices() const;
-#endif
-    /** Create a new SimTK::Function corresponding to each axis; these are
-    heap allocated and it is up to the caller to delete them. **/
-    std::vector<const SimTK::Function*> getFunctions() const;
-    /** Get the axis direction associated with each TransformAxis. **/
-    std::vector<SimTK::Vec3> getAxes() const;
-
-    // SCALE
-    void scale(const SimTK::Vec3 scaleFactors);
-
-    /** Select one of the 6 axis, numbered 0-5 with rotation first, then
-    translation. **/
-    const TransformAxis& getTransformAxis(int whichAxis) const;
-    /** Same, but returns a writable reference to the TransformAxis. **/
-    TransformAxis& updTransformAxis(int whichAxis);
-
-    #ifndef SWIG
-    /** Same as getTransformAxis(). **/
-    const TransformAxis& operator[](int whichAxis) const
-    {   return getTransformAxis(whichAxis); }
-    /** Same as updTransformAxis(). **/
-    TransformAxis& operator[](int whichAxis) 
-    {   return updTransformAxis(whichAxis); }
-    #endif
+    // @}
 
 private:
-    void setNull();
     void constructProperties();
 
+    // There are exactly six TransformAxis objects.
     static const int NumTransformAxes = 6;
 
-//==============================================================================
-};  // END of class SpatialTransform
-//==============================================================================
-//==============================================================================
+};  // class SpatialTransform
 
-} // end of namespace OpenSim
+} // namespace OpenSim
 
 #endif // OPENSIM_SPATIAL_TRANSFORM_H_

--- a/OpenSim/Simulation/SimbodyEngine/TransformAxis.h
+++ b/OpenSim/Simulation/SimbodyEngine/TransformAxis.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
  * Author(s): Peter Loan, Frank C. Anderson, Jeffrey A. Reinbolt, Ajay Seth   *
  *            Michael Sherman                                                 *
  *                                                                            *
@@ -24,7 +24,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Common/Function.h>
@@ -35,13 +34,10 @@ namespace OpenSim {
 
 class Joint;
 
-//==============================================================================
-//                            TRANSFORM AXIS
-//==============================================================================
 /**
  * A class expressing a transformation of a child body in relation to a parent
  * body along either a translation or about a rotation axis. The TransformAxis
- * function specified the spatial displacement that is achieved as a function
+ * function specifies the spatial displacement that is achieved as a function
  * of the generalized coordinate(s).
  *
  * @author Peter Loan, Frank C. Anderson, Jeffrey A. Reinbolt, Ajay Seth,
@@ -53,138 +49,174 @@ public:
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-    /** The "coordinates" property holds a list of strings representing the
-    generalized coordinate names that serve as the independent variables of
-    the transform function. **/
     OpenSim_DECLARE_LIST_PROPERTY(coordinates, std::string,
-        "Names of the coordinates that serve as the independent variables \
-        of the transform function.");
+            "The names of the generalized coordinates that serve as the "
+            "independent variables of the transform function.");
 
-    /** The "axis" property holds the axis direction of the rotation or 
-    translation axis of the transform as a Vec3. **/
     OpenSim_DECLARE_PROPERTY(axis, SimTK::Vec3,
-       "Rotation or translation axis for the transform.");
+            "The rotation or translation axis for the transform. "
+            "Default: (1,0,0).");
 
-    /** The "function" property holds the transform function of the 
-    generalized coordinate(s) used to represent the amount of displacement 
-    about/along the specified axis. If none is specified a Constant function
-    is applied. **/
     OpenSim_DECLARE_PROPERTY(function, Function,
-       "Transform function of the generalized coordinates used to \
-       represent the amount of displacement along a specified axis.");
+            "The transform function with respect to the generalized "
+            "coordinates used to represent the amount of displacement about or "
+            "along the TransformAxis. Default: Constant(0).");
 
 //==============================================================================
-// PUBLIC METHODS
+// METHODS
 //==============================================================================
+    /**
+     * Default constructor.
+     */
     TransformAxis();
-    TransformAxis(const Array<std::string>& coordNames, 
-                  const SimTK::Vec3&        axis);
+
+    /**
+     * Construct a TransformAxis with the specified coordinate names and axis.
+     * The function is set to a Constant(0) by default.
+     * @param coordNames   Names of the generalized coordinates that affect
+     *                     motion along this axis.
+     * @param axis         The rotation or translation axis for the transform.
+     */
+    TransformAxis(const Array<std::string>& coordNames,
+            const SimTK::Vec3& axis);
+
+    /**
+     * Construct a TransformAxis from an XML element node.
+     */
     explicit TransformAxis(SimTK::Xml::Element& node);
 
-    // Uses default (compiler-generated) destructor, copy constructor, and copy
-    // assignment operator.
+    //** @name Accessors */
+    // @{
 
-    /** %Set the names of the generalized coordinates that affect the motion
-    along the axis controlled by this %TransformAxis object.
-    @param coordNames   Names of the generalized coordinates. **/
-    void setCoordinateNames(const Array<std::string>& coordNames) 
-    {   set_coordinates(coordNames); }
-    
-    /** Get the generalized coordinate names associated with this object.
-    The returned value is a references to the Property\<string> that contains
-    the list of coordinate names.
-    @see get_coordinates() **/
-    const Property<std::string>& getCoordinateNames() const 
-    {   return getProperty_coordinates(); }
+    /**
+     * %Set the names of the generalized coordinates that serve as the
+     * independent variables of the Function in this TransformAxis object.
+     *
+     * @param coordNames   Names of the generalized coordinates.
+     */
+    void setCoordinateNames(const Array<std::string>& coordNames);
 
-    /** Copy the coordinate names into an OpenSim::Array for convenience. **/
-    // The GUI uses this.
-    Array<std::string> getCoordinateNamesInArray() const {
-        Array<std::string> coords;
-        for (int i=0; i < getProperty_coordinates().size(); ++i)
-            coords.append(get_coordinates(i));
-        return coords;
-    }
+    /**
+     * Get the names of the generalized coordinates that serve as the
+     * independent variables of the Function in this TransformAxis object.
+     *
+     * The returned value is a references to the Property\<std::string> that
+     * contains the list of coordinate names.
+     *
+     * @see get_coordinates()
+     */
+    const Property<std::string>& getCoordinateNames() const;
 
-    /** %Set the value of the "axis" property. **/
-    void setAxis(const SimTK::Vec3& axis) 
-    {   set_axis(axis); }
+    /**
+     * Get a copy of the coordinate names returned as an OpenSim::Array.
+     **/
+    Array<std::string> getCoordinateNamesInArray() const;
 
-    /** Return the current value of the "axis" property. **/
-    const SimTK::Vec3& getAxis() const
-    {   return get_axis(); }
+    /**
+     * %Set the rotation or translation axis for the transform.
+     */
+    void setAxis(const SimTK::Vec3& axis);
 
-    /** Alternate signature that writes the axis value to its argument. **/
-    void getAxis(SimTK::Vec3& axis) const {axis = getAxis();}
-    /** Get one component (0,1, or 2) of the axis vector. **/
-    double getAxis(int which) const 
-    {   OPENSIM_ASSERT_FRMOBJ(0<=which && which<=2); return getAxis()[which]; }
+    /**
+     * Get the rotation or translation axis for the transform.
+     */
+    const SimTK::Vec3& getAxis() const;
+    /// @copydoc getAxis() const
+    void getAxis(SimTK::Vec3& axis) const;
 
-    /** Determine whether a custom function has been specified to map between 
-    the generalized coordinate and the amount of transformation along the 
-    specified axis. **/
-    bool hasFunction() const 
-    {   return !getProperty_function().empty();}
+    /**
+     * Get one component (0, 1, or 2) of the axis vector.
+     */
+    double getAxis(int which) const;
 
-    /** Get the custom function that maps between the generalized coordinates 
-    and the amount of displacement along the specified axis. If no function 
-    has been specified, this throws an exception; check first with hasFunction()
-    if you aren't sure. **/
+    /**
+     * Determine whether user-supplied function is present in the "function"
+     * property.
+     *
+     * This returns false if the property contains the default Constant(0)
+     * function, and true if it contains any other function.
+     */
+    bool hasFunction() const;
+
+    /**
+     * Get the transform function with respect to the generalized
+     * coordinates used to represent the amount of displacement about or
+     * along the TransformAxis.
+     */
     const Function& getFunction() const;
-    /** Get writable access to the transform function. **/
+
+    /**
+     * Get writable access to the transform function with respect to the
+     * generalized coordinates used to represent the amount of displacement
+     * about or along the TransformAxis.
+     */
     Function& updFunction();
 
-    /** %Set the custom function that maps between the generalized coordinates 
-    and the amount of displacement about/along the specified axis. This object 
-    adopts ownership of the Function object, don't delete it yourself! It will
-    be deleted when this %TransformAxis object is deleted. **/
+    /**
+     * %Set the transform function with respect to the generalized coordinates
+     * used to represent the amount of displacement about or along the
+     * TransformAxis.
+     *
+     * @note The TransformAxis adopts ownership of the Function object. Do not
+     * delete it yourself! It will be deleted when the TransformAxis object is
+     * deleted.
+     */
     void setFunction(Function* function);
 
-    /** %Set the custom function that maps between the generalized coordinates
-    and the amount of transformation about/along the specified axis. This method 
-    creates a \e copy of the supplied Function object, which is unaffected.
-    Use the other signature if you want this %TransformAxis to take over 
-    ownership of the Function object. **/
+    /**
+     * %Set the custom function that maps between the generalized coordinates
+     * and the amount of transformation about/along the specified axis.
+     *
+     * @note This method creates a \e copy of the supplied Function object. Use
+     * TransformAxis::setFunction(Function*) if you want the TransformAxis to
+     * take ownership of the Function object.
+     */
     void setFunction(const Function& function);
 
-    /** Return a reference to the Joint to which this %TransformAxis 
-    applies. **/
-    const Joint& getJoint() const { return *_joint; }
+    /**
+     * Return a reference to the Joint to which this TransformAxis applies.
+     */
+    const Joint& getJoint() const;
 
-    double getValue(const SimTK::State& s );
+    /**
+     * Get the current value of the transform.
+     */
+    double getValue(const SimTK::State& s);
 
+    // @}
 
-    /** Connect the %TransformAxis to its owning Joint after the model has
-    been deserialized or copied. **/
+    //** @name Joint methods */
+    // @{
+    /**
+     * Connect the TransformAxis to its owning Joint after the model has been
+     * deserialized or copied.
+     */
     void connectToJoint(const Joint& owningJoint);
+    // @}
 
 private:
+    // OBJECT INTERFACE
     // Override virtual method from Object to give us a chance to replace the
-    // deprecated property name "coordinate" (if it appears in \a node) with 
+    // deprecated property name "coordinate" (if it appears in \a node) with
     // the current property name "coordinates". Then we'll invoke the base
     // class implementation.
-    void updateFromXMLNode(SimTK::Xml::Element& node, 
-                           int                  versionNumber=-1) override;
+    void updateFromXMLNode(SimTK::Xml::Element& node,
+            int versionNumber=-1) override;
 
-    void setNull();
+    // CONVENIENCE METHODS
     void constructProperties();
+    // Set the data members of this TransformAxis to their null values.
+    void setNull();
 
-
-//==============================================================================
-// DATA
-//==============================================================================
-private:
+    // DATA
     // Pointer to the joint to which the coordinates belong. This is just a
-    // reference -- don't delete it! ReferencePtr means it is zeroed on 
+    // reference -- don't delete it! ReferencePtr means it is zeroed on
     // construction, copy construction, and copy assignment.
     SimTK::ReferencePtr<const Joint> _joint;
 
+};  // class TransformAxis
 
-//==============================================================================
-};  // END of class TransformAxis
-//==============================================================================
-
-} // end of namespace OpenSim
+} // namespace OpenSim
 
 #endif // OPENSIM_TRANSFORM_AXIS_H_
 


### PR DESCRIPTION
Fixes issue #4166

### Brief summary of changes

- Updated the `CustomJoint` constructors to take a `const SpatialTransform&`, rather than `SpatialTransform&`.
- Added the scripting-friendly accessors `SpatialTransform::setTransformAxis()` and `CustomJoint::setSpatialTransform()`.
- Improved documentation and formatting in `CustomJoint`, `SpatialTransform`, and `TransformAxis`.

### Testing I've completed

Ran test suite.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4168)
<!-- Reviewable:end -->
