### PR TITLE
Fix use-after-free violation in OpenSim::Model

### DIFF
--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -798,11 +798,13 @@ void Model::extendFinalizeFromProperties()
 {
     Super::extendFinalizeFromProperties();
 
-    // wipe-out the existing System
+    // wipe-out the existing System: make sure to wipe subsystems first
     _matter.reset();
     _forceSubsystem.reset();
     _contactSubsystem.reset();
-    _system.reset();
+    _cableSubsystem.reset();
+
+    _system.reset();  // after wiping all subsystems
 
     if(getForceSet().getSize()>0)
     {

--- a/OpenSim/Simulation/Model/Model.h
+++ b/OpenSim/Simulation/Model/Model.h
@@ -1154,6 +1154,7 @@ public:
         _forceSubsystem.reset();
         _gravityForce.reset();
         _matter.reset();
+        _cableSubsystem.reset();
     }
 
     /** Override of the default implementation to account for versioning. */


### PR DESCRIPTION
Fixes issue N/A

### Brief summary of changes

Ensures the cable subsystem is removed/reset at the correct time in `OpenSim::Model`. Otherwise, a double-free occurs, where the top-level system deletes the cable subsystem *and* the cable subsystem deletes itself.

### Testing I've completed

- Found with libASAN, patched downstream, worked afterwards

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because small

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4179)
<!-- Reviewable:end -->
