### PR TITLE
Convert `testAddComponents.cpp` to the Catch2 testing framework

### DIFF
--- a/OpenSim/Tests/AddComponents/CMakeLists.txt
+++ b/OpenSim/Tests/AddComponents/CMakeLists.txt
@@ -1,3 +1,6 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
+
 # Define test target and current test dir
 set(TEST_TARGET testAddComponents)
 set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -37,5 +40,5 @@ endforeach(dataFile)
 #
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_TARGET}.cpp
-    LINKLIBS osimTools osimSimulation osimActuators
+    LINKLIBS osimTools osimSimulation osimActuators Catch2::Catch2WithMain
     )


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testAddComponents.cpp` to the Catch2 testing framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4213)
<!-- Reviewable:end -->
