### PR TITLE
Convert `testControllerExample.cpp` to Catch2 testing framework

### DIFF
--- a/OpenSim/Tests/ControllerExample/CMakeLists.txt
+++ b/OpenSim/Tests/ControllerExample/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 # Variable definitions
 set(EXAMPLE_TARGET exampleController)
@@ -10,7 +12,7 @@ add_executable(${EXAMPLE_TARGET} ${SOURCE_FILES})
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 
 target_link_libraries(${EXAMPLE_TARGET} osimTools)
-target_link_libraries(${TEST_TARGET} osimTools)
+target_link_libraries(${TEST_TARGET} osimTools Catch2::Catch2WithMain)
 
 file(GLOB TEST_FILES 
     ${EXAMPLE_DIR}/*.obj 

--- a/OpenSim/Tests/ControllerExample/testControllerExample.cpp
+++ b/OpenSim/Tests/ControllerExample/testControllerExample.cpp
@@ -21,55 +21,43 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Author: Cassidy Kelly
-
-//==============================================================================
-//==============================================================================
-
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <catch2/catch_all.hpp>
 
 using namespace OpenSim;
 using namespace std;
 
-int main()
-{
-    try {
-      const std::string result1Filename{"tugOfWar_controls.sto"};
-      const std::string result1FilenameV1{"tugOfWar_controls_V1.sto"};
-      revertToVersionNumber1(result1Filename, result1FilenameV1);
-        Storage result1(result1FilenameV1), 
-                standard1("std_tugOfWar_controls.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       std::vector<double>(2, 0.01),
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar controls failed");
-        cout << "tugOfWar controls passed\n" << endl;
+TEST_CASE("testControllerExample") {
+    const std::string result1Filename{"tugOfWar_controls.sto"};
+    const std::string result1FilenameV1{"tugOfWar_controls_V1.sto"};
+    revertToVersionNumber1(result1Filename, result1FilenameV1);
+    Storage result1(result1FilenameV1),
+            standard1("std_tugOfWar_controls.sto");
+    CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
+                                    std::vector<double>(2, 0.01),
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar controls failed");
+    cout << "tugOfWar controls passed\n" << endl;
 
-        std::vector<double> tols(16, 0.01);
-        // speeds are not matched as precisely
-        for(int i =0; i < 6; ++i)
-            tols[2*i+1] = 0.03;
-        // activations within 2%
-        tols[12] = tols[14] = 0.02;
+    std::vector<double> tols(16, 0.01);
+    // speeds are not matched as precisely
+    for(int i =0; i < 6; ++i)
+        tols[2*i+1] = 0.03;
+    // activations within 2%
+    tols[12] = tols[14] = 0.02;
 
-      const std::string result2Filename{"tugOfWar_states.sto"};
-      const std::string result2FilenameV1{"tugOfWar_states_V1.sto"};
-      revertToVersionNumber1(result2Filename, result2FilenameV1);
-        Storage result2(result2FilenameV1), 
-                standard2("std_tugOfWar_states.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
-                                       tols, 
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar states failed");
-        cout << "tugOfWar states passed\n" << endl;
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
+    const std::string result2Filename{"tugOfWar_states.sto"};
+    const std::string result2FilenameV1{"tugOfWar_states_V1.sto"};
+    revertToVersionNumber1(result2Filename, result2FilenameV1);
+    Storage result2(result2FilenameV1),
+            standard2("std_tugOfWar_states.sto");
+    CHECK_STORAGE_AGAINST_STANDARD(result2, standard2,
+                                    tols,
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar states failed");
+    cout << "tugOfWar states passed\n" << endl;
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testControllerExample.cpp` to the Catch2 testing framework.

### Testing I've completed

Ran locally on CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4215)
<!-- Reviewable:end -->
