### PR TITLE
Convert `testMuscleExample.cpp` to Catch2 testing framework

### DIFF
--- a/OpenSim/Tests/MuscleExample/CMakeLists.txt
+++ b/OpenSim/Tests/MuscleExample/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 # Variable definitions
 set(EXAMPLE_TARGET exampleMuscle)
@@ -10,7 +12,7 @@ add_executable(${EXAMPLE_TARGET} ${SOURCE_FILES})
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 
 target_link_libraries(${EXAMPLE_TARGET} osimTools)
-target_link_libraries(${TEST_TARGET} osimTools)
+target_link_libraries(${TEST_TARGET} osimTools Catch2::Catch2WithMain)
 
 file(GLOB TEST_FILES 
     ${EXAMPLE_DIR}/*.vtp

--- a/OpenSim/Tests/MuscleExample/testMuscleExample.cpp
+++ b/OpenSim/Tests/MuscleExample/testMuscleExample.cpp
@@ -21,50 +21,39 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Author: Cassidy Kelly
-
-//==============================================================================
-//==============================================================================
-
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <catch2/catch_all.hpp>
 
 using namespace OpenSim;
 using namespace std;
 
-int main()
-{
-    try {
-        const std::string result1Filename{"tugOfWar_fatigue_states.sto"};
-        const std::string result1FilenameV1{"tugOfWar_fatigue_states_V1.sto"};
-        revertToVersionNumber1(result1Filename, result1FilenameV1);
-        Storage result1(result1FilenameV1), 
-                standard1("std_tugOfWar_fatigue_states.sto");
-        int ncols = result1.getColumnLabels().getSize();
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1, 
-                                       std::vector<double>(ncols, 0.01),
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar fatigue states failed");
-        cout << "tugOfWar fatigue states passed\n";
+TEST_CASE("testMuscleExample") {
 
-        const std::string result2Filename{"tugOfWar_fatigue_forces.sto"};
-        const std::string result2FilenameV1{"tugOfWar_fatigue_forces_V1.sto"};
-        revertToVersionNumber1(result2Filename, result2FilenameV1);
-        Storage result2(result2FilenameV1), 
-                standard2("std_tugOfWar_forces.mot");
-        ncols = result2.getColumnLabels().getSize();
-        CHECK_STORAGE_AGAINST_STANDARD(result2, standard2, 
-                                       std::vector<double>(ncols, 20.0),
-                                       __FILE__, 
-                                       __LINE__, 
-                                       "tugOfWar forces failed");
-        cout << "tugOfWar forces passed\n";
-    }
-    catch (const Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
+    const std::string result1Filename{"tugOfWar_fatigue_states.sto"};
+    const std::string result1FilenameV1{"tugOfWar_fatigue_states_V1.sto"};
+    revertToVersionNumber1(result1Filename, result1FilenameV1);
+    Storage result1(result1FilenameV1),
+            standard1("std_tugOfWar_fatigue_states.sto");
+    int ncols = result1.getColumnLabels().getSize();
+    CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
+                                    std::vector<double>(ncols, 0.01),
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar fatigue states failed");
+    cout << "tugOfWar fatigue states passed\n";
+
+    const std::string result2Filename{"tugOfWar_fatigue_forces.sto"};
+    const std::string result2FilenameV1{"tugOfWar_fatigue_forces_V1.sto"};
+    revertToVersionNumber1(result2Filename, result2FilenameV1);
+    Storage result2(result2FilenameV1),
+            standard2("std_tugOfWar_forces.mot");
+    ncols = result2.getColumnLabels().getSize();
+    CHECK_STORAGE_AGAINST_STANDARD(result2, standard2,
+                                    std::vector<double>(ncols, 20.0),
+                                    __FILE__,
+                                    __LINE__,
+                                    "tugOfWar forces failed");
+    cout << "tugOfWar forces passed\n";
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testMuscleExample.cpp` to the Catch2 testing framework.

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4219)
<!-- Reviewable:end -->
