### PR TITLE
Implement `generateDecorations()` for `Station`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ v4.6
 Scholz et al. (2015). This class encapsulates `SimTK::CableSpan`, the Simbody implementation of the core wrapping algorithm, and provides support for using this method to define the
 geometry for path-based OpenSim components (e.g., `Muscle`, `PathSpring`, etc.). This class can be used as a replacement for `GeometryPath`, providing improved computational
 performance and stability in wrapping solutions.
+- Implemented `generateDecorations()` for `Station` to allow visualization in the Simbody visualizer. (#4169)
 
 
 v4.5.2

--- a/OpenSim/Common/ModelDisplayHints.h
+++ b/OpenSim/Common/ModelDisplayHints.h
@@ -49,6 +49,7 @@ your component produces. The currently-supported flags are:
   - show muscle paths (should apply to other path objects too)
   - show path points
   - show markers
+  - show stations
   - show forces
   - show frames
   - show labels
@@ -87,6 +88,10 @@ public:
 
     OpenSim_DECLARE_PROPERTY(show_markers, bool,
         "Flag to indicate whether or not to show markers, default to true.");
+
+    OpenSim_DECLARE_PROPERTY(show_stations, bool,
+        "Flag to indicate whether or not to show stations, default to false.");
+
     OpenSim_DECLARE_PROPERTY(marker_color, SimTK::Vec3,
         "Color is RGB, each components is in the range [0, 1], default to pink.");
 
@@ -119,6 +124,7 @@ private:
         constructProperty_show_path_geometry(true);
         constructProperty_show_path_points(true);
         constructProperty_show_markers(true);
+        constructProperty_show_stations(false);
         constructProperty_marker_color(SimTK::Vec3(1, .6, .8));
         constructProperty_show_frames(false);
         constructProperty_show_labels(false);

--- a/OpenSim/Simulation/Model/Marker.cpp
+++ b/OpenSim/Simulation/Model/Marker.cpp
@@ -160,20 +160,18 @@ void Marker::updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber)
     Super::updateFromXMLNode(aNode, versionNumber);
 }
 
