### PR TITLE
Upgrade language level to C++20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ geometry for path-based OpenSim components (e.g., `Muscle`, `PathSpring`, etc.).
 performance and stability in wrapping solutions.
 - Implemented `generateDecorations()` for `Station` to allow visualization in the Simbody visualizer. (#4169)
 - Added `Component::removeComponent` and `Component::extractComponent` methods, which enable removing subcomponents that were previously added via `Component::addComponent` or the `<components>` XML element (#4174).
-
+- Updated required language level to C++20. (#3929)
 
 v4.5.2
 ======

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,10 +608,10 @@ if (NOT OPENSIM_PYTHON_CONDA)
     include(InstallRequiredSystemLibraries)
 endif()
 
-# C++17
+# C++20
 # -----
-set(CMAKE_CXX_STANDARD 17)
-# Using C++17 is not optional.
+set(CMAKE_CXX_STANDARD 20)
+# Using C++20 is not optional.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1676,7 +1676,7 @@ std::string Object::dump() const {
     updateXMLNode(elem);
     Object::setSerializeAllDefaults(false);
     doc.getRootElement().node_begin()->writeToString(outString);
-    return std::move(outString);
+    return outString;
 }
 
 

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -331,7 +331,8 @@ private:
             const auto& nSigFigs = chan->getOutput().getNumberOfSignificantDigits();
             // Print `value` right-justified in a column with width `_width`,
             // using `nSigFigs`: {:>{_width}.{nSigFigs}g}
-            msg += fmt::format("{:>{}.{}g}| ", value, _width, nSigFigs);
+            msg += fmt::format(fmt::runtime("{:>{}.{}g}| "), value, _width,
+                    nSigFigs);
         }
         log_cout(msg);
 

--- a/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
+++ b/OpenSim/Examples/BuildDynamicWalker/CMakeLists.txt
@@ -3,8 +3,8 @@
 cmake_minimum_required(VERSION 3.2)
 project(BuildDynamicWalker)
 
-# OpenSim requires a compiler that supports C++17.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim requires a compiler that supports C++20.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find the OpenSim libraries and header files.

--- a/OpenSim/Examples/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Examples/ControllerExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleController CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Examples/CustomActuatorExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleCustomActuator CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/ExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleLuxoMuscle/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleLuxoMuscle CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Examples/ExampleMain/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMain CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Examples/MuscleExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET exampleMuscle CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Examples/OptimizationExample_Arm26/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET optimizationExample CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
+++ b/OpenSim/Examples/PluginExampleCMakeListsToInstall.txt.in
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.2)
 project(OpenSim_@_example_name@)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 find_package(OpenSim REQUIRED HINTS
     "${CMAKE_SOURCE_DIR}/@_opensim_install_hint@")

--- a/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/AnalysisPluginExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "osimPlugin" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/BodyDragExample/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB INCLUDE_FILES *.h)
 
 set(PLUGIN_NAME "BodyDragForce" CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
+++ b/OpenSim/Examples/Plugins/CoupledBushingForceExample/CMakeLists.txt
@@ -8,8 +8,8 @@ file(GLOB INCLUDE_FILES *.h)
 set(PLUGIN_NAME "osimCoupledBushingForcePlugin"
     CACHE STRING "Name of shared library to create")
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSim REQUIRED PATHS "${OPENSIM_INSTALL_DIR}")

--- a/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
+++ b/OpenSim/Examples/SimpleOptimizationExample/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET simpleOptimizationExample CACHE TYPE STRING)
 
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
+++ b/OpenSim/Examples/SymbolicExpressionReporter/CMakeLists.txt
@@ -40,8 +40,8 @@ set(PLUGIN_NAME "osimExpressionReporter")
 
 # Settings.
 # ---------
-# OpenSim uses C++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses C++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Examples/checkEnvironment/CMakeLists.txt
+++ b/OpenSim/Examples/checkEnvironment/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.2)
 # ---------
 set(TARGET checkEnvironment CACHE STRING "Name of example to build")
 
-# OpenSim uses c++17 language features.
-set(CMAKE_CXX_STANDARD 17)
+# OpenSim uses c++20 language features.
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find and hook up to OpenSim.

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
@@ -102,8 +102,8 @@ double MocoExpressionBasedParameterGoal::getPropertyValue(int i) const {
         return static_cast<const Property<SimTK::Vec6>*>(propRef.get())
                                                      ->getValue()[elt];
     }
-    OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Property at index {} is not of"
-                                                " a recognized type."));
+    OPENSIM_THROW_FRMOBJ(Exception, fmt::format(fmt::runtime(
+            "Property at index {} is not of a recognized type."), i));
 }
 
 void MocoExpressionBasedParameterGoal::calcGoalImpl(

--- a/OpenSim/Sandbox/xsens/CMakeLists.txt
+++ b/OpenSim/Sandbox/xsens/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT WIN32)
     return()
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(XSENS_SDK_DIR "" CACHE PATH "Directory containing XSENS SDK.")

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -11,7 +11,7 @@ project(myexe)
 set(my_source_files myexe.cpp)
 set(my_header_files myexe.h)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This depends on OpenSimConfig.cmake being located somewhere predictable


### PR DESCRIPTION
Fixes issue #4183 

### Brief summary of changes

Updated all relevant CMake flags to require C++20. 

Other fixes made to patch compile errors :
- Wrapped a few `fmt::format` arguments with `fmt::runtime` to [avoid `consteval` errors with C++20](https://github.com/fmtlib/fmt/issues/2438).
- Removed a redundant `std::move` call in Object.cpp.

### Testing I've completed

[build-gui]

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4185)
<!-- Reviewable:end -->
