### PR TITLE
Remove `ExponentialContactForce::Parameters` subclass and add bindings support for `ExponentialContactForce`

### DIFF
--- a/Bindings/Java/CMakeLists.txt
+++ b/Bindings/Java/CMakeLists.txt
@@ -107,10 +107,11 @@ add_custom_command(
     COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_CURRENT_SOURCE_DIR}/JavaLogSink.java
             ${SWIG_JAVA_SOURCE_BUILD_OUTPUT_DIR}
-    COMMAND ${JAVA_COMPILE}
-            org/opensim/modeling/*.java 
+    COMMAND ${Java_JAVAC_EXECUTABLE}
+            -encoding UTF-8
             -source 1.8 -target 1.8
-    COMMAND ${JAVA_ARCHIVE} -cvf ${SWIG_JAVA_JAR_NAME}
+            org/opensim/modeling/*.java
+    COMMAND ${Java_JAR_EXECUTABLE} -cvf ${SWIG_JAVA_JAR_NAME}
             org/opensim/modeling/*.class
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src
     COMMENT "Compiling Java sources and creating jar archive.")

--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -31,6 +31,7 @@
 #include <OpenSim/Simulation/Model/ElasticFoundationForce.h>
 #include <OpenSim/Simulation/Model/HuntCrossleyForce.h>
 #include <OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h>
+#include <OpenSim/Simulation/Model/ExponentialContactForce.h>
 
 #include <OpenSim/Simulation/Model/ContactGeometrySet.h>
 #include <OpenSim/Simulation/Model/Probe.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -127,6 +127,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/HuntCrossleyForce.h>
 %include <OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h>
 %include <OpenSim/Simulation/Model/MeyerFregly2016Force.h>
+%include <OpenSim/Simulation/Model/ExponentialContactForce.h>
 
 %include <OpenSim/Simulation/Model/Actuator.h>
 %template(SetActuators) OpenSim::Set<OpenSim::Actuator, OpenSim::Object>;

--- a/OpenSim/Simulation/Model/ExponentialContactForce.h
+++ b/OpenSim/Simulation/Model/ExponentialContactForce.h
@@ -1,4 +1,4 @@
-﻿#ifndef OPENSIM_EXPONENTIAL_CONTACT_FORCE_H_
+#ifndef OPENSIM_EXPONENTIAL_CONTACT_FORCE_H_
 #define OPENSIM_EXPONENTIAL_CONTACT_FORCE_H_
 /* -------------------------------------------------------------------------- *
  *                  OpenSim:  ExponentialContactForce.h                       *
@@ -100,7 +100,7 @@ the contact plane or that pertains to calculation of the friction force.
 
 The terms 'contact plane', 'friction plane', and 'tangent plane' are synonymous
 with one another. They all refer to the plane defined by the x-axis and y-axis
-of the contact plane frame. Throughout the documentation, the term 
+of the contact plane frame. Throughout the documentation, the term
 'contact plane' is preferentially used.
 
 ### Normal Force (positive z-axis)
@@ -266,18 +266,6 @@ ecf->setName("myExponentialContactForce");
 model.addForce(ecf);
 \endcode
 
-The default contact parameters can be modified via a fourth, optional argument
-to the constructor. See "Customizable Parameters" below for details on how
-to customize the parameters of an ExponentialContactForce.
-
-\code{.cpp}
-SimTK::ExponentialSpringParameters myParams;
-myParams.setNormalViscosity(0.25);
-auto* ecf = new ExponentialContactForce(transform, frame, location, myParams);
-ecf->setName("myExponentialContactForce");
-model.addForce(ecf);
-\endcode
-
 ### Copy Constructor, Move Constructor, and the Copy Assignment Operator
 
 The copy constructor, move constructor, and copy assignment operator are all
@@ -293,51 +281,68 @@ object.
 ### Customizable Parameters
 
 Customizable Topology-stage parameters specifying the characteristics of the
-exponential spring are managed using SimTK::ExponentialSpringParameters.
-To customize any of the Topology-stage parameters on an ExponentialContactForce
-instance, you should
+exponential spring can be set using individual accessor methods. Each parameter
+has a getter and setter method. Setting any parameter will invalidate the
+model at Stage::Topology, requiring the model to be re-realized to Stage::Model
+before simulation or analysis can proceed. The parameters are stored internally
+in a SimTK::ExponentialSpringParameters object. This object will enforce certain
+constraints on the parameters (e.g., μₖ ≤ μₛ), and therefore internal parameter
+values may differ from the original property values.
 
-1) Create an ExponentialSpringParameters object. This object will come with
-parameters that are suitable for simulating contact in typical situations
-(e.g., foot contact during gait).
+The available parameters  are:
+
+- **Exponential Shape Parameters** (d0, d1, d2): Shape parameters for the
+  exponential that models the normal force (default: d0 = 0.0065905 m,
+  d1 = 0.5336 N, d2 = 1150.0/m).
+- **Normal Viscosity**: Viscosity in the normal direction
+  (default: cz = 0.5 N*s/m).
+- **Max Normal Force**: Maximum allowed normal force
+  (default: maxFz = 100,000.0 N).
+- **Friction Elasticity**: Elasticity of the friction spring
+  (default: kxy = 20,000.0 N/m).
+- **Friction Viscosity**: Viscosity of the friction spring
+  (default: cxy = 2.0*sqrt(kxy*mass) = 2.0*sqrt(20000*1) ~= 282.8427 N*s/m).
+- **Settle Velocity**: Velocity below which static friction conditions are
+  triggered (default: vSettle = 0.01 m/s).
+- **Initial Mu Static**: Initial value of the static coefficient of friction
+  (default: μₛ = 0.5).
+- **Initial Mu Kinetic**: Initial value of the kinetic coefficient of friction
+  (default: μₖ = 0.2).
+
+#### Example: Setting Individual Parameters
 
 \code{.cpp}
-SimTK::ExponentialSpringParameters myParams;
+// Create an ExponentialContactForce instance
+auto* ecf = new ExponentialContactForce(transform, frame, location);
+ecf->setName("myExponentialContactForce");
+
+// Set individual parameters
+ecf->setNormalViscosity(0.25);           // Change normal viscosity
+ecf->setFrictionElasticity(25000.0);     // Increase friction elasticity
+ecf->setSettleVelocity(0.005);           // Lower settle velocity
+ecf->setInitialMuStatic(0.8);            // Set static friction coefficient
+ecf->setInitialMuKinetic(0.6);           // Set kinetic friction coefficient
+
+// Set exponential shape parameters
+SimTK::Vec3 shapeParams(0.005, 0.6, 1200.0);
+ecf->setExponentialShapeParameters(shapeParams);
+
+// Add to model and initialize system
+model.addForce(ecf);
+model.initSystem();
 \endcode
 
-2) Use any of the available 'set' methods in ExponentialSpringParamters to
-change the parameters of that object. For example,
+#### Example: Reading Parameter Values
 
 \code{.cpp}
-myParams.setNormalViscosity(0.25);
+// Get current parameter values
+double normalVisc = ecf->getNormalViscosity();
+double frictionElas = ecf->getFrictionElasticity();
+const SimTK::Vec3& shape = ecf->getExponentialShapeParameters();
+double d0 = shape[0];  // First shape parameter
+double d1 = shape[1];  // Second shape parameter
+double d2 = shape[2];  // Third shape parameter
 \endcode
-
-3) Use ExponentialContactForce::setParameters() to alter the parameters of one
-(or many) ExponentialContactForce instances. For example,
-
-\code{.cpp}
-SimTK::ExponentialContactForce spr1, spr2;
-spr1.setParameters(myParams);
-spr2.setParameters(myParams);
-\endcode
-
-4) Realize the system to Stage::Topology. When a new set of parameters is
-set on an ExponentialContactForce instance, as above in step 3, the System
-will be invalidated at Stage::Topology. The System must therefore be realized
-at Stage::Topology (and hence at Stage::Model) before a simulation can proceed.
-
-        system.realizeTopology();
-
-Note that each ExponentialContactForce instance owns its own private
-ExponentialSpringParameters object. The myParams object is just used to set
-the desired parameter values of the privately owned parameters object. It is
-fine for objects like myParams to go out of scope or for myParams objects
-allocated from the heap to be deleted.
-
-Therefore, also note that the parameter values possessed by an
-ExponentialContactForce instance do not necessarily correspond to the values
-held by a local instance of ExponentialSpringParameters until a call to
-ExponentialContactForce::setParameters() is made.
 
 The default values of the parameters are expressed in units of Newtons,
 meters, seconds, and kilograms; however, you may use an alternate set of
@@ -353,8 +358,6 @@ class OSIMSIMULATION_API ExponentialContactForce : public Force {
     OpenSim_DECLARE_CONCRETE_OBJECT(ExponentialContactForce, Force);
 
 public:
-    class Parameters;
-
     //-------------------------------------------------------------------------
     // Construction
     //-------------------------------------------------------------------------
@@ -374,14 +377,10 @@ public:
     space but measured from the Ground origin (G₀) and expressed in G
     (i.e., point_G = X_GP * point_P).
     @param frame The frame in which the station is located.
-    @param location The location of the station in the frame.
-    @param params Optional parameters object used to customize the
-    topology-stage characteristics of the contact model. */
+    @param location The location of the station in the frame. */
     explicit ExponentialContactForce(const SimTK::Transform& X_GP,
         const PhysicalFrame& frame,
-        const SimTK::Vec3& location,
-        SimTK::ExponentialSpringParameters params =
-        SimTK::ExponentialSpringParameters());
+        const SimTK::Vec3& location);
 
     //-------------------------------------------------------------------------
     // Utility
