### PR TITLE
Extend Java bindings to support selecting `Manager::IntegratorMethod` via integer

### DIFF
--- a/Bindings/Java/swig/java_simulation.i
+++ b/Bindings/Java/swig/java_simulation.i
@@ -221,6 +221,12 @@ using namespace SimTK;
   }
 %}
 
+%extend OpenSim::Manager {
+    void setIntegratorMethod(int method) {
+        self->setIntegratorMethod(static_cast<Manager::IntegratorMethod>(method));
+    };
+};
+
 %import "java_common.i"
 %unique_ptr(OpenSim::PositionMotion);
 %include <Bindings/simulation.i>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ performance and stability in wrapping solutions.
 - Fixed a compile-time issue where `OutputReporter` was using the `Model` API without having access to its definition.
 - Added `ScopeExit`, which is a lightweight C++-only class for calling a function/lambda when it destructs (similar to `std::experimental::scope_exit`).
 - Fixed a leak in `Model::extendConnectToModel` that can occur when an exception is thrown midway through model graph creation.
-- Fixed an issue where `StdVectorDouble::get()` would return `java.lang.Double` in Matlab instead of `double`. (#4275)
+- Fixed an issue where `StdVectorDouble::get()` would return `java.lang.Double` in Matlab
+- Fixed an issue in the Java bindings where setting the `Manager::IntegratorMethod` via `setIntegratorMethod()` with an integer argument did not work. (#4277)
 
 
 v4.5.2


### PR DESCRIPTION

Fixes issue #4267

### Brief summary of changes

Extended the Java bindings to include `Manager::setIntegratorMethod(int)` to support selecting the integrator method via an integer, which is the expected behavior.

### Testing I've completed

Tested locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4277)
<!-- Reviewable:end -->