-void Marker::generateDecorations(bool fixed, const ModelDisplayHints& hints, const SimTK::State& state,
-    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
-{
-    Super::generateDecorations(fixed, hints, state, appendToThis);
+void Marker::generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& state,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const {
     if (!fixed) return;
     if (!hints.get_show_markers()) return;
-    
+
     // @TODO default color, size, shape should be obtained from hints
     const Vec3 color = hints.get_marker_color();
     const OpenSim::PhysicalFrame& frame = getParentFrame();
-    appendToThis.push_back(
+    geometry.push_back(
         SimTK::DecorativeSphere(.01).setBodyId(frame.getMobilizedBodyIndex())
-        .setColor(color).setOpacity(1.0)
-        .setTransform(frame.findTransformInBaseFrame() * get_location())
-        .setScaleFactors(Vec3(1)));
-    
+            .setColor(color).setOpacity(1.0)
+            .setTransform(frame.findTransformInBaseFrame() * get_location())
+            .setScaleFactors(Vec3(1)));
 }

--- a/OpenSim/Simulation/Model/Marker.h
+++ b/OpenSim/Simulation/Model/Marker.h
@@ -89,11 +89,13 @@ public:
     /** Override of the default implementation to account for versioning. */
     void updateFromXMLNode(SimTK::Xml::Element& aNode,
         int versionNumber = -1) override;
-    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& state,
-        SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
 
 private:
+    // STATION INTERFACE
+    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
+            const SimTK::State& state,
+            SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+
     void setNull();
     void constructProperties();
 //=============================================================================

--- a/OpenSim/Simulation/Model/Station.h
+++ b/OpenSim/Simulation/Model/Station.h
@@ -9,8 +9,8 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2017 Stanford University and the Authors                *
- * Author(s): Ayman Habib                                                     *
+ * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Author(s): Ayman Habib, Ajay Seth                                          *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -23,18 +23,15 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include "OpenSim/Simulation/Model/Point.h"
 #include <OpenSim/Simulation/Model/PhysicalFrame.h>
 
 namespace OpenSim {
 
-//=============================================================================
-//=============================================================================
 /**
  * A Station is a Point fixed to and located on a PhysicalFrame, which can be
- * a Body, Ground or any PhysicalOffsetFrame. Stations are analogous to
- * PhyscialOffsetFrames where joints, constraints and forces can be attached
+ * a Body, Ground or any PhysicalOffsetFrame. Station%s are analogous to
+ * PhysicalOffsetFrame%s where joints, constraints and forces can be attached
  * and/or applied.
  *
  * @author Ayman Habib, Ajay Seth
@@ -42,60 +39,99 @@ namespace OpenSim {
 class OSIMSIMULATION_API Station : public Point {
 OpenSim_DECLARE_CONCRETE_OBJECT(Station, Point);
 public:
-    //==============================================================================
-    // PROPERTIES
-    //==============================================================================
+//==============================================================================
+// PROPERTIES
+//==============================================================================
     OpenSim_DECLARE_PROPERTY(location, SimTK::Vec3,
         "The fixed location of the station expressed in its parent frame.");
+
+//==============================================================================
+// SOCKETS
+//==============================================================================
     OpenSim_DECLARE_SOCKET(parent_frame, PhysicalFrame,
         "The frame to which this station is fixed.");
 
+//==============================================================================
+// METHODS
+//==============================================================================
 public:
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
-    /** Default constructor */
+    /**
+     * Default constructor.
+     */
     Station();
 
-    /** Convenience constructor
-    @param[in] frame     PhysicalFrame in which the Station is located.
-    @param[in] location  Vec3 location of the station in its PhysicalFrame */
+    /** Convenience constructor.
+     *
+     * @param[in] frame     PhysicalFrame in which the Station is located.
+     * @param[in] location  Vec3 location of the station in its PhysicalFrame.
+     */
     Station(const PhysicalFrame& frame, const SimTK::Vec3& location);
 
+    /**
+     * Destructor.
+     */
     virtual ~Station();
 
-    /** get the parent PhysicalFrame in which the Station is defined */
+    //** @name Accessors */
+    // @{
+
+    /**
+     * Get the parent PhysicalFrame in which the Station is defined.
+     */
     const PhysicalFrame& getParentFrame() const;
-    /** set the parent PhysicalFrame in which the Station is defined */
+
+    /**
+     * Set the parent PhysicalFrame in which the Station is defined.
+     */
     void setParentFrame(const OpenSim::PhysicalFrame& aFrame);
 
-    /** Find this Station's location in any Frame */
+    /**
+     * Find this Station's location in any Frame.
+     */
     SimTK::Vec3 findLocationInFrame(const SimTK::State& s,
                                     const OpenSim::Frame& frame) const;
 
+    // @}
+
+    //** @name ModelComponent interface */
+    // @{
     void extendScale(const SimTK::State& s, const ScaleSet& scaleSet) override;
+    // @}
+
+    //** @name Component interface */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+            const SimTK::State& state,
+            SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
+protected:
+    // STATION INTERFACE
+    // Derived classes of Station may override this method to
+    // customize `generateDecorations()`.
+    virtual void generateDecorationsImpl(
+            bool fixed, const ModelDisplayHints& hints,
+            const SimTK::State& state,
+            SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const;
 
 private:
-    /* Calculate the Station's location with respect to and expressed in Ground
-    */
+    // POINT INTERFACE
+    // Calculate the Station's location with respect to and expressed in Ground.
     SimTK::Vec3 calcLocationInGround(const SimTK::State& state) const override;
-    /* Calculate the velocity of this Station with respect to and expressed in
-       Ground as a function of the state. */
+    // Calculate the velocity of this Station with respect to and expressed in
+    // Ground as a function of the state.
     SimTK::Vec3 calcVelocityInGround(const SimTK::State& state) const override;
-    /* Calculate the acceleration of this Station with respect to and 
-        expressed in ground as a function of the state. */
-    SimTK::Vec3 calcAccelerationInGround(const SimTK::State& state) const override;
+    // Calculate the acceleration of this Station with respect to and
+    // expressed in ground as a function of the state.
+    SimTK::Vec3 calcAccelerationInGround(
+            const SimTK::State& state) const override;
 
+    // CONVENIENCE METHODS
     void setNull();
     void constructProperties();
 
-//=============================================================================
-};  // END of class Station
-//=============================================================================
-//=============================================================================
+}; // class Station
 
-} // end of namespace OpenSim
+} // namespace OpenSim
 
 #endif // OPENSIM_STATION_H_
-
-


### PR DESCRIPTION
Fixes issue #4165

### Brief summary of changes

Implemented `generateDecorations()` for `Station`. Modified `Marker::generateDecorations()` so that the `Station` decorations do not override the `Marker` decorations. 

### Testing I've completed

Ran test suite.

### Looking for feedback on...

Is there a better way to solve the issue where `Station` decorations override the `Marker` decorations?  Should we just not call `Super::generateDecorations(fixed, hints, state, appendToThis)` inside `Marker::generateDecorations()`? (That feels wrong though...)

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4169)
<!-- Reviewable:end -->