@@ -413,20 +412,101 @@ public:
         return get_contact_plane_transform();
     }
 
-    /** Set the customizable Topology-stage spring parameters.
-    Calling this method will invalidate the SimTK::System at
-    Stage::Toplogy and, thus, require the SimTK::System to be re-realized
-    to Stage::Model before simulation or analysis can be resumed. */
-    void setParameters(const SimTK::ExponentialSpringParameters& params);
-    /** Get the customizable topology-stage spring parameters. Use the copy
-    constructor or the assignment operator on the returned reference to create
-    a parameters object that can be modified. */
-    const SimTK::ExponentialSpringParameters& getParameters() const;
-
     /** Get the Station that is connected to the body frame and at which the
     contact force is applied. The Station is a subcomponent of this
     ExponentialContactForce instance. */
     const Station& getStation() const;
+
+    //-------------------------------------------------------------------------
+    // Accessors for contact parameters
+    //-------------------------------------------------------------------------
+    /** Get the exponential shape parameters (d0, d1, d2) for the normal force
+    from the internal SimTK::ExponentialSpringParameters object.
+    Default: d0 = 0.0065905 m, d1 = 0.5336 N, d2 = 1150.0/m. */
+    SimTK::Vec3 getExponentialShapeParameters() const;
+
+    /** Set the exponential shape parameters (d0, d1, d2) for the normal force.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setExponentialShapeParameters(const SimTK::Vec3& shapeParams);
+
+    /** Get the viscosity in the normal direction. Returns the value from
+    the internal SimTK::ExponentialSpringParameters object. Default: 0.5 s/m. */
+    double getNormalViscosity() const;
+
+    /** Set the viscosity in the normal direction.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setNormalViscosity(double viscosity);
+
+    /** Get the maximum allowed normal force. Returns the value from
+    the internal SimTK::ExponentialSpringParameters object.
+    Default: 100,000.0 N. */
+    double getMaxNormalForce() const;
+
+    /** Set the maximum allowed normal force.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    and, thus, require the SimTK::System to be re-realized to Stage::Model
+    before simulation or analysis can be resumed. */
+    void setMaxNormalForce(double maxForce);
+
+    /** Get the elasticity of the friction spring. Returns the value from
+    the internal SimTK::ExponentialSpringParameters object. if constraints have
+    been applied. Default: 20,000.0 N/m. */
+    double getFrictionElasticity() const;
+
+    /** Set the elasticity of the friction spring.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    and, thus, require the model to be re-realized to Stage::Model before
+    simulation or analysis can be resumed. */
+    void setFrictionElasticity(double elasticity);
+
+    /** Get the viscosity of the friction spring. Returns the value from
+    the internal SimTK::ExponentialSpringParameters object. if constraints have
+    been applied. Default: 282.8427 N*s/m. */
+    double getFrictionViscosity() const;
+
+    /** Set the viscosity of the friction spring.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setFrictionViscosity(double viscosity);
+
+    /** Get the settle velocity (velocity below which static friction conditions
+    are triggered). Returns the value from the internal
+    SimTK::ExponentialSpringParameters object. Default: 0.01 m/s. */
+    double getSettleVelocity() const;
+
+    /** Set the settle velocity (velocity below which static friction conditions
+    are triggered).
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setSettleVelocity(double velocity);
+
+    /** Get the initial value of the static coefficient of friction. Returns the
+    value from SimTK::ExponentialSpringParameters, which may differ from the
+    property value after the constraint that μₖ ≤ μₛ is enforced. */
+    double getInitialMuStatic() const;
+
+    /** Set the initial value of the static coefficient of friction.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setInitialMuStatic(double muStatic);
+
+    /** Get the initial value of the kinetic coefficient of friction. Returns
+    the value from SimTK::ExponentialSpringParameters, which may differ from the
+    property value after the constraint that μₖ ≤ μₛ is enforced. */
+    double getInitialMuKinetic() const;
+
+    /** Set the initial value of the kinetic coefficient of friction.
+    Calling this method will invalidate the model at Stage::Topology and, thus,
+    require the model to be re-realized to Stage::Model before simulation or
+    analysis can be resumed. */
+    void setInitialMuKinetic(double muKinetic);
 
     //-------------------------------------------------------------------------
     // Accessors for Discrete States
