### PR TITLE
Add ScopeExit, use it to plug a leak in Model::extendConnectToModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ performance and stability in wrapping solutions.
 - Breaking: replaced `MocoJointReactionGoal::setWeight()`/`setWeightSet()` with `setReactionWeight()`/`setReactionWeightSet()` to avoid conflict with `MocoGoal::setWeight()`. (#4256)
 - Fixed a double-free issue that libASAN detects when loading/simulating models containing Thelen2003Muscle
 - Fixed a compile-time issue where `OutputReporter` was using the `Model` API without having access to its definition.
+- Added `ScopeExit`, which is a lightweight C++-only class for calling a function/lambda when it destructs (similar to `std::experimental::scope_exit`).
+- Fixed a leak in `Model::extendConnectToModel` that can occur when an exception is thrown midway through model graph creation.
 
 
 v4.5.2

--- a/OpenSim/Common/ScopeExit.h
+++ b/OpenSim/Common/ScopeExit.h
@@ -1,0 +1,109 @@
+#ifndef OPENSIM_SCOPE_EXIT_H_
+#define OPENSIM_SCOPE_EXIT_H_
+
+/* -------------------------------------------------------------------------- *
+ *                          OpenSim: ScopeExit.h                              *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
+ * Author(s): Adam Kewley                                                     *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+namespace OpenSim
+{
+    /**
+     * A general-purpose scope guard intended to call its exit function when
+     * a scope is exited - either normally, or via an exception.
+     *
+     * This utility class is effectively an OpenSim rewrite of `std::experimental::scope_exit`,
+     * which is documented here: https://en.cppreference.com/w/cpp/experimental/scope_exit.html
+     */
+    template<std::invocable EF>
+    class [[nodiscard]] ScopeExit final {
+    public:
+        /**
+         * Constructs a `ScopeExit` from a function or function object.
+         */
+        template<typename Fn>
+        requires (
+            std::destructible<EF> and
+            std::is_constructible_v<EF, Fn> and
+            not std::same_as<std::remove_cvref_t<Fn>, ScopeExit>
+        )
+        explicit ScopeExit(Fn&& fn) : exit_function_{std::forward<Fn>(fn)} {}
+
+        ScopeExit(const ScopeExit&) = delete;
+
+        /**
+         * Move constructor. Initializes the stored function with the one in
+         * `tmp`. The constructed `ScopeExit` is active if and only if `tmp`
+         * is active. After successful move construction, `tmp` becomes
+         * inactive.
+         */
+        ScopeExit(ScopeExit&& tmp) noexcept
+        requires (std::is_nothrow_move_constructible_v<EF>) :
+            exit_function_{std::move(tmp.exit_function_)},
+            is_active_{std::exchange(tmp.is_active_, false)}
+        {}
+
+        /** \copydoc ScopeExit::ScopeExit(ScopeExit&&) */
+        ScopeExit(ScopeExit&& tmp) noexcept(std::is_nothrow_copy_constructible_v<EF>)
+        requires (not std::is_nothrow_move_constructible_v<EF> and std::is_copy_constructible_v<EF>) :
+            exit_function_{tmp.exit_function_},
+            is_active_{std::exchange(tmp.is_active_, false)}
+        {}
+
+        ScopeExit& operator=(const ScopeExit&) = delete;
+        ScopeExit& operator=(ScopeExit&&) noexcept = delete;
+
+        ~ScopeExit() noexcept
+        {
+            if (is_active_) {
+                exit_function_();
+            }
+        }
+
+        /**
+         * Makes the `ScopeExit` inactive, meaning it will not call its
+         * exit function on destruction.
+         *
+         * Once a `ScopeExit` is inactive, it cannot become active again.
+         */
+        void release() noexcept { is_active_ = false; }
+
+        private:
+            EF exit_function_;
+            bool is_active_ = true;
+    };
+
+    /**
+     * One template deduction guide permits the deduction of an argument of function
+     * or function object type.
+     *
+     * The argument (after function-to-pointer decay, if any) is copied or moved into
+     * the constructed scope_exit.
+     */
+    template<typename EF>
+    ScopeExit(EF) -> ScopeExit<EF>;
+}
+
+#endif  // #ifndef OPENSIM_SCOPE_EXIT_H_

