### PR TITLE
Convert IO.cpp to use std::filesystem, so that it can compile in MinGW

### DIFF
--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -521,7 +521,9 @@ stod(const std::string& __str, std::size_t* __idx)
 int IO::
 makeDir(const string &aDirName)
 {
-    return std::filesystem::create_directory(aDirName) ? 0 : 1;
+    std::error_code error;
+    std::filesystem::create_directory(aDirName, error);
+    return error.value();
 }
 //_____________________________________________________________________________
 /**


### PR DESCRIPTION
This fixes a minor issue I found when compiling opensim-core in CLion's bundled MinGW (it's what users will default-use if installing CLion but not Visual Studio on Windows).

### Brief summary of changes

- Switches problematic OS-specific calls for `std::filesystem` equivalents

### Testing I've completed

- Works on my machine etc.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because very small internal change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4195)
<!-- Reviewable:end -->