@@ -489,8 +569,8 @@ public:
     /** Get the Sliding state of this exponential contact instance after it
     has been updated to be consistent with the System State. The Sliding state
     lies between 0.0 and 1.0, where 0.0 indicates that p₀ (the elastic anchor)
-    point is "static" or fixed in place, and 1.0 indicates that p₀ is "kinetic" 
-    or sliding. The System must be realized to Stage::Dynamics to access this 
+    point is "static" or fixed in place, and 1.0 indicates that p₀ is "kinetic"
+    or sliding. The System must be realized to Stage::Dynamics to access this
     data.
     @param state State object on which to base the calculations. */
     SimTK::Real getSliding(const SimTK::State& state) const;
@@ -614,7 +694,7 @@ public:
     method differs from getStation() in terms of the frame in which the
     station is expressed. getStationPosition() expresses the point either in the
     Ground frame or in the frame of the contact plane. getStation() expresses
-    the point in the frame of the MobilizedBody.  The system must be realized to 
+    the point in the frame of the MobilizedBody.  The system must be realized to
     Stage::Position to access this data.
     @param state State object on which to base the calculations.
     @param inGround Flag for choosing the frame in which the returned quantity
@@ -671,68 +751,11 @@ private:
     // PROPERTIES
     //-------------------------------------------------------------------------
     OpenSim_DECLARE_PROPERTY(contact_plane_transform, SimTK::Transform,
-        "Orientation and location of the contact plane wrt Ground. The positive z-axis of the contact plane defines the normal.");
-    OpenSim_DECLARE_PROPERTY(contact_parameters,
-        ExponentialContactForce::Parameters,
-        "Customizable topology-stage parameters.");
-    OpenSim_DECLARE_PROPERTY(station, Station,
-        "The station at which the contact force is applied.");
-
-    void setNull();
-    void constructProperties();
-    const SimTK::ExponentialSpringForce& getExponentialSpringForce() const;
-    SimTK::ExponentialSpringForce& updExponentialSpringForce();
-
-}; // END of class ExponentialContactForce
-
-
-//=============================================================================
-// ExponentialContactForce::Parameters
-//=============================================================================
-/** This subclass helps manage the topology-stage parameters of the underlying
-SimTK::ExponentialSpringForce instance. These parameters (e.g., elasticity,
-viscosity, etc.) determine the force-producing characteristics of the
-exponential spring force.
-
-This class does 3 things:
-
-- Implements an OpenSim Property for each of the customizable contact
-parameters, enabling those parameters to be serialized and de-serialized to
-and from an OpenSim Model file.
-
-- Provides a member variable (_stkparams) for storing user-set parameters
-prior to the existance of the underlying SimTK::ExponentialSpringForce object.
-During model initialization, when the SimTK::ExponetialSpringForce object is
-constructed, the user-set properties/parameters are then pushed to that object.
-
-- Ensures that the values held by the OpenSim properties are kept consistent
-with the values held by a SimTK::ExponentialSpringParameters object.
-Depending on the circumstance, parameters are updated to match properties, or
-properties are updated to match parameters.
-
-To change the values of individual parameters programmatically:
-```
-    // Get a modifiable copy of the underlying parameter object
-    // (`exp_contact` is an instance of ExponentialContactForce)
-    SimTK::ExponentialSpringParameters p = exp_contact.getParameters();
-
-    // Make the desired changes to the copy using the appropropriate setters
-    p.setFrictionElasticity(kpNew);
-    p.setFrictionViscosity(kvNew);
-    ...
-
-    // Call ExponentialContactForce::setParameters() to push the new
-    // parameters to the underlying SimTK::ExponentialSpringForce object.
-    exp_contact.setParameters(p);
-```
-
-@author F. C. Anderson **/
-class ExponentialContactForce::Parameters : public Object {
-    OpenSim_DECLARE_CONCRETE_OBJECT(ExponentialContactForce::Parameters, Object);
-
-public:
+        "Orientation and location of the contact plane wrt Ground. The "
+        "positive z-axis of the contact plane defines the normal.");
     OpenSim_DECLARE_PROPERTY(exponential_shape_parameters, SimTK::Vec3,
-        "Shape parameters for the exponential that models the normal force: d0 (0.0065905 m), d1 (0.5336 N), d2 (1150.0/m).");
+        "Shape parameters for the exponential that models the normal force: "
+        "d0 (0.0065905 m), d1 (0.5336 N), d2 (1150.0/m).");
     OpenSim_DECLARE_PROPERTY(normal_viscosity, double,
         "Viscosity in the normal direction (0.5 s/m).");
     OpenSim_DECLARE_PROPERTY(max_normal_force, double,
@@ -741,45 +764,30 @@ public:
         "Elasticity of the friction spring (20,000.0 N/m).");
     OpenSim_DECLARE_PROPERTY(friction_viscosity, double,
         "Viscosity of the friction spring (282.8427 N*s/m).");
