### PR TITLE
Replace `MocoJointReactionGoal::setWeight()` and `setWeightSet()` to avoid `MocoGoal::setWeight()` conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ performance and stability in wrapping solutions.
 - The experimental classes `AckermannVanDenBogert2010Force` and `EspositoMiller2018Force` have been removed. (#4234)
 - Fixed an issue prevent element-by-element construction of `Mat33` objects in Matlab and Python. (#4241)
 - Added class `MeyerFregly2016Muscle` to support NMSM Pipeline-equivalent muscle models in Moco. (#4233)
+- Breaking: replaced `MocoJointReactionGoal::setWeight()`/`setWeightSet()` with `setReactionWeight()`/`setReactionWeightSet()` to avoid conflict with `MocoGoal::setWeight()`. (#4256)
 
 
 v4.5.2

--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.h
@@ -88,7 +88,7 @@ public:
     already set for the requested measure, then the provided weight
     replaces the previous weight. An exception is thrown during
     initialization if a weight for an unknown measure is provided. */
-    void setWeight(const std::string& measure, const double& weight) {
+    void setReactionWeight(const std::string& measure, double weight) {
         if (get_reaction_weights().contains(measure)) {
             upd_reaction_weights().get(measure).setWeight(weight);
         } else {
@@ -97,7 +97,7 @@ public:
     }
     /** Provide a MocoWeightSet to weight the reaction measures in the cost.
     Replaces the weight set if it already exists. */
-    void setWeightSet(const MocoWeightSet& weightSet) {
+    void setReactionWeightSet(const MocoWeightSet& weightSet) {
         upd_reaction_weights() = weightSet;
     }
 


### PR DESCRIPTION
Fixes issue #4201 

### Brief summary of changes

Replace `MocoJointReactionGoal::setWeight()` and `setWeightSet()` to avoid `MocoGoal::setWeight()` conflict

### Testing I've completed

Run CI test suite.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated, and noted that this a breaking change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4256)
<!-- Reviewable:end -->
