### PR TITLE
Make `SmoothSegmentedFunction` constants `constexpr`

### DIFF
--- a/OpenSim/Common/SmoothSegmentedFunction.cpp
+++ b/OpenSim/Common/SmoothSegmentedFunction.cpp
@@ -41,9 +41,9 @@ using namespace OpenSim;
 using namespace std;
 
 //static bool DEBUG=false;
-static double UTOL = (double)SimTK::Eps*1e2;
-static double INTTOL = (double)SimTK::Eps*1e2;
-static int MAXITER = 20;
+static constexpr double UTOL = std::numeric_limits<double>::epsilon() * 1e2;
+static constexpr double INTTOL = std::numeric_limits<double>::epsilon() * 1e2;
+static constexpr int MAXITER = 20;
 static constexpr int NUM_SAMPLE_PTS = 100;
 static_assert(NUM_SAMPLE_PTS>0, "SmoothSegmentedFunction::NUM_SAMPLE_PTS must be larger than zero.");
 


### PR DESCRIPTION
Fixes issue found when compiling OpenSim as part of [OpenSim Creator](https://www.opensimcreator.com/) / [OPynSim](https://github.com/opynsim/opynsim), which uses a variety of different compilers, linters, libASAN, libUBSAN, etc.  This is part of OPynSim's [custom patchset](https://github.com/opynsim/opynsim/tree/17dbb1df84c70efb306554d386712421d3f60bdc/libosim/opensim-core-patches) that is applied downstream and ran for a while  (e.g. in OpenSim Creator) before upstreaming here.

The issue here is related to static initialization order and doesn't currently affect OpenSim but might do so if OpenSim later decides to statically compile its constituent libraries and simbody into a single library.

The issue is that, when compiling simbody and OpenSim into a single binary, the static initialization order may not happen in the same sequence that it currently does. Currently, because the libraries are dynamically loaded, the dynamic loader will first initialize simTKcommon, then simTKmath, and so on. This means that if an OpenSim class uses something like `SimTK::Eps` (which isn't `constexpr`, it's an `extern` symbol - I also need to patch this upstream) then you can have bugs like `UTOL` (in this patch) containing zeroes because it hasn't been initialized yet. Systems like libUBSAN have techniques for detecting these kinds of issues.

### Brief summary of changes

Minor change from `SimTK::Eps` to `std::numeric_limits<double>::epsilon()`, which is the modern way to acquire the machine epsilon of `double`.

### Testing I've completed

- libUBSAN stopped crying about it downstream during opensim-creator's release testing

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because it's very small

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4263)
<!-- Reviewable:end -->