-     OpenSim_DECLARE_PROPERTY(settle_velocity, double,
-        "Velocity below which static friction conditions are triggered (0.01 m/s) .");
+    OpenSim_DECLARE_PROPERTY(settle_velocity, double,
+        "Velocity below which static friction conditions are triggered "
+        "(0.01 m/s).");
     OpenSim_DECLARE_PROPERTY(initial_mu_static, double,
         "Initial value of the static coefficient of friction.");
     OpenSim_DECLARE_PROPERTY(initial_mu_kinetic, double,
         "Initial value of the kinetic coefficient of friction.");
+    OpenSim_DECLARE_PROPERTY(station, Station,
+        "The station at which the contact force is applied.");
 
-public:
-    /** Default constructor. */
-    Parameters();
-
-    /** Construct an instance based on a SimTK::ExponentialSpringParameters
-    object. */
-    Parameters(const SimTK::ExponentialSpringParameters& params);
-
-    /** Set the underlying SimTK parameters. This method is used to maintain
-    consistency between OpenSim Properties and the underlying parameters.
-    The typical user of OpenSim::ExponentialContactForce will not have reason
-    to call this method. For setting contact parameters, the typical user
-    should call OpenSim::ExponentialContactForce::setParameters(). */
-    void setSimTKParameters(const SimTK::ExponentialSpringParameters& params);
-
-    /** Get a read-only reference to the underlying SimTK parameters. This
-    method is used to maintain consistency between OpenSim Properties and the
-    underlying parameters. The typical user of OpenSim::ExponentialContactForce
-    will not have reason to call this method. For getting contact parameters,
-    the typical user should call
-    OpenSim::ExponentialContactForce::getParameters() */
-    const SimTK::ExponentialSpringParameters& getSimTKParameters() const;
-
-private:
     void setNull();
     void constructProperties();
+    const SimTK::ExponentialSpringForce& getExponentialSpringForce() const;
+    SimTK::ExponentialSpringForce& updExponentialSpringForce();
+
+    // Helper methods to sync properties with SimTK parameters
     void updateParameters();
     void updateProperties();
-    void updateFromXMLNode(SimTK::Xml::Element& node,
-        int versionNumber) override;
-    SimTK::ExponentialSpringParameters _stkparams;
-};
+
+    // Member variable to store SimTK parameters before the underlying
+    // SimTK::ExponentialSpringForce object is constructed
+    mutable SimTK::ExponentialSpringParameters _stkparams;
+
+}; // END of class ExponentialContactForce
 
 } // end of namespace OpenSim
 

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -257,7 +257,6 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( CoordinateLimitForce() );
     Object::registerType( SmoothSphereHalfSpaceForce() );
     Object::registerType( ExponentialContactForce() );
-    Object::registerType( ExponentialContactForce::Parameters() );
     Object::registerType( MeyerFregly2016Force() );
     Object::registerType( HuntCrossleyForce() );
     Object::registerType( ElasticFoundationForce() );

--- a/OpenSim/Simulation/Test/testExponentialContact.cpp
+++ b/OpenSim/Simulation/Test/testExponentialContact.cpp
@@ -115,6 +115,8 @@ public:
         const SimTK::MobilizedBody& body, double dz);
     void printDiscreteVariableAbstractValue(const string& pathName,
         const AbstractValue& value) const;
+    bool isParametersEqual(const ExponentialContactForce& ec0,
+        const ExponentialContactForce& ec1);
 
     //-------------------------------------------------------------------------
     // Member variables
@@ -206,20 +208,17 @@ addExponentialContact(OpenSim::Body* block)
     // ExponentialContactTester declaration.
     Transform floorXForm(defaultFloorRot, defaultFloorOrigin);
 
-    // Contact Parameters
-    SimTK::ExponentialSpringParameters params;  // yields default params
-    if (noDamp) {
-        params.setNormalViscosity(0.0);
-        params.setFrictionViscosity(0.0);
-        params.setInitialMuStatic(0.0);
-    }
-
     // Place a spring at each of the 8 corners
     std::string name = "";
     for (int i = 0; i < n; ++i) {
         name = "Exp" + std::to_string(i);
         sprEC[i] = new OpenSim::ExponentialContactForce(floorXForm,
-            *block, corner[i], params);
+            *block, corner[i]);
+        if (noDamp) {
+            sprEC[i]->setNormalViscosity(0.0);
+            sprEC[i]->setFrictionViscosity(0.0);
+            sprEC[i]->setInitialMuStatic(0.0);
+        }
         sprEC[i]->setName(name);
         model->addForce(sprEC[i]);
     }
