### PR TITLE
Convert `testIterators.cpp` to the Catch2 test framework

### DIFF
--- a/OpenSim/Tests/testIterators/CMakeLists.txt
+++ b/OpenSim/Tests/testIterators/CMakeLists.txt
@@ -1,8 +1,11 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
+
 file(GLOB TEST_PROGS "test*.cpp")
 
 OpenSimCopySharedTestFiles(arm26.osim)
 
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_PROGS}
-    LINKLIBS osimSimulation osimActuators
+    LINKLIBS osimSimulation osimActuators Catch2::Catch2WithMain
     )


### PR DESCRIPTION
Fixes issue #3555

### Brief summary of changes

Converts `testIterators.cpp` to the Catch2 test framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4223)
<!-- Reviewable:end -->
