### PR TITLE
Convert `testCustomActuatorExample.cpp` to Catch2 testing framework

### DIFF
--- a/OpenSim/Tests/CustomActuatorExample/CMakeLists.txt
+++ b/OpenSim/Tests/CustomActuatorExample/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 # Variable definitions
 set(EXAMPLE_TARGET exampleCustomActuator)
@@ -10,7 +12,7 @@ add_executable(${EXAMPLE_TARGET} ${SOURCE_FILES})
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 
 target_link_libraries(${EXAMPLE_TARGET} osimTools)
-target_link_libraries(${TEST_TARGET} osimTools)
+target_link_libraries(${TEST_TARGET} osimTools Catch2::Catch2WithMain)
 
 file(GLOB TEST_FILES 
     ${EXAMPLE_DIR}/*.obj 

--- a/OpenSim/Tests/CustomActuatorExample/testCustomActuatorExample.cpp
+++ b/OpenSim/Tests/CustomActuatorExample/testCustomActuatorExample.cpp
@@ -21,52 +21,40 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Author: Cassidy Kelly
-
-//==============================================================================
-//==============================================================================
-
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <catch2/catch_all.hpp>
 
 using namespace OpenSim;
 using namespace std;
 
-int main()
-{
-    try {
-        const std::string
-          result1Filename{"SpringActuatedLeg_states_degrees.sto"};
-        const std::string
-          result1FilenameV1{"SpringActuatedLeg_states_degrees_V1.sto"};
-        revertToVersionNumber1(result1Filename, result1FilenameV1);
-        Storage result1(result1FilenameV1),
-                standard1("std_SpringActuatedLeg_states_degrees.mot");
-        std::vector<double> tolerances(6, 1.0);   // angles have 1 deg tolerance
-        tolerances[1] = tolerances[3] = tolerances[5] = 5.0; // angular speeds have a 5 deg/s tolerance
+TEST_CASE("testCustomActuatorExample") {
+    const std::string
+        result1Filename{"SpringActuatedLeg_states_degrees.sto"};
+    const std::string
+        result1FilenameV1{"SpringActuatedLeg_states_degrees_V1.sto"};
+    revertToVersionNumber1(result1Filename, result1FilenameV1);
+    Storage result1(result1FilenameV1),
+            standard1("std_SpringActuatedLeg_states_degrees.mot");
+    std::vector<double> tolerances(6, 1.0);   // angles have 1 deg tolerance
+    tolerances[1] = tolerances[3] = tolerances[5] = 5.0; // angular speeds have a 5 deg/s tolerance
 
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, tolerances, 
-            __FILE__, __LINE__, "spring actuated leg states degrees failed");
-        log_info("spring actuated leg states degrees passed");
-        log_info("");
+    CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, tolerances,
+        __FILE__, __LINE__, "spring actuated leg states degrees failed");
+    log_info("spring actuated leg states degrees passed");
+    log_info("");
 
-        std::vector<double> forceTol(2, 1.0); // piston actuator has a tolerance of 1N
-        forceTol[1] = 5.0; // spring has a tolerance of 5N 
+    std::vector<double> forceTol(2, 1.0); // piston actuator has a tolerance of 1N
+    forceTol[1] = 5.0; // spring has a tolerance of 5N
 
-        const std::string result2Filename{"actuator_forces.sto"};
-        const std::string result2FilenameV1{"actuator_forces_V1.sto"};
-        revertToVersionNumber1(result2Filename, result2FilenameV1);
-        Storage result2(result2FilenameV1),
-                standard2("std_actuator_forces.mot");
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, forceTol,
-                                       __FILE__, __LINE__, "actuator forces failed");
-        log_info("actuator forces passed");
-        log_info("");
-    }
-    catch (const Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    log_info("Done");
-    return 0;
+    const std::string result2Filename{"actuator_forces.sto"};
+    const std::string result2FilenameV1{"actuator_forces_V1.sto"};
+    revertToVersionNumber1(result2Filename, result2FilenameV1);
+    Storage result2(result2FilenameV1),
+            standard2("std_actuator_forces.mot");
+    CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, forceTol,
+                                    __FILE__, __LINE__, "actuator forces failed");
+    log_info("actuator forces passed");
+    log_info("");
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testCustomActuatorExample.cpp` to the Catch2 testing framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4217)
<!-- Reviewable:end -->
