### PR TITLE
Convert `testC3DFileAdapter.cpp` to the Catch2 testing framework

### DIFF
--- a/OpenSim/Common/Test/testC3DFileAdapter.cpp
+++ b/OpenSim/Common/Test/testC3DFileAdapter.cpp
@@ -33,6 +33,10 @@
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Common/Stopwatch.h>
 
+#include <catch2/catch_all.hpp>
+
+namespace {
+
 template<typename ETY = SimTK::Real>
 void compare_tables(const OpenSim::TimeSeriesTable_<ETY>& table1,
             const OpenSim::TimeSeriesTable_<ETY>& table2,
@@ -220,9 +224,13 @@ void test(const std::string filename) {
 
 }
 
-int main() {
-    SimTK_START_TEST("testC3DFileAdapter");
-        SimTK_SUBTEST1(test, "walking2.c3d");
-        SimTK_SUBTEST1(test, "walking5.c3d");
-    SimTK_END_TEST();
+}
+
+TEST_CASE("testC3DFileAdapter") {
+    SECTION("walking2.c3d") {
+        test("walking2.c3d");
+    }
+    SECTION("walking5.c3d") {
+        test("walking5.c3d");
+    }
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testC3DFileAdapter.cpp` to the Catch2 testing framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

@adamkewley I know in #3555 we had marked to skip this since ezc3d is not technically built by default, but we almost always do (including releases), so adding this in for completeness.

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4207)
<!-- Reviewable:end -->