--- a/OpenSim/Common/Test/testScopeExit.cpp
+++ b/OpenSim/Common/Test/testScopeExit.cpp
@@ -1,0 +1,161 @@
+/* -------------------------------------------------------------------------- *
+ *                        OpenSim: testScopeExit.h                            *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
+ * Author(s): Adam Kewley                                                     *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Common/ScopeExit.h>
+
+#include <catch2/catch_all.hpp>
+
+using namespace OpenSim;
+
+namespace
+{
+    /**
+     * Helper class for exercising the move-constructor behavior that's
+     * documented for `std::experimental::scope_exit<EF>`, to ensure that
+     * OpenSim's rewrite of it is mostly forward-compatible.
+     */
+    template<bool IsNoexceptMoveConstructible, bool IsNoexceptCopyConstructible>
+    class Callable final {
+    public:
+        explicit Callable(int* calls, int* copies, int* moves) :
+            calls_{calls}, copies_{copies}, moves_{moves}
+        {}
+        Callable(Callable&& tmp) noexcept(IsNoexceptMoveConstructible) :
+            calls_{tmp.calls_}, copies_{tmp.copies_}, moves_{tmp.moves_}
+        {
+            ++(*moves_);
+        }
+        Callable(const Callable& src) noexcept(IsNoexceptCopyConstructible) :
+            calls_{src.calls_}, copies_{src.copies_}, moves_{src.moves_}
+        {
+            ++(*copies_);
+        }
+        ~Callable() noexcept = default;
+
+        Callable& operator=(const Callable&) = delete;
+        Callable& operator=(Callable&&) noexcept = delete;
+
+
+        void operator()() const noexcept { ++(*calls_); }
+    private:
+        int* calls_;
+        int* copies_;
+        int* moves_;
+    };
+}
+
+
+TEST_CASE("ScopeExit calls exit function on normal scope exit")
+{
+    bool called = false;
+    {
+        ScopeExit exit{[&called]() { called = true; }};
+    }
+    REQUIRE(called);
+}
+
+TEST_CASE("ScopeExit calls exit function when an exception is thrown")
+{
+    bool called = false;
+    {
+        try {
+            ScopeExit exit{[&called]() { called = true; }};
+            throw std::runtime_error{"throw something"};
+        }
+        catch (const std::exception&) {}  // ignore the exception
+    }
+    REQUIRE(called);
+}
+
+TEST_CASE("ScopeExit when move constructed only calls exit function once")
+{
+    int calls = 0;
+    {
+        ScopeExit first{[&calls]() { ++calls; }};
+        ScopeExit second{std::move(first)};
+    }
+    REQUIRE(calls == 1);
+}
+
+TEST_CASE("ScopeExit when move constructed does not forget release of source")
+{
+    int calls = 0;
+    {
+        ScopeExit first{[&calls]() { ++calls; }};
+        first.release();
+        ScopeExit second{std::move(first)};
+    }
+    REQUIRE(calls == 0);
+}
+
+TEST_CASE("ScopeExit copies the function object if its move constructor is not noexcept")
+{
+    int calls = 0;
+    int copies = 0;
+    int moves = 0;
+    {
+        ScopeExit first{Callable<false, true>{&calls, &copies, &moves}};
+        ScopeExit second{std::move(first)};
+    }
+    REQUIRE(calls == 1);   // Destruction of `second`
+    REQUIRE(copies == 1);  // Copying via `ScopeExit::ScopeExit(ScopeExit&&)`
+    REQUIRE(moves == 1);   // Initial construction
+}
+
+TEST_CASE("ScopeExit moves the function object if its move constructor is noexcept")
+{
+    int calls = 0;
+    int copies = 0;
+    int moves = 0;
+    {
+        ScopeExit first{Callable<true, true>{&calls, &copies, &moves}};
+        ScopeExit second{std::move(first)};
+    }
+    REQUIRE(calls == 1);   // Destruction of `second`
+    REQUIRE(copies == 0);
+    REQUIRE(moves == 2);   // Initial construction and move construction of `ScopeExit`
+}
+
+TEST_CASE("ScopeExit release stops the exit function from being called on normal scope exit")
+{
+    bool called = false;
+    {
+        ScopeExit exit{[&called]() { called = true; }};
+        exit.release();
+    }
+    REQUIRE(not called);
+}
+
+TEST_CASE("ScopeExit release stops the exit function from being called when an exception is thrown")
+{
+    bool called = false;
+    {
+        try {
+            ScopeExit exit{[&called]() { called = true; }};
+            exit.release();
+            throw std::runtime_error{"throw something"};
+        }
+        catch (const std::exception&) {}  // ignore the exception
+    }
+    REQUIRE(not called);
+}


### PR DESCRIPTION
Fixes issue found when compiling OpenSim as part of [OpenSim Creator](https://www.opensimcreator.com/) / [OPynSim](https://github.com/opynsim/opynsim), which uses a variety of different compilers, linters, libASAN, libUBSAN, etc.  This is part of OPynSim's [custom patchset](https://github.com/opynsim/opynsim/tree/17dbb1df84c70efb306554d386712421d3f60bdc/libosim/opensim-core-patches) that is applied downstream and ran for a while  (e.g. in OpenSim Creator) before upstreaming here.

This shouldn't change behavior or break any APIs. What this changeset does it plug a memory leak that can occur when an exception is thrown midway though `Model::extendConnectToModel`. What happens is that `jointset.setMemoryOwner` is set to `false` temporarily during some part of the graph creation process, which then throws, which then leaves the jointset in a not-memory-owning state.

This normally doesn't leak memory because the ownership is manually set to `true`, but that won't happen if an exception is thrown midway through the process.

The design pattern for handling "set something here, make sure it's unset afterwards - even if an exception is thrown" is usually called "defer", "scope guard", or "RAII". C++ uses RAII most of the time, but a scope guard (or [defer](https://zig.guide/language-basics/defer/))  is useful for functions that don't use RAII to control cleanup, such as `setMemoryOwner`, or C functions. The "trick" to be aware of is that C++ can actually implement manual scope guards using its own type system. There's experimental support for the pattern in the form of [std::experimental::scope_exit](https://en.cppreference.com/w/cpp/experimental/scope_exit.html). This PR just implements a very very basic implementation of it so that it's definitely available on all platforms. Later on, it could be changed to:

```c++
namespace OpenSim { using ScopeExit = std::experimental::scope_exit; }
```

### Brief summary of changes

- Add `ScopeExit`
- Add tests for `ScopeExit`
- Refactor `extendConnectToModel` to use a scope exit rather than manual cleanup, so it's resillient to exceptions

### Testing I've completed

- Unit tests
- Running this patch via OPynSim and OpenSim Creator and confirming the leak is gone

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4261)
<!-- Reviewable:end -->
