### PR TITLE
Convert `testModelInterface.cpp` to the Catch2 testing framework

### DIFF
--- a/OpenSim/Simulation/Test/testModelInterface.cpp
+++ b/OpenSim/Simulation/Test/testModelInterface.cpp
@@ -29,14 +29,12 @@
 
 #include <memory>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
-using namespace std;
 
-void testModelFinalizePropertiesAndConnections();
-void testModelTopologyErrors();
-void testDoesNotSegfaultWithUnusualConnections();
+TEST_CASE("testModelFinalizePropertiesAndConnections") {
 
-int main() {
     // The following model(s) contains Actuators that are registered when the
     // osimActuators library is loaded. But unless we call at least one
     // function defined in the osimActuators library, some linkers will omit
@@ -44,115 +42,112 @@ int main() {
     // startup.
     { PointActuator t; }
 
-    SimTK_START_TEST("testModelInterface");
-        SimTK_SUBTEST(testModelFinalizePropertiesAndConnections);
-        SimTK_SUBTEST(testModelTopologyErrors);
-        SimTK_SUBTEST(testDoesNotSegfaultWithUnusualConnections);
-    SimTK_END_TEST();
+    Model model("arm26.osim");
+
+    model.printSubcomponentInfo();
+
+    // all subcomponents are accounted for since Model constructor invokes
+    // finalizeFromProperties().
+    ASSERT(model.countNumComponents() > 0);
+
+    // model must be up-to-date with its properties
+    ASSERT(model.isObjectUpToDateWithProperties());
+
+    // get writable access to Components contained in the model's Set
+    auto& muscles = model.updMuscles();
+    // to make edits, for example, muscles[0].upd_min_control() = 0.02;
+    ASSERT(!model.isObjectUpToDateWithProperties());
+
+    model.finalizeFromProperties();
+    ASSERT(model.isObjectUpToDateWithProperties());
+
+    // get writable access to another Set for the purpose of editing
+    auto& bodies = model.updBodySet();
+    // for example, bodies[1].upd_mass() = 0.05;
+    ASSERT(!model.isObjectUpToDateWithProperties());
+
+    model.finalizeFromProperties();
+    ASSERT(model.isObjectUpToDateWithProperties());
+
+    // make an edit through model's ComponentList access
+    for (auto& body : model.updComponentList<Body>()) {
+        body.upd_mass_center() = SimTK::Vec3(0);
+        break;
+    }
+    ASSERT(!model.isObjectUpToDateWithProperties());
+
+    SimTK::State dummy_state;
+
+    ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+    ASSERT_THROW(ComponentHasNoSystem, model.realizeDynamics(dummy_state));
+    ASSERT_THROW(ComponentHasNoSystem,
+                    model.computeStateVariableDerivatives(dummy_state));
+    // should not be able to create a Manager either
+    ASSERT_THROW(ComponentHasNoSystem,
+                    Manager manager(model));
+
+    // get a valid System and corresponding state
+    SimTK::State state = model.initSystem();
+    Manager manager(model);
+    state.setTime(0.0);
+
+    // this should invalidate the System
+    model.finalizeFromProperties();
+
+    // verify that finalizeFromProperties() wipes out the underlying System
+    ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+
+    // should not be able to "trick" the manager into integrating a model
+    // given a stale but compatible state
+    ASSERT_THROW(Exception, manager.initialize(state));
+
+    // once again, get a valid System and corresponding state
+    state = model.initSystem();
+
+    // Test for the effects of calling finalizeConnections() on the model
+    // after initSystem() has been called.
+    // In this case, there are no changes to the connections to be finalized.
+    model.finalizeConnections();
+
+    // verify that finalizeConnections() does not wipe out the underlying
+    // System when there are no changes to the connections
+    auto& sys = model.getSystem();
+
+    auto elbowInHumerus = new PhysicalOffsetFrame("elbow_in_humerus",
+        model.getComponent<Body>("./bodyset/r_humerus"),
+        SimTK::Transform(SimTK::Vec3(0, -0.33, 0)) );
+
+    model.addComponent(elbowInHumerus);
+
+    // establish the new offset frame as part of the model but not
+    // used by any joints, constraints or forces
+    state = model.initSystem();
+
+    // update the elbow Joint and connect its socket to the new frame
+    Joint& elbow = model.updComponent<Joint>("./jointset/r_elbow");
+    elbow.connectSocket_parent_frame(*elbowInHumerus);
+
+    // satisfy the new connections in the model
+    model.finalizeConnections();
+
+    // now finalizing the connections will invalidate the System because
+    // a Component (the elbow Joint and its connection) was updated
+    ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
+
+    // verify the new connection was made
+    ASSERT(model.getComponent<Joint>("./jointset/r_elbow")
+        .getParentFrame().getName() == "elbow_in_humerus");
 }
 
+TEST_CASE("testModelTopologyErrors") {
 
-void testModelFinalizePropertiesAndConnections() 
-{
-        Model model("arm26.osim");
+    // The following model(s) contains Actuators that are registered when the
+    // osimActuators library is loaded. But unless we call at least one
+    // function defined in the osimActuators library, some linkers will omit
+    // its dependency from the executable and it will not be loaded at
+    // startup.
+    { PointActuator t; }
 
-        model.printSubcomponentInfo();
-
-        // all subcomponents are accounted for since Model constructor invokes
-        // finalizeFromProperties().
-        ASSERT(model.countNumComponents() > 0);
-
-        // model must be up-to-date with its properties
-        ASSERT(model.isObjectUpToDateWithProperties());
-
-        // get writable access to Components contained in the model's Set
-        auto& muscles = model.updMuscles();
-        // to make edits, for example, muscles[0].upd_min_control() = 0.02;
-        ASSERT(!model.isObjectUpToDateWithProperties());
-
-        model.finalizeFromProperties();
-        ASSERT(model.isObjectUpToDateWithProperties());
-
-        // get writable access to another Set for the purpose of editing
-        auto& bodies = model.updBodySet();
-        // for example, bodies[1].upd_mass() = 0.05;
-        ASSERT(!model.isObjectUpToDateWithProperties());
-
-        model.finalizeFromProperties();
-        ASSERT(model.isObjectUpToDateWithProperties());
-
-        // make an edit through model's ComponentList access
-        for (auto& body : model.updComponentList<Body>()) {
-            body.upd_mass_center() = SimTK::Vec3(0);
-            break;
-        }
-        ASSERT(!model.isObjectUpToDateWithProperties());
-
-        SimTK::State dummy_state;
-
-        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
-        ASSERT_THROW(ComponentHasNoSystem, model.realizeDynamics(dummy_state));
-        ASSERT_THROW(ComponentHasNoSystem, 
-                     model.computeStateVariableDerivatives(dummy_state));
-        // should not be able to create a Manager either
-        ASSERT_THROW(ComponentHasNoSystem,
-                     Manager manager(model));
-
-        // get a valid System and corresponding state
-        SimTK::State state = model.initSystem();
-        Manager manager(model);
-        state.setTime(0.0);
-
-        // this should invalidate the System
-        model.finalizeFromProperties();
-
-        // verify that finalizeFromProperties() wipes out the underlying System
-        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
-
-        // should not be able to "trick" the manager into integrating a model
-        // given a stale but compatible state
-        ASSERT_THROW(Exception, manager.initialize(state));
-
-        // once again, get a valid System and corresponding state
-        state = model.initSystem();
-        
-        // Test for the effects of calling finalizeConnections() on the model
-        // after initSystem() has been called.
-        // In this case, there are no changes to the connections to be finalized.
-        model.finalizeConnections();
-
-        // verify that finalizeConnections() does not wipe out the underlying 
-        // System when there are no changes to the connections
-        auto& sys = model.getSystem();
-
-        auto elbowInHumerus = new PhysicalOffsetFrame("elbow_in_humerus",
-            model.getComponent<Body>("./bodyset/r_humerus"),
-            SimTK::Transform(SimTK::Vec3(0, -0.33, 0)) );
-
-        model.addComponent(elbowInHumerus);
-
-        // establish the new offset frame as part of the model but not
-        // used by any joints, constraints or forces
-        state = model.initSystem();
-
-        // update the elbow Joint and connect its socket to the new frame
-        Joint& elbow = model.updComponent<Joint>("./jointset/r_elbow");
-        elbow.connectSocket_parent_frame(*elbowInHumerus);
-
-        // satisfy the new connections in the model
-        model.finalizeConnections();
-
-        // now finalizing the connections will invalidate the System because
-        // a Component (the elbow Joint and its connection) was updated
-        ASSERT_THROW(ComponentHasNoSystem, model.getSystem());
-
-        // verify the new connection was made
-        ASSERT(model.getComponent<Joint>("./jointset/r_elbow")
-            .getParentFrame().getName() == "elbow_in_humerus");
-}
-
-void testModelTopologyErrors()
-{
     Model model("arm26.osim");
     model.initSystem();
 
@@ -221,9 +216,9 @@ void testModelTopologyErrors()
     // is a subcomponent of either the parent or child frame. This test is why
     // the Joint cannot resolve whether two frames have the same base frame.
     frame1->addComponent(joint1);
-    
+
     // Parent and child frames of a Joint cannot be the same frame
-    ASSERT_THROW(JointFramesAreTheSame, 
+    ASSERT_THROW(JointFramesAreTheSame,
         joint1->finalizeConnections(degenerate));
 
     // Joint should also throw JointFramesAreTheSame before
@@ -237,8 +232,7 @@ void testModelTopologyErrors()
     ASSERT_THROW(JointFramesHaveSameBaseFrame, degenerate.initSystem());
 }
 
-void testDoesNotSegfaultWithUnusualConnections()
-{
+TEST_CASE("testDoesNotSegfaultWithUnusualConnections") {
     // automated reproduction for bug reported in #3299
     //
     // effectively, the multibody graph making procedure contained


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testModelInterface.cpp` to user the Catch2 testing framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4196)
<!-- Reviewable:end -->