@@ -315,6 +314,27 @@ printDiscreteVariableAbstractValue(const string& pathName,
         Vec3 x = SimTK::Value<Vec3>::downcast(value);
         cout << x << endl;
     }
+}
+
+bool
+ExponentialContactTester::
+isParametersEqual(const ExponentialContactForce& ec0,
+    const ExponentialContactForce& ec1)
+{
+    // Compare all parameters (using getters to get true values)
+    if (ec0.getExponentialShapeParameters() !=
+            ec1.getExponentialShapeParameters() ||
+        ec0.getNormalViscosity() != ec1.getNormalViscosity() ||
+        ec0.getMaxNormalForce() != ec1.getMaxNormalForce() ||
+        ec0.getFrictionElasticity() != ec1.getFrictionElasticity() ||
+        ec0.getFrictionViscosity() != ec1.getFrictionViscosity() ||
+        ec0.getSettleVelocity() != ec1.getSettleVelocity() ||
+        ec0.getInitialMuStatic() != ec1.getInitialMuStatic() ||
+        ec0.getInitialMuKinetic() != ec1.getInitialMuKinetic()) {
+        return false;
+    }
+
+    return true;
 }
 
 
@@ -420,15 +440,14 @@ TEST_CASE("Model Serialization")
                 dynamic_cast<ExponentialContactForce&>(fSet1.get(i));
 
             CHECK(ec1.getContactPlaneTransform() ==
-                    ec0.getContactPlaneTransform());
+            ec0.getContactPlaneTransform());
 
