### PR TITLE
Remove use of Component API in ComponentOutput

### DIFF
--- a/OpenSim/Common/ComponentOutput.h
+++ b/OpenSim/Common/ComponentOutput.h
@@ -351,11 +351,18 @@ public:
         return getOutput().getTypeName();
     }
     std::string getName() const override {
-        if (_channelName.empty()) return getOutput().getName();
-        return getOutput().getName() + ":" + _channelName;
+        auto rv = getOutput().getName();
+        if (not _channelName.empty()) {
+            rv += ":" + _channelName;
+        }
+        return rv;
     }
     std::string getPathName() const override {
-        return getOutput().getOwner().getAbsolutePathString() + "|" + getName();
+        auto rv = getOutput().getPathName();
+        if (not _channelName.empty()) {
+            rv += ":" + _channelName;
+        }
+        return rv;
     }
 private:
     mutable T _result;


### PR DESCRIPTION
Fixes issue found when compiling OpenSim as part of [OpenSim Creator](https://www.opensimcreator.com/) / [OPynSim](https://github.com/opynsim/opynsim), which uses a variety of different compilers, linters, libASAN, libUBSAN, etc.  This is part of OPynSim's [custom patchset](https://github.com/opynsim/opynsim/tree/17dbb1df84c70efb306554d386712421d3f60bdc/libosim/opensim-core-patches) that is applied downstream and ran for a while  (e.g. in OpenSim Creator) before upstreaming here.

The issue here is that `ComponentOutput` must be defined before `Component` (because `Component` *has* outputs), so `Component` must be forward-declared in `ComponentOutput`. However, this line of code uses the `Component` API before it's defined, which means that if any downstream code only includes `ComponentOutput.h` but not `Component.h` it's technically using undefined symbols, which may later result in linker errors.

The solution to the problem is to declare the function that needs the `Component` API and then later define the function in a separate compilation unit `ComponentOutput.cpp`. Luckily, the definition part has already been done, because `ComponentOutput::getPathName` calls [this](https://github.com/opensim-org/opensim-core/blob/d0037c5acb635c54cb5277169dfd1cc3c9572420/OpenSim/Common/ComponentOutput.cpp#L30) code:

```c++
std::string AbstractOutput::getPathName() const {
    return getOwner().getAbsolutePathString() + "|" + getName();
}
```

Which is equivalent to the code this PR replaces.

### Brief summary of changes

Minor refactor of `ComponentOutput` API: shouldn't change behavior

### Testing I've completed

- Didn't compile, or compiled with warnings downstream, patched it, worked fine

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because minor internal change with no behavioral side-effects

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4265)
<!-- Reviewable:end -->
