### PR TITLE
Convert `testReportersWithModel.cpp` to Catch2 testing framework

### DIFF
--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -29,11 +29,13 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace std;
 using namespace SimTK;
 using namespace OpenSim;
 
-void testConsoleReporterLabels() {
+TEST_CASE("testConsoleReporterLabels") {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -82,7 +84,7 @@ void testConsoleReporterLabels() {
     SimTK_TEST(idxHeading2 < idxHeading3);
 }
 
-void testTableReporterLabels() {
+TEST_CASE("testTableReporterLabels") {
     // Create a model consisting of a falling ball.
     Model model;
     model.setName("world");
@@ -115,10 +117,3 @@ void testTableReporterLabels() {
     SimTK_TEST(headings[0] == "/jointset/slider/sliderCoord|value");
     SimTK_TEST(headings[1] == "height");
 }
-
-int main() {
-    SimTK_START_TEST("testReporters");
-        SimTK_SUBTEST(testConsoleReporterLabels);
-        SimTK_SUBTEST(testTableReporterLabels);
-    SimTK_END_TEST();
-};


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testReportersWithModel.cpp` to the Catch2 testing framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4204)
<!-- Reviewable:end -->
