### PR TITLE
Create `SimTK::DecorativeGeometry` directly for `ContactGeometry`

### DIFF
--- a/OpenSim/Simulation/Model/ContactGeometry.cpp
+++ b/OpenSim/Simulation/Model/ContactGeometry.cpp
@@ -92,18 +92,6 @@ SimTK::ContactGeometry ContactGeometry::createSimTKContactGeometry() const
 }
 
 //=============================================================================
-// VISUALIZATION
-//=============================================================================
-void ContactGeometry::generateDecorations(
-        bool fixed,
-        const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const {
-    Super::generateDecorations(fixed, hints, s, geometry);
-    generateDecorationsImpl(fixed, hints, s, geometry);
-}
-
-//=============================================================================
 // OBJECT INTERFACE
 //=============================================================================
 void ContactGeometry::updateFromXMLNode(SimTK::Xml::Element& node,
@@ -227,7 +215,7 @@ SimTK::ContactGeometry ContactSphere::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::Sphere(get_radius());
 }
 
-void ContactSphere::generateDecorationsImpl(
+void ContactSphere::generateDecorations(
         bool fixed,
         const ModelDisplayHints& hints,
         const SimTK::State& s,
@@ -303,7 +291,7 @@ SimTK::ContactGeometry ContactCylinder::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::Cylinder(get_radius());
 }
 
-void ContactCylinder::generateDecorationsImpl(
+void ContactCylinder::generateDecorations(
         bool fixed,
         const ModelDisplayHints& hints,
         const SimTK::State& s,
@@ -383,7 +371,7 @@ SimTK::ContactGeometry ContactEllipsoid::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::Ellipsoid(get_radii());
 }
 
-void ContactEllipsoid::generateDecorationsImpl(
+void ContactEllipsoid::generateDecorations(
         bool fixed,
         const ModelDisplayHints& hints,
         const SimTK::State& s,
@@ -473,7 +461,7 @@ SimTK::ContactGeometry ContactTorus::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::Torus(get_torus_radius(), get_tube_radius());
 }
 
-void ContactTorus::generateDecorationsImpl(
+void ContactTorus::generateDecorations(
         bool fixed,
         const ModelDisplayHints& hints,
         const SimTK::State& s,

--- a/OpenSim/Simulation/Model/ContactGeometry.h
+++ b/OpenSim/Simulation/Model/ContactGeometry.h
@@ -135,25 +135,11 @@ public:
     SimTK::ContactGeometry createSimTKContactGeometry() const;
     // @}
 
-    /** @name Visualization */
-    // @{
-    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
-    // @}
-
 protected:
     // CONTACT GEOMETRY INTERFACE
     // Concrete implementations of ContactGeometry must implement this method to
     // provide an equivalent SimTK::ContactGeometry object.
     virtual SimTK::ContactGeometry createSimTKContactGeometryImpl() const = 0;
-
-    // Concrete implementations of ContactGeometry must override this method to
-    // implement `generateDecorations()`.
-    virtual void generateDecorationsImpl(
-            bool fixed, const ModelDisplayHints& hints,
-            const SimTK::State& state,
-            SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const = 0;
 
     // OBJECT INTERFACE
     void updateFromXMLNode(SimTK::Xml::Element& node, int versionNumber)
@@ -234,12 +220,16 @@ public:
     void setRadius(double radius);
     // @}
 
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
 private:
     // CONTACT GEOMETRY INTERFACE
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
 };
 
 /**
@@ -319,12 +309,16 @@ public:
     void setRadius(double radius);
     // @}
 
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
 private:
     // CONTACT GEOMETRY INTERFACE
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
 };
 
 /**
@@ -397,12 +391,16 @@ public:
     void setRadii(const SimTK::Vec3& radii);
     // @}
 
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
 private:
     // CONTACT GEOMETRY INTERFACE
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
 };
 
 /**
@@ -500,12 +498,16 @@ public:
     void setTubeRadius(double radius);
     // @}
 
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
 private:
     // CONTACT GEOMETRY INTERFACE
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
 };
 
 } // namespace OpenSim

--- a/OpenSim/Simulation/Model/ContactHalfSpace.cpp
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.cpp
@@ -59,7 +59,7 @@ SimTK::ContactGeometry ContactHalfSpace::createSimTKContactGeometryImpl() const
     return SimTK::ContactGeometry::HalfSpace();
 }
 
-void ContactHalfSpace::generateDecorationsImpl(bool fixed,
+void ContactHalfSpace::generateDecorations(bool fixed,
     const ModelDisplayHints& hints,
     const SimTK::State& s,
     SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const

--- a/OpenSim/Simulation/Model/ContactHalfSpace.h
+++ b/OpenSim/Simulation/Model/ContactHalfSpace.h
@@ -84,11 +84,15 @@ public:
                      const PhysicalFrame& frame,
                      const std::string& name);
 
-private:
-    // CONTACT GEOMETRY INTERFACE
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
         const SimTK::State& s,
         SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
+private:
+    // CONTACT GEOMETRY INTERFACE
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
 
     // INITIALIZATION

--- a/OpenSim/Simulation/Model/ContactMesh.cpp
+++ b/OpenSim/Simulation/Model/ContactMesh.cpp
@@ -134,7 +134,7 @@ SimTK::ContactGeometry ContactMesh::createSimTKContactGeometryImpl() const
 //=============================================================================
 // VISUALIZATION
 //=============================================================================
-void ContactMesh::generateDecorationsImpl(
+void ContactMesh::generateDecorations(
     bool fixed,
     const ModelDisplayHints& hints,
     const SimTK::State& s,

--- a/OpenSim/Simulation/Model/ContactMesh.h
+++ b/OpenSim/Simulation/Model/ContactMesh.h
@@ -94,6 +94,13 @@ public:
      */
     void setFilename(const std::string& filename);
 
+    /** @name Visualization */
+    // @{
+    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
+        const SimTK::State& s,
+        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
+    // @}
+
 private:
     // INITIALIZATION
     void setNull();
@@ -101,9 +108,6 @@ private:
     void extendFinalizeFromProperties() override;
 
     // CONTACT GEOMETRY INTERFACE
-    void generateDecorationsImpl(bool fixed, const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geometry) const override;
     SimTK::ContactGeometry createSimTKContactGeometryImpl() const override;
 
     // LOAD MESH


### PR DESCRIPTION
### Brief summary of changes

This changes concrete class implementations of `ContactGeometry::generateDecorationsImpl()` to create `SimTK::DecorativeGeometry` directly instead of creating an intermediate `SimTK::ContactGeometry`  and calling `createDecorativeGeometry()`. This change is applied to all concrete classes except `ContactTorus`, since `SimTK::DecorativeTorus` does not yet have a visualizer implementation in Simbody.

### Testing I've completed

Checked locally that all geometry are correctly visualized using the "Suspended pendulum" tests in `testScholz2015GeometryPath.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...minor internal fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4182)
<!-- Reviewable:end -->
