### PR TITLE
Fix `enforceContraints` typo

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -145,7 +145,7 @@ public:
         The provided value will be clamped to the coordinate's range if
         the coordinate is clamped and enforceConstraints is true.
         */
-    void setValue(SimTK::State& s, double aValue, bool enforceContraints=true) const;
+    void setValue(SimTK::State& s, double aValue, bool enforceConstraints=true) const;
 
     /** get the speed value of the Coordinate from the state */
     double getSpeedValue(const SimTK::State& s) const;


### PR DESCRIPTION
Fixes issue #4212

### Brief summary of changes
Fix the typo in the keyword argument,

### Testing I've completed
None, will see if this breaks anything or not in CI tests.

### CHANGELOG.md (choose one)
- no need to update because it's trivial

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4224)
<!-- Reviewable:end -->
