### PR TITLE
Functionality to specify a specific axis when using MocoAverageSpeedGoal

### DIFF
--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -50,12 +50,19 @@ void MocoGoal::printDescription() const {
 }
 
 double MocoGoal::calcSystemDisplacement(const GoalInput& input) const {
+    // Default behaviour: full 3D Euclidean norm of CoM displacement.
+    return calcSystemDisplacement(input, -1);
+}
+
+double MocoGoal::calcSystemDisplacement(const GoalInput& input,
+        int axisComponent) const {
     const SimTK::Vec3 comInitial =
             getModel().calcMassCenterPosition(input.initial_state);
     const SimTK::Vec3 comFinal =
             getModel().calcMassCenterPosition(input.final_state);
-    // TODO: Use distance squared for convexity.
-    return (comFinal - comInitial).norm();
+    const SimTK::Vec3 delta = comFinal - comInitial;
+    if (axisComponent == -1) { return delta.norm(); }
+    return delta[axisComponent];
 }
 
 double MocoGoal::calcDuration(const GoalInput& input) const {

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -51,18 +51,16 @@ void MocoGoal::printDescription() const {
 
 double MocoGoal::calcSystemDisplacement(const GoalInput& input) const {
     // Default behaviour: full 3D Euclidean norm of CoM displacement.
-    return calcSystemDisplacement(input, -1);
+    return calcSystemDisplacementVector(input).norm();
 }
 
-double MocoGoal::calcSystemDisplacement(const GoalInput& input,
-        int axisComponent) const {
+SimTK::Vec3 MocoGoal::calcSystemDisplacementVector(
+    const GoalInput& input) const {
     const SimTK::Vec3 comInitial =
             getModel().calcMassCenterPosition(input.initial_state);
     const SimTK::Vec3 comFinal =
             getModel().calcMassCenterPosition(input.final_state);
-    const SimTK::Vec3 delta = comFinal - comInitial;
-    if (axisComponent == -1) { return delta.norm(); }
-    return delta[axisComponent];
+    return comFinal - comInitial;
 }
 
 double MocoGoal::calcDuration(const GoalInput& input) const {

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -50,7 +50,7 @@ void MocoGoal::printDescription() const {
 }
 
 double MocoGoal::calcSystemDisplacement(const GoalInput& input) const {
-    // Default behaviour: full 3D Euclidean norm of CoM displacement.
+    // TODO: instead use squared norm for convexity.
     return calcSystemDisplacementVector(input).norm();
 }
 

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -473,10 +473,11 @@ protected:
         return m_model.getRef();
     }
 
+    /// Calculate the norm displacement of the system's center of mass
+    /// over the phase.
+    double calcSystemDisplacement(const GoalInput& input) const;
     /// Calculate the displacement of the system's center of mass over the
     /// phase.
-    double calcSystemDisplacement(const GoalInput& input) const;
-    // Calculate the displacement of the system's center of mass...
     SimTK::Vec3 calcSystemDisplacementVector(const GoalInput& input) const;
     /// Calculate the duration of the phase.
     double calcDuration(const GoalInput& input) const;

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -474,15 +474,10 @@ protected:
     }
 
     /// Calculate the displacement of the system's center of mass over the
-    // phase.
+    /// phase.
     double calcSystemDisplacement(const GoalInput& input) const;
-    // Calculate the displacement of the system's center of mass over the
-    // phase for a specific axis/direction.
-    // The axis_component argument selects which component of the displacement
-    // vector to return: 0=X, 1=Y, 2=Z, or -1 (default) for the full 3D
-    // Euclidean norm.
-    double calcSystemDisplacement(const GoalInput& input,
-            int axisComponent) const;
+    // Calculate the displacement of the system's center of mass...
+    SimTK::Vec3 calcSystemDisplacementVector(const GoalInput& input) const;
     /// Calculate the duration of the phase.
     double calcDuration(const GoalInput& input) const;
     /// Calculate the mass of the system.
@@ -586,9 +581,13 @@ class MocoAverageSpeedGoal : public MocoGoal {
 public:
     OpenSim_DECLARE_PROPERTY(desired_average_speed, double,
             "The desired average speed of the system (m/s). Default: 0.");
-    OpenSim_DECLARE_PROPERTY(axis_component, int,
-            "The component of the displacement vector to use: 0=X, 1=Y, 2=Z, "
-            "or -1 (default) for the full 3D Euclidean norm.");
+    OpenSim_DECLARE_PROPERTY(displacement_direction, std::string,
+            "The direction of motion used to compute average speed. Accepted "
+            "values are 'positive-x', 'positive-y', 'positive-z', "
+            "'negative-x','negative-y', 'negative-z', or 'norm' (default) "
+            "for the full 3D Euclidean norm of the CoM displacement. Note "
+            "that 'desired_average_speed' should always be positive; the "
+            "sign of the direction is embedded in this property.");
     MocoAverageSpeedGoal() { constructProperties(); }
     MocoAverageSpeedGoal(std::string name) : MocoGoal(std::move(name)) {
         constructProperties();
@@ -602,9 +601,15 @@ protected:
     void calcGoalImpl(
             const GoalInput& input, SimTK::Vector& values) const override {
         // Calculate average gait speed.
-        const double displacement =
-                calcSystemDisplacement(
-                    input, get_axis_component());
+        double displacement;
+        if (get_displacement_direction() == "norm") {
+            displacement = calcSystemDisplacement(input);
+        } else {
+            SimTK::Vec3 displacementVector =
+                    calcSystemDisplacementVector(input);
+            displacement =
+                    m_direction_sign * displacementVector[m_direction_index];
+        }
         const double duration = calcDuration(input);
         values[0] = get_desired_average_speed() - (displacement / duration);
         if (getModeIsCost()) { values[0] = SimTK::square(values[0]); }
@@ -612,21 +617,49 @@ protected:
     void initializeOnModelImpl(const Model&) const override {
         setRequirements(0, 1);
 
-        // Validate axis_component value at initialization time.
-        const int axisComponent = get_axis_component();
-        OPENSIM_THROW_IF_FRMOBJ(axisComponent != -1 && axisComponent != 0 &&
-                                        axisComponent != 1 &&
-                                        axisComponent != 2,
-                Exception,
-                "axis_component must be -1 (norm), 0 (X), 1 (Y), or 2 (Z), "
-                "but got {}.",
-                axisComponent);
+        // Validate displacement_direction property.
+        std::set<std::string> directions{"positive-x", "positive-y",
+                "positive-z", "negative-x", "negative-y", "negative-z",
+                "norm"};
+        checkPropertyValueIsInSet(
+                getProperty_displacement_direction(), directions);
+
+        // Pre-compute index and sign for use in calcGoalImpl.
+        auto setIndexAndSign = [](const std::string& dir, int& index,
+                                       int& sign) {
+            if (dir == "positive-x") {
+                index = 0;
+                sign = 1;
+            } else if (dir == "positive-y") {
+                index = 1;
+                sign = 1;
+            } else if (dir == "positive-z") {
+                index = 2;
+                sign = 1;
+            } else if (dir == "negative-x") {
+                index = 0;
+                sign = -1;
+            } else if (dir == "negative-y") {
+                index = 1;
+                sign = -1;
+            } else if (dir == "negative-z") {
+                index = 2;
+                sign = -1;
+            }
+        };
+        if (get_displacement_direction() != "norm") {
+            setIndexAndSign(get_displacement_direction(), m_direction_index,
+                    m_direction_sign);
+        }
     }
 
 private:
-    void constructProperties() { constructProperty_desired_average_speed(0);
-                                 constructProperty_axis_component(-1);
+    void constructProperties() { 
+        constructProperty_desired_average_speed(0);
+        constructProperty_displacement_direction("norm");
     }
+    mutable int m_direction_index{0};
+    mutable int m_direction_sign{1};
 };
 
 } // namespace OpenSim

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -473,11 +473,13 @@ protected:
         return m_model.getRef();
     }
 
-    /// Calculate the norm displacement of the system's center of mass
-    /// over the phase.
+    /// Calculate the displacement of the system's center of mass
+    /// (i.e., the norm of the difference between the initial and
+    /// final center of mass position) over the phase.
     double calcSystemDisplacement(const GoalInput& input) const;
-    /// Calculate the displacement of the system's center of mass over the
-    /// phase.
+    /// Calculate the displacement vector of the system's center of mass
+    /// (i.e., the difference between the initial and final center of
+    /// mass position) over the phase.
     SimTK::Vec3 calcSystemDisplacementVector(const GoalInput& input) const;
     /// Calculate the duration of the phase.
     double calcDuration(const GoalInput& input) const;
@@ -582,13 +584,9 @@ class MocoAverageSpeedGoal : public MocoGoal {
 public:
     OpenSim_DECLARE_PROPERTY(desired_average_speed, double,
             "The desired average speed of the system (m/s). Default: 0.");
-    OpenSim_DECLARE_PROPERTY(displacement_direction, std::string,
-            "The direction of motion used to compute average speed. Accepted "
-            "values are 'positive-x', 'positive-y', 'positive-z', "
-            "'negative-x','negative-y', 'negative-z', or 'norm' (default) "
-            "for the full 3D Euclidean norm of the CoM displacement. Note "
-            "that 'desired_average_speed' should always be positive; the "
-            "sign of the direction is embedded in this property.");
+    OpenSim_DECLARE_PROPERTY(displacement_axis, int,
+            "Specify an axis to compute the average desired speed. "
+            "Accepted values are 0, 1, 2 or -1 (norm - default).");
     MocoAverageSpeedGoal() { constructProperties(); }
     MocoAverageSpeedGoal(std::string name) : MocoGoal(std::move(name)) {
         constructProperties();
@@ -603,13 +601,13 @@ protected:
             const GoalInput& input, SimTK::Vector& values) const override {
         // Calculate average gait speed.
         double displacement;
-        if (get_displacement_direction() == "norm") {
+        if (get_displacement_axis() == -1) {
             displacement = calcSystemDisplacement(input);
         } else {
             SimTK::Vec3 displacementVector =
                     calcSystemDisplacementVector(input);
             displacement =
-                    m_direction_sign * displacementVector[m_direction_index];
+                    displacementVector[get_displacement_axis()];
         }
         const double duration = calcDuration(input);
         values[0] = get_desired_average_speed() - (displacement / duration);
@@ -618,49 +616,15 @@ protected:
     void initializeOnModelImpl(const Model&) const override {
         setRequirements(0, 1);
 
-        // Validate displacement_direction property.
-        std::set<std::string> directions{"positive-x", "positive-y",
-                "positive-z", "negative-x", "negative-y", "negative-z",
-                "norm"};
-        checkPropertyValueIsInSet(
-                getProperty_displacement_direction(), directions);
-
-        // Pre-compute index and sign for use in calcGoalImpl.
-        auto setIndexAndSign = [](const std::string& dir, int& index,
-                                       int& sign) {
-            if (dir == "positive-x") {
-                index = 0;
-                sign = 1;
-            } else if (dir == "positive-y") {
-                index = 1;
-                sign = 1;
-            } else if (dir == "positive-z") {
-                index = 2;
-                sign = 1;
-            } else if (dir == "negative-x") {
-                index = 0;
-                sign = -1;
-            } else if (dir == "negative-y") {
-                index = 1;
-                sign = -1;
-            } else if (dir == "negative-z") {
-                index = 2;
-                sign = -1;
-            }
-        };
-        if (get_displacement_direction() != "norm") {
-            setIndexAndSign(get_displacement_direction(), m_direction_index,
-                    m_direction_sign);
-        }
+        checkPropertyValueIsInSet(getProperty_displacement_axis(),
+            {-1, 0, 1, 2});
     }
 
 private:
     void constructProperties() { 
         constructProperty_desired_average_speed(0);
-        constructProperty_displacement_direction("norm");
+        constructProperty_displacement_axis(-1);
     }
-    mutable int m_direction_index{0};
-    mutable int m_direction_sign{1};
 };
 
 } // namespace OpenSim


### PR DESCRIPTION
I was having some strange MocoTrack simulations in that they would converge... but they would start further forward at the beginning than at the end (so go backwards). I looked into MocoAverageSpeedGoal and noticed it was calculating the norm of the COM displacement to enforce the constraint... explains why solutions stepping back are still feasible or even solutions that fly. 

When using this goal I wanted to simply use the anterior-posterior COM displacement, rather than the norm, so I have exposed a new property `axis_component` to do so. If the user sets -1 for the property it performs the norm approach. 

I found greater success with getting reasonable tracking simulations using approach.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4262)
<!-- Reviewable:end -->