-            const Station& s0 = ec0.getStation();
-            const Station& s1 = ec1.getStation();
-            CHECK(s0.getParentFrame().getAbsolutePathString() ==
-                  s1.getParentFrame().getAbsolutePathString());
-            CHECK(s0.get_location() == s1.get_location());
-
-            CHECK(ec1.getParameters() == ec0.getParameters());
+        const Station& s0 = ec0.getStation();
+        const Station& s1 = ec1.getStation();
+        CHECK(s0.getParentFrame().getAbsolutePathString() ==
+              s1.getParentFrame().getAbsolutePathString());
+        CHECK(s0.get_location() == s1.get_location());
+        CHECK(tester.isParametersEqual(ec0, ec1));
 
         } catch (const std::bad_cast&) {
             // Nothing should happen here. Execution is just skipping any
@@ -438,24 +457,23 @@ TEST_CASE("Model Serialization")
 
     // Alter the default spring parameters to test re-serialization.
     double delta = 0.123;
-    Vec3 shape;
-    ExponentialSpringParameters p = tester.sprEC[0]->getParameters();
-    p.getShapeParameters(shape[0], shape[1], shape[2]);
-    p.setShapeParameters(
-        shape[0] + delta, shape[1] + delta, shape[2] + delta);
-    p.setNormalViscosity(p.getNormalViscosity() + delta);
-    p.setMaxNormalForce(p.getMaxNormalForce() + delta);
-    p.setFrictionElasticity(p.getFrictionElasticity() + delta);
-    p.setFrictionViscosity(p.getFrictionViscosity() + delta);
-    p.setSettleVelocity(p.getSettleVelocity() + delta);
-    p.setInitialMuStatic(p.getInitialMuStatic() + delta);
-    p.setInitialMuKinetic(p.getInitialMuKinetic() + delta);
+    Vec3 shape = tester.sprEC[0]->getExponentialShapeParameters();
+    shape[0] += delta;
+    shape[1] += delta;
+    shape[2] += delta;
     n = fSet0.getSize();
     for (int i = 0; i < n; ++i) {
         try {
             ExponentialContactForce& ec =
                 dynamic_cast<ExponentialContactForce&>(fSet0.get(i));
-            ec.setParameters(p);
+            ec.setExponentialShapeParameters(shape);
+            ec.setNormalViscosity(ec.getNormalViscosity() + delta);
+            ec.setMaxNormalForce(ec.getMaxNormalForce() + delta);
+            ec.setFrictionElasticity(ec.getFrictionElasticity() + delta);
+            ec.setFrictionViscosity(ec.getFrictionViscosity() + delta);
+            ec.setSettleVelocity(ec.getSettleVelocity() + delta);
+            ec.setInitialMuStatic(ec.getInitialMuStatic() + delta);
+            ec.setInitialMuKinetic(ec.getInitialMuKinetic() + delta);
 
         } catch (const std::bad_cast&) {
             // Nothing should happen here. Execution is just skipping any
@@ -481,16 +499,12 @@ TEST_CASE("Model Serialization")
             ExponentialContactForce& ec2 =
                 dynamic_cast<ExponentialContactForce&>(fSet2.get(i));
 
-            CHECK(ec2.getContactPlaneTransform() ==
-                ec0.getContactPlaneTransform());
-
             const Station& s0 = ec0.getStation();
             const Station& s2 = ec2.getStation();
             CHECK(s0.getParentFrame().getAbsolutePathString() ==
                   s2.getParentFrame().getAbsolutePathString());
             CHECK(s0.get_location() == s2.get_location());
-
-            CHECK(ec2.getParameters() == ec0.getParameters());
+            CHECK(tester.isParametersEqual(ec0, ec2));
 
         } catch (const std::bad_cast&) {
             // Nothing should happen here. Execution is just skipping any
@@ -577,11 +591,10 @@ TEST_CASE("Discrete State Accessors")
 
 
 // Test that the contact plane property of an ExponentialContactForce instance
-// can be set and retrieved properly. This property, along with the properties
-// encapsulated in the ExponentialContactForce::Parameters class (see below),
-// is needed to construct an ExponentialContactForce instance.
-// The ExponentialContactForce::Parameters are tested below in the test case
-// "Spring Parameters".
+// can be set and retrieved properly. This property, along with the contact
+// parameter properties, is needed to construct an ExponentialContactForce
+// instance. The contact parameters are tested below in the test case "Spring
+// Parameters".
 TEST_CASE("Contact Plane Transform")
 {
     // Create the tester and build the model.
@@ -616,161 +629,151 @@ TEST_CASE("Spring Parameters")
     // Pick a contact force instance to manipulate.
     ExponentialContactForce& spr = *tester.sprEC[0];
 
-    // Save the initial parameters.
-    // Note that pi is not a reference to a set of parameters, but an
-    // independent copy of parameters of the contact force instance.
-    const SimTK::ExponentialSpringParameters pi = spr.getParameters();
-
-    // Create a copy of the parameters that will be systematically modified.
-    SimTK::ExponentialSpringParameters pf = pi;
-
-    // Test equality of the Paremeter instances.
-    CHECK(pf == pi);
+    // Save the initial parameter values.
+    Vec3 initialShape = spr.getExponentialShapeParameters();
+    double initialNormalVisc = spr.getNormalViscosity();
+    double initialMaxForce = spr.getMaxNormalForce();
+    double initialFrictionElas = spr.getFrictionElasticity();
+    double initialFrictionVisc = spr.getFrictionViscosity();
+    double initialSettleVel = spr.getSettleVelocity();
+    double initialMuStatic = spr.getInitialMuStatic();
+    double initialMuKinetic = spr.getInitialMuKinetic();
 
     // Exponential Shape
     double delta = 0.1;
-    Vec3 di, df;
-    pf.getShapeParameters(di[0], di[1], di[2]);
+    Vec3 shape = initialShape;
     // d[0]
-    pf.setShapeParameters(di[0] + delta, di[1], di[2]);
-    pf.getShapeParameters(df[0], df[1], df[2]);
-    CHECK(df[0] == di[0] + delta);
-    CHECK(df[1] == di[1]);
-    CHECK(df[2] == di[2]);
-    spr.setParameters(pi);
+    shape[0] += delta;
+    spr.setExponentialShapeParameters(shape);
+    CHECK(spr.getExponentialShapeParameters()[0] == initialShape[0] + delta);
+    CHECK(spr.getExponentialShapeParameters()[1] == initialShape[1]);
+    CHECK(spr.getExponentialShapeParameters()[2] == initialShape[2]);
+    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
+    spr.setExponentialShapeParameters(initialShape);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
     // d[1]
-    pf.setShapeParameters(di[0], di[1] + delta, di[2]);
-    pf.getShapeParameters(df[0], df[1], df[2]);
-    CHECK(df[0] == di[0]);
-    CHECK(df[1] == di[1] + delta);
-    CHECK(df[2] == di[2]);
-    spr.setParameters(pi);
+    shape = initialShape;
+    shape[1] += delta;
+    spr.setExponentialShapeParameters(shape);
+    CHECK(spr.getExponentialShapeParameters()[0] == initialShape[0]);
+    CHECK(spr.getExponentialShapeParameters()[1] == initialShape[1] + delta);
+    CHECK(spr.getExponentialShapeParameters()[2] == initialShape[2]);
+    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
+    spr.setExponentialShapeParameters(initialShape);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
     // d[2]
-    pf.setShapeParameters(di[0], di[1], di[2] + delta);
-    pf.getShapeParameters(df[0], df[1], df[2]);
-    CHECK(df[0] == di[0]);
-    CHECK(df[1] == di[1]);
-    CHECK(df[2] == di[2] + delta);
-    spr.setParameters(pi);
+    shape = initialShape;
+    shape[2] += delta;
+    spr.setExponentialShapeParameters(shape);
+    CHECK(spr.getExponentialShapeParameters()[0] == initialShape[0]);
+    CHECK(spr.getExponentialShapeParameters()[1] == initialShape[1]);
+    CHECK(spr.getExponentialShapeParameters()[2] == initialShape[2] + delta);
+    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
+    spr.setExponentialShapeParameters(initialShape);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
     // all at once
-    pf.setShapeParameters(di[0] + delta, di[1] + delta, di[2] + delta);
-    pf.getShapeParameters(df[0], df[1], df[2]);
-    CHECK(df[0] == di[0] + delta);
-    CHECK(df[1] == di[1] + delta);
-    CHECK(df[2] == di[2] + delta);
-    spr.setParameters(pf);
+    shape = initialShape;
+    shape[0] += delta;
+    shape[1] += delta;
+    shape[2] += delta;
+    spr.setExponentialShapeParameters(shape);
+    CHECK(spr.getExponentialShapeParameters()[0] == initialShape[0] + delta);
+    CHECK(spr.getExponentialShapeParameters()[1] == initialShape[1] + delta);
+    CHECK(spr.getExponentialShapeParameters()[2] == initialShape[2] + delta);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setExponentialShapeParameters(initialShape);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Normal Viscosity
     double vali, valf;
-    vali = pi.getNormalViscosity();
-    pf.setNormalViscosity(vali + delta);
+    vali = initialNormalVisc;
+    spr.setNormalViscosity(vali + delta);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    valf = pf.getNormalViscosity();
+    valf = spr.getNormalViscosity();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
-    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setNormalViscosity(initialNormalVisc);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Max Normal Force
-    vali = pi.getMaxNormalForce();
-    pf.setMaxNormalForce(vali + delta);
-    valf = pf.getMaxNormalForce();
+    vali = initialMaxForce;
+    spr.setMaxNormalForce(vali + delta);
+    valf = spr.getMaxNormalForce();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setMaxNormalForce(initialMaxForce);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Settle Velocity
-    vali = pi.getSettleVelocity();
-    pf.setSettleVelocity(vali + delta);
-    valf = pf.getSettleVelocity();
+    vali = initialSettleVel;
+    spr.setSettleVelocity(vali + delta);
+    valf = spr.getSettleVelocity();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setSettleVelocity(initialSettleVel);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Friction Elasticity
-    vali = pi.getFrictionElasticity();
-    pf.setFrictionElasticity(vali + delta);
-    valf = pf.getFrictionElasticity();
+    vali = initialFrictionElas;
+    spr.setFrictionElasticity(vali + delta);
+    valf = spr.getFrictionElasticity();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setFrictionElasticity(initialFrictionElas);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Friction Viscosity
-    vali = pi.getFrictionViscosity();
-    pf.setFrictionViscosity(vali + delta);
+    vali = initialFrictionVisc;
+    spr.setFrictionViscosity(vali + delta);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pf);
-    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
-    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-
-    // Settle Velocity
-    vali = pi.getSettleVelocity();
-    pf.setSettleVelocity(vali + delta);
-    valf = pf.getSettleVelocity();
+    valf = spr.getFrictionViscosity();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
-    CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setFrictionViscosity(initialFrictionVisc);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Initial Static Coefficient of Friction
-    vali = pi.getInitialMuStatic();
-    pf.setInitialMuStatic(vali + delta);
-    valf = pf.getInitialMuStatic();
+    vali = initialMuStatic;
+    spr.setInitialMuStatic(vali + delta);
+    valf = spr.getInitialMuStatic();
     CHECK(valf == vali + delta);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setInitialMuStatic(initialMuStatic);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Initial Kinetic Coefficient of Friction
-    vali = pi.getInitialMuKinetic();
-    pf.setInitialMuKinetic(vali - delta);
-    valf = pf.getInitialMuKinetic();
+    vali = initialMuKinetic;
+    spr.setInitialMuKinetic(vali - delta);
+    valf = spr.getInitialMuKinetic();
     CHECK(valf == vali - delta);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setInitialMuKinetic(initialMuKinetic);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Make a change to mus that should also change muk
-    double musi = pi.getInitialMuStatic();
-    double muki = pi.getInitialMuKinetic();
-    pf.setInitialMuStatic(muki - delta);  // this should enforce muk <= mus
-    double musf = pf.getInitialMuStatic();
-    double mukf = pf.getInitialMuKinetic();
+    // Note: The constraint muk <= mus is enforced by SimTK::ExponentialSpringParameters
+    // when setting values. We test this by setting mus to a value less than muk.
+    double musi = initialMuStatic;
+    double muki = initialMuKinetic;
+    spr.setInitialMuStatic(muki - delta);  // this should enforce muk <= mus
+    double musf = spr.getInitialMuStatic();
+    double mukf = spr.getInitialMuKinetic();
     CHECK(musf == muki - delta);
     CHECK(mukf == musf);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi);
+    spr.setInitialMuStatic(initialMuStatic);
+    spr.setInitialMuKinetic(initialMuKinetic);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 
     // Make a change to muk that should also change mus
-    musi = pi.getInitialMuStatic();
-    muki = pi.getInitialMuKinetic();
-    pf.setInitialMuKinetic(musi + delta);  // this should enforce mus >= muk
-    musf = pf.getInitialMuStatic();
-    mukf = pf.getInitialMuKinetic();
+    musi = initialMuStatic;
+    muki = initialMuKinetic;
+    spr.setInitialMuKinetic(musi + delta);  // this should enforce mus >= muk
+    musf = spr.getInitialMuStatic();
+    mukf = spr.getInitialMuKinetic();
     CHECK(mukf == musi + delta);
     CHECK(musf == mukf);
-    spr.setParameters(pf);
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
-    spr.setParameters(pi); // now back to original
+    spr.setInitialMuStatic(initialMuStatic);
+    spr.setInitialMuKinetic(initialMuKinetic); // now back to original
     CHECK_NOTHROW( spr.assertPropertiesAndParametersEqual() );
 }
 
@@ -797,11 +800,6 @@ TEST_CASE("Construction")
 
     // Add ExponentialContactForce instances
     Vec3 floorOrigin(0., -0.004, 0.);
-    SimTK::ExponentialSpringParameters params;
-    Real elasticity0 = params.getFrictionElasticity();
-    // ---- params1
-    Real elasticity1 = elasticity0 + 0.1;
-    params.setFrictionElasticity(elasticity1);
     // ---- transform1
     Real angle1 = convertDegreesToRadians(85.0);
     Rotation floorRot1(-angle1, XAxis);
@@ -809,12 +807,14 @@ TEST_CASE("Construction")
     Vec3 v1(0.1, 0.1, 0.1);
     // ----frc1
     ExponentialContactForce* frc1 = new
-        ExponentialContactForce(floorXForm1, *block, v1, params);
+        ExponentialContactForce(floorXForm1, *block, v1);
+    Real elasticity0 = frc1->getFrictionElasticity();
+    Real elasticity1 = elasticity0 + 0.1;
+    frc1->setFrictionElasticity(elasticity1);
     frc1->setName("ExpFrc1");
     model->addForce(frc1);
     // ---- params2
     Real elasticity2 = elasticity0 + 0.2;
-    params.setFrictionElasticity(elasticity2);
     // ---- transform2
     Real angle2 = convertDegreesToRadians(95.0);
     Rotation floorRot2(-angle2, XAxis);
@@ -822,7 +822,8 @@ TEST_CASE("Construction")
     Vec3 v2(-0.1, -0.1, -0.1);
     // ---- frc2
     ExponentialContactForce* frc2 = new
-        ExponentialContactForce(floorXForm2, *block, v2, params);
+        ExponentialContactForce(floorXForm2, *block, v2);
+    frc2->setFrictionElasticity(elasticity2);
     frc2->setName("ExpFrc2");
     model->addForce(frc2);
 
@@ -831,18 +832,18 @@ TEST_CASE("Construction")
     // ExponentialSpringForce.
     ExponentialContactForce* frc1Copy = new ExponentialContactForce(*frc1);
     frc1Copy->setName("ExpFrc1Copy");
-    CHECK(frc1Copy->getParameters().getFrictionElasticity() == elasticity1);
+    CHECK(frc1Copy->getFrictionElasticity() == elasticity1);
     CHECK(frc1Copy->getContactPlaneTransform() == floorXForm1);
 
     // Copy Assignment
     // All properties and the station can be assigned because frcDefault
     // doesn't wrap an instantiated SimTK::ExponentialSpringForce.
     ExponentialContactForce* frcDefault = new ExponentialContactForce();
-    CHECK(frcDefault->getParameters().getFrictionElasticity() == elasticity0);
+    CHECK(frcDefault->getFrictionElasticity() == elasticity0);
     CHECK_FALSE(SimTK::Test::numericallyEqual(
             frcDefault->getContactPlaneTransform(), floorXForm1, 1))  ;
     *frcDefault = *frc1;
-    CHECK(frcDefault->getParameters().getFrictionElasticity() == elasticity1);
+    CHECK(frcDefault->getFrictionElasticity() == elasticity1);
     CHECK(frcDefault->getContactPlaneTransform() == floorXForm1);
     delete frcDefault;
 
@@ -851,7 +852,7 @@ TEST_CASE("Construction")
     // assignment breaks the Station's Socket connection to the PhysicalFrame.
     // Copy assignment when the springs have been added to the model
     // *frc1 = *frc2;
-    // CHECK(frc1->getParameters().getFrictionElasticity() == elasticity2);
+    // CHECK(frc1->getFrictionElasticity() == elasticity2);
     // CHECK(frc1->getContactPlaneTransform() == floorXForm2);
 
     // Build the system
@@ -859,43 +860,43 @@ TEST_CASE("Construction")
 
     // Perform similar checks again.
     *frc1 = *frc1Copy;
-    CHECK(frc1->getParameters().getFrictionElasticity() == elasticity1);
+    CHECK(frc1->getFrictionElasticity() == elasticity1);
     CHECK(frc1->getContactPlaneTransform() == floorXForm1);
     *frc1 = *frc2;
-    CHECK(frc1->getParameters().getFrictionElasticity() == elasticity2);
+    CHECK(frc1->getFrictionElasticity() == elasticity2);
     CHECK(frc1->getContactPlaneTransform() == floorXForm2);
     ExponentialContactForce* frc2Copy = new ExponentialContactForce(*frc2);
     frc2Copy->setName("ExpFrc2Copy");
-    CHECK(frc2Copy->getParameters().getFrictionElasticity() == elasticity2);
+    CHECK(frc2Copy->getFrictionElasticity() == elasticity2);
     CHECK(frc2Copy->getContactPlaneTransform() == floorXForm2);
 
     // Check that no segfaults occur when deleting the original and its copy.
     frcDefault = new ExponentialContactForce();
-    CHECK(frcDefault->getParameters().getFrictionElasticity() == elasticity0);
+    CHECK(frcDefault->getFrictionElasticity() == elasticity0);
     CHECK_FALSE(SimTK::Test::numericallyEqual(
             frcDefault->getContactPlaneTransform(), floorXForm1, 1));
     ExponentialContactForce* frcDefaultCopy =
         new ExponentialContactForce(*frcDefault);
-    CHECK(frcDefaultCopy->getParameters().getFrictionElasticity() == elasticity0);
+    CHECK(frcDefaultCopy->getFrictionElasticity() == elasticity0);
     CHECK_FALSE(SimTK::Test::numericallyEqual(
             frcDefaultCopy->getContactPlaneTransform(), floorXForm1, 1));
     delete frcDefault;
     delete frcDefaultCopy;
 
     // Move Construction
-    params.setFrictionElasticity(elasticity1);
     ExponentialContactForce* frc3 =
-        new ExponentialContactForce(floorXForm1, *block, v1, params);
+        new ExponentialContactForce(floorXForm1, *block, v1);
+    frc3->setFrictionElasticity(elasticity1);
     frc3->setName("ExpFrc3");
     ExponentialContactForce* frc3Move =
         new ExponentialContactForce(std::move(*frc3));
-    CHECK(frc3Move->getParameters().getFrictionElasticity() == elasticity1);
+    CHECK(frc3Move->getFrictionElasticity() == elasticity1);
     CHECK(frc3Move->getContactPlaneTransform() == floorXForm1);
     model->addForce(frc3);
     model->buildSystem();
     ExponentialContactForce* frc3MoveAfterBuild =
         new ExponentialContactForce(std::move(*frc3));
-    CHECK(frc3MoveAfterBuild->getParameters().getFrictionElasticity() == elasticity1);
+    CHECK(frc3MoveAfterBuild->getFrictionElasticity() == elasticity1);
     CHECK(frc3MoveAfterBuild->getContactPlaneTransform() == floorXForm1);
     delete frc3Move;
     delete frc3MoveAfterBuild;


### PR DESCRIPTION
### Brief summary of changes

In some cases, SWIG struggles with creating bindings for classes with subclasses, and this is the case for `ExponentialContactForce` on Windows builds. This change removes the `ExponentialContactForce::Parameters` subclass and moves all of the properties into `ExponentialContactForce`. Additionally, `ExponentialContactForce` has been refactored to not expose `SimTK::ExponentialSpringParameters` to the user, which should be more friendly to scripting users.

A brief list of individual changes:
- Getter and setter methods are added to `ExponentialContactForce` for each property. The getter methods return the value stored in the internal `SimTK::ExponentialSpringParameters`. The setter methods handle syncing the property value updates with the internal parameters.
- Added `isPropertiesEqual` and `isParametersEqual` testing helper functions.
- Updated `testExponentialContact.cpp` to accommodate all above changes. 

Finally, `ExponentialContactForce` is added to the bindings to provide access in Python/Matlab.

### Testing I've completed

Ran tests locally on MacOS (arm64).

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal fixes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4228)
<!-- Reviewable:end -->
