### PR TITLE
Add `AbstractGeometryPath` interface for decorative points and resample `Scholz2015GeometryPath` curve points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ The property `moment_arm_threshold` has been removed, and the methods `get/setMo
   number of elements (e.g. 2 elements for a `Vec2`, 3 for `Vec3`; #4416).
 - The `OpenSim/Common/Detail/` directory is now copied during installation. Fixes build failures related to compilation units
   not finding the enclosed header files. (#4434)
+- `AbstractGeometryPath` now has a private `forEachDecorativePathPoint` virtual function and
+  corresponding `generateDecorations` (overridable) implementation, which simplifies concrete
+  path implementations (e.g. `GeometryPath`, `Scholz2015GeometryPath`) so that they only need
+  to produce points, rather than decorations (#4286).
+- `ModelDisplayHints` now has `discretize_path` and `num_samples_per_wrap_segment` properties, which
+  constrains the decoration-generation behavior of some path implementations (for now, `Scholz2015GeometryPath`)
+  to generating a constant number of decorations. This can be useful for renderers that benefit from
+  a fixed scene graph (#4286).
 
 
 v4.6

--- a/OpenSim/Common/ModelDisplayHints.h
+++ b/OpenSim/Common/ModelDisplayHints.h
@@ -86,6 +86,12 @@ public:
     OpenSim_DECLARE_PROPERTY(show_path_points, bool,
         "Flag to indicate whether or not to show points along path are shown, default to true.");
 
+    OpenSim_DECLARE_PROPERTY(discretize_path, bool,
+        "Flag to indicate whether or not to visualize a path wrapping segment as a fixed number of points, default to false.");
+
+    OpenSim_DECLARE_PROPERTY(num_samples_per_wrap_segment, int,
+        "The number of points used to sample a path segment when `discretize_path` is `true`, default to 4");
+
     OpenSim_DECLARE_PROPERTY(show_markers, bool,
         "Flag to indicate whether or not to show markers, default to true.");
 
@@ -123,6 +129,8 @@ private:
         constructProperty_show_contact_geometry(true);
         constructProperty_show_path_geometry(true);
         constructProperty_show_path_points(true);
+        constructProperty_discretize_path(false);
+        constructProperty_num_samples_per_wrap_segment(4);
         constructProperty_show_markers(true);
         constructProperty_show_stations(false);
         constructProperty_marker_color(SimTK::Vec3(1, .6, .8));

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
@@ -130,32 +130,25 @@ void AbstractGeometryPath::generateDecorations(bool fixed,
 
     int index = 0;
     std::optional<DecorativePathPoint> previous;
-    forEachDecorativePathPoint(s, [&](const DecorativePathPoint& dpp)
-    {
+    forEachDecorativePathPoint(s, [&](const DecorativePathPoint& dpp) {
+        ++index;
+        if (showPathPoints) {
+            geoms.push_back(SimTK::DecorativeSphere(0.005)
+                    .setTransform(dpp.getLocationInGround())
+                    .setColor(color)
+                    .setOpacity(0.8)
+                    .setBodyId(0));
+        }
+
         if (previous) {
-            // Emit line between points
+            // Emit line between points.
             const SimTK::Vec3& p1 = previous->getLocationInGround();
             const SimTK::Vec3& p2 = dpp.getLocationInGround();
             geoms.push_back(SimTK::DecorativeLine(p1, p2)
-                .setLineThickness(4)
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setOpacity(opacity)
-                .setRepresentation(representation)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
-        }
-        if (showPathPoints) {
-            geoms.push_back(SimTK::DecorativeSphere(0.005)
-                .setTransform(dpp.getLocationInGround())
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setOpacity(opacity)
-                .setRepresentation(representation)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
+                    .setLineThickness(4)
+                    .setColor(color)
+                    .setBodyId(0)
+                    .setIndexOnBody(index-1));
         }
 
         previous = dpp;

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
@@ -26,6 +26,8 @@
 #include <OpenSim/Simulation/Model/ForceApplier.h>
 #include <OpenSim/Simulation/Model/Model.h>
 
+#include <optional>
+
 using namespace OpenSim;
 
 //=============================================================================
@@ -90,4 +92,72 @@ void AbstractGeometryPath::setPreScaleLength(const SimTK::State&,
         double preScaleLength)
 {
     _preScaleLength = preScaleLength;
+}
+
+void AbstractGeometryPath::forEachDecorativePathPoint(
+    const SimTK::State& state,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    implForEachDecorativePathPoint(state, callback);
+}
+
+std::vector<AbstractGeometryPath::DecorativePathPoint>
+AbstractGeometryPath::getDecorativePathPoints(const SimTK::State& state) const
+{
+    std::vector<AbstractGeometryPath::DecorativePathPoint> rv;
+    forEachDecorativePathPoint(state,
+            [&rv](const DecorativePathPoint& dp) { rv.push_back(dp); });
+    return rv;
+}
+
+void AbstractGeometryPath::generateDecorations(bool fixed,
+    const ModelDisplayHints& hints, const SimTK::State& s,
+    SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const
+{
+    if (fixed) {
+        return;
+    }
+    if (not get_Appearance().get_visible()) {
+        // Don't render a path that's hidden
+        // (ComputationalBiomechanicsLab/opensim-creator#1166)
+        return;
+    }
+
+    const bool showPathPoints = hints.get_show_path_points();
+    const SimTK::Vec3 color = getColor(s);
+    const double opacity = get_Appearance().get_opacity();
+    const auto representation = get_Appearance().get_representation();
+
+    int index = 0;
+    std::optional<DecorativePathPoint> previous;
+    forEachDecorativePathPoint(s, [&](const DecorativePathPoint& dpp)
+    {
+        if (previous) {
+            // Emit line between points
+            const SimTK::Vec3& p1 = previous->getLocationInGround();
+            const SimTK::Vec3& p2 = dpp.getLocationInGround();
+            geoms.push_back(SimTK::DecorativeLine(p1, p2)
+                .setLineThickness(4)
+                .setScaleFactors(SimTK::Vec3{1.0})
+                .setColor(color)
+                .setOpacity(opacity)
+                .setRepresentation(representation)
+                .setBodyId(0)
+                .setIndexOnBody(index++)
+            );
+        }
+        if (showPathPoints) {
+            geoms.push_back(SimTK::DecorativeSphere(0.005)
+                .setTransform(dpp.getLocationInGround())
+                .setScaleFactors(SimTK::Vec3{1.0})
+                .setColor(color)
+                .setOpacity(opacity)
+                .setRepresentation(representation)
+                .setBodyId(0)
+                .setIndexOnBody(index++)
+            );
+        }
+
+        previous = dpp;
+    });
 }

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.cpp
@@ -26,6 +26,8 @@
 #include <OpenSim/Simulation/Model/ForceApplier.h>
 #include <OpenSim/Simulation/Model/Model.h>
 
+#include <optional>
+
 using namespace OpenSim;
 
 //=============================================================================
@@ -90,4 +92,79 @@ void AbstractGeometryPath::setPreScaleLength(const SimTK::State&,
         double preScaleLength)
 {
     _preScaleLength = preScaleLength;
+}
+
+void AbstractGeometryPath::forEachDecorativePathPoint(
+    const SimTK::State& state,
+    const ModelDisplayHints& modelDisplayHints,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    implForEachDecorativePathPoint(state, modelDisplayHints, callback);
+}
+
+std::vector<AbstractGeometryPath::DecorativePathPoint>
+AbstractGeometryPath::getDecorativePathPoints(
+    const SimTK::State& state,
+    const ModelDisplayHints& modelDisplayHints) const
+{
+    std::vector<AbstractGeometryPath::DecorativePathPoint> rv;
+    forEachDecorativePathPoint(
+        state,
+        modelDisplayHints,
+        [&rv](const DecorativePathPoint& dp) { rv.push_back(dp); }
+    );
+    return rv;
+}
+
+void AbstractGeometryPath::generateDecorations(
+    bool fixed,
+    const ModelDisplayHints& hints,
+    const SimTK::State& s,
+    SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const
+{
+    if (fixed) {
+        return;
+    }
+    if (not get_Appearance().get_visible()) {
+        // Don't render a path that's hidden
+        // (ComputationalBiomechanicsLab/opensim-creator#1166)
+        return;
+    }
+
+    const bool showPathPoints = hints.get_show_path_points();
+    const SimTK::Vec3 color = getColor(s);
+    const double opacity = get_Appearance().get_opacity();
+    const auto representation = get_Appearance().get_representation();
+
+    int index = 0;
+    std::optional<DecorativePathPoint> previous;
+    forEachDecorativePathPoint(s, hints, [&](const DecorativePathPoint& dpp)
+    {
+        if (showPathPoints) {
+            geoms.push_back(SimTK::DecorativeSphere(0.005)
+                .setTransform(dpp.getLocationInGround())
+                .setColor(color)
+                .setOpacity(opacity)
+                .setRepresentation(representation)
+                .setBodyId(0)
+                .setIndexOnBody(index++)
+            );
+        }
+
+        if (previous) {
+            // Emit line between points
+            const SimTK::Vec3& p1 = previous->getLocationInGround();
+            const SimTK::Vec3& p2 = dpp.getLocationInGround();
+            geoms.push_back(SimTK::DecorativeLine(p1, p2)
+                .setLineThickness(4)
+                .setColor(color)
+                .setOpacity(opacity)
+                .setRepresentation(representation)
+                .setBodyId(0)
+                .setIndexOnBody(index++)
+            );
+        }
+
+        previous = dpp;
+    });
 }

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -27,6 +27,9 @@
 #include <OpenSim/Simulation/Model/ModelComponent.h>
 #include <OpenSim/Simulation/Model/Appearance.h>
 
+#include <functional>
+#include <vector>
+
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
         #undef OSIMSIMULATION_API
@@ -229,8 +232,86 @@ public:
      */
     double getPreScaleLength(const SimTK::State& s) const;
     void setPreScaleLength(const SimTK::State& s, double preScaleLength);
-    
+
+    /**
+     * Represents a decorative (i.e. visualization-only) point of an
+     * `AbstractGeometryPath`. Can be used by UI implementations to
+     * display the path.
+     */
+    class DecorativePathPoint final {
+    public:
+        explicit DecorativePathPoint(
+            const SimTK::Vec3& locationInGround,
+            const Component* associatedComponent = nullptr) :
+            m_locationInGround{locationInGround},
+            m_maybeAssociatedComponent{associatedComponent}
+        {}
+
+        SimTK::Vec3 getLocationInGround() const { return m_locationInGround; }
+        void setLocationInGround(const SimTK::Vec3& p) {
+            m_locationInGround = p;
+        }
+        const Component* getAssociatedComponent() const {
+            return m_maybeAssociatedComponent;
+        }
+    private:
+        SimTK::Vec3 m_locationInGround;
+        const Component* m_maybeAssociatedComponent;
+    };
+
+    /**
+     * Calls `callback` with each point of a decorative representation of the
+     * path, if such a representation is available.
+     *
+     * @param s        Current simulation state, used to read the state of this
+     *                 path.
+     * @param callback A callback that should be called with each point of the
+     *                 decorative path.
+     */
+    void forEachDecorativePathPoint(const SimTK::State& state,
+        const std::function<void(const DecorativePathPoint&)>& callback) const;
+
+    /**
+     * Get a vector of decorative path points.
+     *
+     * @param s   Current simulation state, used to read the state of this path.
+     */
+    std::vector<DecorativePathPoint> getDecorativePathPoints(
+        const SimTK::State& s) const;
+
+protected:
+    /**
+     * Generates default decorations for this `AbstractGeometryPath`, based on
+     * the decorative points emitted by `implForEachDecorativePathPoint`.
+     *
+     * Derived classes may override this to provide different display behavior
+     * for the path.
+     */
+    void generateDecorations(bool fixed, const ModelDisplayHints&,
+        const SimTK::State&,
+        SimTK::Array_<SimTK::DecorativeGeometry>&) const override;
+
 private:
+    /**
+     * Implementors should call `callback` with each point of a decorative
+     * representation of the path.
+     *
+     * The decorative representation does not necessarily need to be the same
+     * as the computational representation: it only needs to be a "suitable"
+     * visual representation of the path (if any).
+     *
+     * @param s        Current simulation state, used to read the state of this
+     *                 path.
+     * @param callback A callback that should be called with each point of the
+     *                 decorative path.
+     */
+    virtual void implForEachDecorativePathPoint(const SimTK::State& s,
+        const std::function<void(const DecorativePathPoint&)>& callback) const
+    {
+        // No-op: implementations are also permitted to provide no decorative
+        // point representation at all.
+    }
+
     // Used by `(get|set)PreLengthScale`. Used during `extend(Pre|Post)Scale` by
     // downstream users of AbstractGeometryPath to cache the length of the path
     // before scaling.

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -27,6 +27,9 @@
 #include <OpenSim/Simulation/Model/ModelComponent.h>
 #include <OpenSim/Simulation/Model/Appearance.h>
 
+#include <functional>
+#include <vector>
+
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
         #undef OSIMSIMULATION_API
@@ -243,8 +246,100 @@ public:
      */
     double getPreScaleLength(const SimTK::State& s) const;
     void setPreScaleLength(const SimTK::State& s, double preScaleLength);
-    
+
+#ifndef SWIG  // `DecorativePathPoint` is a C++-only API
+    /**
+     * Represents a decorative (i.e. visualization-only) point of an
+     * `AbstractGeometryPath`. Can be used by visualizers and
+     * `generateDecorations` to display the path.
+     */
+    class DecorativePathPoint final {
+    public:
+        explicit DecorativePathPoint(
+            const SimTK::Vec3& locationInGround,
+            const Component* associatedComponent = nullptr) :
+            m_locationInGround{locationInGround},
+            m_maybeAssociatedComponent{associatedComponent}
+        {}
+
+        SimTK::Vec3 getLocationInGround() const { return m_locationInGround; }
+        void setLocationInGround(const SimTK::Vec3& p) {
+            m_locationInGround = p;
+        }
+
+        const Component* getAssociatedComponent() const {
+            return m_maybeAssociatedComponent;
+        }
+    private:
+        SimTK::Vec3 m_locationInGround;
+        const Component* m_maybeAssociatedComponent;
+    };
+
+    /**
+     * Calls `callback` with each point of a decorative representation of the
+     * path, if such a representation is available.
+     *
+     * @param state Current simulation state, used to read the state of this
+     *              path.
+     * @param modelDisplayHints Model-level decorative display hints, which may
+     *                          affect how decorative path points are generated.
+     * @param callback A callback that should be called with each point of the
+     *                 decorative path.
+     */
+    void forEachDecorativePathPoint(
+        const SimTK::State& state,
+        const ModelDisplayHints& modelDisplayHints,
+        const std::function<void(const DecorativePathPoint&)>& callback) const;
+
+    /**
+     * Get a vector of decorative path points.
+     *
+     * @param state Current simulation state, used to read the state of this
+     *              path.
+     * @param modelDisplayHints Model-level decorative display hints, which may
+     *                          affect how decorative path points are generated.
+     */
+    std::vector<DecorativePathPoint> getDecorativePathPoints(
+        const SimTK::State& state,
+        const ModelDisplayHints& modelDisplayHints) const;
+#endif  // #ifndef SWIG
+
+    /**
+     * Generates default decorations for this `AbstractGeometryPath`, based on
+     * the decorative points emitted by `implForEachDecorativePathPoint`.
+     *
+     * Derived classes may override this to provide different display behavior
+     * for the path.
+     */
+    void generateDecorations(bool fixed, const ModelDisplayHints&,
+        const SimTK::State&,
+        SimTK::Array_<SimTK::DecorativeGeometry>&) const override;
+
 private:
+    /**
+     * Implementors should call `callback` with each point of a decorative
+     * representation of the path.
+     *
+     * The decorative representation of a path does not necessarily need to be
+     * the same as the computational representation: it only needs to be a
+     * "suitable" visual representation of the path (if any).
+     *
+     * @param state    Current simulation state, used to read the state of this
+     *                 path.
+     * @param modelDisplayHints Model-level display hints. Implementors may
+     *                          use pertinent decoration hints from this.
+     * @param callback A callback that should be called with each point of the
+     *                 decorative path.
+     */
+    virtual void implForEachDecorativePathPoint(
+        const SimTK::State& state,
+        const ModelDisplayHints& modelDisplayHints,
+        const std::function<void(const DecorativePathPoint&)>& callback) const
+    {
+        // No-op: implementations are also permitted to provide no decorative
+        // point representation at all.
+    }
+
     // Used by `(get|set)PreLengthScale`. Used during `extend(Pre|Post)Scale` by
     // downstream users of AbstractGeometryPath to cache the length of the path
     // before scaling.

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -177,6 +177,35 @@ void GeometryPath::extendFinalizeFromProperties()
     }
 }
 
+void GeometryPath::implForEachDecorativePathPoint(
+    const SimTK::State& state,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
+
+    for (int i = 0; i < pathPoints.size(); ++i) {
+        const AbstractPathPoint& p = *pathPoints[i];
+
+        if (auto* pwp = dynamic_cast<const PathWrapPoint*>(&p)) {
+            // A `PathWrapPoint`'s surface points are expressed w.r.t. the wrap
+            // surface's body frame. Ensure they're transformed to ground.
+            const SimTK::Transform& X_BG =
+                    pwp->getParentFrame().getTransformInGround(state);
+
+            // A `PathWrapPoint`'s surface points should be emitted, but not
+            // associated to a component in the model (they are synthetic).
+            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
+
+            for (int j = 0; j < surfacePoints.getSize(); ++j) {
+                callback(DecorativePathPoint{X_BG * surfacePoints[j]});
+            }
+        }
+        else {  // Otherwise, it's a regular `PathPoint`, so just emit it.
+            callback(DecorativePathPoint{p.getLocationInGround(state), &p});
+        }
+    }
+}
+
 void GeometryPath::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
@@ -218,82 +247,6 @@ void GeometryPath::extendConnectToModel(Model& aModel)
 {
     Super::extendInitStateFromProperties(s);
     markCacheVariableValid(s, _colorCV);  // it is OK at its default value
-}
-
-//------------------------------------------------------------------------------
-//                         GENERATE DECORATIONS
-//------------------------------------------------------------------------------
-// The GeometryPath takes care of drawing itself here, using information it
-// can extract from the supplied state, including position information and
-// color information that may have been calculated as late as Stage::Dynamics.
-// For example, muscles may want the color to reflect activation level and 
-// other path-using components might want to use forces (tension). We will
-// ensure that the state has been realized to Stage::Dynamics before looking
-// at it. (It is only guaranteed to be at Stage::Position here.)
-void GeometryPath::
-generateDecorations(bool fixed, const ModelDisplayHints& hints, 
-                    const SimTK::State& state, 
-                    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
-{        
-    // There is no fixed geometry to generate here.
-    if (fixed) { return; }
-
-    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
-
-    OPENSIM_ASSERT_FRMOBJ(pathPoints.size() > 1);
-
-    const AbstractPathPoint* lastPoint = pathPoints[0];
-    SimTK::MobilizedBodyIndex mbix(0);
-
-    Vec3 lastPos = lastPoint->getLocationInGround(state);
-    if (hints.get_show_path_points())
-        SimTK::DefaultGeometry::drawPathPoint(
-                mbix, lastPos, getColor(state), appendToThis);
-
-    Vec3 pos;
-
-    for (int i = 1; i < pathPoints.getSize(); ++i) {
-        AbstractPathPoint* point = pathPoints[i];
-        PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
-
-        if (pwp) {
-            // A PathWrapPoint provides points on the wrapping surface as Vec3s
-            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
-            // The surface points are expressed w.r.t. the wrap surface's body frame.
-            // Transform the surface points into the ground reference frame to draw
-            // the surface point as the wrapping portion of the GeometryPath
-            const SimTK::Transform& X_BG =
-                    pwp->getParentFrame().getTransformInGround(state);
-            // Cycle through each surface point and draw it the Ground frame
-            for (int j = 0; j<surfacePoints.getSize(); ++j) {
-                // transform the surface point into the Ground reference frame
-                pos = X_BG*surfacePoints[j];
-                if (hints.get_show_path_points())
-                    SimTK::DefaultGeometry::drawPathPoint(
-                            mbix, pos, getColor(state), appendToThis);
-                // Line segments will be in ground frame
-                appendToThis.push_back(SimTK::DecorativeLine(lastPos, pos)
-                                .setLineThickness(4)
-                                .setColor(getColor(state))
-                                .setBodyId(0)
-                                .setIndexOnBody(j));
-                lastPos = pos;
-            }
-        } 
-        else { // otherwise a regular PathPoint so just draw its location
-            pos = point->getLocationInGround(state);
-            if (hints.get_show_path_points())
-                SimTK::DefaultGeometry::drawPathPoint(
-                        mbix, pos, getColor(state), appendToThis);
-            // Line segments will be in ground frame
-            appendToThis.push_back(SimTK::DecorativeLine(lastPos, pos)
-                            .setLineThickness(4)
-                            .setColor(getColor(state))
-                            .setBodyId(0)
-                            .setIndexOnBody(i));
-            lastPos = pos;
-        }
-    }
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -178,6 +178,36 @@ void GeometryPath::extendFinalizeFromProperties()
     }
 }
 
+void GeometryPath::implForEachDecorativePathPoint(
+    const SimTK::State& state,
+    const ModelDisplayHints&,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
+
+    for (int i = 0; i < pathPoints.size(); ++i) {
+        const AbstractPathPoint& p = *pathPoints[i];
+
+        if (auto* pwp = dynamic_cast<const PathWrapPoint*>(&p)) {
+            // A `PathWrapPoint`'s surface points are expressed w.r.t. the wrap
+            // surface's body frame. Ensure they're transformed to ground.
+            const SimTK::Transform& X_BG =
+                    pwp->getParentFrame().getTransformInGround(state);
+
+            // A `PathWrapPoint`'s surface points should be emitted, but not
+            // associated to a component in the model (they are synthetic).
+            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
+
+            for (int j = 0; j < surfacePoints.getSize(); ++j) {
+                callback(DecorativePathPoint{X_BG * surfacePoints[j]});
+            }
+        }
+        else {  // Otherwise, it's a regular `PathPoint`, so just emit it.
+            callback(DecorativePathPoint{p.getLocationInGround(state), &p});
+        }
+    }
+}
+
 void GeometryPath::extendConnectToModel(Model& aModel)
 {
     Super::extendConnectToModel(aModel);
@@ -219,82 +249,6 @@ void GeometryPath::extendConnectToModel(Model& aModel)
 {
     Super::extendInitStateFromProperties(s);
     markCacheVariableValid(s, _colorCV);  // it is OK at its default value
-}
-
-//------------------------------------------------------------------------------
-//                         GENERATE DECORATIONS
-//------------------------------------------------------------------------------
-// The GeometryPath takes care of drawing itself here, using information it
-// can extract from the supplied state, including position information and
-// color information that may have been calculated as late as Stage::Dynamics.
-// For example, muscles may want the color to reflect activation level and 
-// other path-using components might want to use forces (tension). We will
-// ensure that the state has been realized to Stage::Dynamics before looking
-// at it. (It is only guaranteed to be at Stage::Position here.)
-void GeometryPath::
-generateDecorations(bool fixed, const ModelDisplayHints& hints, 
-                    const SimTK::State& state, 
-                    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
-{        
-    // There is no fixed geometry to generate here.
-    if (fixed) { return; }
-
-    const Array<AbstractPathPoint*>& pathPoints = getCurrentPath(state);
-
-    OPENSIM_ASSERT_FRMOBJ(pathPoints.size() > 1);
-
-    const AbstractPathPoint* lastPoint = pathPoints[0];
-    SimTK::MobilizedBodyIndex mbix(0);
-
-    Vec3 lastPos = lastPoint->getLocationInGround(state);
-    if (hints.get_show_path_points())
-        SimTK::DefaultGeometry::drawPathPoint(
-                mbix, lastPos, getColor(state), appendToThis);
-
-    Vec3 pos;
-
-    for (int i = 1; i < pathPoints.getSize(); ++i) {
-        AbstractPathPoint* point = pathPoints[i];
-        PathWrapPoint* pwp = dynamic_cast<PathWrapPoint*>(point);
-
-        if (pwp) {
-            // A PathWrapPoint provides points on the wrapping surface as Vec3s
-            const Array<Vec3>& surfacePoints = pwp->getWrapPath(state);
-            // The surface points are expressed w.r.t. the wrap surface's body frame.
-            // Transform the surface points into the ground reference frame to draw
-            // the surface point as the wrapping portion of the GeometryPath
-            const SimTK::Transform& X_BG =
-                    pwp->getParentFrame().getTransformInGround(state);
-            // Cycle through each surface point and draw it the Ground frame
-            for (int j = 0; j<surfacePoints.getSize(); ++j) {
-                // transform the surface point into the Ground reference frame
-                pos = X_BG*surfacePoints[j];
-                if (hints.get_show_path_points())
-                    SimTK::DefaultGeometry::drawPathPoint(
-                            mbix, pos, getColor(state), appendToThis);
-                // Line segments will be in ground frame
-                appendToThis.push_back(SimTK::DecorativeLine(lastPos, pos)
-                                .setLineThickness(4)
-                                .setColor(getColor(state))
-                                .setBodyId(0)
-                                .setIndexOnBody(j));
-                lastPos = pos;
-            }
-        } 
-        else { // otherwise a regular PathPoint so just draw its location
-            pos = point->getLocationInGround(state);
-            if (hints.get_show_path_points())
-                SimTK::DefaultGeometry::drawPathPoint(
-                        mbix, pos, getColor(state), appendToThis);
-            // Line segments will be in ground frame
-            appendToThis.push_back(SimTK::DecorativeLine(lastPos, pos)
-                            .setLineThickness(4)
-                            .setColor(getColor(state))
-                            .setBodyId(0)
-                            .setIndexOnBody(i));
-            lastPos = pos;
-        }
-    }
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -193,17 +193,11 @@ protected:
     void extendInitStateFromProperties(SimTK::State& s) const override;
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
 
-    // Visual support GeometryPath drawing in SimTK visualizer.
-    void generateDecorations(
-            bool                                        fixed,
-            const ModelDisplayHints&                    hints,
-            const SimTK::State&                         state,
-            SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
-            override;
-
     void extendFinalizeFromProperties() override;
 
 private:
+    void implForEachDecorativePathPoint(const SimTK::State&,
+        const std::function<void(const DecorativePathPoint&)>&) const override;
 
     void computePath(const SimTK::State& s ) const;
     void computeLengtheningSpeed(const SimTK::State& s) const;

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -211,17 +211,13 @@ protected:
     void extendInitStateFromProperties(SimTK::State& s) const override;
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
 
-    // Visual support GeometryPath drawing in SimTK visualizer.
-    void generateDecorations(
-            bool                                        fixed,
-            const ModelDisplayHints&                    hints,
-            const SimTK::State&                         state,
-            SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
-            override;
-
     void extendFinalizeFromProperties() override;
 
 private:
+    void implForEachDecorativePathPoint(
+        const SimTK::State&,
+        const ModelDisplayHints&,
+        const std::function<void(const DecorativePathPoint&)>&) const override;
 
     void computePath(const SimTK::State& s ) const;
     void computeLengtheningSpeed(const SimTK::State& s) const;

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -28,8 +28,6 @@
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 #include <OpenSim/Simulation/Model/Model.h>
 
-#include <optional>
-
 using namespace OpenSim;
 
 //=============================================================================
@@ -189,6 +187,15 @@ int Scholz2015GeometryPath::getNumPathElements() const {
     return getProperty_path_elements().size();
 }
 
+void Scholz2015GeometryPath::setNumDecorativeCurvePoints(
+        int numDecorativeCurvePoints) {
+    set_num_decorative_curve_points(numDecorativeCurvePoints);
+}
+
+int Scholz2015GeometryPath::getNumDecorativeCurvePoints() const {
+    return get_num_decorative_curve_points();
+}
+
 //=============================================================================
 // ABSTRACT PATH INTERFACE
 //=============================================================================
@@ -210,6 +217,16 @@ double Scholz2015GeometryPath::computeMomentArm(const SimTK::State& s,
     }
 
     return _maSolver->solve(s, coord,  *this);
+}
+
+void Scholz2015GeometryPath::implForEachDecorativePathPoint(
+    const SimTK::State& state,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    getCableSpan().calcResampledDecorativePathPoints(
+        state, get_num_decorative_curve_points(),
+        [&callback](SimTK::Vec3 p) { callback(DecorativePathPoint{p});
+    });
 }
 
 void Scholz2015GeometryPath::produceForces(const SimTK::State& state,
@@ -329,47 +346,12 @@ void Scholz2015GeometryPath::extendAddToSystem(
     _index = cable.getIndex();
 }
 
-void Scholz2015GeometryPath::generateDecorations(
-        bool fixed,
-        const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const {
-
-    if (fixed) { return; }
-    const bool showPathPoints = hints.get_show_path_points();
-    const SimTK::Vec3 color = getColor(s);
-    int index = 0;
-    std::optional<SimTK::Vec3> previous;
-    getCableSpan().calcDecorativePathPoints(s, [&](SimTK::Vec3 x_G) {
-        if (previous) {
-            // Emit line between points
-            geoms.push_back(SimTK::DecorativeLine(*previous, x_G)
-                .setLineThickness(4)
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
-        }
-        if (showPathPoints) {
-            geoms.push_back(SimTK::DecorativeSphere(0.005)
-                .setTransform(x_G)
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
-        }
-
-        previous = x_G;
-    });
-}
-
 //=============================================================================
 // CONVENIENCE METHODS
 //=============================================================================
 void Scholz2015GeometryPath::constructProperties() {
     constructProperty_path_elements();
+    constructProperty_num_decorative_curve_points(5);
 }
 
 const Scholz2015GeometryPathObstacle* Scholz2015GeometryPath::getObstacle(

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -29,8 +29,6 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
 
-#include <optional>
-
 using namespace OpenSim;
 
 //=============================================================================
@@ -256,6 +254,26 @@ findIndependentCoordinates(const SimTK::State& s) const {
 //=============================================================================
 // FORCE PRODUCER INTERFACE
 //=============================================================================
+void Scholz2015GeometryPath::implForEachDecorativePathPoint(
+    const SimTK::State& state,
+    const ModelDisplayHints& hints,
+    const std::function<void(const DecorativePathPoint&)>& callback) const
+{
+    const auto sink = [&callback](SimTK::Vec3 p) {
+        callback(DecorativePathPoint{p});
+    };
+
+    if (hints.get_discretize_path()) {
+        getCableSpan().calcResampledDecorativePathPoints(
+            state,
+            hints.get_num_samples_per_wrap_segment(),
+            sink
+        );
+    } else {
+        getCableSpan().calcDecorativePathPoints(state, sink);
+    }
+}
+
 void Scholz2015GeometryPath::produceForces(const SimTK::State& state,
         double tension, ForceConsumer& forceConsumer) const {
 
@@ -411,41 +429,6 @@ void Scholz2015GeometryPath::extendAddToSystem(
     _index = cable.getIndex();
 }
 
-void Scholz2015GeometryPath::generateDecorations(
-        bool fixed,
-        const ModelDisplayHints& hints,
-        const SimTK::State& s,
-        SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const {
-
-    if (fixed) { return; }
-    const bool showPathPoints = hints.get_show_path_points();
-    const SimTK::Vec3 color = getColor(s);
-    int index = 0;
-    std::optional<SimTK::Vec3> previous;
-    getCableSpan().calcDecorativePathPoints(s, [&](SimTK::Vec3 x_G) {
-        if (previous) {
-            // Emit line between points
-            geoms.push_back(SimTK::DecorativeLine(*previous, x_G)
-                .setLineThickness(4)
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
-        }
-        if (showPathPoints) {
-            geoms.push_back(SimTK::DecorativeSphere(0.005)
-                .setTransform(x_G)
-                .setScaleFactors(SimTK::Vec3{1.0})
-                .setColor(color)
-                .setBodyId(0)
-                .setIndexOnBody(index++)
-            );
-        }
-
-        previous = x_G;
-    });
-}
 
 void Scholz2015GeometryPath::extendPreScale(const SimTK::State& s,
         const ScaleSet& scaleSet) {

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -421,6 +421,18 @@ public:
      */
     int getNumPathElements() const;
 
+    /**
+     * Set the number of decorative path points per curve segment used when
+     * generating path decorations.
+     */
+    void setNumDecorativeCurvePoints(int numDecorativeCurvePoints);
+
+    /**
+     * Get the number of decorative path points per curve segment used when
+     * generating path decorations (default: 5).
+     */
+    int getNumDecorativeCurvePoints() const;
+
     // @}
 
     //** @name `AbstractGeometryPath` interface */
@@ -430,6 +442,8 @@ public:
     double computeMomentArm(const SimTK::State& s,
             const Coordinate& coord) const override;
     bool isVisualPath() const override { return true; }
+    void implForEachDecorativePathPoint(const SimTK::State&,
+        const std::function<void(const DecorativePathPoint&)>&) const override;
     // @}
 
     //** @name `ForceProducer` interface */
@@ -442,13 +456,13 @@ private:
     // PROPERTIES
     OpenSim_DECLARE_LIST_PROPERTY(path_elements, Scholz2015GeometryPathElement,
         "The list of elements (path points or obstacles) defining the path.");
+    OpenSim_DECLARE_PROPERTY(num_decorative_curve_points, int,
+        "The number of decorative path points per curve segment used when "
+        "generating path decorations (default: 5).");
 
     // MODEL COMPONENT INTERFACE
     void extendConnectToModel(Model& model) override;
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
-    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
-            const SimTK::State& s,
-            SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const override;
 
     // CONVENIENCE METHODS
     void constructProperties();

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -492,6 +492,11 @@ public:
     // @}
 
 private:
+    void implForEachDecorativePathPoint(
+        const SimTK::State&,
+        const ModelDisplayHints&,
+        const std::function<void(const DecorativePathPoint&)>&) const override;
+
     // PROPERTIES
     OpenSim_DECLARE_LIST_PROPERTY(path_elements, Scholz2015GeometryPathElement,
         "The list of elements (path points or obstacles) defining the path.");
@@ -504,9 +509,6 @@ private:
     // MODEL COMPONENT INTERFACE
     void extendConnectToModel(Model& model) override;
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
-    void generateDecorations(bool fixed, const ModelDisplayHints& hints,
-            const SimTK::State& s,
-            SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const override;
     void extendPreScale(const SimTK::State&, const ScaleSet&) override;
     void extendPostScale(const SimTK::State&, const ScaleSet&) override;
 

--- a/OpenSim/Tools/tests/resources/BuiltinGeometry.osim
+++ b/OpenSim/Tools/tests/resources/BuiltinGeometry.osim
@@ -286,6 +286,10 @@
 						<Appearance>
 							<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
 							<color>0.80000000000000004 0.10000000000000001 0.10000000000000001</color>
+							<opacity>0.8</opacity>
+							<SurfaceProperties>
+							    <representation>-1</representation>
+							</SurfaceProperties>
 						</Appearance>
 					</GeometryPath>
 					<!--Maximum isometric force that the fibers can generate-->
@@ -326,6 +330,10 @@
 						<Appearance>
 							<!--The color, (red, green, blue), [0, 1], used to display the geometry. -->
 							<color>0.80000000000000004 0.10000000000000001 0.10000000000000001</color>
+							<opacity>0.5</opacity>
+							<SurfaceProperties>
+							    <representation>2</representation>
+							</SurfaceProperties>
 						</Appearance>
 					</GeometryPath>
 					<!--Maximum isometric force that the fibers can generate-->

--- a/OpenSim/Tools/tests/resources/vis_BuiltinGeometry.txt
+++ b/OpenSim/Tools/tests/resources/vis_BuiltinGeometry.txt
@@ -82,37 +82,37 @@ DecorativeLine:~[0,0.05,0]~[0.19999,0.0480388,0] bodyId:0 color:~[1,0.6,0.8] ind
 [0,0,1,0]
 [0,0,0,1]
 
-DecorativeSphere:0.005 bodyId:0 color:~[1,0,0] indexOnBody:-1 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeSphere:0.005 bodyId:0 color:~[1,0,0] indexOnBody:0 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0]
 [0,1,0,0.05]
 [0,0,1,-0.35]
 [0,0,0,1]
 
-DecorativeSphere:0.005 bodyId:0 color:~[1,0,0] indexOnBody:-1 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeSphere:0.005 bodyId:0 color:~[1,0,0] indexOnBody:1 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0.19999]
 [0,1,0,0.0480388]
 [0,0,1,-0.05]
 [0,0,0,1]
 
-DecorativeLine:~[0,0.05,-0.35]~[0.19999,0.0480388,-0.05] bodyId:0 color:~[1,0,0] indexOnBody:1 Opacity:-1 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeLine:~[0,0.05,-0.35]~[0.19999,0.0480388,-0.05] bodyId:0 color:~[1,0,0] indexOnBody:2 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0]
 [0,1,0,0]
 [0,0,1,0]
 [0,0,0,1]
 
-DecorativeSphere:0.005 bodyId:0 color:~[0.05,0,0.95] indexOnBody:-1 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeSphere:0.005 bodyId:0 color:~[0.05,0,0.95] indexOnBody:0 Opacity:0.5 Rep:2 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0]
 [0,1,0,0.05]
 [0,0,1,0.35]
 [0,0,0,1]
 
-DecorativeSphere:0.005 bodyId:0 color:~[0.05,0,0.95] indexOnBody:-1 Opacity:0.8 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeSphere:0.005 bodyId:0 color:~[0.05,0,0.95] indexOnBody:1 Opacity:0.5 Rep:2 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0.19999]
 [0,1,0,0.0480388]
 [0,0,1,0.05]
 [0,0,0,1]
 
-DecorativeLine:~[0,0.05,0.35]~[0.19999,0.0480388,0.05] bodyId:0 color:~[0.05,0,0.95] indexOnBody:1 Opacity:-1 Rep:-1 Scale:~[-1,-1,-1] Transform:
+DecorativeLine:~[0,0.05,0.35]~[0.19999,0.0480388,0.05] bodyId:0 color:~[0.05,0,0.95] indexOnBody:2 Opacity:0.5 Rep:2 Scale:~[-1,-1,-1] Transform:
 [1,0,0,0]
 [0,1,0,0]
 [0,0,1,0]

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -185,7 +185,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    7f35622b3c5daac919fc39a2865498c03c553e53
+              GIT_TAG    8a62e27882838708ae98e72c6902704f836aacb9
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Fixes issue #4279 

### Brief summary of changes

Upstreams @adamkewley's [patch for unifying path point decorations within the AbstractGeometryPath API](https://github.com/opynsim/opynsim/blob/af9afa74448bfc05641b9e8a1230efa6e3a8747e/libosim/opensim-core-patches/0011_add-abstractgeometrypath-decorative-points-api.patch).

Added the property `Scholz2015GeometryPath::num_decorative_curve_points()` for defining the fixed number of equally-spaced decorative points that are generative for each curve segment in a path. Internally, this calls `SimTK::CableSpan::calcResampledDecorativePathPoints()`.

### Testing I've completed

Ran `exampleScholz2015GeometryPath` and verified visually that a fixed number of path points are visualized.

### Looking for feedback on...

Should we expose `Scholz2015GeometryPath::set_num_decorative_curve_points()` as a property, or make it a fixed internal value? Or perhaps set it via `ModelDisplayHints`? 

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4286)
<!-- Reviewable:end -->
