### PR TITLE
Convert `testExampleMain.cpp` to Catch2 testing framework

### DIFF
--- a/OpenSim/Tests/ExampleMain/CMakeLists.txt
+++ b/OpenSim/Tests/ExampleMain/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 # Variable definitions
 set(EXAMPLE_TARGET exampleMain)
@@ -11,7 +13,7 @@ add_executable(${EXAMPLE_TARGET} ${SOURCE_FILES})
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 
 target_link_libraries(${EXAMPLE_TARGET} osimTools)
-target_link_libraries(${TEST_TARGET} osimTools)
+target_link_libraries(${TEST_TARGET} osimTools Catch2::Catch2WithMain)
 
 file(GLOB TEST_FILES 
     ${EXAMPLE_DIR}/*.obj 

--- a/OpenSim/Tests/ExampleMain/testExampleMain.cpp
+++ b/OpenSim/Tests/ExampleMain/testExampleMain.cpp
@@ -21,53 +21,42 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Author: Cassidy Kelly
-
-//==============================================================================
-//==============================================================================
-
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <catch2/catch_all.hpp>
 
 using namespace OpenSim;
 using namespace std;
 
-int main()
-{
-    try {
-        const std::string result1Filename{"tugOfWar_states.sto"};
-        const std::string result1FilenameV1{"tugOfWar_states_V1.sto"};
-        revertToVersionNumber1(result1Filename, result1FilenameV1);
-        Storage result1(result1FilenameV1), 
-                standard1("std_tugOfWar_states.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       std::vector<double>(16, 0.1),
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar states failed");
-        cout << "tugOfWar states passed\n";
+TEST_CASE("testExampleMain") {
 
-        const std::string result3Filename{"tugOfWar_forces.sto"};
-        const std::string result3FilenameV1{"tugOfWar_forces_V1.sto"};
-        revertToVersionNumber1(result3Filename, result3FilenameV1);
-        Storage result3(result3FilenameV1), 
-                standard3("std_tugOfWar_forces.mot");
-        
-        std::vector<double> tols(20, 1.0);
-        // 10N is 1% of the muscles maximum isometric force
-        tols[0] = tols[1] = 10;
+    const std::string result1Filename{"tugOfWar_states.sto"};
+    const std::string result1FilenameV1{"tugOfWar_states_V1.sto"};
+    revertToVersionNumber1(result1Filename, result1FilenameV1);
+    Storage result1(result1FilenameV1),
+            standard1("std_tugOfWar_states.sto");
+    CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
+                                    std::vector<double>(16, 0.1),
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar states failed");
+    cout << "tugOfWar states passed\n";
 
-        CHECK_STORAGE_AGAINST_STANDARD(result3, standard3, 
-                                       tols, 
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar forces failed");
-        cout << "tugOfWar forces passed\n";
-    }
-    catch (const Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
+    const std::string result3Filename{"tugOfWar_forces.sto"};
+    const std::string result3FilenameV1{"tugOfWar_forces_V1.sto"};
+    revertToVersionNumber1(result3Filename, result3FilenameV1);
+    Storage result3(result3FilenameV1),
+            standard3("std_tugOfWar_forces.mot");
+
+    std::vector<double> tols(20, 1.0);
+    // 10N is 1% of the muscles maximum isometric force
+    tols[0] = tols[1] = 10;
+
+    CHECK_STORAGE_AGAINST_STANDARD(result3, standard3,
+                                    tols,
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar forces failed");
+    cout << "tugOfWar forces passed\n";
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testExampleMain.cpp` to the Catch2 testing framework.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4218)
<!-- Reviewable:end -->
