### PR TITLE
Ensure `StdVectorDouble::get()` returns `double` in Matlab

### DIFF
--- a/Bindings/Java/Matlab/tests/testBasics.m
+++ b/Bindings/Java/Matlab/tests/testBasics.m
@@ -1,0 +1,36 @@
+% -------------------------------------------------------------------------- %
+%                          OpenSim:  testBasics.m                            %
+% -------------------------------------------------------------------------- %
+% The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  %
+% See http://opensim.stanford.edu and the NOTICE file for more information.  %
+% OpenSim is developed at Stanford University and supported by the US        %
+% National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    %
+% through the Warrior Web program.                                           %
+%                                                                            %
+% Copyright (c) 2026 Stanford University and the Authors                     %
+% Author(s): Nicholas Bianco                                                 %
+%                                                                            %
+% Licensed under the Apache License, Version 2.0 (the "License"); you may    %
+% not use this file except in compliance with the License. You may obtain a  %
+% copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         %
+%                                                                            %
+% Unless required by applicable law or agreed to in writing, software        %
+% distributed under the License is distributed on an "AS IS" BASIS,          %
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   %
+% See the License for the specific language governing permissions and        %
+% limitations under the License.                                             %
+% -------------------------------------------------------------------------- %
+import org.opensim.modeling.*;
+
+% Test STL typemaps.
+% ------------------
+vec = StdVectorDouble();
+for i = 0:4
+    vec.add(i);
+end
+assert(vec.size() == 5);
+for i = 0:vec.size() - 1
+    value = vec.get(i);
+    assert(value == i);
+    assert(string(class(value)) == 'double');
+end

--- a/Bindings/Java/swig/java_preliminaries.i
+++ b/Bindings/Java/swig/java_preliminaries.i
@@ -71,3 +71,9 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
               }
 	  }
 }
+
+%typemap(javacode) StdVectorDouble %{
+    public double get(int i) {
+        return (*$self).get(i).doubleValue();
+    }
+%}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ performance and stability in wrapping solutions.
 - Fixed a compile-time issue where `OutputReporter` was using the `Model` API without having access to its definition.
 - Added `ScopeExit`, which is a lightweight C++-only class for calling a function/lambda when it destructs (similar to `std::experimental::scope_exit`).
 - Fixed a leak in `Model::extendConnectToModel` that can occur when an exception is thrown midway through model graph creation.
+- Fixed an issue where `StdVectorDouble::get()` would return `java.lang.Double` in Matlab instead of `double`. (#4275)
 
 
 v4.5.2


### PR DESCRIPTION

Fixes issues #4048, #4269

### Brief summary of changes

Updated the typemap `StdVectorDouble` in `java_preliminaries.i` to force `.get()` to return `double` instead of `java.lang.Double`. 

### Testing I've completed

Tested locally, run `examplePolynomialPathFitter.m`, and created `testBasics.m`.

### Looking for feedback on...

I looked at the methods `.set()` and `.remove()`, which also display `java.lang.Double` in `methodsview` in Matlab, but both of these methods return `double` when called. It would be nice if all of these methods showed `double` instead of `java.lang.Double`, but I'm not sure how to fix that.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4275)
<!-- Reviewable:end -->
