### PR TITLE
Fix compile-time issue where the Model API is used without access to the definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ performance and stability in wrapping solutions.
 - Fixed an issue prevent element-by-element construction of `Mat33` objects in Matlab and Python. (#4241)
 - Added class `MeyerFregly2016Muscle` to support NMSM Pipeline-equivalent muscle models in Moco. (#4233)
 - Breaking: replaced `MocoJointReactionGoal::setWeight()`/`setWeightSet()` with `setReactionWeight()`/`setReactionWeightSet()` to avoid conflict with `MocoGoal::setWeight()`. (#4256)
+- Fixed a compile-time issue where `OutputReporter` was using the `Model` API without having access to its definition.
 
 
 v4.5.2

--- a/OpenSim/Analyses/OutputReporter.cpp
+++ b/OpenSim/Analyses/OutputReporter.cpp
@@ -32,6 +32,13 @@
 using namespace OpenSim;
 using namespace std;
 
+
+OutputReporter::OutputReporter(const OutputReporter&) = default;
+OutputReporter::OutputReporter(OutputReporter&&) noexcept = default;
+OutputReporter::~OutputReporter() noexcept = default;
+OutputReporter& OutputReporter::operator=(const OutputReporter&) = default;
+OutputReporter& OutputReporter::operator=(OutputReporter&&) noexcept = default;
+
 //=============================================================================
 // ANALYSIS
 //=============================================================================

--- a/OpenSim/Analyses/OutputReporter.h
+++ b/OpenSim/Analyses/OutputReporter.h
@@ -28,6 +28,7 @@
 // INCLUDES
 //=============================================================================
 #include <OpenSim/Simulation/Model/Analysis.h>
+#include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Common/Reporter.h>
 #include <OpenSim/Common/STOFileAdapter.h>
 #include "osimAnalysesDLL.h"
@@ -85,7 +86,12 @@ OpenSim_DECLARE_LIST_PROPERTY(output_paths, std::string,
         setName("OutputReporter");
     }
 
-    virtual ~OutputReporter() = default;
+    OutputReporter(const OutputReporter&);
+    OutputReporter(OutputReporter&&) noexcept;
+    ~OutputReporter() noexcept override;
+
+    OutputReporter& operator=(const OutputReporter&);
+    OutputReporter& operator=(OutputReporter&&) noexcept;
 
 protected:
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue found when compiling OpenSim as part of [OpenSim Creator](https://www.opensimcreator.com/) / [OPynSim](https://github.com/opynsim/opynsim), which uses a variety of different compilers, linters, libASAN, libUBSAN, etc.  This is part of OPynSim's [custom patchset](https://github.com/opynsim/opynsim/tree/17dbb1df84c70efb306554d386712421d3f60bdc/libosim/opensim-core-patches) that is applied downstream and ran in prod (e.g. in OpenSim Creator) for a while before upstreaming here.

This shouldn't change behavior, but the issue is that the C++ for `OutputReporter` technically uses the `Model` API (iirc - it was a while ago) and some compilers in strict/linter mode won't let it through.

### Brief summary of changes

- Minor change to header/c++ file

### Testing I've completed

- It compiles

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4259)
<!-- Reviewable:end -->
