### PR TITLE
Accept paths as Path objects (not only strings)

### DIFF
--- a/Bindings/Python/swig/python_preliminaries.i
+++ b/Bindings/Python/swig/python_preliminaries.i
@@ -48,3 +48,22 @@ note: ## is a "glue" operator: `a ## b` --> `ab`.
 %}
 };
 %enddef
+
+// Support for pathlib.Path objects
+// ================================
+%typemap(in) std::string const & (std::string temp) {
+    if (PyUnicode_Check($input)) {
+        temp = std::string(PyUnicode_AsUTF8($input));
+        $1 = &temp;
+    } else {
+        PyObject* fspath = PyOS_FSPath($input);
+        if (fspath != NULL) {
+            temp = std::string(PyUnicode_AsUTF8(fspath));
+            Py_DECREF(fspath);
+            $1 = &temp;
+        } else {
+            PyErr_Clear();
+            %argument_fail(SWIG_TypeError, "std::string const &", $symname, $argnum);
+        }
+    }
+}

--- a/Bindings/Python/swig/python_preliminaries.i
+++ b/Bindings/Python/swig/python_preliminaries.i
@@ -51,7 +51,7 @@ note: ## is a "glue" operator: `a ## b` --> `ab`.
 
 // Support for pathlib.Path objects
 // ================================
-%typemap(in) std::string const & (std::string temp) {
+%typemap(in) std::string const & (std::string temp, int res = SWIG_OLDOBJ) {
     if (PyUnicode_Check($input)) {
         temp = std::string(PyUnicode_AsUTF8($input));
         $1 = &temp;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ performance and stability in wrapping solutions.
 - Implemented `generateDecorations()` for `Station` to allow visualization in the Simbody visualizer. (#4169)
 - Added `Component::removeComponent` and `Component::extractComponent` methods, which enable removing subcomponents that were previously added via `Component::addComponent` or the `<components>` XML element (#4174).
 - Updated required language level to C++20. (#3929)
+- Python API accepts Path objects instead of only strings
 
 v4.5.2
 ======


### PR DESCRIPTION
### Brief summary of changes

Python pathlib paths are much cleaner and easier to use than strings, and it is the recommended Python approach for manipulating paths since Python 3.6 (introduced in Python 3.4). When using OpenSim in other libraries that work with Path objects, it is a bit of a pain and a source of errors to have to convert the path into a string.

The PR lets the OpenSim Python bindings accept paths both as strings and Path objects. 

### Testing I've completed

~~Please note that I spent a full day trying to build it from source without success (I'm definitely lacking practice for this), and I feel like I need to let it go for now.~~
I built it successfully now, but OpenSim still struggles to accept Path objects. Working on it now.

I'm fairly confident that it would work, but I did not test it. At the very least, someone should try to build it and test this:
```python
import opensim as osim
from pathlib import Path
model = osim.Model("arm26.osim")
model = osim.Model(Path("arm26.osim"))
```

Fixes issue #4190

### Looking for feedback on...

### CHANGELOG.md (choose one)
Updated: https://github.com/opensim-org/opensim-core/blob/main/CHANGELOG.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4191)
<!-- Reviewable:end -->
