### PR TITLE
Replace `ControlLinearNode` operator overloads with utility functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ performance and stability in wrapping solutions.
 - Implemented `generateDecorations()` for `Station` to allow visualization in the Simbody visualizer. (#4169)
 - Added `Component::removeComponent` and `Component::extractComponent` methods, which enable removing subcomponents that were previously added via `Component::addComponent` or the `<components>` XML element (#4174).
 - Updated required language level to C++20. (#3929)
+- Breaking: removed the `operator==` and `operator<` overloads in `ControlLinearNode` and replaced usages with the equivalent utility functions `isEqual()` and `isLessThan()`. (#4095)
+
 
 v4.5.2
 ======

--- a/OpenSim/Simulation/Control/ControlLinear.h
+++ b/OpenSim/Simulation/Control/ControlLinear.h
@@ -386,6 +386,8 @@ private:
     double getControlValue(ArrayPtrs<ControlLinearNode> &aNodes,double aT);
     double extrapolateBefore(const ArrayPtrs<ControlLinearNode> &aNodes,double aT) const;
     double extrapolateAfter(ArrayPtrs<ControlLinearNode> &aNodes,double aT) const;
+    int searchBinary(const ArrayPtrs<ControlLinearNode>& nodes,
+            const ControlLinearNode& value) const;
 
 //=============================================================================
 };  // END of class ControlLinear

--- a/OpenSim/Simulation/Control/ControlLinearNode.cpp
+++ b/OpenSim/Simulation/Control/ControlLinearNode.cpp
@@ -141,7 +141,7 @@ operator=(const ControlLinearNode &aNode)
  * @return True if the times are equal, false otherwise.
  */
 bool ControlLinearNode::
-operator==(const ControlLinearNode &aNode) const
+isEqual(const ControlLinearNode &aNode) const
 {
     if((_t) > aNode._t) return(false);
     if((_t) < aNode._t) return(false);
@@ -159,7 +159,7 @@ operator==(const ControlLinearNode &aNode) const
  * @return True if the time of this node is less than the time of aNode.
  */
 bool ControlLinearNode::
-operator<(const ControlLinearNode &aNode) const
+isLessThan(const ControlLinearNode &aNode) const
 {
     if(_t<aNode._t) return(true);
     else return(false);

--- a/OpenSim/Simulation/Control/ControlLinearNode.h
+++ b/OpenSim/Simulation/Control/ControlLinearNode.h
@@ -92,8 +92,6 @@ private:
 public:
 #ifndef SWIG
     ControlLinearNode& operator=(const ControlLinearNode &aControl);
-    bool operator==(const ControlLinearNode &aControl) const;
-    bool operator<(const ControlLinearNode &aControl) const;
 
     friend std::ostream& operator<<(std::ostream &aOut,
         const ControlLinearNode &aControlLinearNode);
@@ -111,6 +109,8 @@ public:
     //--------------------------------------------------------------------------
     // UTILITY
     //--------------------------------------------------------------------------
+    bool isEqual(const ControlLinearNode &aControl) const;
+    bool isLessThan(const ControlLinearNode &aControl) const;
     char* toString();
 
 //=============================================================================


### PR DESCRIPTION
Fixes issue #4095

### Brief summary of changes

Rather than looking for a very specific fix to the operator overload issue in `ControlLinearNode`, this change removes the operator overloads entirely in favor of the utility functions `isEqual()` and `isLessThan()`. While a breaking change, `ControlLinearNode` is used almost exclusively by `ControlLinear` (one other usage by `CMC`), and I doubt many users interact with this class directly.  

IMO, `ControlLinear` and `ControlLinearNode` seem overly complicated for what they accomplished should probably be deprecated in favor of solutions specific to the needs of `CMC` and other dependent tools.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4188)
<!-- Reviewable:end -->
