### PR TITLE
Convert `testOptimizationExample.cpp` to the Catch2 test framework

### DIFF
--- a/OpenSim/Tests/OptimizationExample_Arm26/CMakeLists.txt
+++ b/OpenSim/Tests/OptimizationExample_Arm26/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 # Variable definitions
 set(EXAMPLE_TARGET exampleOptimization)
@@ -10,7 +12,7 @@ add_executable(${EXAMPLE_TARGET} ${SOURCE_FILES})
 add_executable(${TEST_TARGET} ${TEST_TARGET}.cpp)
 
 target_link_libraries(${EXAMPLE_TARGET} osimTools)
-target_link_libraries(${TEST_TARGET} osimTools)
+target_link_libraries(${TEST_TARGET} osimTools Catch2::Catch2WithMain)
 
 file(GLOB TEST_FILES 
     ${EXAMPLE_DIR}/*.obj 

--- a/OpenSim/Tests/OptimizationExample_Arm26/testOptimizationExample.cpp
+++ b/OpenSim/Tests/OptimizationExample_Arm26/testOptimizationExample.cpp
@@ -21,17 +21,16 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Author: Cassidy Kelly
-
-//==============================================================================
-//==============================================================================
-
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <istream>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
+
+namespace {
 
 #define ARM26_DESIGN_SPACE_DIM 6
 #define REF_MAX_VEL 4.8
@@ -50,51 +49,43 @@ using namespace std;
 const static double refControls[ARM26_DESIGN_SPACE_DIM]
     = { 0.0231781, 0.0195227, 0.0224382, 0.987157, 0.835002, 0.608971 };
 
+}
 
-int main()
-{
-    try {
-        // Load optimization results
-        ifstream resFile;
-        resFile.open("Arm26_optimization_result");
-        ASSERT(resFile.is_open(), __FILE__, __LINE__,
-               "Can't open optimization result file" );
+TEST_CASE("testOptimizationExample") {
+    // Load optimization results
+    ifstream resFile;
+    resFile.open("Arm26_optimization_result");
+    ASSERT(resFile.is_open(), __FILE__, __LINE__,
+            "Can't open optimization result file" );
 
-        SimTK::Array_<double> resVec;
-        for ( ; ; ) {
-            double tmp;
-            resFile >> tmp;
-            if (!resFile.good())
-                break;
-            resVec.push_back(tmp);
-        }
-
-        ASSERT(resVec.size() == ARM26_DESIGN_SPACE_DIM+1, __FILE__, __LINE__,
-               "Optimization result size mismatch" );
-
-        // Ensure the optimization result achieved a velocity of at least
-        // REF_MAX_VEL
-        ASSERT(resVec[ARM26_DESIGN_SPACE_DIM] > REF_MAX_VEL, __FILE__, __LINE__,
-            "Optimized velocity smaller than reference");
-
-        
-        // Ensure the optimizer found controls within 10% of "optimal" controls
-        // Or that the absolute difference in controls with optimal < 0.01
-        for (int i = 0; i < ARM26_DESIGN_SPACE_DIM; ++i) {
-            double relErr = fabs(resVec[i] - refControls[i]) / refControls[i];
-            double absErr = fabs(resVec[i] - refControls[i]);
-            cout << i << ": relErr = " << relErr << " | absErr = " << absErr <<endl;
-            ASSERT( (relErr < 0.1) || (absErr < 0.01), __FILE__, __LINE__,
-                   "Control value does not match reference" );
-        }
-
-
-        cout << "Arm26 optimization results passed\n";
+    SimTK::Array_<double> resVec;
+    for ( ; ; ) {
+        double tmp;
+        resFile >> tmp;
+        if (!resFile.good())
+            break;
+        resVec.push_back(tmp);
     }
-    catch (const Exception& e) {
-        e.print(cerr);
-        return 1;
+
+    ASSERT(resVec.size() == ARM26_DESIGN_SPACE_DIM+1, __FILE__, __LINE__,
+            "Optimization result size mismatch" );
+
+    // Ensure the optimization result achieved a velocity of at least
+    // REF_MAX_VEL
+    ASSERT(resVec[ARM26_DESIGN_SPACE_DIM] > REF_MAX_VEL, __FILE__, __LINE__,
+        "Optimized velocity smaller than reference");
+
+
+    // Ensure the optimizer found controls within 10% of "optimal" controls
+    // Or that the absolute difference in controls with optimal < 0.01
+    for (int i = 0; i < ARM26_DESIGN_SPACE_DIM; ++i) {
+        double relErr = fabs(resVec[i] - refControls[i]) / refControls[i];
+        double absErr = fabs(resVec[i] - refControls[i]);
+        cout << i << ": relErr = " << relErr << " | absErr = " << absErr <<endl;
+        ASSERT( (relErr < 0.1) || (absErr < 0.01), __FILE__, __LINE__,
+                "Control value does not match reference" );
     }
-    cout << "Done" << endl;
-    return 0;
+
+
+    cout << "Arm26 optimization results passed\n";
 }


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Convert `testOptimizationExample.cpp` to the Catch2 test framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4220)
<!-- Reviewable:end -->
