### PR TITLE
Revert (unsuccessful) fix to Matlab returning `java.lang.Double` 

### DIFF
--- a/Bindings/Java/swig/java_preliminaries.i
+++ b/Bindings/Java/swig/java_preliminaries.i
@@ -71,9 +71,3 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
               }
 	  }
 }
-
-%typemap(javacode) StdVectorDouble %{
-    public double get(int i) {
-        return (*$self).get(i).doubleValue();
-    }
-%}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@ performance and stability in wrapping solutions.
 - Fixed a leak in `Model::extendConnectToModel` that can occur when an exception is thrown midway through model graph creation.
 - Updated `osimMocoTrajectoryReport.m` to directly generate a PDF report, rather than converting from a PostScript file. (#4274)
 - Fixed an issue where the final time used for `example2DWalking` and `example2DWalkingMetabolics` was inconsistent with the filtered coordinate reference data. (#4273)
-- Fixed an issue where `StdVectorDouble::get()` would return `java.lang.Double` in Matlab
 - Fixed an issue in the Java bindings where setting the `Manager::IntegratorMethod` via `setIntegratorMethod()` with an integer argument did not work. (#4277)
 - Fixed simbody-visualizer not found in PATH on windows when launching program lives on different drive. (simbody#765)
 - Fixed an issue in `PolynomialPathFitter` where the process would segfault if too few coordinate samples were used. (#4280)


### PR DESCRIPTION
### Brief summary of changes

Reverts the changes from #4275, which do not consistently address the issue in #4048. 

### Testing I've completed

### Looking for feedback on...

I did not revert the tests in `testBasics.m`, since they do not get return as part of CI. Should we keep them as a target for #4048, or remove them until a permanent fix exists.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4287)
<!-- Reviewable:end -->
