### PR TITLE
Add note to mark `Scholz2015GeometryPath` as experimental

### DIFF
--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -148,6 +148,10 @@ public:
  * A concrete class representing a geometric path object defined by a list of
  * path points and wrapping obstacles.
  *
+ * @note `Scholz2015GeometryPath` is an experimental class. The default settings
+ *       and algorithms in the underlying wrapping engine (`SimTK::CableSpan`)
+ *       may change in future releases to address robustness issues.
+ *
  * The path consists of straight line segments and curved line segments: a
  * curved segment over each obstacle, and straight segments connecting path
  * points to obstacles. If no obstacle lies between two path points, the points


### PR DESCRIPTION
### Brief summary of changes

This PR adds a small update to the `Scholz2015GeometryPath` documentation to mark it as experimental since the underlying algorithms will likely change in the near future to solve known robustness issues. Additionally, it will have limited support in the OpenSim GUI.

### CHANGELOG.md (choose one)

- no need to update because...minor documentation issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4285)
<!-- Reviewable:end -->
