### PR TITLE
Add interfaces for finding coordinates associated with an `AbstractGeometryPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ v4.6.1
 - Added `CoordinateLinearStopForce`, a force element for enforcing coordinate limits using a
 linear spring force and Hunt and Crossley-like damping. (#4329)
 - Updated `ExponentialCoordinateLimitForce` to use `Socket` to define the connection to a particular `Coordinate`. (#4329)
+- Added `SimulationUtilities::findJointsBetweenPhysicalFrames`, a utility function for finding the set of
+joints that lie between two frames based on a model's topology. (#4301)
+- Added `AbstractGeometryPath::findIndependentCoordinatePaths()`, a utility method for finding the list of
+coordinate paths associated with a path element. Derived classes provide concrete implementations based on
+the model's topology (e.g., `GeometryPath`) or via a user-defined list of coordinates
+(e.g., `FunctionBasedPath`). (#4301)
 
 
 v4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ linear spring force and Hunt and Crossley-like damping. (#4329)
 - Updated `ExponentialCoordinateLimitForce` to use `Socket` to define the connection to a particular `Coordinate`. (#4329)
 - Added `SimulationUtilities::findJointsBetweenPhysicalFrames`, a utility function for finding the set of
 joints that lie between two frames based on a model's topology. (#4301)
-- Added `AbstractGeometryPath::findIndependentCoordinatePaths()`, a utility method for finding the list of
+- Added `AbstractGeometryPath::findIndependentCoordinates()`, a utility method for finding the list of
 coordinate paths associated with a path element. Derived classes provide concrete implementations based on
 the model's topology (e.g., `GeometryPath`) or via a user-defined list of coordinates
 (e.g., `FunctionBasedPath`). (#4301)

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -158,11 +158,16 @@ public:
     virtual bool isVisualPath() const = 0;
 
     /**
-     * Find the list of independent coordinates associated with the joints that
-     * lie between the origin and insertion of the path.
+     * Find the list of coordinates actuated by the path.
+     *
+     * Internally, this may use a variety of methods to find the list of
+     * actuated coordinates. It may search the kinematic tree to find the joints
+     * lying between the origin and insertion points of the path, or it may use
+     * a user-defined list of coordinates. It is up to concrete implementations
+     * (e.g., `GeometryPath`) to provide a relevant implementation.
      */
     virtual std::vector<std::string>
-    findIndependentCoordinatesBetween(const SimTK::State&) const = 0;
+    findCoordinates(const SimTK::State&) const = 0;
 
     // DEFAULTED METHODS
     //

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -157,6 +157,13 @@ public:
      */
     virtual bool isVisualPath() const = 0;
 
+    /**
+     * Find the list of independent coordinates associated with the joints that
+     * lie between the origin and insertion of the path.
+     */
+    virtual std::vector<std::string>
+    findIndependentCoordinatesBetween(const SimTK::State&) const = 0;
+
     // DEFAULTED METHODS
     //
     // These are methods that for which AbstractGeometryPath provides default

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -157,6 +157,20 @@ public:
      */
     virtual bool isVisualPath() const = 0;
 
+    /**
+     * Find the list of paths to independent coordinates which fully determine
+     * the kinematic state of this path.
+     *
+     * Internally, this may use a variety of methods to find the list of
+     * coordinates. It may search the kinematic tree to find the joints lying
+     * between the origin and insertion points of the path, or it may use
+     * a user-defined list of coordinates as part of a function-based path
+     * representation. It is up to concrete implementations
+     * (e.g., `GeometryPath`) to provide a relevant implementation.
+     */
+    virtual std::vector<std::string>
+    findIndependentCoordinatePaths(const SimTK::State&) const = 0;
+
     // DEFAULTED METHODS
     //
     // These are methods that for which AbstractGeometryPath provides default

--- a/OpenSim/Simulation/Model/AbstractGeometryPath.h
+++ b/OpenSim/Simulation/Model/AbstractGeometryPath.h
@@ -168,8 +168,8 @@ public:
      * representation. It is up to concrete implementations
      * (e.g., `GeometryPath`) to provide a relevant implementation.
      */
-    virtual std::vector<std::string>
-    findIndependentCoordinatePaths(const SimTK::State&) const = 0;
+    virtual std::vector<ComponentPath>
+    findIndependentCoordinates(const SimTK::State&) const = 0;
 
     // DEFAULTED METHODS
     //

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -167,8 +167,7 @@ bool FunctionBasedPath::isVisualPath() const
 }
 
 std::vector<std::string>
-FunctionBasedPath::
-findIndependentCoordinatesBetween(const SimTK::State& state) const
+FunctionBasedPath::findCoordinates(const SimTK::State& state) const
 {
     return getCoordinatePaths();
 }

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -125,6 +125,12 @@ double FunctionBasedPath::getLength(const SimTK::State& s) const
     return getCacheVariableValue<double>(s, _lengthCV);
 }
 
+double FunctionBasedPath::getLengtheningSpeed(const SimTK::State& s) const
+{
+    computeLengtheningSpeed(s);
+    return getCacheVariableValue<double>(s, _lengtheningSpeedCV);
+}
+
 double FunctionBasedPath::computeMomentArm(const SimTK::State& s,
         const Coordinate& coord) const
 {
@@ -150,14 +156,21 @@ void FunctionBasedPath::produceForces(const SimTK::State& state,
 
     // Produce mobility forces
     for (int i = 0; i < (int)_coordinates.size(); ++i) {
-        forceConsumer.consumeGeneralizedForce(state, *_coordinates[i], momentArms[i] * tension);
+        forceConsumer.consumeGeneralizedForce(
+                state, *_coordinates[i], momentArms[i] * tension);
     }
 }
 
-double FunctionBasedPath::getLengtheningSpeed(const SimTK::State& s) const
+bool FunctionBasedPath::isVisualPath() const
 {
-    computeLengtheningSpeed(s);
-    return getCacheVariableValue<double>(s, _lengtheningSpeedCV);
+    return false;
+}
+
+std::vector<std::string>
+FunctionBasedPath::
+findIndependentCoordinatesBetween(const SimTK::State& state) const
+{
+    return getCoordinatePaths();
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -166,11 +166,15 @@ bool FunctionBasedPath::isVisualPath() const
     return false;
 }
 
-std::vector<std::string>
+std::vector<ComponentPath>
 FunctionBasedPath::
-findIndependentCoordinatePaths(const SimTK::State& state) const
+findIndependentCoordinates(const SimTK::State& state) const
 {
-    return getCoordinatePaths();
+    std::vector<ComponentPath> coordinates;
+    for (const auto& path : getCoordinatePaths()) {
+        coordinates.push_back(ComponentPath(path));
+    }
+    return coordinates;
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -167,12 +167,12 @@ bool FunctionBasedPath::isVisualPath() const
 }
 
 std::vector<ComponentPath>
-FunctionBasedPath::
-findIndependentCoordinates(const SimTK::State& state) const
+FunctionBasedPath::findIndependentCoordinates(const SimTK::State&) const
 {
     std::vector<ComponentPath> coordinates;
-    for (const auto& path : getCoordinatePaths()) {
-        coordinates.push_back(ComponentPath(path));
+    coordinates.reserve(getProperty_coordinate_paths().size());
+    for (int i = 0; i < getProperty_coordinate_paths().size(); ++i) {
+        coordinates.push_back(ComponentPath(get_coordinate_paths(i)));
     }
     return coordinates;
 }

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -125,6 +125,12 @@ double FunctionBasedPath::getLength(const SimTK::State& s) const
     return getCacheVariableValue<double>(s, _lengthCV);
 }
 
+double FunctionBasedPath::getLengtheningSpeed(const SimTK::State& s) const
+{
+    computeLengtheningSpeed(s);
+    return getCacheVariableValue<double>(s, _lengtheningSpeedCV);
+}
+
 double FunctionBasedPath::computeMomentArm(const SimTK::State& s,
         const Coordinate& coord) const
 {
@@ -150,14 +156,21 @@ void FunctionBasedPath::produceForces(const SimTK::State& state,
 
     // Produce mobility forces
     for (int i = 0; i < (int)_coordinates.size(); ++i) {
-        forceConsumer.consumeGeneralizedForce(state, *_coordinates[i], momentArms[i] * tension);
+        forceConsumer.consumeGeneralizedForce(
+                state, *_coordinates[i], momentArms[i] * tension);
     }
 }
 
-double FunctionBasedPath::getLengtheningSpeed(const SimTK::State& s) const
+bool FunctionBasedPath::isVisualPath() const
 {
-    computeLengtheningSpeed(s);
-    return getCacheVariableValue<double>(s, _lengtheningSpeedCV);
+    return false;
+}
+
+std::vector<std::string>
+FunctionBasedPath::
+findIndependentCoordinatePaths(const SimTK::State& state) const
+{
+    return getCoordinatePaths();
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -193,8 +193,7 @@ public:
 
     bool isVisualPath() const override;
 
-    std::vector<std::string>
-    findIndependentCoordinatesBetween(const SimTK::State&) const override;
+    std::vector<std::string> findCoordinates(const SimTK::State&) const override;
 
 private:
     // MODEL COMPONENT INTERFACE

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -191,7 +191,10 @@ public:
             double tension,
             ForceConsumer&) const override;
 
-    bool isVisualPath() const override { return false; }
+    bool isVisualPath() const override;
+
+    std::vector<std::string>
+    findIndependentCoordinatesBetween(const SimTK::State&) const override;
 
 private:
     // MODEL COMPONENT INTERFACE

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -193,8 +193,8 @@ public:
 
     bool isVisualPath() const override;
 
-    std::vector<std::string>
-    findIndependentCoordinatePaths(const SimTK::State&) const override;
+    std::vector<ComponentPath>
+    findIndependentCoordinates(const SimTK::State&) const override;
 
 private:
     // MODEL COMPONENT INTERFACE

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -191,7 +191,10 @@ public:
             double tension,
             ForceConsumer&) const override;
 
-    bool isVisualPath() const override { return false; }
+    bool isVisualPath() const override;
+
+    std::vector<std::string>
+    findIndependentCoordinatePaths(const SimTK::State&) const override;
 
 private:
     // MODEL COMPONENT INTERFACE

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -193,6 +193,15 @@ public:
 
     bool isVisualPath() const override;
 
+    /**
+     * Find the list of paths to independent coordinates which fully determine
+     * the kinematic state of this path.
+     *
+     * `FunctionBasedPath`'s concrete implementation of this method
+     * constructs the list of `ComponentPath` element directly from the
+     * list property 'component_path' (i.e., the `SimTK::State` argument is
+     * unused).
+     */
     std::vector<ComponentPath>
     findIndependentCoordinates(const SimTK::State&) const override;
 

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -33,6 +33,7 @@
 #include <OpenSim/Simulation/Model/MovingPathPoint.h>
 #include <OpenSim/Simulation/Model/PointForceDirection.h>
 #include <OpenSim/Simulation/Wrap/PathWrap.h>
+#include <OpenSim/Simulation/SimulationUtilities.h>
 
 //=============================================================================
 // STATICS
@@ -469,7 +470,7 @@ bool GeometryPath::isVisualPath() const
 }
 
 std::vector<std::string>
-GeometryPath::findIndependentCoordinatesBetween(const SimTK::State& s) const {
+GeometryPath::findCoordinates(const SimTK::State& s) const {
     const PathPointSet& pps = get_PathPointSet();
     const PhysicalFrame& firstFrame = pps.get(0).getParentFrame();
     const PhysicalFrame& lastFrame = pps.get(pps.getSize() - 1).getParentFrame();

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -463,6 +463,35 @@ void GeometryPath::produceForces(const SimTK::State& s,
     }
 }
 
+bool GeometryPath::isVisualPath() const
+{
+    return true;
+}
+
+std::vector<std::string>
+GeometryPath::findIndependentCoordinatesBetween(const SimTK::State& s) const {
+    const PathPointSet& pps = get_PathPointSet();
+    const PhysicalFrame& firstFrame = pps.get(0).getParentFrame();
+    const PhysicalFrame& lastFrame = pps.get(pps.getSize() - 1).getParentFrame();
+
+    std::vector<SimTK::ReferencePtr<const Joint>>
+    jointsBetweenFrames = findJointsBetweenPhysicalFrames(
+            getModel(),
+            firstFrame.getAbsolutePathString(),
+            lastFrame.getAbsolutePathString());
+
+    std::vector<std::string> coordinatePaths;
+    for (const auto& joint : jointsBetweenFrames) {
+        for (int i = 0; i < joint->numCoordinates(); ++i) {
+            const Coordinate& coord = joint->get_coordinates(i);
+            if (!coord.isConstrained(s)) {
+                coordinatePaths.push_back(coord.getAbsolutePathString());
+            }
+        }
+    }
+    return coordinatePaths;
+}
+
 //_____________________________________________________________________________
 /*
  * Update the geometric representation of the path.

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -469,8 +469,8 @@ bool GeometryPath::isVisualPath() const
     return true;
 }
 
-std::vector<std::string>
-GeometryPath::findIndependentCoordinatePaths(const SimTK::State& s) const {
+std::vector<ComponentPath>
+GeometryPath::findIndependentCoordinates(const SimTK::State& s) const {
     const PathPointSet& pps = get_PathPointSet();
     const PhysicalFrame& firstFrame = pps.get(0).getParentFrame();
     const PhysicalFrame& lastFrame = pps.get(pps.getSize() - 1).getParentFrame();
@@ -481,16 +481,17 @@ GeometryPath::findIndependentCoordinatePaths(const SimTK::State& s) const {
             firstFrame.getAbsolutePathString(),
             lastFrame.getAbsolutePathString());
 
-    std::vector<std::string> coordinatePaths;
+    std::vector<ComponentPath> coordinates;
     for (const auto& joint : jointsBetweenFrames) {
         for (int i = 0; i < joint->numCoordinates(); ++i) {
             const Coordinate& coord = joint->get_coordinates(i);
             if (!coord.isConstrained(s)) {
-                coordinatePaths.push_back(coord.getAbsolutePathString());
+                coordinates.push_back(
+                    ComponentPath(coord.getAbsolutePathString()));
             }
         }
     }
-    return coordinatePaths;
+    return coordinates;
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/GeometryPath.cpp
@@ -33,6 +33,7 @@
 #include <OpenSim/Simulation/Model/MovingPathPoint.h>
 #include <OpenSim/Simulation/Model/PointForceDirection.h>
 #include <OpenSim/Simulation/Wrap/PathWrap.h>
+#include <OpenSim/Simulation/SimulationUtilities.h>
 
 //=============================================================================
 // STATICS
@@ -461,6 +462,35 @@ void GeometryPath::produceForces(const SimTK::State& s,
             forceConsumer.consumePointForce(s, currentPoint.getParentFrame(), currentPoint.getLocation(s), force);
         }
     }
+}
+
+bool GeometryPath::isVisualPath() const
+{
+    return true;
+}
+
+std::vector<std::string>
+GeometryPath::findIndependentCoordinatePaths(const SimTK::State& s) const {
+    const PathPointSet& pps = get_PathPointSet();
+    const PhysicalFrame& firstFrame = pps.get(0).getParentFrame();
+    const PhysicalFrame& lastFrame = pps.get(pps.getSize() - 1).getParentFrame();
+
+    std::vector<SimTK::ReferencePtr<const Joint>>
+    jointsBetweenFrames = findJointsBetweenPhysicalFrames(
+            getModel(),
+            firstFrame.getAbsolutePathString(),
+            lastFrame.getAbsolutePathString());
+
+    std::vector<std::string> coordinatePaths;
+    for (const auto& joint : jointsBetweenFrames) {
+        for (int i = 0; i < joint->numCoordinates(); ++i) {
+            const Coordinate& coord = joint->get_coordinates(i);
+            if (!coord.isConstrained(s)) {
+                coordinatePaths.push_back(coord.getAbsolutePathString());
+            }
+        }
+    }
+    return coordinatePaths;
 }
 
 //_____________________________________________________________________________

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -158,9 +158,12 @@ public:
     void produceForces(const SimTK::State& state,
         double tension,
         ForceConsumer& forceConsumer) const override;
-    
-    bool isVisualPath() const override { return true; }
-    
+
+    bool isVisualPath() const override;
+
+    std::vector<std::string>
+    findIndependentCoordinatesBetween(const SimTK::State& s) const override;
+
     //--------------------------------------------------------------------------
     // COMPUTATIONS
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -161,8 +161,7 @@ public:
 
     bool isVisualPath() const override;
 
-    std::vector<std::string>
-    findIndependentCoordinatesBetween(const SimTK::State& s) const override;
+    std::vector<std::string> findCoordinates(const SimTK::State&) const override;
 
     //--------------------------------------------------------------------------
     // COMPUTATIONS

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -161,6 +161,21 @@ public:
 
     bool isVisualPath() const override;
 
+    /**
+     * Find the list of paths to independent coordinates which fully determine
+     * the kinematic state of this path.
+     *
+     * `Scholz2015GeometryPath`'s concrete implementation of this method finds
+     * the joints lying between the frames associated with the path's origin and
+     * insertion points and returns the coordinate paths associated with these
+     * joints. Locked coordinates, prescribed coordinates, and coordinates
+     * dependent on other coordinates via a `CoordinateCouplerConstraint` are
+     * excluded from the list.
+     *
+     * @note This method uses several passes through the model's topology to
+     * form the list of coordinate paths, so avoid repeated calls in performance
+     * critical applications.
+     */
     std::vector<ComponentPath>
     findIndependentCoordinates(const SimTK::State&) const override;
 

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -161,8 +161,8 @@ public:
 
     bool isVisualPath() const override;
 
-    std::vector<std::string>
-    findIndependentCoordinatePaths(const SimTK::State&) const override;
+    std::vector<ComponentPath>
+    findIndependentCoordinates(const SimTK::State&) const override;
 
     //--------------------------------------------------------------------------
     // COMPUTATIONS

--- a/OpenSim/Simulation/Model/GeometryPath.h
+++ b/OpenSim/Simulation/Model/GeometryPath.h
@@ -158,9 +158,12 @@ public:
     void produceForces(const SimTK::State& state,
         double tension,
         ForceConsumer& forceConsumer) const override;
-    
-    bool isVisualPath() const override { return true; }
-    
+
+    bool isVisualPath() const override;
+
+    std::vector<std::string>
+    findIndependentCoordinatePaths(const SimTK::State&) const override;
+
     //--------------------------------------------------------------------------
     // COMPUTATIONS
     //--------------------------------------------------------------------------

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -27,6 +27,7 @@
 #include <OpenSim/Simulation/Model/ForceConsumer.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/SimulationUtilities.h>
 
 #include <optional>
 
@@ -212,6 +213,37 @@ double Scholz2015GeometryPath::computeMomentArm(const SimTK::State& s,
     return _maSolver->solve(s, coord,  *this);
 }
 
+bool Scholz2015GeometryPath::isVisualPath() const {
+    return true;
+}
+
+std::vector<std::string>
+Scholz2015GeometryPath::
+findIndependentCoordinatesBetween(const SimTK::State& s) const {
+    const PhysicalFrame& originFrame = getOrigin().getParentFrame();
+    const PhysicalFrame& insertionFrame = getInsertion().getParentFrame();
+
+    std::vector<SimTK::ReferencePtr<const Joint>>
+    jointsBetweenFrames = findJointsBetweenPhysicalFrames(
+            getModel(),
+            originFrame.getAbsolutePathString(),
+            insertionFrame.getAbsolutePathString());
+
+    std::vector<std::string> coordinatePaths;
+    for (const auto& joint : jointsBetweenFrames) {
+        for (int i = 0; i < joint->numCoordinates(); ++i) {
+            const Coordinate& coord = joint->get_coordinates(i);
+            if (!coord.isConstrained(s)) {
+                coordinatePaths.push_back(coord.getAbsolutePathString());
+            }
+        }
+    }
+    return coordinatePaths;
+}
+
+//=============================================================================
+// FORCE PRODUCER INTERFACE
+//=============================================================================
 void Scholz2015GeometryPath::produceForces(const SimTK::State& state,
         double tension, ForceConsumer& forceConsumer) const {
 

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -218,8 +218,7 @@ bool Scholz2015GeometryPath::isVisualPath() const {
 }
 
 std::vector<std::string>
-Scholz2015GeometryPath::
-findIndependentCoordinatesBetween(const SimTK::State& s) const {
+Scholz2015GeometryPath::findCoordinates(const SimTK::State& s) const {
     const PhysicalFrame& originFrame = getOrigin().getParentFrame();
     const PhysicalFrame& insertionFrame = getInsertion().getParentFrame();
 

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -217,9 +217,9 @@ bool Scholz2015GeometryPath::isVisualPath() const {
     return true;
 }
 
-std::vector<std::string>
+std::vector<ComponentPath>
 Scholz2015GeometryPath::
-findIndependentCoordinatePaths(const SimTK::State& s) const {
+findIndependentCoordinates(const SimTK::State& s) const {
     const PhysicalFrame& originFrame = getOrigin().getParentFrame();
     const PhysicalFrame& insertionFrame = getInsertion().getParentFrame();
 
@@ -229,16 +229,17 @@ findIndependentCoordinatePaths(const SimTK::State& s) const {
             originFrame.getAbsolutePathString(),
             insertionFrame.getAbsolutePathString());
 
-    std::vector<std::string> coordinatePaths;
+    std::vector<ComponentPath> coordinates;
     for (const auto& joint : jointsBetweenFrames) {
         for (int i = 0; i < joint->numCoordinates(); ++i) {
             const Coordinate& coord = joint->get_coordinates(i);
             if (!coord.isConstrained(s)) {
-                coordinatePaths.push_back(coord.getAbsolutePathString());
+                coordinates.push_back(
+                    ComponentPath(coord.getAbsolutePathString()));
             }
         }
     }
-    return coordinatePaths;
+    return coordinates;
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -27,6 +27,7 @@
 #include <OpenSim/Simulation/Model/ForceConsumer.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/SimulationUtilities.h>
 
 #include <optional>
 
@@ -212,6 +213,37 @@ double Scholz2015GeometryPath::computeMomentArm(const SimTK::State& s,
     return _maSolver->solve(s, coord,  *this);
 }
 
+bool Scholz2015GeometryPath::isVisualPath() const {
+    return true;
+}
+
+std::vector<std::string>
+Scholz2015GeometryPath::
+findIndependentCoordinatePaths(const SimTK::State& s) const {
+    const PhysicalFrame& originFrame = getOrigin().getParentFrame();
+    const PhysicalFrame& insertionFrame = getInsertion().getParentFrame();
+
+    std::vector<SimTK::ReferencePtr<const Joint>>
+    jointsBetweenFrames = findJointsBetweenPhysicalFrames(
+            getModel(),
+            originFrame.getAbsolutePathString(),
+            insertionFrame.getAbsolutePathString());
+
+    std::vector<std::string> coordinatePaths;
+    for (const auto& joint : jointsBetweenFrames) {
+        for (int i = 0; i < joint->numCoordinates(); ++i) {
+            const Coordinate& coord = joint->get_coordinates(i);
+            if (!coord.isConstrained(s)) {
+                coordinatePaths.push_back(coord.getAbsolutePathString());
+            }
+        }
+    }
+    return coordinatePaths;
+}
+
+//=============================================================================
+// FORCE PRODUCER INTERFACE
+//=============================================================================
 void Scholz2015GeometryPath::produceForces(const SimTK::State& state,
         double tension, ForceConsumer& forceConsumer) const {
 

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -433,7 +433,9 @@ public:
     double getLengtheningSpeed(const SimTK::State& s) const override;
     double computeMomentArm(const SimTK::State& s,
             const Coordinate& coord) const override;
-    bool isVisualPath() const override { return true; }
+    bool isVisualPath() const override;
+    std::vector<std::string>
+    findIndependentCoordinatesBetween(const SimTK::State& s) const override;
     // @}
 
     //** @name `ForceProducer` interface */

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -434,8 +434,7 @@ public:
     double computeMomentArm(const SimTK::State& s,
             const Coordinate& coord) const override;
     bool isVisualPath() const override;
-    std::vector<std::string>
-    findIndependentCoordinatesBetween(const SimTK::State& s) const override;
+    std::vector<std::string> findCoordinates(const SimTK::State&) const override;
     // @}
 
     //** @name `ForceProducer` interface */

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -433,7 +433,10 @@ public:
     double getLengtheningSpeed(const SimTK::State& s) const override;
     double computeMomentArm(const SimTK::State& s,
             const Coordinate& coord) const override;
-    bool isVisualPath() const override { return true; }
+    bool isVisualPath() const override;
+
+    std::vector<std::string>
+    findIndependentCoordinatePaths(const SimTK::State&) const override;
     // @}
 
     //** @name `ForceProducer` interface */

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -435,8 +435,8 @@ public:
             const Coordinate& coord) const override;
     bool isVisualPath() const override;
 
-    std::vector<std::string>
-    findIndependentCoordinatePaths(const SimTK::State&) const override;
+    std::vector<ComponentPath>
+    findIndependentCoordinates(const SimTK::State&) const override;
     // @}
 
     //** @name `ForceProducer` interface */

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -435,6 +435,23 @@ public:
             const Coordinate& coord) const override;
     bool isVisualPath() const override;
 
+    /**
+     * Find the list of paths to independent coordinates which fully determine
+     * the kinematic state of this path.
+     *
+     * `Scholz2015GeometryPath`'s concrete implementation of this method finds
+     * the joints lying between the frames associated with the path's origin and
+     * insertion points and returns the coordinate paths associated with these
+     * joints. Locked coordinates, prescribed coordinates, and coordinates
+     * dependent on other coordinates via a `CoordinateCouplerConstraint` are
+     * excluded from the list.
+     *
+     * @note This method uses several passes through the model's topology to
+     * form the list of coordinate paths, so avoid repeated calls in performance
+     * critical applications.
+     *
+     * @see SimulationUtilities::findJointsBetweenPhysicalFrames()
+     */
     std::vector<ComponentPath>
     findIndependentCoordinates(const SimTK::State&) const override;
     // @}

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -578,9 +578,9 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
     const std::string secondBasePath =
             secondFrame.findBaseFrame().getAbsolutePathString();
 
-    // Case 1: the second frame is an ancestor of the first frame. Trace from
-    // the first frame toward ground; if second frame's base body is
-    // encountered, return the joints collected so far.
+    // The second frame is an ancestor of the first frame. Trace from the first
+    // frame toward ground; if second frame's base body is encountered, return
+    // the joints collected so far.
     {
         std::vector<SimTK::ReferencePtr<const Joint>> joints;
         const Frame* current = &firstFrame.findBaseFrame();
@@ -598,9 +598,9 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
         }
     }
 
-    // Case 2: the first frame is an ancestor of the second frame. Trace from
-    // the second frame toward ground; if first frame's base body is
-    // encountered, return the joints collected so far.
+    // The first frame is an ancestor of the second frame. Trace from the second
+    // frame toward ground; if first frame's base body is encountered, return
+    // the joints collected so far.
     {
         std::vector<SimTK::ReferencePtr<const Joint>> joints;
         const Frame* current = &secondFrame.findBaseFrame();
@@ -618,7 +618,7 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
         }
     }
 
-    // Case 3: the frames are not on the same branch of the kinematic tree.
+    // The frames are not on the same branch of the kinematic tree.
     OPENSIM_THROW(Exception,
             "Could not find a path between frames '{}' and '{}': "
             "neither frame is an ancestor of the other in the kinematic tree.",

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -1,6 +1,6 @@
 /* -------------------------------------------------------------------------- *
- *                     OpenSim:  SimulationUtilities.cpp                      *
- * -------------------------------------------------------------------------- *
+* -------------------------------------------------------------------------- *
+*                     OpenSim:  SimulationUtilities.cpp                      *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
  * OpenSim is developed at Stanford University and supported by the US        *
@@ -564,6 +564,10 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
             secondFramePath);
     const auto& firstFrame = model.getComponent<PhysicalFrame>(firstFramePath);
     const auto& secondFrame = model.getComponent<PhysicalFrame>(secondFramePath);
+        const std::string firstPath =
+            firstFrame.findBaseFrame().getAbsolutePathString();
+    const std::string secondPath =
+            secondFrame.findBaseFrame().getAbsolutePathString();
 
     // Build a map between the model's joints and the base frames of the joint
     // child frames.
@@ -573,55 +577,50 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
         childBodyToJoint[childBase.getAbsolutePathString()] = &joint;
     }
 
-    const std::string firstBasePath =
-            firstFrame.findBaseFrame().getAbsolutePathString();
-    const std::string secondBasePath =
-            secondFrame.findBaseFrame().getAbsolutePathString();
-
-    // The second frame is an ancestor of the first frame. Trace from the first
-    // frame toward ground; if second frame's base body is encountered, return
-    // the joints collected so far.
-    {
-        std::vector<SimTK::ReferencePtr<const Joint>> joints;
-        const Frame* current = &firstFrame.findBaseFrame();
+    // A helper function to trace from a starting frame to a target frame,
+    // populating a list of joints along the way and returning whether the
+    // target frame was found. If the target frame is not found, the list of
+    // joints will contain the path from the starting frame to the ground frame.
+    auto traceToGround = [&](const std::string& startBasePath,
+            const std::string& targetBasePath,
+            std::vector<SimTK::ReferencePtr<const Joint>>& joints) -> bool {
+        const Frame* current = &model.getComponent<PhysicalFrame>(startBasePath);
         while (true) {
-            if (current->getAbsolutePathString() == secondBasePath) {
-                // Reverse the order of the joints so they are returned in
-                // root-to-leaf order.
-                std::reverse(joints.begin(), joints.end());
-                return joints;
+            if (current->getAbsolutePathString() == targetBasePath) {
+                return true;
             }
             auto it = childBodyToJoint.find(current->getAbsolutePathString());
             if (it == childBodyToJoint.end()) break; // reached ground
             joints.emplace_back(it->second);
             current = &it->second->getParentFrame().findBaseFrame();
         }
+        return false;
+    };
+
+    std::vector<SimTK::ReferencePtr<const Joint>> firstJoints;
+    bool firstFoundTarget = traceToGround(firstPath, secondPath, firstJoints);
+    if (firstFoundTarget) {
+        // Reverse the order of the joints so they are returned in root-to-leaf
+        // order.
+        std::reverse(firstJoints.begin(), firstJoints.end());
+        return firstJoints;
     }
 
-    // The first frame is an ancestor of the second frame. Trace from the second
-    // frame toward ground; if first frame's base body is encountered, return
-    // the joints collected so far.
-    {
-        std::vector<SimTK::ReferencePtr<const Joint>> joints;
-        const Frame* current = &secondFrame.findBaseFrame();
-        while (true) {
-            if (current->getAbsolutePathString() == firstBasePath) {
-                // Reverse the order of the joints so they are returned in
-                // root-to-leaf order.
-                std::reverse(joints.begin(), joints.end());
-                return joints;
-            }
-            auto it = childBodyToJoint.find(current->getAbsolutePathString());
-            if (it == childBodyToJoint.end()) break; // reached ground
-            joints.emplace_back(it->second);
-            current = &it->second->getParentFrame().findBaseFrame();
-        }
+    std::vector<SimTK::ReferencePtr<const Joint>> secondJoints;
+    bool secondFoundTarget = traceToGround(secondPath, firstPath, secondJoints);
+    if (secondFoundTarget) {
+        // Reverse the order of the joints so they are returned in root-to-leaf
+        // order.
+        std::reverse(secondJoints.begin(), secondJoints.end());
+        return secondJoints;
     }
 
-    // The frames are not on the same branch of the kinematic tree.
-    OPENSIM_THROW(Exception,
-            "Could not find a path between frames '{}' and '{}': "
-            "neither frame is an ancestor of the other in the kinematic tree.",
-            firstFrame.getAbsolutePathString(),
-            secondFrame.getAbsolutePathString());
+    // Combine the first list of joints with the reverse of the second list of
+    // joints.
+    std::reverse(secondJoints.begin(), secondJoints.end());
+    for (const auto& joint : secondJoints) {
+        firstJoints.emplace_back(joint.get());
+    }
+
+    return firstJoints;
 }

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -546,3 +546,82 @@ void OpenSim::appendCoordinateValueDerivativesAsSpeeds(TimeSeriesTable& table,
     }
 
 }
+
+std::vector<SimTK::ReferencePtr<const Joint>>
+OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
+        const std::string& firstFramePath, const std::string& secondFramePath) {
+
+    // Get the frames from the model.
+    OPENSIM_THROW_IF(
+            !model.hasComponent<PhysicalFrame>(firstFramePath), Exception,
+            "Expected the model to contain a PhysicalFrame with path '{}', "
+            "but no such component was found.",
+            firstFramePath);
+    OPENSIM_THROW_IF(
+            !model.hasComponent<PhysicalFrame>(secondFramePath), Exception,
+            "Expected the model to contain a PhysicalFrame with path '{}', "
+            "but no such component was found.",
+            secondFramePath);
+    const auto& firstFrame = model.getComponent<PhysicalFrame>(firstFramePath);
+    const auto& secondFrame = model.getComponent<PhysicalFrame>(secondFramePath);
+
+    // Build a map between the model's joints and the base frames of the joint
+    // child frames.
+    std::unordered_map<std::string, const Joint*> childBodyToJoint;
+    for (const auto& joint : model.getComponentList<Joint>()) {
+        const auto& childBase = joint.getChildFrame().findBaseFrame();
+        childBodyToJoint[childBase.getAbsolutePathString()] = &joint;
+    }
+
+    const std::string firstBasePath =
+            firstFrame.findBaseFrame().getAbsolutePathString();
+    const std::string secondBasePath =
+            secondFrame.findBaseFrame().getAbsolutePathString();
+
+    // Case 1: the second frame is an ancestor of the first frame. Trace from
+    // the first frame toward ground; if second frame's base body is
+    // encountered, return the joints collected so far.
+    {
+        std::vector<SimTK::ReferencePtr<const Joint>> joints;
+        const Frame* current = &firstFrame.findBaseFrame();
+        while (true) {
+            if (current->getAbsolutePathString() == secondBasePath) {
+                // Reverse the order of the joints so they are returned in
+                // root-to-leaf order.
+                std::reverse(joints.begin(), joints.end());
+                return joints;
+            }
+            auto it = childBodyToJoint.find(current->getAbsolutePathString());
+            if (it == childBodyToJoint.end()) break; // reached ground
+            joints.emplace_back(it->second);
+            current = &it->second->getParentFrame().findBaseFrame();
+        }
+    }
+
+    // Case 2: the first frame is an ancestor of the second frame. Trace from
+    // the second frame toward ground; if first frame's base body is
+    // encountered, return the joints collected so far.
+    {
+        std::vector<SimTK::ReferencePtr<const Joint>> joints;
+        const Frame* current = &secondFrame.findBaseFrame();
+        while (true) {
+            if (current->getAbsolutePathString() == firstBasePath) {
+                // Reverse the order of the joints so they are returned in
+                // root-to-leaf order.
+                std::reverse(joints.begin(), joints.end());
+                return joints;
+            }
+            auto it = childBodyToJoint.find(current->getAbsolutePathString());
+            if (it == childBodyToJoint.end()) break; // reached ground
+            joints.emplace_back(it->second);
+            current = &it->second->getParentFrame().findBaseFrame();
+        }
+    }
+
+    // Case 3: the frames are not on the same branch of the kinematic tree.
+    OPENSIM_THROW(Exception,
+            "Could not find a path between frames '{}' and '{}': "
+            "neither frame is an ancestor of the other in the kinematic tree.",
+            firstFrame.getAbsolutePathString(),
+            secondFrame.getAbsolutePathString());
+}

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -546,3 +546,81 @@ void OpenSim::appendCoordinateValueDerivativesAsSpeeds(TimeSeriesTable& table,
     }
 
 }
+
+std::vector<SimTK::ReferencePtr<const Joint>>
+OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
+        const std::string& firstFramePath, const std::string& secondFramePath) {
+
+    // Get the frames from the model.
+    OPENSIM_THROW_IF(
+            !model.hasComponent<PhysicalFrame>(firstFramePath), Exception,
+            "Expected the model to contain a PhysicalFrame with path '{}', "
+            "but no such component was found.",
+            firstFramePath);
+    OPENSIM_THROW_IF(
+            !model.hasComponent<PhysicalFrame>(secondFramePath), Exception,
+            "Expected the model to contain a PhysicalFrame with path '{}', "
+            "but no such component was found.",
+            secondFramePath);
+    const auto& firstFrame = model.getComponent<PhysicalFrame>(firstFramePath);
+    const auto& secondFrame = model.getComponent<PhysicalFrame>(secondFramePath);
+        const std::string firstPath =
+            firstFrame.findBaseFrame().getAbsolutePathString();
+    const std::string secondPath =
+            secondFrame.findBaseFrame().getAbsolutePathString();
+
+    // Build a map between the model's joints and the base frames of the joint
+    // child frames.
+    std::unordered_map<std::string, const Joint*> childBodyToJoint;
+    for (const auto& joint : model.getComponentList<Joint>()) {
+        const auto& childBase = joint.getChildFrame().findBaseFrame();
+        childBodyToJoint[childBase.getAbsolutePathString()] = &joint;
+    }
+
+    // A helper function to trace from a starting frame to a target frame,
+    // populating a list of joints along the way and returning whether the
+    // target frame was found. If the target frame is not found, the list of
+    // joints will contain the path from the starting frame to the ground frame.
+    auto traceToGround = [&](const std::string& startBasePath,
+            const std::string& targetBasePath,
+            std::vector<SimTK::ReferencePtr<const Joint>>& joints) -> bool {
+        const Frame* current = &model.getComponent<PhysicalFrame>(startBasePath);
+        while (true) {
+            if (current->getAbsolutePathString() == targetBasePath) {
+                return true;
+            }
+            auto it = childBodyToJoint.find(current->getAbsolutePathString());
+            if (it == childBodyToJoint.end()) break; // reached ground
+            joints.emplace_back(it->second);
+            current = &it->second->getParentFrame().findBaseFrame();
+        }
+        return false;
+    };
+
+    std::vector<SimTK::ReferencePtr<const Joint>> firstJoints;
+    bool firstFoundTarget = traceToGround(firstPath, secondPath, firstJoints);
+    if (firstFoundTarget) {
+        // Reverse the order of the joints so they are returned in root-to-leaf
+        // order.
+        std::reverse(firstJoints.begin(), firstJoints.end());
+        return firstJoints;
+    }
+
+    std::vector<SimTK::ReferencePtr<const Joint>> secondJoints;
+    bool secondFoundTarget = traceToGround(secondPath, firstPath, secondJoints);
+    if (secondFoundTarget) {
+        // Reverse the order of the joints so they are returned in root-to-leaf
+        // order.
+        std::reverse(secondJoints.begin(), secondJoints.end());
+        return secondJoints;
+    }
+
+    // Combine the first list of joints with the reverse of the second list of
+    // joints.
+    std::reverse(secondJoints.begin(), secondJoints.end());
+    for (const auto& joint : secondJoints) {
+        firstJoints.emplace_back(joint.get());
+    }
+
+    return firstJoints;
+}

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -564,7 +564,7 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
             secondFramePath);
     const auto& firstFrame = model.getComponent<PhysicalFrame>(firstFramePath);
     const auto& secondFrame = model.getComponent<PhysicalFrame>(secondFramePath);
-        const std::string firstPath =
+    const std::string firstPath =
             firstFrame.findBaseFrame().getAbsolutePathString();
     const std::string secondPath =
             secondFrame.findBaseFrame().getAbsolutePathString();
@@ -581,7 +581,7 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
     // populating a list of joints along the way and returning whether the
     // target frame was found. If the target frame is not found, the list of
     // joints will contain the path from the starting frame to the ground frame.
-    auto traceToGround = [&](const std::string& startBasePath,
+    auto traceTowardGround = [&](const std::string& startBasePath,
             const std::string& targetBasePath,
             std::vector<SimTK::ReferencePtr<const Joint>>& joints) -> bool {
         const Frame* current = &model.getComponent<PhysicalFrame>(startBasePath);
@@ -598,7 +598,7 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
     };
 
     std::vector<SimTK::ReferencePtr<const Joint>> firstJoints;
-    bool firstFoundTarget = traceToGround(firstPath, secondPath, firstJoints);
+    bool firstFoundTarget = traceTowardGround(firstPath, secondPath, firstJoints);
     if (firstFoundTarget) {
         // Reverse the order of the joints so they are returned in root-to-leaf
         // order.
@@ -607,7 +607,7 @@ OpenSim::findJointsBetweenPhysicalFrames(const Model& model,
     }
 
     std::vector<SimTK::ReferencePtr<const Joint>> secondJoints;
-    bool secondFoundTarget = traceToGround(secondPath, firstPath, secondJoints);
+    bool secondFoundTarget = traceTowardGround(secondPath, firstPath, secondJoints);
     if (secondFoundTarget) {
         // Reverse the order of the joints so they are returned in root-to-leaf
         // order.

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -447,9 +447,16 @@ OSIMSIMULATION_API void appendCoordinateValueDerivativesAsSpeeds(
         bool overwriteExistingColumns = true);
 
 /// Find the Joint%s that lie between two PhysicalFrame%s in a Model. The second
-/// frame need not be a descendant of the first frame or vice versa, but the two
-/// frames must be along the same branch of the kinematic tree. Otherwise,
-/// an exception is thrown.
+/// frame need not be a descendant of the first frame or vice versa. If the
+/// frames are on different branches of the model, this function will return the
+/// list of joints ordered from the first frame to the second frame. Otherwise,
+/// the list of joint with be ordered promixally to distally, i.e., moving away
+/// from the ground frame.
+///
+/// @note This function uses several passes through the model's topology to form
+/// the list of joints, so avoided repeated calls to this function in
+/// performance critical applications.
+///
 /// @ingroup simulationutil
 OSIMSIMULATION_API
 std::vector<SimTK::ReferencePtr<const Joint>>

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -446,6 +446,23 @@ OSIMSIMULATION_API void appendCoordinateValueDerivativesAsSpeeds(
         TimeSeriesTable& table, const Model& model,
         bool overwriteExistingColumns = true);
 
+/// Find the Joint%s that lie between two PhysicalFrame%s in a Model. The second
+/// frame need not be a descendant of the first frame or vice versa. If the
+/// frames are on different branches of the model, this function will return the
+/// list of joints ordered from the first frame to the second frame. Otherwise,
+/// the list of joint with be ordered promixally to distally, i.e., moving away
+/// from the ground frame.
+///
+/// @note This function uses several passes through the model's topology to form
+/// the list of joints, so avoided repeated calls to this function in
+/// performance critical applications.
+///
+/// @ingroup simulationutil
+OSIMSIMULATION_API
+std::vector<SimTK::ReferencePtr<const Joint>>
+findJointsBetweenPhysicalFrames(const Model& model,
+        const std::string& firstFramePath, const std::string& secondFramePath);
+
 } // end of namespace OpenSim
 
 

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -446,6 +446,16 @@ OSIMSIMULATION_API void appendCoordinateValueDerivativesAsSpeeds(
         TimeSeriesTable& table, const Model& model,
         bool overwriteExistingColumns = true);
 
+/// Find the Joint%s that lie between two PhysicalFrame%s in a Model. The second
+/// frame need not be a descendant of the first frame or vice versa, but the two
+/// frames must be along the same branch of the kinematic tree. Otherwise,
+/// an exception is thrown.
+/// @ingroup simulationutil
+OSIMSIMULATION_API
+std::vector<SimTK::ReferencePtr<const Joint>>
+findJointsBetweenPhysicalFrames(const Model& model,
+        const std::string& firstFramePath, const std::string& secondFramePath);
+
 } // end of namespace OpenSim
 
 

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -453,8 +453,8 @@ OSIMSIMULATION_API void appendCoordinateValueDerivativesAsSpeeds(
 /// the list of joints will use a root-to-leaf ordering.
 ///
 /// @note This function uses several passes through the model's topology to form
-/// the list of joints, so avoid repeated calls to this function in performance
-/// critical applications.
+/// the list of joints, so avoid repeated calls in performance critical
+/// applications.
 ///
 /// @ingroup simulationutil
 OSIMSIMULATION_API

--- a/OpenSim/Simulation/SimulationUtilities.h
+++ b/OpenSim/Simulation/SimulationUtilities.h
@@ -450,12 +450,11 @@ OSIMSIMULATION_API void appendCoordinateValueDerivativesAsSpeeds(
 /// frame need not be a descendant of the first frame or vice versa. If the
 /// frames are on different branches of the model, this function will return the
 /// list of joints ordered from the first frame to the second frame. Otherwise,
-/// the list of joint with be ordered promixally to distally, i.e., moving away
-/// from the ground frame.
+/// the list of joints will use a root-to-leaf ordering.
 ///
 /// @note This function uses several passes through the model's topology to form
-/// the list of joints, so avoided repeated calls to this function in
-/// performance critical applications.
+/// the list of joints, so avoid repeated calls to this function in performance
+/// critical applications.
 ///
 /// @ingroup simulationutil
 OSIMSIMULATION_API

--- a/OpenSim/Simulation/Test/testFunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Test/testFunctionBasedPath.cpp
@@ -370,4 +370,27 @@ TEST_CASE("testFunctionBasedPath") {
         CHECK_THAT(genForce_y, WithinAbs(residuals[1], tol));
     }
 
+    SECTION("findIndependentCoordinates") {
+        // Create a planar point mass model and add a PathActuator with a 2-DOF
+        // FunctionBasedPath.
+        Model model = ModelFactory::createPlanarPointMass();
+
+        FunctionBasedPath fbPath;
+        fbPath.setName("polynomial_path_2dof");
+        fbPath.setLengthFunction(MultivariatePolynomialFunction(
+            createVector({1.0, 2.0, 3.0, 4.0, 5.0, 6.0}), 2, 2));
+        fbPath.setCoordinatePaths({"/jointset/tx/tx", "/jointset/ty/ty"});
+        auto* actu = new PathActuator();
+        actu->set_path(fbPath);
+        model.addComponent(actu);
+        model.finalizeConnections();
+
+        // findIndependentCoordinates() should return the coordinates we
+        // prescribed in the FunctionBasedPath above.
+        SimTK::State state = model.initSystem();
+        auto coords = fbPath.findIndependentCoordinates(state);
+        CHECK(coords.size() == 2);
+        CHECK(coords[0].toString() == "/jointset/tx/tx");
+        CHECK(coords[1].toString() == "/jointset/ty/ty");
+    }
 }

--- a/OpenSim/Simulation/Test/testSimulationUtilities.cpp
+++ b/OpenSim/Simulation/Test/testSimulationUtilities.cpp
@@ -23,6 +23,7 @@
 
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
 #include <OpenSim/Actuators/PointActuator.h>
@@ -169,5 +170,94 @@ TEST_CASE("testUpdatePre40KinematicsFor40MotionType") {
         SimTK_TEST_MUST_THROW_EXC(
             updatePre40KinematicsStorageFor40MotionType(updatedModel, origKinematics),
             Exception);
+    }
+}
+
+TEST_CASE("findJointsBetweenPhysicalFrames") {
+
+    using SimTK::Inertia;
+    using SimTK::Vec3;
+
+    // Create a pendulum model with two branches branches in the kinematic tree.
+    Model model;
+    const auto& ground = model.getGround();
+
+    auto addBranch = [&ground](Model& model, int numLinks, std::string name) {
+        const PhysicalFrame* prevBody = &ground;
+        for (int i = 0; i < numLinks; ++i) {
+            const std::string istr = std::to_string(i);
+            auto* bi = new OpenSim::Body(fmt::format("b{}_{}", istr, name),
+                1, Vec3(0), Inertia(1));
+            model.addBody(bi);
+
+            auto* ji = new PinJoint(fmt::format("j{}_{}", istr, name),
+                    *prevBody, Vec3(0), Vec3(0),
+                    *bi, Vec3(-1, 0, 0), Vec3(0));
+            auto& qi = ji->updCoordinate();
+            qi.setName(fmt::format("q{}_{}", istr, name));
+            model.addJoint(ji);
+
+            prevBody = bi;
+        }
+    };
+
+    addBranch(model, 3, "l");
+    addBranch(model, 2, "r");
+    model.finalizeConnections();
+
+    SECTION("Bodies do not exist in the model") {
+        CHECK_THROWS_WITH(
+            findJointsBetweenPhysicalFrames(
+                    model, "/not/a/body", "/bodyset/b1_l"),
+            Catch::Matchers::ContainsSubstring(
+                    "Expected the model to contain a PhysicalFrame with "
+                    "path '/not/a/body'"));
+
+        CHECK_THROWS_WITH(
+                findJointsBetweenPhysicalFrames(
+                        model, "/bodyset/b0_l", "/also/not/a/body"),
+                Catch::Matchers::ContainsSubstring(
+                        "Expected the model to contain a PhysicalFrame with "
+                        "path '/also/not/a/body'"));
+    }
+
+    SECTION("Frames on same branch") {
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b1_l");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+
+        // Joints should be returned in root-to-leaf order.
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b2_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j2_l");
+
+        // Flipping the order of the frames should produce the same joints.
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b2_l", "/bodyset/b0_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_l", "/bodyset/b2_l");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_r", "/bodyset/b1_r");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_r");
+    }
+
+    SECTION("Frames on different branches") {
+        CHECK_THROWS_WITH(
+            findJointsBetweenPhysicalFrames(
+                    model, "/bodyset/b0_l", "/bodyset/b0_r"),
+            Catch::Matchers::ContainsSubstring(
+                    "Could not find a path between frames '/bodyset/b0_l' and "
+                    "'/bodyset/b0_r'"));
     }
 }

--- a/OpenSim/Simulation/Test/testSimulationUtilities.cpp
+++ b/OpenSim/Simulation/Test/testSimulationUtilities.cpp
@@ -253,11 +253,49 @@ TEST_CASE("findJointsBetweenPhysicalFrames") {
     }
 
     SECTION("Frames on different branches") {
-        CHECK_THROWS_WITH(
-            findJointsBetweenPhysicalFrames(
-                    model, "/bodyset/b0_l", "/bodyset/b0_r"),
-            Catch::Matchers::ContainsSubstring(
-                    "Could not find a path between frames '/bodyset/b0_l' and "
-                    "'/bodyset/b0_r'"));
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b0_r");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_r");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_r", "/bodyset/b0_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b2_l", "/bodyset/b1_r");
+        CHECK(joints.size() == 5);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j2_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[3]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[4]->getAbsolutePathString() == "/jointset/j1_r");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_r", "/bodyset/b2_l");
+        CHECK(joints.size() == 5);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[3]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[4]->getAbsolutePathString() == "/jointset/j2_l");
+    }
+
+    SECTION("One frame is ground") {
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/ground", "/bodyset/b2_l");
+        CHECK(joints.size() == 3);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_r", "/ground");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_r");
     }
 }

--- a/OpenSim/Simulation/Test/testSimulationUtilities.cpp
+++ b/OpenSim/Simulation/Test/testSimulationUtilities.cpp
@@ -23,6 +23,7 @@
 
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Simulation/Model/Model.h>
+#include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
 #include <OpenSim/Actuators/PointActuator.h>
@@ -169,5 +170,132 @@ TEST_CASE("testUpdatePre40KinematicsFor40MotionType") {
         SimTK_TEST_MUST_THROW_EXC(
             updatePre40KinematicsStorageFor40MotionType(updatedModel, origKinematics),
             Exception);
+    }
+}
+
+TEST_CASE("findJointsBetweenPhysicalFrames") {
+
+    using SimTK::Inertia;
+    using SimTK::Vec3;
+
+    // Create a pendulum model with two branches in the kinematic tree.
+    Model model;
+    const auto& ground = model.getGround();
+
+    auto addBranch = [&ground](Model& model, int numLinks, std::string name) {
+        const PhysicalFrame* prevBody = &ground;
+        for (int i = 0; i < numLinks; ++i) {
+            const std::string istr = std::to_string(i);
+            auto* bi = new OpenSim::Body(fmt::format("b{}_{}", istr, name),
+                1, Vec3(0), Inertia(1));
+            model.addBody(bi);
+
+            auto* ji = new PinJoint(fmt::format("j{}_{}", istr, name),
+                    *prevBody, Vec3(0), Vec3(0),
+                    *bi, Vec3(-1, 0, 0), Vec3(0));
+            auto& qi = ji->updCoordinate();
+            qi.setName(fmt::format("q{}_{}", istr, name));
+            model.addJoint(ji);
+
+            prevBody = bi;
+        }
+    };
+
+    addBranch(model, 3, "l");
+    addBranch(model, 2, "r");
+    model.finalizeConnections();
+
+    SECTION("Bodies do not exist in the model") {
+        CHECK_THROWS_WITH(
+            findJointsBetweenPhysicalFrames(
+                    model, "/not/a/body", "/bodyset/b1_l"),
+            Catch::Matchers::ContainsSubstring(
+                    "Expected the model to contain a PhysicalFrame with "
+                    "path '/not/a/body'"));
+
+        CHECK_THROWS_WITH(
+                findJointsBetweenPhysicalFrames(
+                        model, "/bodyset/b0_l", "/also/not/a/body"),
+                Catch::Matchers::ContainsSubstring(
+                        "Expected the model to contain a PhysicalFrame with "
+                        "path '/also/not/a/body'"));
+    }
+
+    SECTION("Frames on same branch") {
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b1_l");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+
+        // Joints should be returned in root-to-leaf order.
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b2_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j2_l");
+
+        // Flipping the order of the frames should produce the same joints.
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b2_l", "/bodyset/b0_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_l", "/bodyset/b2_l");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_r", "/bodyset/b1_r");
+        CHECK(joints.size() == 1);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_r");
+    }
+
+    SECTION("Frames on different branches") {
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_l", "/bodyset/b0_r");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_r");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b0_r", "/bodyset/b0_l");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b2_l", "/bodyset/b1_r");
+        CHECK(joints.size() == 5);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j2_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[3]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[4]->getAbsolutePathString() == "/jointset/j1_r");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_r", "/bodyset/b2_l");
+        CHECK(joints.size() == 5);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j1_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[3]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[4]->getAbsolutePathString() == "/jointset/j2_l");
+    }
+
+    SECTION("One frame is ground") {
+        auto joints = findJointsBetweenPhysicalFrames(
+                model, "/ground", "/bodyset/b2_l");
+        CHECK(joints.size() == 3);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_l");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_l");
+        CHECK(joints[2]->getAbsolutePathString() == "/jointset/j2_l");
+
+        joints = findJointsBetweenPhysicalFrames(
+                model, "/bodyset/b1_r", "/ground");
+        CHECK(joints.size() == 2);
+        CHECK(joints[0]->getAbsolutePathString() == "/jointset/j0_r");
+        CHECK(joints[1]->getAbsolutePathString() == "/jointset/j1_r");
     }
 }

--- a/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
@@ -460,54 +460,50 @@ TEST_CASE("WrapEllipsoid") {
     }
 }
 
-TEST_CASE("findCoordinatesBetween") {
-    Model model("subject_walk_armless_18musc.osim");
+TEST_CASE("findIndependentCoordinates") {
+    Model model("walk_gait1018_subject01.osim");
     SimTK::State state = model.initSystem();
 
     SECTION("hip muscles") {
-        const std::string muscle_name = GENERATE("psoas_r", "glut_max2_r");
+        const std::string muscle_name = GENERATE("iliopsoas_r", "glut_max_r");
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
-        auto coordinates = path.findIndependentCoordinatePaths(state);
-        CHECK(coordinates[0] == "/jointset/hip_r/hip_flexion_r");
-        CHECK(coordinates[1] == "/jointset/hip_r/hip_adduction_r");
-        CHECK(coordinates[2] == "/jointset/hip_r/hip_rotation_r");
+        auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords[0].toString() == "/jointset/hip_r/hip_flexion_r");
     }
 
     SECTION("hip/knee biarticular muscles") {
-        const std::string muscle_name = GENERATE("rect_fem_r", "semimem_r");
+        const std::string muscle_name = GENERATE("rect_fem_r", "hamstrings_r");
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
-        auto coordinates = path.findIndependentCoordinatePaths(state);
-        CHECK(coordinates[0] == "/jointset/hip_r/hip_flexion_r");
-        CHECK(coordinates[1] == "/jointset/hip_r/hip_adduction_r");
-        CHECK(coordinates[2] == "/jointset/hip_r/hip_rotation_r");
-        CHECK(coordinates[3] == "/jointset/walker_knee_r/knee_angle_r");
+        auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords[0].toString() == "/jointset/hip_r/hip_flexion_r");
+        CHECK(coords[1].toString() == "/jointset/knee_r/knee_angle_r");
     }
 
     SECTION("knee muscles") {
-        const std::string muscle_name = GENERATE("vas_int_r", "bifemsh_r");
+        const std::string muscle_name = GENERATE("vasti_r", "bifemsh_r");
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
-        auto coordinates = path.findIndependentCoordinatePaths(state);
-        CHECK(coordinates[0] == "/jointset/walker_knee_r/knee_angle_r");
+        auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords[0].toString() == "/jointset/knee_r/knee_angle_r");
     }
 
     SECTION("gastrocnemius") {
-        const std::string muscle_path = "/forceset/med_gas_r";
+        const std::string muscle_path = "/forceset/gastroc_r";
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
-        auto coordinates = path.findIndependentCoordinatePaths(state);
-        CHECK(coordinates[0] == "/jointset/walker_knee_r/knee_angle_r");
-        CHECK(coordinates[1] == "/jointset/ankle_r/ankle_angle_r");
+        auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords[0].toString() == "/jointset/knee_r/knee_angle_r");
+        CHECK(coords[1].toString() == "/jointset/ankle_r/ankle_angle_r");
     }
 
     SECTION("ankle muscles") {
         const std::string muscle_name = GENERATE("tib_ant_r", "soleus_r");
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
-        auto coordinates = path.findIndependentCoordinatePaths(state);
-        CHECK(coordinates[0] == "/jointset/ankle_r/ankle_angle_r");
+        auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords[0].toString() == "/jointset/ankle_r/ankle_angle_r");
     }
 }

--- a/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
@@ -459,3 +459,55 @@ TEST_CASE("WrapEllipsoid") {
         }
     }
 }
+
+TEST_CASE("findCoordinatesBetween") {
+    Model model("subject_walk_armless_18musc.osim");
+    SimTK::State state = model.initSystem();
+
+    SECTION("hip muscles") {
+        const std::string muscle_name = GENERATE("psoas_r", "glut_max2_r");
+        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
+        auto coordinates = path.findIndependentCoordinatePaths(state);
+        CHECK(coordinates[0] == "/jointset/hip_r/hip_flexion_r");
+        CHECK(coordinates[1] == "/jointset/hip_r/hip_adduction_r");
+        CHECK(coordinates[2] == "/jointset/hip_r/hip_rotation_r");
+    }
+
+    SECTION("hip/knee biarticular muscles") {
+        const std::string muscle_name = GENERATE("rect_fem_r", "semimem_r");
+        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const auto& muscle = model.getComponent<Muscle>(muscle_path);
+        const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
+        auto coordinates = path.findIndependentCoordinatePaths(state);
+        CHECK(coordinates[0] == "/jointset/hip_r/hip_flexion_r");
+        CHECK(coordinates[1] == "/jointset/hip_r/hip_adduction_r");
+        CHECK(coordinates[2] == "/jointset/hip_r/hip_rotation_r");
+        CHECK(coordinates[3] == "/jointset/walker_knee_r/knee_angle_r");
+    }
+
+    SECTION("knee muscles") {
+        const std::string muscle_name = GENERATE("vas_int_r", "bifemsh_r");
+        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const auto& muscle = model.getComponent<Muscle>(muscle_path);
+        const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
+        auto coordinates = path.findIndependentCoordinatePaths(state);
+        CHECK(coordinates[0] == "/jointset/walker_knee_r/knee_angle_r");
+    }
+
+    SECTION("gastrocnemius") {
+        const std::string muscle_path = "/forceset/med_gas_r";
+        const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
+        auto coordinates = path.findIndependentCoordinatePaths(state);
+        CHECK(coordinates[0] == "/jointset/walker_knee_r/knee_angle_r");
+        CHECK(coordinates[1] == "/jointset/ankle_r/ankle_angle_r");
+    }
+
+    SECTION("ankle muscles") {
+        const std::string muscle_name = GENERATE("tib_ant_r", "soleus_r");
+        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
+        auto coordinates = path.findIndependentCoordinatePaths(state);
+        CHECK(coordinates[0] == "/jointset/ankle_r/ankle_angle_r");
+    }
+}

--- a/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
@@ -469,6 +469,7 @@ TEST_CASE("findIndependentCoordinates") {
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords.size() == 1);
         CHECK(coords[0].toString() == "/jointset/hip_r/hip_flexion_r");
     }
 
@@ -478,6 +479,7 @@ TEST_CASE("findIndependentCoordinates") {
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords.size() == 2);
         CHECK(coords[0].toString() == "/jointset/hip_r/hip_flexion_r");
         CHECK(coords[1].toString() == "/jointset/knee_r/knee_angle_r");
     }
@@ -488,6 +490,7 @@ TEST_CASE("findIndependentCoordinates") {
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords.size() == 1);
         CHECK(coords[0].toString() == "/jointset/knee_r/knee_angle_r");
     }
 
@@ -495,6 +498,7 @@ TEST_CASE("findIndependentCoordinates") {
         const std::string muscle_path = "/forceset/gastroc_r";
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords.size() == 2);
         CHECK(coords[0].toString() == "/jointset/knee_r/knee_angle_r");
         CHECK(coords[1].toString() == "/jointset/ankle_r/ankle_angle_r");
     }
@@ -504,6 +508,7 @@ TEST_CASE("findIndependentCoordinates") {
         const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
+        CHECK(coords.size() == 1);
         CHECK(coords[0].toString() == "/jointset/ankle_r/ankle_angle_r");
     }
 }


### PR DESCRIPTION
Fixes #4347.

### Brief summary of changes

This change adds utilities for finding the set of coordinates an `AbstractGeometryPath` spans based on the model's topology. 
- Added `SimulationUtilities::findJointsBetweenPhysicalFrames`, a utility function for finding the set of
joints that lie between two frames based on a model's topology.
- Added `AbstractGeometryPath::findIndependentCoordinatePaths()`, a utility method for finding the list of
coordinate paths associated with a path element. Derived classes provide concrete implementations based on
the model's topology (e.g., `GeometryPath`) or via a user-defined list of coordinates
(e.g., `FunctionBasedPath`).

### Testing I've completed

Added tests to `testGeometryPathWrapping.cpp` and `testSimulationUtilities.cpp`.

### Looking for feedback on...

Any edge cases that I'm missing that we should explicitly test.

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4301)
<!-- Reviewable:end -->
