### PR TITLE
Add `StationDefinedFrame` to the bindings

### DIFF
--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -17,6 +17,7 @@
 #include <OpenSim/Simulation/Model/Ground.h>
 #include <OpenSim/Simulation/Model/OffsetFrame.h>
 #include <OpenSim/Simulation/Model/PhysicalOffsetFrame.h>
+#include <OpenSim/Simulation/Model/StationDefinedFrame.h>
 
 #include <OpenSim/Simulation/Model/Force.h>
 #include <OpenSim/Simulation/Model/ForceProducer.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -35,6 +35,7 @@
 %template(SetFrames) OpenSim::Set<OpenSim::Frame, OpenSim::ModelComponent>;
 %template(ModelComponentSetFrames)
 OpenSim::ModelComponentSet<OpenSim::Frame>;
+%include <OpenSim/Simulation/Model/StationDefinedFrame.h>
 
 %include <OpenSim/Simulation/SimbodyEngine/Body.h>
 %template(SetBodies) OpenSim::Set<OpenSim::Body, OpenSim::ModelComponent>;


### PR DESCRIPTION
### Brief summary of changes

Adds `StationDefinedFrame` to the bindings to be accessible in MATLAB and Python.

### Testing I've completed

Tested locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...minor fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4172)
<!-- Reviewable:end -->
