### PR TITLE
#include missing DecorativeGeometry header in Appearance.h

### DIFF
--- a/OpenSim/Simulation/Model/Appearance.h
+++ b/OpenSim/Simulation/Model/Appearance.h
@@ -28,6 +28,7 @@
 #include <OpenSim/Simulation/osimSimulationDLL.h>
 #include <OpenSim/Common/Object.h>
 #include <OpenSim/Common/XMLDocument.h>
+#include <SimTKcommon/internal/DecorativeGeometry.h>
 
 namespace OpenSim {
 


### PR DESCRIPTION
Fixes issue N/A

### Brief summary of changes

Upstreams minor patch from [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator), which `#include`s `Appearance.h` in its sources, but that sometimes doesn't work because the header doesn't include its dependency on simbody's DecorativeGeometry header

### Testing I've completed

- Works downstream, minor change

### Looking for feedback on...

N/A

### CHANGELOG.md

- no need to update because it's very minor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4173)
<!-- Reviewable:end -->
