### PR TITLE
Add bindings fix for `Mat33` element-by-element constuctor

### DIFF
--- a/Bindings/Python/tests/test_simbody.py
+++ b/Bindings/Python/tests/test_simbody.py
@@ -252,4 +252,16 @@ class TestSimbody(unittest.TestCase):
         for i in range(residual.size()):
             assert abs(residual[i]) < 1e-10
 
-    
+    def test_Mat33(self):
+        mat33 = osim.Mat33(1, 2, 3, 4, 5, 6, 7, 8, 9)
+        assert mat33.nrow() == 3
+        assert mat33.ncol() == 3
+        assert mat33.get(0, 0) == 1
+        assert mat33.get(0, 1) == 2
+        assert mat33.get(0, 2) == 3
+        assert mat33.get(1, 0) == 4
+        assert mat33.get(1, 1) == 5
+        assert mat33.get(1, 2) == 6
+        assert mat33.get(2, 0) == 7
+        assert mat33.get(2, 1) == 8
+        assert mat33.get(2, 2) == 9

--- a/Bindings/SWIGSimTK/Mat.h
+++ b/Bindings/SWIGSimTK/Mat.h
@@ -356,18 +356,10 @@ public:
         );
     }
 #else
-    template <int MM = M, int NN = N,
-              typename std::enable_if<(MM==3 && NN==3), int>::type = 0>
-    Mat(const E& e00, const E& e01, const E& e02,
-        const E& e10, const E& e11, const E& e12,
-        const E& e20, const E& e21, const E& e22)
-    {
-        const E elems[9] = {e00, e01, e02,
-                            e10, e11, e12,
-                            e20, e21, e22};
-        for (int idx = 0; idx < 9; ++idx)
-            d[rIx(idx)] = elems[idx];
-    }
+    Mat(const ELT& e0,const ELT& e1,const ELT& e2,const ELT& e3,const ELT& e4,
+        const ELT& e5,const ELT& e6,const ELT& e7,const ELT& e8)
+      {assert(M*N==9);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
+       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;}
 #endif
 
 #ifndef SWIG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ performance and stability in wrapping solutions.
 - Support building PYPI distribution python wheels on all platforms, upgrade builds to python 3.11 and numpy 2.0. (#4189)
 - Completed the implementation of the `MeyerFregly2016Force` class to support NMSM Pipeline-equivalent contact models in Moco. (#4234)
 - The experimental classes `AckermannVanDenBogert2010Force` and `EspositoMiller2018Force` have been removed. (#4234)
+- Fixed an issue prevent element-by-element construction of `Mat33` objects in Matlab and Python. (#4241)
 
 
 v4.5.2


### PR DESCRIPTION
Fixes issue #4216

### Brief summary of changes

Replaced the element-by-element constructor for `Mat33` in `Bindings/SWIGSimTK/Mat.h` with the original implementation which is parseable by SWIG.

### Testing I've completed

Added a unit test to `test_simbody.py`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4241)
<!-- Reviewable:end -->
