### PR TITLE
Convert `testConstantCurvature.cpp` to the Catch2 test framework

### DIFF
--- a/OpenSim/Tests/ConstantCurvatureExample/CMakeLists.txt
+++ b/OpenSim/Tests/ConstantCurvatureExample/CMakeLists.txt
@@ -1,7 +1,9 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 file(GLOB TEST_PROGS "test*.cpp")
 
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_PROGS}
-    LINKLIBS osimTools
+    LINKLIBS osimTools Catch2::Catch2WithMain
     )

--- a/OpenSim/Tests/ConstantCurvatureExample/testConstantCurvature.cpp
+++ b/OpenSim/Tests/ConstantCurvatureExample/testConstantCurvature.cpp
@@ -29,12 +29,17 @@
 
 #include "OpenSim/Actuators/SpringGeneralizedForce.h"
 #include "OpenSim/Auxiliary/auxiliaryTestFunctions.h"
-#include "OpenSim/Simulation/Model/CoordinateLimitForce.h"
+#include "OpenSim/Common/Reporter.h"
+#include "OpenSim/Simulation/Model/Model.h"
 #include "OpenSim/Simulation/Model/Geometry.h"
+#include "OpenSim/Simulation/SimbodyEngine/ConstantCurvatureJoint.h"
+#include "OpenSim/Simulation/SimulationUtilities.h"
 #include <string>
 // #define VISUALIZE
 
-#include "OpenSim/OpenSim.h"
+#include <catch2/catch_all.hpp>
+
+namespace {
 
 using namespace SimTK;
 using namespace OpenSim;
@@ -220,7 +225,9 @@ void testJacobians3() {
     (void)J; // keep compiler from complaining
 }
 
-int main() {
+}
+
+TEST_CASE("testConstantCurvature") {
     testJacobians1();
     testJacobians2();
     testJacobians3();
@@ -353,6 +360,4 @@ int main() {
 
     // Simulate.
     simulate(model, state, 20.0);
-
-    return 0;
-};
+}


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testConstantCurvature.cpp` to the Catch2 test framework. Changed includes to "include what you use".

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4214)
<!-- Reviewable:end -->
