### PR TITLE
Add runtime check for nullptr in SimbodyEngine

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/SimbodyEngine.cpp
@@ -87,7 +87,9 @@ SimbodyEngine::SimbodyEngine(const string &aFileName) :
     Object(aFileName, false)
 {
     setNull();
-    connectSimbodyEngineToModel(*_model);
+    if (_model) {
+        connectSimbodyEngineToModel(*_model);
+    }
 }
 
 
@@ -100,7 +102,9 @@ SimbodyEngine::SimbodyEngine(const SimbodyEngine& aEngine) :
 {
     setNull();
     copyData(aEngine);
-    connectSimbodyEngineToModel(*_model);
+    if (_model) {
+        connectSimbodyEngineToModel(*_model);
+    }
 }
 
 
@@ -158,7 +162,9 @@ SimbodyEngine& SimbodyEngine::operator=(const SimbodyEngine &aEngine)
     // Base class
     Object::operator=(aEngine);
     copyData(aEngine);
-    connectSimbodyEngineToModel(*aEngine._model);
+    if (_model) {
+        connectSimbodyEngineToModel(*aEngine._model);
+    }
     return(*this);
 }
 


### PR DESCRIPTION
Fixes issue found when compiling OpenSim as part of [OpenSim Creator](https://www.opensimcreator.com/) / [OPynSim](https://github.com/opynsim/opynsim), which uses a variety of different compilers, linters, libASAN, libUBSAN, etc.  This is part of OPynSim's [custom patchset](https://github.com/opynsim/opynsim/tree/17dbb1df84c70efb306554d386712421d3f60bdc/libosim/opensim-core-patches) that is applied downstream and ran for a while  (e.g. in OpenSim Creator) before upstreaming here.

This is a minor issue that linters/libUBSAN will spot, which is that `connectSimbodyEngineToModel` accepts a `Model&` but `aEngine._model` may be `nullptr`, so should be checked. 

### Brief summary of changes

- Minor `if` guard added to code: shouldn't change functionality unless there was originally a bug it wasn't detecting

### Testing I've completed

- libUBSAN etc. stopped crying once I applied this patch to OpenSim

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because very small and doesn't affect behavior

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4264)
<!-- Reviewable:end -->
