### PR TITLE
Refactor `PolynomialPathFitter`

### DIFF
--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2023 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  * Author(s): Nicholas Bianco                                                 *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -25,6 +25,7 @@
 
 #include <OpenSim/Actuators/ModelOperators.h>
 
+#include <OpenSim/Common/CommonUtilities.h>
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Common/STOFileAdapter.h>
 #include <OpenSim/Common/LatinHypercubeDesign.h>
@@ -37,464 +38,44 @@
 
 using namespace OpenSim;
 
-//=============================================================================
-// POLYNOMIAL PATH FITTER BOUNDS
-//=============================================================================
-PolynomialPathFitterBounds::PolynomialPathFitterBounds() : Object()
-{
-    setAuthors("Nicholas Bianco");
-    constructProperties();
-}
+namespace {
 
-PolynomialPathFitterBounds::PolynomialPathFitterBounds(
-        const std::string& coordinatePath, const SimTK::Vec2& bounds) :
-        PolynomialPathFitterBounds() {
-    set_coordinate_path(coordinatePath);
-    OPENSIM_THROW_IF_FRMOBJ(bounds[0] >= bounds[1], Exception,
-            "Expected the lower bound to be less than the upper bound, but "
-            "it is not.")
-    set_bounds(bounds);
-}
+// Type alias for the moment arm map. The keys are the paths in the model
+// and the values are vectors containing the names of coordinates on which
+// the paths depend.
+using MomentArmMap = std::unordered_map<std::string, std::vector<std::string>>;
 
-void PolynomialPathFitterBounds::constructProperties() {
-    constructProperty_coordinate_path("");
-    constructProperty_bounds({-10.0, 10.0});
-}
+// Type alias for the coordinate bounds and coordinate range maps. The keys are
+// the coordinate paths in the model and the values are `SimTK::Vec2` objects
+// containing the bounds or ranges for each coordinate.
+using CoordinateMap = std::unordered_map<std::string, SimTK::Vec2>;
 
-//=============================================================================
-// POLYNOMIAL PATH FITTER
-//=============================================================================
-PolynomialPathFitter::PolynomialPathFitter() : Object()
-{
-    setAuthors("Nicholas Bianco");
-    constructProperties();
-}
+// A struct for containing validated settings based on the values provided by
+// the user via the PolynomialPathFitter properties.
+struct Settings {
+    bool useStepwiseRegression = false;
+    double momentArmThreshold = 1e-3;
+    double momentArmTolerance = 1e-4;
+    double pathLengthTolerance = 1e-4;
+    int minimumPolynomialOrder = 2;
+    int maximumPolynomialOrder = 6;
+    int numParallelThreads = (int)std::thread::hardware_concurrency();
+    SimTK::Vec2 globalCoordinateSamplingBounds{-10.0, 10.0};
+    int numSamplesPerFrame = 25;
+    bool useStochasticEvolutionaryLHS = false;
+    bool includeMomentArmFunctions = false;
+    bool includeLengtheningSpeedFunction = false;
+};
 
-PolynomialPathFitter::~PolynomialPathFitter() noexcept = default;
-
-PolynomialPathFitter::PolynomialPathFitter(
-        PolynomialPathFitter const&) = default;
-
-PolynomialPathFitter& PolynomialPathFitter::operator=(
-        const PolynomialPathFitter&) = default;
-
-PolynomialPathFitter::PolynomialPathFitter(
-        PolynomialPathFitter&& other) = default;
-
-PolynomialPathFitter& PolynomialPathFitter::operator=(
-        PolynomialPathFitter&& other) = default;
-
-//=============================================================================
-// PATH FITTING PIPELINE
-//=============================================================================
-
-void PolynomialPathFitter::run() {
-
-    log_info("");
-    log_info("====================");
-    log_info("PolynomialPathFitter");
-    log_info("====================");
-    log_info("");
-
-    // Process the inputs.
-    // -------------------
-    log_info("Step 1/9: Load the model and coordinate values table.");
-    log_info("-----------------------------------------------------");
-
-    // Load the model.
-    Model model = get_model().process(getDocumentDirectory());
-    model.initSystem();
-
-    // Load the coordinate values table.
-    TimeSeriesTable values = loadCoordinateValuesAndValidateModel(
-            getDocumentDirectory(), get_coordinate_values(), model);
-
-    // Get the path-based forces in the model.
-    std::vector<std::string> forcePaths;
-    const auto& forces = model.getComponentList<Force>();
-    for (const auto& force : forces) {
-        if (force.hasProperty("path")) {
-            forcePaths.push_back(force.getAbsolutePathString());
-        }
-    }
-
-    // Coordinate sampling bounds.
-    // ---------------------------
-    log_info("");
-    log_info("Step 2/9: Set the coordinate bounds.");
-    log_info("------------------------------------");
-    // Set the global bounds for all coordinates.
-    SimTK::Vec2 globalBounds = get_global_coordinate_sampling_bounds();
-    log_info("Global bounds: [{}, {}] degrees.",
-             globalBounds[0], globalBounds[1]);
-
-    globalBounds[0] = SimTK::convertDegreesToRadians(globalBounds[0]);
-    globalBounds[1] = SimTK::convertDegreesToRadians(globalBounds[1]);
-    m_coordinateBoundsMap.reserve(model.getNumCoordinates());
-    m_coordinateRangeMap.reserve(model.getNumCoordinates());
-    for (const auto& coordinate : model.getComponentList<Coordinate>()) {
-        std::string valuePath = fmt::format("{}/value",
-                coordinate.getAbsolutePathString());
-        m_coordinateBoundsMap.insert({valuePath, globalBounds});
-
-        // If the coordinate is clamped, then we also store the allowable range
-        // of motion.
-        if (coordinate.get_clamped()) {
-            SimTK::Vec2 range = {coordinate.getRangeMin(),
-                    coordinate.getRangeMax()};
-            m_coordinateRangeMap.insert({valuePath, range});
-        } else {
-            m_coordinateRangeMap.insert({valuePath,
-                    {-SimTK::Infinity, SimTK::Infinity}});
-        }
-    }
-
-    // Set any coordinate-specific bounds. This will overwrite the default
-    // bounds.
-    for (int i = 0; i < getProperty_coordinate_sampling_bounds().size(); ++i) {
-        const auto& coordinatePath =
-                get_coordinate_sampling_bounds(i).get_coordinate_path();
-        OPENSIM_THROW_IF_FRMOBJ(!model.hasComponent<Coordinate>(coordinatePath),
-                Exception, "Expected the model to contain the coordinate '{}', "
-                           "but it does not.", coordinatePath)
-        SimTK::Vec2 bounds = get_coordinate_sampling_bounds(i).get_bounds();
-        log_info("Bounds for coordinate '{}': [{}, {}] degrees.",
-                coordinatePath, bounds[0], bounds[1]);
-
-        bounds[0] = SimTK::convertDegreesToRadians(bounds[0]);
-        bounds[1] = SimTK::convertDegreesToRadians(bounds[1]);
-        std::string valuePath = fmt::format("{}/value", coordinatePath);
-        m_coordinateBoundsMap[valuePath] = bounds;
-    }
-
-    // Validate settings.
-    // ------------------
-    log_info("");
-    log_info("Step 3/9: Verify the user-defined settings.");
-    log_info("-------------------------------------------");
-    // Parallelization.
-    OPENSIM_THROW_IF_FRMOBJ(get_num_parallel_threads() < 1 ||
-            get_num_parallel_threads() >
-                (int)std::thread::hardware_concurrency(), Exception,
-            "Expected 'num_parallel_threads' to be between 1 and {}, but "
-            "received {}.", std::thread::hardware_concurrency(),
-            get_num_parallel_threads())
-    OPENSIM_THROW_IF_FRMOBJ(
-            static_cast<int>(values.getNumRows()) < get_num_parallel_threads(),
-            Exception, "Expected the number of time points in the coordinate "
-            "values table to be greater than 'num_parallel_threads', but "
-            "received {} and {}, respectively.",
-            values.getNumRows(), get_num_parallel_threads())
-    log_info("Number of parallel threads = {}", get_num_parallel_threads());
-
-    // Number of samples per frame.
-    OPENSIM_THROW_IF_FRMOBJ(get_num_samples_per_frame() < 1, Exception,
-            "Expected 'num_samples_per_frame' to be a non-zero integer value, "
-            "but received {}.", get_num_samples_per_frame());
-    log_info("Number of samples per frame = {}", get_num_samples_per_frame());
-
-    // Latin hypercube algorithm.
-    checkPropertyValueIsInSet(getProperty_latin_hypercube_algorithm(),
-            {"random", "ESEA"});
-    m_useStochasticEvolutionaryLHS =
-            (get_latin_hypercube_algorithm() == "ESEA");
-    log_info("Latin hypercube algorithm = '{}'",
-            get_latin_hypercube_algorithm());
-
-    // Moment arm threshold.
-    OPENSIM_THROW_IF_FRMOBJ(get_moment_arm_threshold() < 0 ||
-                            get_moment_arm_threshold() > 1, Exception,
-            "Expected 'moment_arm_threshold' to be in the range [0, 1], but "
-            "received {:2g}.", get_moment_arm_threshold())
-    log_info("Moment arm threshold = {:1.1e} meters",
-            get_moment_arm_threshold(), 1);
-
-    // Polynomial order.
-    checkPropertyValueIsPositive(getProperty_minimum_polynomial_order());
-    checkPropertyValueIsPositive(getProperty_maximum_polynomial_order());
-    OPENSIM_THROW_IF_FRMOBJ(get_maximum_polynomial_order() > 9, Exception,
-            "Expected 'maximum_polynomial_order' to be at most 9, but "
-            "received {}.", get_maximum_polynomial_order())
-    OPENSIM_THROW_IF_FRMOBJ(get_minimum_polynomial_order() >
-                            get_maximum_polynomial_order(), Exception,
-            "Expected 'minimum_polynomial_order' to be less than or equal to "
-            "'maximum_polynomial_order', but received {} and {}, "
-            "respectively.", get_minimum_polynomial_order(),
-            get_maximum_polynomial_order())
-    log_info("Minimum polynomial order = {}", get_minimum_polynomial_order());
-    log_info("Maximum polynomial order = {}", get_maximum_polynomial_order());
-
-    // Fitting tolerances.
-    checkPropertyValueIsInRangeOrSet(getProperty_path_length_tolerance(),
-                                     0.0, 1.0, {});
-    checkPropertyValueIsInRangeOrSet(getProperty_moment_arm_tolerance(),
-                                     0.0, 1.0, {});
-    log_info("Path length fitting tolerance = {:1.1e} meters",
-             get_path_length_tolerance(), 1);
-    log_info("Moment arm fitting tolerance = {:1.1e} meters",
-            get_moment_arm_tolerance(), 1);
-
-    // Stepwise regression
-    log_info("Use stepwise regression = {}",
-            get_use_stepwise_regression() ? "true" : "false");
-
-    // Output directory.
-    std::string outputDir = get_output_directory();
-    if (outputDir.empty()) {
-        if (getDocumentDirectory().empty()) {
-            outputDir = SimTK::Pathname::getCurrentWorkingDirectory();
-        } else {
-            outputDir = getDocumentDirectory();
-        }
-    } else {
-        IO::makeDir(outputDir);
-    }
-
-    // Sample coordinate values around the provided trajectory.
-    // --------------------------------------------------------
-    log_info("");
-    log_info("Step 4/9: Sample coordinate values around the provided trajectory.");
-    log_info("------------------------------------------------------------------");
-    TimeSeriesTable valuesSampled = sampleCoordinateValues(values);
-
-    // Recompute the coupled coordinate values.
-    auto tableProcessorSampled = TableProcessor(valuesSampled) |
-                                 TabOpAppendCoupledCoordinateValues();
-    valuesSampled = tableProcessorSampled.process(&model);
-    log_info("Total number of samples = {}", valuesSampled.getNumRows());
-    if (valuesSampled.getNumRows() < 500) {
-        log_warn("The number of samples is less than 500. This may result in "
-                 "poorly fit paths. Consider increasing the number of samples "
-                 "per frame or the number of frames in the coordinate values "
-                 "table.");
-    }
-
-    // Compute path lengths and moment arms.
-    // -------------------------------------
-    log_info("");
-    log_info("Step 5/9: Compute path lengths and moment arms.");
-    log_info("-----------------------------------------------");
-    log_info("Computing path lengths and moment arms for the original "
-             "coordinate data...");
-    TimeSeriesTable pathLengths;
-    TimeSeriesTable momentArms;
-    computePathLengthsAndMomentArms(model, values, forcePaths,
-            get_num_parallel_threads(), pathLengths, momentArms);
-
-    log_info("");
-    log_info("Computing path lengths and moment arms for the sampled "
-             "coordinate data...");
-    TimeSeriesTable pathLengthsSampled;
-    TimeSeriesTable momentArmsSampled;
-    computePathLengthsAndMomentArms(model, valuesSampled, forcePaths,
-            get_num_parallel_threads(), pathLengthsSampled, momentArmsSampled);
-
-    // Filter sampled data.
-    // --------------------
-    log_info("");
-    log_info("Step 6/9: Filter the sampled path data.");
-    log_info("---------------------------------------");
-    MomentArmMap momentArmMap;
-    filterSampledData(model, valuesSampled, pathLengthsSampled,
-            momentArmsSampled, momentArmMap);
-
-    // Fit the FunctionBasedPaths.
-    // ---------------------------
-    log_info("");
-    log_info("Step 7/9: Fit the polynomial coefficients.");
-    log_info("------------------------------------------");
-    Set<FunctionBasedPath> functionBasedPaths = fitPolynomialCoefficients(
-            model, valuesSampled, forcePaths, pathLengthsSampled,
-            momentArmsSampled, momentArmMap);
-    Array<std::string> pathNames;
-    functionBasedPaths.getNames(pathNames);
-
-    // Evaluate the fit.
-    // -----------------
-    log_info("");
-    log_info("Step 8/9: Evaluate the fit.");
-    log_info("---------------------------");
-
-    // Find the longest path name.
-    int longestPathName = 0;
-    for (int i = 0; i < pathNames.getSize(); ++i) {
-        std::string pathName = pathNames[i];
-        if ((int)pathName.size() > longestPathName) {
-            longestPathName = (int)pathName.size();
-        }
-    }
-
-    // Print the information for each path.
-    log_info("");
-    std::string pathName = fmt::format("{}path",
-            std::string((int)(0.5*longestPathName)-2, ' '));
-    std::string fitName = fmt::format("{}polynomial fit", std::string(15, ' '));
-    std::string line = fmt::format("{:{}} | {:{}}", pathName, longestPathName,
-            fitName, 44);
-    std::string separator(line.size(), '-');
-    log_info(separator);
-    log_info(line);
-    log_info(separator);
-    for (int i = 0; i < functionBasedPaths.getSize(); ++i) {
-        auto path = functionBasedPaths.get(pathNames[i]);
-        auto function = dynamic_cast<const MultivariatePolynomialFunction&>(
-                path.getLengthFunction());
-        SimTK::Vector coefficients = function.getCoefficients();
-        int numNonZeroCoeffs = 0;
-        for (int i = 0; i < coefficients.size(); ++i) {
-            if (coefficients[i] != 0.0) {
-                ++numNonZeroCoeffs;
-            }
-        }
-        line = fmt::format("{:{}} | order = {}, dimension = "
-                "{}, coefficients = {}", path.getName(), longestPathName,
-                function.getOrder(), function.getDimension(), numNonZeroCoeffs);
-        log_info(line);
-    }
-    log_info(separator);
-
-    // Add the FunctionBasedPaths to the model.
-    log_info("");
-    log_info("Computing path lengths and moment arms from the fitted paths...");
-    Model modelFitted = model;
-    modelFitted.initSystem();
-    ModelFactory::replacePathsWithFunctionBasedPaths(modelFitted,
-            functionBasedPaths);
-
-    // Recompute the path lengths and moment arms.
-    TimeSeriesTable pathLengthsFitted;
-    TimeSeriesTable momentArmsFitted;
-    computePathLengthsAndMomentArms(modelFitted, values, forcePaths,
-            get_num_parallel_threads(), pathLengthsFitted, momentArmsFitted);
-
-    TimeSeriesTable pathLengthsSampledFitted;
-    TimeSeriesTable momentArmsSampledFitted;
-    computePathLengthsAndMomentArms(modelFitted, valuesSampled, forcePaths,
-            get_num_parallel_threads(), pathLengthsSampledFitted,
-            momentArmsSampledFitted);
-
-    // Remove moment arm columns that are not in the map.
-    removeMomentArmColumns(momentArms, momentArmMap);
-    removeMomentArmColumns(momentArmsFitted, momentArmMap);
-    removeMomentArmColumns(momentArmsSampledFitted, momentArmMap);
-
-    // Compute the RMS error between the original and fitted path lengths and
-    // moment arms.
-    computeFittingErrors(modelFitted, pathLengthsSampled, momentArmsSampled,
-            pathLengthsSampledFitted, momentArmsSampledFitted,
-            get_path_length_tolerance(), get_moment_arm_tolerance());
-
-    // Print out results.
-    // ------------------
-    log_info("");
-    log_info("Step 9/9: Print the results to the output directory.");
-    log_info("----------------------------------------------------");
-
-    // Print the FunctionBasedPaths to file.
-    std::string functionBasedPathsFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_FunctionBasedPathSet.xml",
-                            outputDir, model.getName()));
-    log_info("Printing the FunctionBasedPaths to '{}'...",
-            functionBasedPathsFileName);
-    functionBasedPaths.print(functionBasedPathsFileName);
-
-    // Print the coordinate values to file.
-    std::string coordinatesFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_coordinate_values.sto",
-                            outputDir, model.getName()));
-    std::string sampledCoordinatesFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_coordinate_values_sampled.sto",
-                            outputDir, model.getName()));
-    log_info("");
-    log_info(fmt::format("Printing original coordinate values to '{}'...",
-            coordinatesFileName));
-    STOFileAdapter::write(values, coordinatesFileName);
-    log_info(fmt::format("Printing sampled coordinate values to '{}'...",
-            sampledCoordinatesFileName));
-    STOFileAdapter::write(valuesSampled, sampledCoordinatesFileName);
-
-    // Print the path lengths and moment arms from the original coordinate
-    // data to file.
-    std::string pathLengthsFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths.sto",
-                            outputDir, model.getName()));
-    std::string momentArmsFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms.sto",
-                            outputDir, model.getName()));
-    log_info("");
-    log_info("Printing the path lengths to '{}'...",
-            pathLengthsFileName);
-    STOFileAdapter::write(pathLengths, pathLengthsFileName);
-    log_info("Printing the moment arms to '{}'...", momentArmsFileName);
-    STOFileAdapter::write(momentArms, momentArmsFileName);
-
-    // Print the path lengths and moment arms from the sampled coordinate
-    // data to file.
-    std::string pathLengthsSampledFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_sampled.sto",
-                            outputDir, model.getName()));
-    std::string momentArmsSampledFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_sampled.sto",
-                            outputDir, model.getName()));
-
-    log_info("");
-    log_info("Printing the sampled path lengths to '{}'...",
-            pathLengthsSampledFileName);
-    STOFileAdapter::write(pathLengthsSampled, pathLengthsSampledFileName);
-    log_info("Printing the sampled moment arms to '{}'...",
-            momentArmsSampledFileName);
-    STOFileAdapter::write(momentArmsSampled, momentArmsSampledFileName);
-
-    // Print the fitted path lengths and moment arms using the original
-    // coordinate data to file.
-    std::string pathLengthsFittedFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_fitted.sto",
-                            outputDir, model.getName()));
-    std::string momentArmsFittedFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_fitted.sto",
-                            outputDir, model.getName()));
-
-    log_info("");
-    log_info("Printing the fitted path lengths from the original coordinate "
-             "values to '{}'...", pathLengthsFittedFileName);
-    STOFileAdapter::write(pathLengthsFitted, pathLengthsFittedFileName);
-    log_info("Printing the fitted moment arms from the original coordinate "
-             "to '{}'...", momentArmsFittedFileName);
-    STOFileAdapter::write(momentArmsFitted, momentArmsFittedFileName);
-
-    // Print the fitted path lengths and moment arms using the sampled
-    // coordinate data to file.
-    std::string pathLengthsSampledFittedFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_sampled_fitted.sto",
-                            outputDir, model.getName()));
-    std::string momentArmsSampledFittedFileName =
-            SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_sampled_fitted.sto",
-                            outputDir, model.getName()));
-
-    log_info("");
-    log_info("Printing the fitted path lengths from the sampled coordinate "
-             "values to '{}'...", pathLengthsSampledFittedFileName);
-    STOFileAdapter::write(pathLengthsSampledFitted,
-            pathLengthsSampledFittedFileName);
-    log_info("Printing the fitted moment arms from the sampled coordinate "
-             "values to '{}'...", momentArmsSampledFittedFileName);
-    STOFileAdapter::write(momentArmsSampledFitted,
-            momentArmsSampledFittedFileName);
-}
-
-TimeSeriesTable PolynomialPathFitter::loadCoordinateValuesAndValidateModel(
-        const std::string& documentDir, TableProcessor tableProcessor,
+// Helper function to load the reference coordinate values trajectory and
+// validate the model. The coordinate values table is modified to update the
+// column labels based on the model coordinate paths, to update any
+// coordinates dependent on `CoordinateCouplerConstraint`s, and to convert
+// the coordinate values to radians if the "inDegrees" metadata flag is set
+// to "yes".
+TimeSeriesTable loadCoordinateValuesAndValidateModel(
+        const std::string& documentDir,
+        TableProcessor tableProcessor,
         Model& model) {
 
     const auto pathList = model.getComponentList<AbstractGeometryPath>();
@@ -585,8 +166,17 @@ TimeSeriesTable PolynomialPathFitter::loadCoordinateValuesAndValidateModel(
     return values;
 }
 
-TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
-        const TimeSeriesTable& values) {
+// Helper function to sample coordinate values around the user-provided
+// coordinate trajectory contained in the `values` input table. The
+// sampling is defined based on the coordinate bounds and range maps,
+// the number of samples per frame, and the Latin hypercube sampling
+// algorithm.
+TimeSeriesTable sampleCoordinateValues(
+        const TimeSeriesTable& values,
+        const CoordinateMap& coordinateBoundsMap,
+        const CoordinateMap& coordinateRangeMap,
+        const Settings& settings) {
+
     // Mute the Latin hypercube sampling output, so it doesn't print out for
     // every time point.
     Logger::Level origLoggerLevel = Logger::getLevel();
@@ -594,16 +184,18 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
 
     // Create a Latin hypercube design to sample the coordinate values.
     LatinHypercubeDesign lhs;
-    lhs.setNumSamples(get_num_samples_per_frame());
+    lhs.setNumSamples(settings.numSamplesPerFrame);
     lhs.setNumVariables((int)values.getNumColumns());
 
     // Helper function for sampling the coordinate values between two time
     // indexes.
-    auto sampleCoordinateValuesSubset = [this, lhs](
+    auto sampleCoordinateValuesSubset = [lhs](
             std::vector<int>::iterator begin_iter,
             std::vector<int>::iterator end_iter,
-            const TimeSeriesTable& values)
-                -> SimTK::Matrix {
+            const TimeSeriesTable& values,
+            const CoordinateMap& coordinateBoundsMap,
+            const CoordinateMap& coordinateRangeMap,
+            bool useStochasticEvolutionaryLHS) -> SimTK::Matrix {
 
         SimTK::Matrix results(
                 lhs.getNumSamples()*(int)std::distance(begin_iter, end_iter),
@@ -612,7 +204,7 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
         int thisTimeIndex = 0;
         for (auto it = begin_iter; it != end_iter; ++it) {
             // Generate the design and shift its values between [-1, 1].
-            if (m_useStochasticEvolutionaryLHS) {
+            if (useStochasticEvolutionaryLHS) {
                 design = lhs.generateStochasticEvolutionaryDesign();
             } else {
                 design = lhs.generateRandomDesign();
@@ -624,8 +216,8 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
             for (const std::string& label : values.getColumnLabels()) {
                 const SimTK::VectorView column =
                         values.getDependentColumn(label);
-                const auto& bounds = m_coordinateBoundsMap.at(label);
-                const auto& range = m_coordinateRangeMap.at(label);
+                const auto& bounds = coordinateBoundsMap.at(label);
+                const auto& range = coordinateRangeMap.at(label);
 
                 // Linearly transform the design to the specified bounds for
                 // each coordinate.
@@ -659,7 +251,7 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     // Determine the number of threads and the stride based on the number of
     // forces and the number of threads.
     int numTimePoints = static_cast<int>(values.getNumRows());
-    int numThreads = std::min(numTimePoints, get_num_parallel_threads());
+    int numThreads = std::min(numTimePoints, settings.numParallelThreads);
     int stride = static_cast<int>(std::floor(numTimePoints / numThreads));
     int offset = 0;
 
@@ -674,7 +266,8 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
                 timeIndexes.begin() + offset + stride;
         futures.push_back(std::async(std::launch::async,
                 sampleCoordinateValuesSubset,
-                begin_iter, end_iter, values));
+                begin_iter, end_iter, values, coordinateBoundsMap,
+                coordinateRangeMap, settings.useStochasticEvolutionaryLHS));
         offset += stride;
     }
 
@@ -693,9 +286,9 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     const auto& times = values.getIndependentColumn();
     TimeSeriesTable valuesSampled;
     double dt = (times.size() < 2) ? 0.01 :
-                (times[1] - times[0]) / (get_num_samples_per_frame() + 2);
+                (times[1] - times[0]) / (settings.numSamplesPerFrame + 2);
     for (int i = 0; i < numThreads; ++i) {
-        int numTimeIndexes = outputs[i].nrow() / get_num_samples_per_frame();
+        int numTimeIndexes = outputs[i].nrow() / settings.numSamplesPerFrame;
         for (int j = 0; j < numTimeIndexes; ++j) {
             // Append the original values.
             valuesSampled.appendRow(times[timeIdx],
@@ -705,13 +298,13 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
             // step.
             if (timeIdx+1 < static_cast<int>(values.getNumRows())) {
                 dt = (times[timeIdx+1] - times[timeIdx]) /
-                     (get_num_samples_per_frame() + 2);
+                     (settings.numSamplesPerFrame + 2);
             }
 
             // Append the sampled values.
-            for (int irow = 0; irow < get_num_samples_per_frame(); ++irow) {
+            for (int irow = 0; irow < settings.numSamplesPerFrame; ++irow) {
                 valuesSampled.appendRow(times[timeIdx] + (irow + 1)*dt,
-                        outputs[i].row(irow + j*get_num_samples_per_frame()));
+                        outputs[i].row(irow + j*settings.numSamplesPerFrame));
             }
             ++timeIdx;
         }
@@ -722,15 +315,26 @@ TimeSeriesTable PolynomialPathFitter::sampleCoordinateValues(
     return valuesSampled;
 }
 
-void PolynomialPathFitter::computePathLengthsAndMomentArms(
-        const Model& model, const TimeSeriesTable& coordinateValues,
-        const std::vector<std::string>& forcePaths, int numAvailableThreads,
-        TimeSeriesTable& pathLengths, TimeSeriesTable& momentArms) {
+// Helper function to compute path lengths and moment arms for the
+// geometry-based paths in the model. The path lengths and moment arms
+// are computed using the coordinate values in the `coordinateValues`
+// table. The `numThreads` argument specifies the number of threads used
+// to parallelize the computations.
+void computePathLengthsAndMomentArms(
+        const Model& model,
+        const TimeSeriesTable& coordinateValues,
+        const std::vector<std::string>& forcePaths,
+        const Settings& settings,
+        TimeSeriesTable& pathLengths,
+        TimeSeriesTable& momentArms) {
 
     // Determine the number of threads to use for the path length and moment
     // arm computations.
-    int numTimePoints = static_cast<int>(coordinateValues.getNumRows());
-    int numThreads = std::min(numTimePoints, numAvailableThreads);
+    const int numTimePoints = static_cast<int>(coordinateValues.getNumRows());
+    OPENSIM_THROW_IF(numTimePoints == 0, Exception,
+            "Tried to compute path lengths and moment arms, but the provided "
+            "coordinate values table is empty.");
+    const int numThreads = std::min(numTimePoints, settings.numParallelThreads);
 
     // Create a StatesTrajectory from the coordinate values.
     auto statesTrajectory = StatesTrajectory::createFromStatesTable(
@@ -856,7 +460,16 @@ void PolynomialPathFitter::computePathLengthsAndMomentArms(
     momentArms.setColumnLabels(momentArmLabels);
 }
 
-void PolynomialPathFitter::filterSampledData(const Model& model,
+// Helper function to filter out bad coordinate value samples and determine
+// which coordinates each path is dependent on. Bad samples are defined as
+// coordinate values that produce path length and/or moment are values that
+// deviate by a set number of standard deviations away from the nominal
+// trajectories. The `momentArmMap` argument is a map containing the
+// coordinates each path is dependent on. Columns in the `momentArms` table
+// are removed if they do not correspond to entries in the `momentArmMap`.
+void filterSampledData(
+        const Model& model,
+        const Settings& settings,
         TimeSeriesTable& coordinateValues,
         TimeSeriesTable& pathLengths,
         TimeSeriesTable& momentArms,
@@ -879,7 +492,7 @@ void PolynomialPathFitter::filterSampledData(const Model& model,
     for (const auto& label : momentArms.getColumnLabels()) {
         if (label.find("_moment_arm_") != std::string::npos) {
             const auto& col = momentArms.getDependentColumn(label);
-            bool removeColumn = col.normInf() < get_moment_arm_threshold();
+            bool removeColumn = col.normInf() < settings.momentArmThreshold;
             std::string path = label.substr(0, label.find("_moment_arm_"));
             std::string coordinate = label.substr(
                     label.find("_moment_arm_") + 12);
@@ -910,11 +523,11 @@ void PolynomialPathFitter::filterSampledData(const Model& model,
     // data in each column.
     double threshold = 5.0;
     std::vector<double> rejectedTimePoints;
-    auto rejectTimePoints = [this, threshold](
+    auto rejectTimePoints = [threshold, &settings](
             const TimeSeriesTable& table,
             std::vector<double>& rejectedTimePoints) {
         const auto& times = table.getIndependentColumn();
-        int increment = get_num_samples_per_frame() + 1;
+        int increment = settings.numSamplesPerFrame + 1;
         int numOriginalTimes = (int)table.getNumRows() / increment;
         for (const auto& label : table.getColumnLabels()) {
             SimTK::Vector column = table.getDependentColumn(label);
@@ -941,7 +554,8 @@ void PolynomialPathFitter::filterSampledData(const Model& model,
                 if (std::abs(column[i] - nominal) > threshold * avgStd) {
                     rejectedTimePoints.push_back(times[i]);
                 }
-                if (i % increment == 0) {
+                if ((i + 1) % increment == 0 &&
+                        currentNominalIndex + increment < column.size()) {
                     currentNominalIndex += increment;
                 }
             }
@@ -970,13 +584,249 @@ void PolynomialPathFitter::filterSampledData(const Model& model,
     }
 }
 
-Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
+// Fit to the path length and moment arm samples using all possible
+// polynomial coefficients. `coordinates` is the matrix of coordinate values
+// for coordinates that the current path depends on. The vector `b` contains
+// the path length and moment arm values for the current path.
+// We solve for the coefficients of the polynomial using a least squares of
+// fit, `Ax = b`. Each row of `A` contains polynomial terms evaluated using
+// the coordinate values from a particular point in time. `x` is the vector
+// polynomial coefficients. The first N elements of `b` contain the path
+// length values, where N is the number of time points. The remaining N*Nc
+// rows of `b` contain the moment arm values, where Nc is the number of
+// coordinates the path depends on.
+int fitAllCoefficients(
+        const SimTK::Matrix& coordinates,
+        const SimTK::Vector& b,
+        const Settings& settings,
+        SimTK::Vector& coefficients) {
+
+    int numTimes = coordinates.nrow();
+    int numCoordinates = coordinates.ncol();
+    int order = settings.minimumPolynomialOrder;
+    while (true) {
+        // Initialize the multivariate polynomial function.
+        int numCoefficients = choose(numCoordinates + order, order);
+        SimTK::Vector dummyCoefficients(numCoefficients, 1.0);
+        MultivariatePolynomialFunction dummyFunction(dummyCoefficients,
+                numCoordinates, order);
+
+        // Initialize the 'A' matrix.
+        SimTK::Matrix A(numTimes * (numCoordinates + 1),
+                numCoefficients, 0.0);
+
+        // Fill in the A matrix. This contains the polynomial terms for
+        // the path length and moment arms.
+        for (int itime = 0; itime < numTimes; ++itime) {
+            A(itime, 0, 1, numCoefficients) =
+                    dummyFunction.getTermValues(
+                        coordinates.row(itime).transpose().getAsVector());
+
+            for (int ic = 0; ic < numCoordinates; ++ic) {
+                SimTK::Vector termDerivatives =
+                    dummyFunction.getTermDerivatives({ic},
+                        coordinates.row(itime).transpose().getAsVector())
+                        .negate();
+                A((ic+1)*numTimes + itime, 0, 1, numCoefficients) =
+                        termDerivatives;
+            }
+        }
+
+        // Solve the least-squares problem.
+        SimTK::FactorQTZ factor(A);
+        factor.solve(b, coefficients);
+
+        // Calculate the RMS error.
+        SimTK::Vector b_fit = A * coefficients;
+        SimTK::Vector error = b - b_fit;
+
+        // If the fit achieves the path length and moment arm thresholds
+        // we set, then exit the loop.
+        SimTK::Vector pathLengthError = error.block(
+                0, 0, numTimes, 1).getAsVector();
+        double pathLengthRMSError = std::sqrt(
+                pathLengthError.normSqr() / pathLengthError.size());
+        bool pathLengthMet = pathLengthRMSError < settings.pathLengthTolerance;
+
+        bool momentArmMet = true;
+        for (int ic = 0; ic < numCoordinates; ++ic) {
+            SimTK::Vector momentArmError = error.block(
+                    numTimes + ic*numTimes, 0, numTimes, 1).getAsVector();
+            double momentArmRMSError = std::sqrt(
+                    momentArmError.normSqr() / numTimes);
+            if (momentArmRMSError > settings.momentArmTolerance) {
+                momentArmMet = false;
+                break;
+            }
+        }
+
+        if ((pathLengthMet && momentArmMet) ||
+                order == settings.maximumPolynomialOrder) {
+            break;
+        }
+        ++order;
+    }
+
+    return order;
+}
+
+// Fit to the path length and moment arm samples using stepwise regression
+// to find a minimal set of polynomial coefficients. `coordinates` is the
+// matrix of coordinate values for coordinates that the current path depends
+// on. The vector `b` contains the path length and moment arm values for the
+// current path.
+void fitCoefficientsStepwiseRegression(
+        const SimTK::Matrix& coordinates,
+        const SimTK::Vector& b,
+        const Settings& settings,
+        SimTK::Vector& coefficients) {
+
+    // Preliminaries.
+    int numTimes = coordinates.nrow();
+    int numCoordinates = coordinates.ncol();
+    int order = settings.maximumPolynomialOrder;
+    int numCoefficients = choose(numCoordinates + order, order);
+
+    // Construct the full 'A' matrix.
+    SimTK::Vector dummyCoefficients(numCoefficients, 1.0);
+    MultivariatePolynomialFunction dummyFunction(dummyCoefficients,
+            numCoordinates, order);
+    SimTK::Matrix Afull(numTimes * (numCoordinates + 1),
+            numCoefficients, 0.0);
+    for (int itime = 0; itime < numTimes; ++itime) {
+        Afull(itime, 0, 1, numCoefficients) =
+                dummyFunction.getTermValues(
+                    coordinates.row(itime).transpose().getAsVector());
+
+        for (int ic = 0; ic < numCoordinates; ++ic) {
+            SimTK::Vector termDerivatives =
+                dummyFunction.getTermDerivatives({ic},
+                    coordinates.row(itime).transpose().getAsVector())
+                    .negate();
+            Afull((ic+1)*numTimes + itime, 0, 1, numCoefficients) =
+                    termDerivatives;
+        }
+    }
+
+    // Manage the coefficient indexes that will be included in the final
+    // polynomial. The "out" indexes are the indexes that are not included in
+    // the final polynomial, which is initialized to all indexes. The "keep"
+    // indexes are the indexes that are included in the final polynomial, which
+    // is initialized to an empty vector.
+    std::vector<int> outIndexes;
+    outIndexes.reserve(numCoefficients);
+    for (int i = 0; i < numCoefficients; ++i) {
+        outIndexes.push_back(i);
+    }
+    std::vector<int> keepIndexes;
+    SimTK::Vector x_sol;
+    while (true) {
+
+        // Initialize the 'A' matrix.
+        // The number of terms in the polynomial is the number of "kept"
+        // coefficients plus one.
+        int numTerms = static_cast<int>(keepIndexes.size()) + 1;
+        SimTK::Matrix A(numTimes * (numCoordinates + 1), numTerms, 0.0);
+        SimTK::Vector x(numTerms, 0.0);
+
+        // First, set the columns of 'A' for the "kept" coefficients.
+        int icol = 0;
+        for (const auto& ki : keepIndexes) {
+            A.updCol(icol++) = Afull.col(ki);
+        }
+
+        // Next, loop through all of the remaining "out" coefficients and fit
+        // the polynomial. We will keep the coefficient that results in the
+        // smallest RMS error.
+        SimTK::Real bestError = SimTK::Infinity;
+        int bestIndex = -1;
+        for (const auto& oi : outIndexes) {
+            A.updCol(icol) = Afull.col(oi);
+
+            // Solve the least-squares problem.
+            SimTK::FactorQTZ factor(A);
+            factor.solve(b, x);
+
+            // Calculate the RMS error.
+            SimTK::Vector b_fit = A * x;
+            SimTK::Vector error = b - b_fit;
+
+            // Calculate the RMS error. Update the best error and index.
+            double currentError = std::sqrt(error.normSqr() / error.size());
+            if (currentError < bestError) {
+                bestError = currentError;
+                bestIndex = oi;
+            }
+        }
+
+        // Add the best index to the "keep" indexes and remove it from the "out"
+        // indexes.
+        keepIndexes.push_back(bestIndex);
+        outIndexes.erase(std::remove(outIndexes.begin(), outIndexes.end(),
+                bestIndex), outIndexes.end());
+
+        // Refit the polynomial with the "keep" indexes.
+        icol = 0;
+        for (const auto& ki : keepIndexes) {
+            A.updCol(icol++) = Afull.col(ki);
+        }
+        SimTK::FactorQTZ factor(A);
+        factor.solve(b, x);
+        SimTK::Vector b_fit = A * x;
+        SimTK::Vector error = b - b_fit;
+
+        // If the current polynomial achieves our path length and moment arm
+        // tolerances or if the "out" indexes is empty, exit the loop.
+        SimTK::Vector pathLengthError = error.block(
+                0, 0, numTimes, 1).getAsVector();
+        double pathLengthRMSError = std::sqrt(
+                pathLengthError.normSqr() / pathLengthError.size());
+        bool pathLengthMet = pathLengthRMSError < settings.pathLengthTolerance;
+
+        bool momentArmMet = true;
+        for (int ic = 0; ic < numCoordinates; ++ic) {
+            SimTK::Vector momentArmError = error.block(
+                    numTimes + ic*numTimes, 0, numTimes, 1).getAsVector();
+            double momentArmRMSError = std::sqrt(
+                    momentArmError.normSqr() / numTimes);
+            if (momentArmRMSError > settings.momentArmTolerance) {
+                momentArmMet = false;
+                break;
+            }
+        }
+
+        int numOutIndexes = static_cast<int>(outIndexes.size());
+        if ((pathLengthMet && momentArmMet) || !numOutIndexes) {
+            x_sol = x;
+            break;
+        }
+    }
+
+    // Update the coefficients vector
+    coefficients.resize(numCoefficients);
+    coefficients.setToZero();
+    int icoeff = 0;
+    for (const auto& ki : keepIndexes) {
+        coefficients.set(ki, x_sol(icoeff++));
+    }
+}
+
+// Helper function to fit polynomial coefficients to the path lengths and
+// moment arms computed from the geometry-based paths in the model. The
+// `coordinateValues`, `pathLengths`, and `momentArms` table arguments are
+// the result of previous model sampling and data filtering steps. The
+// `momentArmMap` argument is a map containing the coordinates each path is
+// dependent on, which determines the number of independent coordinates
+// that each `MultivariatePolynomialFunction` contains to approximate the
+// original path.
+Set<FunctionBasedPath> fitPolynomialCoefficients(
         const Model& model,
         const TimeSeriesTable& coordinateValues,
         const std::vector<std::string>& forcePaths,
         const TimeSeriesTable& pathLengths,
         const TimeSeriesTable& momentArms,
-        const MomentArmMap& momentArmMap) {
+        const MomentArmMap& momentArmMap,
+        const Settings& settings) {
 
     // Coordinate references.
     // ----------------------
@@ -1015,7 +865,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
                 continue;
             }
             log_info("Thread {:2d}/{:2d}: fitting coefficients for force "
-                     "'{}'...", thread+1, get_num_parallel_threads(),
+                     "'{}'...", thread+1, settings.numParallelThreads,
                     forcePath);
 
             // The current force path and the number of coordinates it depends
@@ -1065,15 +915,13 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
             // -------------------
             SimTK::Vector coefficients;
             int order;
-            if (get_use_stepwise_regression()) {
-                order = get_maximum_polynomial_order();
+            if (settings.useStepwiseRegression) {
+                order = settings.maximumPolynomialOrder;
                 fitCoefficientsStepwiseRegression(coordinatesThisForce, b,
-                        order, coefficients);
+                        settings, coefficients);
             } else {
                 order = fitAllCoefficients(coordinatesThisForce, b,
-                        get_minimum_polynomial_order(),
-                        get_maximum_polynomial_order(),
-                        coefficients);
+                        settings, coefficients);
             }
 
             // Create a FunctionBasedPath for the current path-based force.
@@ -1085,7 +933,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
             functionBasedPath->setName(forcePath);
             functionBasedPath->setCoordinatePaths(coordinatePathsThisForce);
             functionBasedPath->setLengthFunction(lengthFunction);
-            if (getIncludeMomentArmFunctions()) {
+            if (settings.includeMomentArmFunctions) {
                 for (int iq = 0; iq < numCoordinatesThisForce; ++iq) {
                     MultivariatePolynomialFunction momentArmFunction =
                             lengthFunction.generateDerivativeFunction(iq, true);
@@ -1093,7 +941,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
                             momentArmFunction);
                 }
             }
-            if (getIncludeLengtheningSpeedFunction()) {
+            if (settings.includeLengtheningSpeedFunction) {
                 MultivariatePolynomialFunction lengtheningSpeedFunction =
                         lengthFunction.generatePartialVelocityFunction();
                 functionBasedPath->setLengtheningSpeedFunction(
@@ -1109,7 +957,7 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
 
     // Determine the number of threads and the stride based on the number of
     // forces and the number of threads.
-    int numThreads = std::min(numForces, get_num_parallel_threads());
+    int numThreads = std::min(numForces, settings.numParallelThreads);
     int stride = static_cast<int>(std::floor(numForces / numThreads));
     int offset = 0;
 
@@ -1138,6 +986,540 @@ Set<FunctionBasedPath> PolynomialPathFitter::fitPolynomialCoefficients(
 
     return functionBasedPaths;
 }
+
+// Remove columns from the `momentArms` table that do not correspond to
+// entries in the `momentArmMap`.
+void removeMomentArmColumns(TimeSeriesTable& momentArms,
+        const MomentArmMap& momentArmMap) {
+
+    // Remove entries from the table that are not in the moment arm map.
+    for (const auto& label : momentArms.getColumnLabels()) {
+        std::string path = label.substr(0, label.find("_moment_arm_"));
+        std::string coordinate = label.substr(
+                label.find("_moment_arm_") + 12);
+        if (momentArmMap.find(path) != momentArmMap.end()) {
+            if (std::find(momentArmMap.at(path).begin(),
+                        momentArmMap.at(path).end(), coordinate) ==
+                    momentArmMap.at(path).end()) {
+                momentArms.removeColumn(label);
+            }
+        } else {
+            momentArms.removeColumn(label);
+        }
+    }
+}
+
+// Get the RMS errors between two sets of path lengths and moment arms
+// computed from a model with FunctionBasedPaths and the original model. The
+// `modelFitted` argument must be the model with the FunctionBasedPaths.
+void computeFittingErrors(
+        const Model& modelFitted,
+        const TimeSeriesTable& pathLengths,
+        const TimeSeriesTable& momentArms,
+        const TimeSeriesTable& pathLengthsFitted,
+        const TimeSeriesTable& momentArmsFitted,
+        const Settings& settings) {
+
+    // Convert the tolerances to centimeters.
+    double pathLengthTolerance = settings.pathLengthTolerance * 100.0;
+    double momentArmTolerance = settings.momentArmTolerance * 100.0;
+
+    // Helper function for printing warning messages.
+    auto printWarningMessage = [](const std::string& pathLengthOrMomentArm,
+                                double tolerance) {
+        log_warn("-----------------------------------------------------------");
+        log_warn(fmt::format("The {} RMS error is greater than the prescribed "
+                             "tolerance of {:g} cm.",
+                             pathLengthOrMomentArm, tolerance));
+        log_warn("");
+        log_warn("Consider increasing the number of samples per frame or the ");
+        log_warn("polynomial order and re-fitting the model. If a re-fitting ");
+        log_warn("is not successful, check that the original model produces ");
+        log_warn("path lengths and moment arms that are free of ");
+        log_warn("discontinuities or other irregularities.");
+        log_warn("-----------------------------------------------------------");
+    };
+
+    // Check inputs.
+    OPENSIM_ASSERT_ALWAYS(pathLengths.getNumRows() ==
+            pathLengthsFitted.getNumRows());
+    OPENSIM_ASSERT_ALWAYS(momentArms.getNumRows() ==
+            momentArmsFitted.getNumRows());
+    OPENSIM_ASSERT_ALWAYS(pathLengths.getNumColumns() ==
+            pathLengthsFitted.getNumColumns());
+    OPENSIM_ASSERT_ALWAYS(momentArms.getNumColumns() ==
+            momentArmsFitted.getNumColumns());
+    const auto& functionBasedPaths =
+            modelFitted.getComponentList<FunctionBasedPath>();
+    int numPaths = (int)std::distance(functionBasedPaths.begin(),
+            functionBasedPaths.end());
+    OPENSIM_THROW_IF(numPaths == 0, Exception,
+            "Expected the model to contain 'FunctionBasedPath's, but none were "
+            "found.");
+
+    // Print the path length and moment arm RMS errors for each path.
+    log_info("");
+    log_info("Summary of path length and moment arm RMS errors");
+    log_info("------------------------------------------------");
+    SimTK::Vector pathLengthRMSErrors((int)pathLengths.getNumColumns());
+    SimTK::Vector momentArmRMSErrors((int)momentArms.getNumColumns());
+    int ip = 0;
+    int ima = 0;
+    for (const auto& path : modelFitted.getComponentList<FunctionBasedPath>()) {
+        std::string pathName = path.getAbsolutePathString();
+        pathName = pathName.substr(0, pathName.length() - 5);
+        log_info("'{}' path errors:", pathName);
+
+        const std::string lengthLabel = fmt::format("{}_length", pathName);
+        SimTK::Vector pathLength = pathLengths.getDependentColumn(lengthLabel);
+        SimTK::Vector pathLengthFitted = pathLengthsFitted.getDependentColumn(
+                lengthLabel);
+        SimTK::Vector pathLengthError = pathLength - pathLengthFitted;
+        double pathLengthRMSError = 100.0 * std::sqrt(
+                pathLengthError.normSqr() / pathLengthError.size());
+        pathLengthRMSErrors[ip++] = pathLengthRMSError;
+        log_info(" - path length RMSE: {:1.3f} cm", pathLengthRMSError);
+
+        if (pathLengthRMSError > 10.0*pathLengthTolerance) {
+            printWarningMessage("path length", pathLengthTolerance);
+        }
+
+        for (const auto& coordinatePath : path.getCoordinatePaths()) {
+            const auto& coordinate =
+                    modelFitted.getComponent<Coordinate>(coordinatePath);
+            const std::string& coordinateName = coordinate.getName();
+
+            const std::string momentArmLabel = fmt::format(
+                "{}_moment_arm_{}", pathName, coordinateName);
+            SimTK::Vector momentArm = momentArms.getDependentColumn(
+                    momentArmLabel);
+            SimTK::Vector momentArmFitted = momentArmsFitted.getDependentColumn(
+                    momentArmLabel);
+            SimTK::Vector momentArmError = momentArm - momentArmFitted;
+            double momentArmRMSError = 100.0 * std::sqrt(
+                    momentArmError.normSqr() / momentArmError.size());
+            momentArmRMSErrors[ima++] = momentArmRMSError;
+            log_info(" - '{}' moment arm RMSE: {:1.3f} cm", coordinateName,
+                    momentArmRMSError);
+
+            if (momentArmRMSError > 10.0*momentArmTolerance) {
+                printWarningMessage(
+                        fmt::format("'{}' moment arm", coordinateName),
+                        momentArmTolerance);
+            }
+
+        }
+        log_info("");
+    }
+
+    // Print the average path length and moment arm RMS errors.
+    double averagePathLengthError = pathLengthRMSErrors.sum() /
+                                    pathLengthRMSErrors.size();
+    double averageMomentArmError = momentArmRMSErrors.sum() /
+                                   momentArmRMSErrors.size();
+    log_info("Average path length RMSE = {:1.3f} cm", averagePathLengthError);
+    if (averagePathLengthError > pathLengthTolerance) {
+        printWarningMessage("average path length", pathLengthTolerance);
+    }
+
+    log_info("Average moment arm RMSE  = {:1.3f} cm", averageMomentArmError);
+    if (averageMomentArmError > momentArmTolerance) {
+        printWarningMessage("average moment arm", momentArmTolerance);
+    }
+}
+
+}
+
+//=============================================================================
+// POLYNOMIAL PATH FITTER BOUNDS
+//=============================================================================
+PolynomialPathFitterBounds::PolynomialPathFitterBounds() : Object() {
+    setAuthors("Nicholas Bianco");
+    constructProperties();
+}
+
+PolynomialPathFitterBounds::PolynomialPathFitterBounds(
+        const std::string& coordinatePath, const SimTK::Vec2& bounds) :
+        PolynomialPathFitterBounds() {
+    set_coordinate_path(coordinatePath);
+    OPENSIM_THROW_IF_FRMOBJ(bounds[0] >= bounds[1], Exception,
+            "Expected the lower bound to be less than the upper bound, but "
+            "it is not.")
+    set_bounds(bounds);
+}
+
+void PolynomialPathFitterBounds::constructProperties() {
+    constructProperty_coordinate_path("");
+    constructProperty_bounds({-10.0, 10.0});
+}
+
+//=============================================================================
+// POLYNOMIAL PATH FITTER
+//=============================================================================
+PolynomialPathFitter::PolynomialPathFitter() : Object() {
+    setAuthors("Nicholas Bianco");
+    constructProperties();
+}
+
+PolynomialPathFitter::~PolynomialPathFitter() noexcept = default;
+
+PolynomialPathFitter::PolynomialPathFitter(
+        PolynomialPathFitter const&) = default;
+
+PolynomialPathFitter& PolynomialPathFitter::operator=(
+        const PolynomialPathFitter&) = default;
+
+PolynomialPathFitter::PolynomialPathFitter(
+        PolynomialPathFitter&& other) = default;
+
+PolynomialPathFitter& PolynomialPathFitter::operator=(
+        PolynomialPathFitter&& other) = default;
+
+//=============================================================================
+// PATH FITTING PIPELINE
+//=============================================================================
+
+void PolynomialPathFitter::run() {
+
+    log_info("");
+    log_info("====================");
+    log_info("PolynomialPathFitter");
+    log_info("====================");
+    log_info("");
+
+    log_info("Step 1/9: Load the model and coordinate values table.");
+    log_info("-----------------------------------------------------");
+
+    // Load the model.
+    m_model = get_model().process(getDocumentDirectory());
+    m_model.initSystem();
+
+    // Load the coordinate values table.
+    m_values = loadCoordinateValuesAndValidateModel(
+            getDocumentDirectory(), get_coordinate_values(), m_model);
+    OPENSIM_THROW_IF_FRMOBJ(!m_values.getNumRows(), Exception,
+            "Expected the coordinate values table to contain at least one row, "
+            "but it is empty.");
+
+    // Get the path-based forces in the model.
+    std::vector<std::string> forcePaths;
+    const auto& forces = m_model.getComponentList<Force>();
+    for (const auto& force : forces) {
+        if (force.hasProperty("path")) {
+            forcePaths.push_back(force.getAbsolutePathString());
+        }
+    }
+
+    log_info("");
+    log_info("Step 2/9: Set the coordinate bounds.");
+    log_info("------------------------------------");
+    // Set the global bounds for all coordinates.
+    SimTK::Vec2 globalBounds = get_global_coordinate_sampling_bounds();
+    log_info("Global bounds: [{}, {}] degrees.",
+             globalBounds[0], globalBounds[1]);
+    globalBounds[0] = SimTK::convertDegreesToRadians(globalBounds[0]);
+    globalBounds[1] = SimTK::convertDegreesToRadians(globalBounds[1]);
+
+    // Initialize coordinate bounds based on whether coordinates are clamped
+    // in the model.
+    CoordinateMap coordinateBoundsMap;
+    CoordinateMap coordinateRangeMap;
+    coordinateBoundsMap.reserve(m_model.getNumCoordinates());
+    coordinateRangeMap.reserve(m_model.getNumCoordinates());
+    for (const auto& coordinate : m_model.getComponentList<Coordinate>()) {
+        std::string valuePath = fmt::format("{}/value",
+                coordinate.getAbsolutePathString());
+        coordinateBoundsMap.insert({valuePath, globalBounds});
+
+        // If the coordinate is clamped, then we also store the allowable range
+        // of motion.
+        if (coordinate.get_clamped()) {
+            SimTK::Vec2 range = {coordinate.getRangeMin(),
+                    coordinate.getRangeMax()};
+            coordinateRangeMap.insert({valuePath, range});
+        } else {
+            coordinateRangeMap.insert({valuePath,
+                    {-SimTK::Infinity, SimTK::Infinity}});
+        }
+    }
+
+    // Set any coordinate-specific bounds. This will overwrite the default
+    // bounds.
+    for (int i = 0; i < getProperty_coordinate_sampling_bounds().size(); ++i) {
+        const auto& coordinatePath =
+                get_coordinate_sampling_bounds(i).get_coordinate_path();
+        OPENSIM_THROW_IF_FRMOBJ(
+                !m_model.hasComponent<Coordinate>(coordinatePath),
+                Exception, "Expected the model to contain the coordinate '{}', "
+                           "but it does not.", coordinatePath)
+        SimTK::Vec2 bounds = get_coordinate_sampling_bounds(i).get_bounds();
+        log_info("Bounds for coordinate '{}': [{}, {}] degrees.",
+                coordinatePath, bounds[0], bounds[1]);
+
+        bounds[0] = SimTK::convertDegreesToRadians(bounds[0]);
+        bounds[1] = SimTK::convertDegreesToRadians(bounds[1]);
+        std::string valuePath = fmt::format("{}/value", coordinatePath);
+        coordinateBoundsMap[valuePath] = bounds;
+    }
+
+    log_info("");
+    log_info("Step 3/9: Verify the user-defined settings.");
+    log_info("-------------------------------------------");
+    validateProperties();
+
+    Settings settings;
+    settings.useStepwiseRegression = get_use_stepwise_regression();
+    settings.momentArmThreshold = get_moment_arm_threshold();
+    settings.momentArmTolerance = get_moment_arm_tolerance();
+    settings.pathLengthTolerance = get_path_length_tolerance();
+    settings.minimumPolynomialOrder = get_minimum_polynomial_order();
+    settings.maximumPolynomialOrder = get_maximum_polynomial_order();
+    settings.numParallelThreads = get_num_parallel_threads();
+    settings.numSamplesPerFrame = get_num_samples_per_frame();
+    settings.useStochasticEvolutionaryLHS =
+            get_latin_hypercube_algorithm() == "ESEA";
+    settings.includeMomentArmFunctions = get_include_moment_arm_functions();
+    settings.includeLengtheningSpeedFunction =
+            get_include_lengthening_speed_function();
+
+    // Construct the output directory.
+    std::string outputDir = get_output_directory();
+    if (outputDir.empty()) {
+        if (getDocumentDirectory().empty()) {
+            outputDir = SimTK::Pathname::getCurrentWorkingDirectory();
+        } else {
+            outputDir = getDocumentDirectory();
+        }
+    } else {
+        IO::makeDir(outputDir);
+    }
+
+    log_info("");
+    log_info("Step 4/9: Sample coordinate values around the provided trajectory.");
+    log_info("------------------------------------------------------------------");
+    TimeSeriesTable valuesSampled = sampleCoordinateValues(m_values,
+            coordinateBoundsMap, coordinateRangeMap, settings);
+
+    // Recompute the coupled coordinate values.
+    auto tableProcessorSampled = TableProcessor(valuesSampled) |
+                                 TabOpAppendCoupledCoordinateValues();
+    valuesSampled = tableProcessorSampled.process(&m_model);
+    log_info("Total number of samples = {}", valuesSampled.getNumRows());
+
+    log_info("");
+    log_info("Step 5/9: Compute path lengths and moment arms.");
+    log_info("-----------------------------------------------");
+    log_info("Computing path lengths and moment arms for the original "
+             "coordinate data...");
+    TimeSeriesTable pathLengths;
+    TimeSeriesTable momentArms;
+    computePathLengthsAndMomentArms(m_model, m_values, forcePaths,
+            settings, pathLengths, momentArms);
+
+    log_info("");
+    log_info("Computing path lengths and moment arms for the sampled "
+             "coordinate data...");
+    TimeSeriesTable pathLengthsSampled;
+    TimeSeriesTable momentArmsSampled;
+    computePathLengthsAndMomentArms(m_model, valuesSampled, forcePaths,
+            settings, pathLengthsSampled, momentArmsSampled);
+
+    log_info("");
+    log_info("Step 6/9: Filter the sampled path data.");
+    log_info("---------------------------------------");
+    MomentArmMap momentArmMap;
+    filterSampledData(m_model, settings, valuesSampled, pathLengthsSampled,
+            momentArmsSampled, momentArmMap);
+
+    log_info("");
+    log_info("Step 7/9: Fit the polynomial coefficients.");
+    log_info("------------------------------------------");
+    Set<FunctionBasedPath> functionBasedPaths = fitPolynomialCoefficients(
+            m_model, valuesSampled, forcePaths, pathLengthsSampled,
+            momentArmsSampled, momentArmMap, settings);
+    Array<std::string> pathNames;
+    functionBasedPaths.getNames(pathNames);
+
+    log_info("");
+    log_info("Step 8/9: Evaluate the fit.");
+    log_info("---------------------------");
+
+    // Find the longest path name.
+    int longestPathName = 0;
+    for (int i = 0; i < pathNames.getSize(); ++i) {
+        std::string pathName = pathNames[i];
+        if ((int)pathName.size() > longestPathName) {
+            longestPathName = (int)pathName.size();
+        }
+    }
+
+    // Print the information for each path.
+    log_info("");
+    std::string pathName = fmt::format("{}path",
+            std::string((int)(0.5*longestPathName)-2, ' '));
+    std::string fitName = fmt::format("{}polynomial fit", std::string(15, ' '));
+    std::string line = fmt::format("{:{}} | {:{}}", pathName, longestPathName,
+            fitName, 44);
+    std::string separator(line.size(), '-');
+    log_info(separator);
+    log_info(line);
+    log_info(separator);
+    for (int i = 0; i < functionBasedPaths.getSize(); ++i) {
+        auto path = functionBasedPaths.get(pathNames[i]);
+        auto function = dynamic_cast<const MultivariatePolynomialFunction&>(
+                path.getLengthFunction());
+        SimTK::Vector coefficients = function.getCoefficients();
+        int numNonZeroCoeffs = 0;
+        for (int i = 0; i < coefficients.size(); ++i) {
+            if (coefficients[i] != 0.0) {
+                ++numNonZeroCoeffs;
+            }
+        }
+        line = fmt::format("{:{}} | order = {}, dimension = "
+                "{}, coefficients = {}", path.getName(), longestPathName,
+                function.getOrder(), function.getDimension(), numNonZeroCoeffs);
+        log_info(line);
+    }
+    log_info(separator);
+
+    // Add the FunctionBasedPaths to the model.
+    log_info("");
+    log_info("Computing path lengths and moment arms from the fitted paths...");
+    Model modelFitted = m_model;
+    modelFitted.initSystem();
+    ModelFactory::replacePathsWithFunctionBasedPaths(modelFitted,
+            functionBasedPaths);
+
+    // Recompute the path lengths and moment arms.
+    TimeSeriesTable pathLengthsFitted;
+    TimeSeriesTable momentArmsFitted;
+    computePathLengthsAndMomentArms(modelFitted, m_values, forcePaths,
+            settings, pathLengthsFitted, momentArmsFitted);
+
+    TimeSeriesTable pathLengthsSampledFitted;
+    TimeSeriesTable momentArmsSampledFitted;
+    computePathLengthsAndMomentArms(modelFitted, valuesSampled, forcePaths,
+            settings, pathLengthsSampledFitted,
+            momentArmsSampledFitted);
+
+    // Remove moment arm columns that are not in the map.
+    removeMomentArmColumns(momentArms, momentArmMap);
+    removeMomentArmColumns(momentArmsFitted, momentArmMap);
+    removeMomentArmColumns(momentArmsSampledFitted, momentArmMap);
+
+    // Compute the RMS error between the original and fitted path lengths and
+    // moment arms.
+    computeFittingErrors(modelFitted, pathLengthsSampled, momentArmsSampled,
+            pathLengthsSampledFitted, momentArmsSampledFitted, settings);
+
+    log_info("");
+    log_info("Step 9/9: Print the results to the output directory.");
+    log_info("----------------------------------------------------");
+
+    // Print the FunctionBasedPaths to file.
+    std::string functionBasedPathsFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_FunctionBasedPathSet.xml",
+                            outputDir, m_model.getName()));
+    log_info("Printing the FunctionBasedPaths to '{}'...",
+            functionBasedPathsFileName);
+    functionBasedPaths.print(functionBasedPathsFileName);
+
+    // Print the coordinate values to file.
+    std::string coordinatesFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_coordinate_values.sto",
+                            outputDir, m_model.getName()));
+    std::string sampledCoordinatesFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_coordinate_values_sampled.sto",
+                            outputDir, m_model.getName()));
+    log_info("");
+    log_info(fmt::format("Printing original coordinate values to '{}'...",
+            coordinatesFileName));
+    STOFileAdapter::write(m_values, coordinatesFileName);
+    log_info(fmt::format("Printing sampled coordinate values to '{}'...",
+            sampledCoordinatesFileName));
+    STOFileAdapter::write(valuesSampled, sampledCoordinatesFileName);
+
+    // Print the path lengths and moment arms from the original coordinate
+    // data to file.
+    std::string pathLengthsFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_path_lengths.sto",
+                            outputDir, m_model.getName()));
+    std::string momentArmsFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_moment_arms.sto",
+                            outputDir, m_model.getName()));
+    log_info("");
+    log_info("Printing the path lengths to '{}'...",
+            pathLengthsFileName);
+    STOFileAdapter::write(pathLengths, pathLengthsFileName);
+    log_info("Printing the moment arms to '{}'...", momentArmsFileName);
+    STOFileAdapter::write(momentArms, momentArmsFileName);
+
+    // Print the path lengths and moment arms from the sampled coordinate
+    // data to file.
+    std::string pathLengthsSampledFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_path_lengths_sampled.sto",
+                            outputDir, m_model.getName()));
+    std::string momentArmsSampledFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_moment_arms_sampled.sto",
+                            outputDir, m_model.getName()));
+
+    log_info("");
+    log_info("Printing the sampled path lengths to '{}'...",
+            pathLengthsSampledFileName);
+    STOFileAdapter::write(pathLengthsSampled, pathLengthsSampledFileName);
+    log_info("Printing the sampled moment arms to '{}'...",
+            momentArmsSampledFileName);
+    STOFileAdapter::write(momentArmsSampled, momentArmsSampledFileName);
+
+    // Print the fitted path lengths and moment arms using the original
+    // coordinate data to file.
+    std::string pathLengthsFittedFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_path_lengths_fitted.sto",
+                            outputDir, m_model.getName()));
+    std::string momentArmsFittedFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_moment_arms_fitted.sto",
+                            outputDir, m_model.getName()));
+
+    log_info("");
+    log_info("Printing the fitted path lengths from the original coordinate "
+             "values to '{}'...", pathLengthsFittedFileName);
+    STOFileAdapter::write(pathLengthsFitted, pathLengthsFittedFileName);
+    log_info("Printing the fitted moment arms from the original coordinate "
+             "to '{}'...", momentArmsFittedFileName);
+    STOFileAdapter::write(momentArmsFitted, momentArmsFittedFileName);
+
+    // Print the fitted path lengths and moment arms using the sampled
+    // coordinate data to file.
+    std::string pathLengthsSampledFittedFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_path_lengths_sampled_fitted.sto",
+                            outputDir, m_model.getName()));
+    std::string momentArmsSampledFittedFileName =
+            SimTK::Pathname::getAbsolutePathname(
+                    fmt::format("{}/{}_moment_arms_sampled_fitted.sto",
+                            outputDir, m_model.getName()));
+
+    log_info("");
+    log_info("Printing the fitted path lengths from the sampled coordinate "
+             "values to '{}'...", pathLengthsSampledFittedFileName);
+    STOFileAdapter::write(pathLengthsSampledFitted,
+            pathLengthsSampledFittedFileName);
+    log_info("Printing the fitted moment arms from the sampled coordinate "
+             "values to '{}'...", momentArmsSampledFittedFileName);
+    STOFileAdapter::write(momentArmsSampledFitted,
+            momentArmsSampledFittedFileName);
+}
+
+
 
 //=============================================================================
 // SETTINGS
@@ -1255,6 +1637,15 @@ void PolynomialPathFitter::evaluateFunctionBasedPaths(Model model,
         const std::string& functionBasedPathsFileName,
         double pathLengthTolerance, double momentArmTolerance) {
 
+    Settings settings;
+    settings.pathLengthTolerance = pathLengthTolerance;
+    settings.momentArmTolerance = momentArmTolerance;
+    settings.numParallelThreads =
+            static_cast<int>(std::thread::hardware_concurrency());
+    OPENSIM_THROW_IF(settings.numParallelThreads == 0, Exception,
+            "Tried to evaluate the FunctionBasedPaths, but no hardware threads "
+            "were found.");
+
     // Initialize the original model.
     model.initSystem();
 
@@ -1288,26 +1679,28 @@ void PolynomialPathFitter::evaluateFunctionBasedPaths(Model model,
     }
 
     // Get the coordinate values table from the trajectory. This may contain
-    // extra values, but that's okay.
+    // extra columns, but that's okay.
     std::string currentDirectory = IO::getCwd();
     TimeSeriesTable coordinateValues = loadCoordinateValuesAndValidateModel(
             currentDirectory, std::move(trajectory), model);
+    OPENSIM_THROW_IF(coordinateValues.getNumRows() == 0, Exception,
+            "Expected the coordinate values table to contain at least one row, "
+            "but it is empty.");
 
     // Compute path lengths and moment arms for the original and fitted models.
     log_info("");
     log_info("Computing path lengths and moment arms for the original model..");
     TimeSeriesTable pathLengths;
     TimeSeriesTable momentArms;
-    int numThreads = static_cast<int>(std::thread::hardware_concurrency());
     computePathLengthsAndMomentArms(model, coordinateValues, forcePaths,
-            numThreads, pathLengths, momentArms);
+            settings, pathLengths, momentArms);
 
     log_info("");
     log_info("Computing path lengths and moment arms for the fitted model..");
     TimeSeriesTable pathLengthsFitted;
     TimeSeriesTable momentArmsFitted;
     computePathLengthsAndMomentArms(modelFitted, coordinateValues, forcePaths,
-            numThreads, pathLengthsFitted, momentArmsFitted);
+            settings, pathLengthsFitted, momentArmsFitted);
 
     // Remove moment arm columns that are not in the map.
     removeMomentArmColumns(momentArms, momentArmMap);
@@ -1315,347 +1708,7 @@ void PolynomialPathFitter::evaluateFunctionBasedPaths(Model model,
 
     // Compute the RMS errors.
     computeFittingErrors(modelFitted, pathLengths, momentArms,
-            pathLengthsFitted, momentArmsFitted,
-            pathLengthTolerance, momentArmTolerance);
-}
-
-void PolynomialPathFitter::removeMomentArmColumns(TimeSeriesTable& momentArms,
-        const MomentArmMap& momentArmMap) {
-
-    // Remove entries from the table that are not in the moment arm map.
-    for (const auto& label : momentArms.getColumnLabels()) {
-        std::string path = label.substr(0, label.find("_moment_arm_"));
-        std::string coordinate = label.substr(
-                label.find("_moment_arm_") + 12);
-        if (momentArmMap.find(path) != momentArmMap.end()) {
-            if (std::find(momentArmMap.at(path).begin(),
-                        momentArmMap.at(path).end(), coordinate) ==
-                    momentArmMap.at(path).end()) {
-                momentArms.removeColumn(label);
-            }
-        } else {
-            momentArms.removeColumn(label);
-        }
-    }
-}
-
-int PolynomialPathFitter::fitAllCoefficients(
-        const SimTK::Matrix& coordinates, const SimTK::Vector& b, int minOrder,
-        int maxOrder, SimTK::Vector& coefficients) const {
-
-    int numTimes = coordinates.nrow();
-    int numCoordinates = coordinates.ncol();
-    int order = minOrder;
-    while (true) {
-        // Initialize the multivariate polynomial function.
-        int numCoefficients = choose(numCoordinates + order, order);
-        SimTK::Vector dummyCoefficients(numCoefficients, 1.0);
-        MultivariatePolynomialFunction dummyFunction(dummyCoefficients,
-                numCoordinates, order);
-
-        // Initialize the 'A' matrix.
-        SimTK::Matrix A(numTimes * (numCoordinates + 1),
-                numCoefficients, 0.0);
-
-        // Fill in the A matrix. This contains the polynomial terms for
-        // the path length and moment arms.
-        for (int itime = 0; itime < numTimes; ++itime) {
-            A(itime, 0, 1, numCoefficients) =
-                    dummyFunction.getTermValues(
-                        coordinates.row(itime).transpose().getAsVector());
-
-            for (int ic = 0; ic < numCoordinates; ++ic) {
-                SimTK::Vector termDerivatives =
-                    dummyFunction.getTermDerivatives({ic},
-                        coordinates.row(itime).transpose().getAsVector())
-                        .negate();
-                A((ic+1)*numTimes + itime, 0, 1, numCoefficients) =
-                        termDerivatives;
-            }
-        }
-
-        // Solve the least-squares problem.
-        SimTK::FactorQTZ factor(A);
-        factor.solve(b, coefficients);
-
-        // Calculate the RMS error.
-        SimTK::Vector b_fit = A * coefficients;
-        SimTK::Vector error = b - b_fit;
-
-        // If the fit achieves the path length and moment arm thresholds
-        // we set, then exit the loop.
-        SimTK::Vector pathLengthError = error.block(
-                0, 0, numTimes, 1).getAsVector();
-        double pathLengthRMSError = std::sqrt(
-                pathLengthError.normSqr() / pathLengthError.size());
-        bool pathLengthMet = pathLengthRMSError < get_path_length_tolerance();
-
-        bool momentArmMet = true;
-        for (int ic = 0; ic < numCoordinates; ++ic) {
-            SimTK::Vector momentArmError = error.block(
-                    numTimes + ic*numTimes, 0, numTimes, 1).getAsVector();
-            double momentArmRMSError = std::sqrt(
-                    momentArmError.normSqr() / numTimes);
-            if (momentArmRMSError > get_moment_arm_tolerance()) {
-                momentArmMet = false;
-                break;
-            }
-        }
-
-        if ((pathLengthMet && momentArmMet) || order == maxOrder) {
-            break;
-        }
-        ++order;
-    }
-
-    return order;
-}
-
-void PolynomialPathFitter::fitCoefficientsStepwiseRegression(
-        const SimTK::Matrix& coordinates, const SimTK::Vector& b, int order,
-        SimTK::Vector& coefficients) const {
-
-    // Preliminaries.
-    int numTimes = coordinates.nrow();
-    int numCoordinates = coordinates.ncol();
-    int numCoefficients = choose(numCoordinates + order, order);
-
-    // Construct the full 'A' matrix.
-    SimTK::Vector dummyCoefficients(numCoefficients, 1.0);
-    MultivariatePolynomialFunction dummyFunction(dummyCoefficients,
-            numCoordinates, order);
-    SimTK::Matrix Afull(numTimes * (numCoordinates + 1),
-            numCoefficients, 0.0);
-    for (int itime = 0; itime < numTimes; ++itime) {
-        Afull(itime, 0, 1, numCoefficients) =
-                dummyFunction.getTermValues(
-                    coordinates.row(itime).transpose().getAsVector());
-
-        for (int ic = 0; ic < numCoordinates; ++ic) {
-            SimTK::Vector termDerivatives =
-                dummyFunction.getTermDerivatives({ic},
-                    coordinates.row(itime).transpose().getAsVector())
-                    .negate();
-            Afull((ic+1)*numTimes + itime, 0, 1, numCoefficients) =
-                    termDerivatives;
-        }
-    }
-
-    // Manage the coefficient indexes that will be included in the final
-    // polynomial. The "out" indexes are the indexes that are not included in
-    // the final polynomial, which is initialized to all indexes. The "keep"
-    // indexes are the indexes that are included in the final polynomial, which
-    // is initialized to an empty vector.
-    std::vector<int> outIndexes;
-    outIndexes.reserve(numCoefficients);
-    for (int i = 0; i < numCoefficients; ++i) {
-        outIndexes.push_back(i);
-    }
-    std::vector<int> keepIndexes;
-    SimTK::Vector x_sol;
-    while (true) {
-
-        // Initialize the 'A' matrix.
-        // The number of terms in the polynomial is the number of "kept"
-        // coefficients plus one.
-        int numTerms = static_cast<int>(keepIndexes.size()) + 1;
-        SimTK::Matrix A(numTimes * (numCoordinates + 1), numTerms, 0.0);
-        SimTK::Vector x(numTerms, 0.0);
-
-        // First, set the columns of 'A' for the "kept" coefficients.
-        int icol = 0;
-        for (const auto& ki : keepIndexes) {
-            A.updCol(icol++) = Afull.col(ki);
-        }
-
-        // Next, loop through all of the remaining "out" coefficients and fit
-        // the polynomial. We will keep the coefficient that results in the
-        // smallest RMS error.
-        SimTK::Real bestError = SimTK::Infinity;
-        int bestIndex = -1;
-        for (const auto& oi : outIndexes) {
-            A.updCol(icol) = Afull.col(oi);
-
-            // Solve the least-squares problem.
-            SimTK::FactorQTZ factor(A);
-            factor.solve(b, x);
-
-            // Calculate the RMS error.
-            SimTK::Vector b_fit = A * x;
-            SimTK::Vector error = b - b_fit;
-
-            // Calculate the RMS error. Update the best error and index.
-            double currentError = std::sqrt(error.normSqr() / error.size());
-            if (currentError < bestError) {
-                bestError = currentError;
-                bestIndex = oi;
-            }
-        }
-
-        // Add the best index to the "keep" indexes and remove it from the "out"
-        // indexes.
-        keepIndexes.push_back(bestIndex);
-        outIndexes.erase(std::remove(outIndexes.begin(), outIndexes.end(),
-                bestIndex), outIndexes.end());
-
-        // Refit the polynomial with the "keep" indexes.
-        icol = 0;
-        for (const auto& ki : keepIndexes) {
-            A.updCol(icol++) = Afull.col(ki);
-        }
-        SimTK::FactorQTZ factor(A);
-        factor.solve(b, x);
-        SimTK::Vector b_fit = A * x;
-        SimTK::Vector error = b - b_fit;
-
-        // If the current polynomial achieves our path length and moment arm
-        // tolerances or if the "out" indexes is empty, exit the loop.
-        SimTK::Vector pathLengthError = error.block(
-                0, 0, numTimes, 1).getAsVector();
-        double pathLengthRMSError = std::sqrt(
-                pathLengthError.normSqr() / pathLengthError.size());
-        bool pathLengthMet = pathLengthRMSError < get_path_length_tolerance();
-
-        bool momentArmMet = true;
-        for (int ic = 0; ic < numCoordinates; ++ic) {
-            SimTK::Vector momentArmError = error.block(
-                    numTimes + ic*numTimes, 0, numTimes, 1).getAsVector();
-            double momentArmRMSError = std::sqrt(
-                    momentArmError.normSqr() / numTimes);
-            if (momentArmRMSError > get_moment_arm_tolerance()) {
-                momentArmMet = false;
-                break;
-            }
-        }
-
-        int numOutIndexes = static_cast<int>(outIndexes.size());
-        if ((pathLengthMet && momentArmMet) || !numOutIndexes) {
-            x_sol = x;
-            break;
-        }
-    }
-
-    // Update the coefficients vector
-    coefficients.resize(numCoefficients);
-    coefficients.setToZero();
-    int icoeff = 0;
-    for (const auto& ki : keepIndexes) {
-        coefficients.set(ki, x_sol(icoeff++));
-    }
-}
-
-void PolynomialPathFitter::computeFittingErrors(const Model& modelFitted,
-        const TimeSeriesTable& pathLengths, const TimeSeriesTable& momentArms,
-        const TimeSeriesTable& pathLengthsFitted,
-        const TimeSeriesTable& momentArmsFitted, double pathLengthTolerance,
-        double momentArmTolerance) {
-
-    // Convert the tolerances to centimeters.
-    pathLengthTolerance *= 100.0;
-    momentArmTolerance *= 100.0;
-
-    // Helper function for printing warning messages.
-    auto printWarningMessage = [](const std::string& pathLengthOrMomentArm,
-                                double tolerance) {
-        log_warn("-----------------------------------------------------------");
-        log_warn(fmt::format("The {} RMS error is greater than the prescribed "
-                             "tolerance of {:g} cm.",
-                             pathLengthOrMomentArm, tolerance));
-        log_warn("");
-        log_warn("Consider increasing the number of samples per frame or the ");
-        log_warn("polynomial order and re-fitting the model. If a re-fitting ");
-        log_warn("is not successful, check that the original model produces ");
-        log_warn("path lengths and moment arms that are free of ");
-        log_warn("discontinuities or other irregularities.");
-        log_warn("-----------------------------------------------------------");
-    };
-
-    // Check inputs.
-    OPENSIM_ASSERT_ALWAYS(pathLengths.getNumRows() ==
-            pathLengthsFitted.getNumRows());
-    OPENSIM_ASSERT_ALWAYS(momentArms.getNumRows() ==
-            momentArmsFitted.getNumRows());
-    OPENSIM_ASSERT_ALWAYS(pathLengths.getNumColumns() ==
-            pathLengthsFitted.getNumColumns());
-    OPENSIM_ASSERT_ALWAYS(momentArms.getNumColumns() ==
-            momentArmsFitted.getNumColumns());
-    const auto& functionBasedPaths =
-            modelFitted.getComponentList<FunctionBasedPath>();
-    int numPaths = (int)std::distance(functionBasedPaths.begin(),
-            functionBasedPaths.end());
-    OPENSIM_THROW_IF(numPaths == 0, Exception,
-            "Expected the model to contain 'FunctionBasedPath's, but none were "
-            "found.");
-
-    // Print the path length and moment arm RMS errors for each path.
-    log_info("");
-    log_info("Summary of path length and moment arm RMS errors");
-    log_info("------------------------------------------------");
-    SimTK::Vector pathLengthRMSErrors((int)pathLengths.getNumColumns());
-    SimTK::Vector momentArmRMSErrors((int)momentArms.getNumColumns());
-    int ip = 0;
-    int ima = 0;
-    for (const auto& path : modelFitted.getComponentList<FunctionBasedPath>()) {
-        std::string pathName = path.getAbsolutePathString();
-        pathName = pathName.substr(0, pathName.length() - 5);
-        log_info("'{}' path errors:", pathName);
-
-        const std::string lengthLabel = fmt::format("{}_length", pathName);
-        SimTK::Vector pathLength = pathLengths.getDependentColumn(lengthLabel);
-        SimTK::Vector pathLengthFitted = pathLengthsFitted.getDependentColumn(
-                lengthLabel);
-        SimTK::Vector pathLengthError = pathLength - pathLengthFitted;
-        double pathLengthRMSError = 100.0 * std::sqrt(
-                pathLengthError.normSqr() / pathLengthError.size());
-        pathLengthRMSErrors[ip++] = pathLengthRMSError;
-        log_info(" - path length RMSE: {:1.3f} cm", pathLengthRMSError);
-
-        if (pathLengthRMSError > 10.0*pathLengthTolerance) {
-            printWarningMessage("path length", pathLengthTolerance);
-        }
-
-        for (const auto& coordinatePath : path.getCoordinatePaths()) {
-            const auto& coordinate =
-                    modelFitted.getComponent<Coordinate>(coordinatePath);
-            const std::string& coordinateName = coordinate.getName();
-
-            const std::string momentArmLabel = fmt::format(
-                "{}_moment_arm_{}", pathName, coordinateName);
-            SimTK::Vector momentArm = momentArms.getDependentColumn(
-                    momentArmLabel);
-            SimTK::Vector momentArmFitted = momentArmsFitted.getDependentColumn(
-                    momentArmLabel);
-            SimTK::Vector momentArmError = momentArm - momentArmFitted;
-            double momentArmRMSError = 100.0 * std::sqrt(
-                    momentArmError.normSqr() / momentArmError.size());
-            momentArmRMSErrors[ima++] = momentArmRMSError;
-            log_info(" - '{}' moment arm RMSE: {:1.3f} cm", coordinateName,
-                    momentArmRMSError);
-
-            if (momentArmRMSError > 10.0*momentArmTolerance) {
-                printWarningMessage(
-                        fmt::format("'{}' moment arm", coordinateName),
-                        momentArmTolerance);
-            }
-
-        }
-        log_info("");
-    }
-
-    // Print the average path length and moment arm RMS errors.
-    double averagePathLengthError = pathLengthRMSErrors.sum() /
-                                    pathLengthRMSErrors.size();
-    double averageMomentArmError = momentArmRMSErrors.sum() /
-                                   momentArmRMSErrors.size();
-    log_info("Average path length RMSE = {:1.3f} cm", averagePathLengthError);
-    if (averagePathLengthError > pathLengthTolerance) {
-        printWarningMessage("average path length", pathLengthTolerance);
-    }
-
-    log_info("Average moment arm RMSE  = {:1.3f} cm", averageMomentArmError);
-    if (averageMomentArmError > momentArmTolerance) {
-        printWarningMessage("average moment arm", momentArmTolerance);
-    }
+            pathLengthsFitted, momentArmsFitted, settings);
 }
 
 void PolynomialPathFitter::constructProperties() {
@@ -1676,6 +1729,75 @@ void PolynomialPathFitter::constructProperties() {
     constructProperty_latin_hypercube_algorithm("random");
     constructProperty_include_moment_arm_functions(false);
     constructProperty_include_lengthening_speed_function(false);
+}
+
+void PolynomialPathFitter::validateProperties() {
+    // Parallelization.
+    OPENSIM_THROW_IF_FRMOBJ(std::thread::hardware_concurrency() == 0, Exception,
+            "Expected at least one hardware thread for parallelization, but "
+            "none were found.")
+    OPENSIM_THROW_IF_FRMOBJ(get_num_parallel_threads() < 1 ||
+            get_num_parallel_threads() >
+                (int)std::thread::hardware_concurrency(), Exception,
+            "Expected 'num_parallel_threads' to be between 1 and {}, but "
+            "received {}.", std::thread::hardware_concurrency(),
+            get_num_parallel_threads())
+    OPENSIM_THROW_IF_FRMOBJ(
+            static_cast<int>(m_values.getNumRows()) < get_num_parallel_threads(),
+            Exception, "Expected the number of time points in the coordinate "
+            "values table to be greater than 'num_parallel_threads', but "
+            "received {} and {}, respectively.",
+            m_values.getNumRows(), get_num_parallel_threads())
+    log_info("Number of parallel threads = {}", get_num_parallel_threads());
+
+    // Number of samples per frame.
+    OPENSIM_THROW_IF_FRMOBJ(get_num_samples_per_frame() < 1, Exception,
+            "Expected 'num_samples_per_frame' to be a non-zero integer value, "
+            "but received {}.", get_num_samples_per_frame());
+    log_info("Number of samples per frame = {}", get_num_samples_per_frame());
+
+    // Latin hypercube algorithm.
+    checkPropertyValueIsInSet(getProperty_latin_hypercube_algorithm(),
+            {"random", "ESEA"});
+    log_info("Latin hypercube algorithm = '{}'",
+            get_latin_hypercube_algorithm());
+
+    // Moment arm threshold.
+    OPENSIM_THROW_IF_FRMOBJ(get_moment_arm_threshold() < 0 ||
+                            get_moment_arm_threshold() > 1, Exception,
+            "Expected 'moment_arm_threshold' to be in the range [0, 1], but "
+            "received {:2g}.", get_moment_arm_threshold())
+    log_info("Moment arm threshold = {:1.1e} meters",
+            get_moment_arm_threshold(), 1);
+
+    // Polynomial order.
+    checkPropertyValueIsPositive(getProperty_minimum_polynomial_order());
+    checkPropertyValueIsPositive(getProperty_maximum_polynomial_order());
+    OPENSIM_THROW_IF_FRMOBJ(get_maximum_polynomial_order() > 9, Exception,
+            "Expected 'maximum_polynomial_order' to be at most 9, but "
+            "received {}.", get_maximum_polynomial_order())
+    OPENSIM_THROW_IF_FRMOBJ(get_minimum_polynomial_order() >
+                            get_maximum_polynomial_order(), Exception,
+            "Expected 'minimum_polynomial_order' to be less than or equal to "
+            "'maximum_polynomial_order', but received {} and {}, "
+            "respectively.", get_minimum_polynomial_order(),
+            get_maximum_polynomial_order())
+    log_info("Minimum polynomial order = {}", get_minimum_polynomial_order());
+    log_info("Maximum polynomial order = {}", get_maximum_polynomial_order());
+
+    // Fitting tolerances.
+    checkPropertyValueIsInRangeOrSet(getProperty_path_length_tolerance(),
+                                     0.0, 1.0, {});
+    checkPropertyValueIsInRangeOrSet(getProperty_moment_arm_tolerance(),
+                                     0.0, 1.0, {});
+    log_info("Path length fitting tolerance = {:1.1e} meters",
+             get_path_length_tolerance(), 1);
+    log_info("Moment arm fitting tolerance = {:1.1e} meters",
+            get_moment_arm_tolerance(), 1);
+
+    // Stepwise regression
+    log_info("Use stepwise regression = {}",
+            get_use_stepwise_regression() ? "true" : "false");
 }
 
 std::string PolynomialPathFitter::getDocumentDirectory() const {

--- a/OpenSim/Actuators/PolynomialPathFitter.h
+++ b/OpenSim/Actuators/PolynomialPathFitter.h
@@ -1,5 +1,5 @@
-#ifndef OPENSIM_POLYNOMIALPATHFITTER_H
-#define OPENSIM_POLYNOMIALPATHFITTER_H
+#ifndef OPENSIM_POLYNOMIAL_PATH_FITTER_H
+#define OPENSIM_POLYNOMIAL_PATH_FITTER_H
 /* -------------------------------------------------------------------------- *
  *                    OpenSim:  PolynomialPathFitter.h                        *
  * -------------------------------------------------------------------------- *
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2023 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  * Author(s): Nicholas Bianco                                                 *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -23,8 +23,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <OpenSim/Simulation/TableProcessor.h>
 #include <OpenSim/Actuators/ModelProcessor.h>
+#include <OpenSim/Simulation/TableProcessor.h>
 #include <OpenSim/Simulation/Model/FunctionBasedPath.h>
 
 namespace OpenSim {
@@ -579,151 +579,18 @@ private:
             "fitted path (default: false).");
 
     void constructProperties();
+    void validateProperties();
 
-    // HELPER FUNCTIONS
-    /**
-     * Generate the number of possible combinations of `k` elements from a set
-     * of `n` total elements.
-     */
-     static int choose(int n, int k) {
-        if (k == 0) { return 1; }
-        return (n * choose(n - 1, k - 1)) / k;
-    }
-
-    /**
-     * Get the (canonicalized) absolute directory containing the file from
-     * which this tool was loaded. If the `FunctionBasedPathFitter` was not
-     * loaded from a file, this returns an empty string.
-     */
+    // Get the (canonicalized) absolute directory containing the file from
+    // which this tool was loaded. If the `FunctionBasedPathFitter` was not
+    // loaded from a file, this returns an empty string.
     std::string getDocumentDirectory() const;
 
-    // PATH FITTING PIPELINE
-    /**
-     * Type alias for the moment arm map. The keys are the paths in the model
-     * and the values are vectors containing the names of coordinates on which
-     * the paths depend.
-     */
-    typedef std::unordered_map<std::string, std::vector<std::string>>
-            MomentArmMap;
-
-    /**
-     * Helper function to load the reference coordinate values trajectory and
-     * validate the model. The coordinate values table is modified to update the
-     * column labels based on the model coordinate paths, to update any
-     * coordinates dependent on `CoordinateCouplerConstraint`s, and to convert
-     * the coordinate values to radians if the "inDegrees" metadata flag is set
-     * to "yes".
-     */
-    static TimeSeriesTable loadCoordinateValuesAndValidateModel(
-            const std::string& documentDir,
-            TableProcessor tableProcessor,
-            Model& model);
-
-    /**
-     * Helper function to sample coordinate values around the user-provided
-     * coordinate trajectory contained in the `values` input table. The
-     * sampling is defined based on the coordinate bounds and range maps,
-     * the number of samples per frame, and the Latin hypercube sampling
-     * algorithm.
-     */
-    TimeSeriesTable sampleCoordinateValues(const TimeSeriesTable& values);
-
-    /**
-     * Helper function to compute path lengths and moment arms for the
-     * geometry-based paths in the model. The path lengths and moment arms
-     * are computed using the coordinate values in the `coordinateValues`
-     * table. The `numThreads` argument specifies the number of threads used
-     * to parallelize the computations.
-     */
-    static void computePathLengthsAndMomentArms(const Model& model,
-            const TimeSeriesTable& coordinateValues,
-            const std::vector<std::string>& pathBasedForcePaths, int numThreads,
-            TimeSeriesTable& pathLengths, TimeSeriesTable& momentArms);
-
-    /**
-     * Helper function to filter out bad coordinate value samples and determine
-     * which coordinates each path is dependent on. Bad samples are defined as
-     * coordinate values that produce path length and/or moment are values that
-     * deviate by a set number of standard deviations away from the nominal
-     * trajectories. The `momentArmMap` argument is a map containing the
-     * coordinates each path is dependent on. Columns in the `momentArms` table
-     * are removed if they do not correspond to entries in the `momentArmMap`.
-     */
-    void filterSampledData(const Model& model,
-            TimeSeriesTable& coordinateValues, TimeSeriesTable& pathLengths,
-            TimeSeriesTable& momentArms, MomentArmMap& momentArmMap);
-
-    /**
-     * Helper function to fit polynomial coefficients to the path lengths and
-     * moment arms computed from the geometry-based paths in the model. The
-     * `coordinateValues`, `pathLengths`, and `momentArms` table arguments are
-     * the result of previous model sampling and data filtering steps. The
-     * `momentArmMap` argument is a map containing the coordinates each path is
-     * dependent on, which determines the number of independent coordinates
-     * that each `MultivariatePolynomialFunction` contains to approximate the
-     * original path.
-     */
-    Set<FunctionBasedPath> fitPolynomialCoefficients(const Model& model,
-            const TimeSeriesTable& coordinateValues,
-            const std::vector<std::string>& forcePaths,
-            const TimeSeriesTable& pathLengths,
-            const TimeSeriesTable& momentArms,
-            const MomentArmMap& momentArmMap);
-
-    /**
-     * Remove columns from the `momentArms` table that do not correspond to
-     * entries in the `momentArmMap`.
-     */
-    static void removeMomentArmColumns(TimeSeriesTable& momentArms,
-            const MomentArmMap& momentArmMap);
-
-    /**
-     * Fit to the path length and moment arm samples using all possible
-     * polynomial coefficients. `coordinates` is the matrix of coordinate values
-     * for coordinates that the current path depends on. The vector `b` contains
-     * the path length and moment arm values for the current path.
-     *
-     * We solve for the coefficients of the polynomial using a least squares of
-     * fit, `Ax = b`. Each row of `A` contains polynomial terms evaluated using
-     * the coordinate values from a particular point in time. `x` is the vector
-     * polynomial coefficients. The first N elements of `b` contain the path
-     * length values, where N is the number of time points. The remaining N*Nc
-     * rows of `b` contain the moment arm values, where Nc is the number of
-     * coordinates the path depends on.
-     */
-    int fitAllCoefficients(const SimTK::Matrix& coordinates,
-            const SimTK::Vector& b, int minOrder, int maxOrder,
-            SimTK::Vector& coefficients) const;
-
-    /**
-     * Fit to the path length and moment arm samples using stepwise regression
-     * to find a minimal set of polynomial coefficients. `coordinates` is the
-     * matrix of coordinate values for coordinates that the current path depends
-     * on. The vector `b` contains the path length and moment arm values for the
-     * current path.
-     */
-    void fitCoefficientsStepwiseRegression(
-            const SimTK::Matrix& coordinates, const SimTK::Vector& b, int order,
-            SimTK::Vector& coefficients) const;
-
-    /**
-     * Get the RMS errors between two sets of path lengths and moment arms
-     * computed from a model with FunctionBasedPaths and the original model. The
-     * `modelFitted` argument must be the model with the FunctionBasedPaths.
-     */
-    static void computeFittingErrors(const Model& modelFitted,
-            const TimeSeriesTable& pathLengths,
-            const TimeSeriesTable& momentArms,
-            const TimeSeriesTable& pathLengthsFitted,
-            const TimeSeriesTable& momentArmsFitted,
-            double pathLengthTolerance, double momentArmTolerance);
-
     // MEMBER VARIABLES
-    std::unordered_map<std::string, SimTK::Vec2> m_coordinateBoundsMap;
-    std::unordered_map<std::string, SimTK::Vec2> m_coordinateRangeMap;
-    bool m_useStochasticEvolutionaryLHS = false;
+    Model m_model;
+    TimeSeriesTable m_values;
 };
 
 } // namespace OpenSim
 
-#endif // OPENSIM_POLYNOMIALPATHFITTER_H
+#endif // OPENSIM_POLYNOMIAL_PATH_FITTER_H

--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -27,8 +27,10 @@
 #include "STOFileAdapter.h"
 #include "TimeSeriesTable.h"
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <unordered_map>
@@ -252,8 +254,8 @@ SimTK::Matrix OpenSim::computeKNearestNeighbors(const SimTK::Matrix& x,
     return distances;
 }
 
-double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A, 
-        int numFactors, int maxIterations, double tolerance, 
+double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A,
+        int numFactors, int maxIterations, double tolerance,
         SimTK::Matrix& W, SimTK::Matrix& H) {
 
     // Initialize W and H.
@@ -287,7 +289,7 @@ double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A,
     SimTK::Matrix error(A.nrow(), A.ncol());
     double normError0 = SimTK::Infinity;
     double normError = SimTK::Infinity;
-    double deltaError = SimTK::Infinity;    
+    double deltaError = SimTK::Infinity;
     for (int j = 0; j < maxIterations; ++j) {
 
         // Alternating least squares.
@@ -300,7 +302,7 @@ double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A,
                 H(i, k) = std::max(0.0, H(i, k));
             }
         }
-        // ~H * ~W = ~A --> ~W = ~H^(-1) * ~A  
+        // ~H * ~W = ~A --> ~W = ~H^(-1) * ~A
         SimTK::FactorSVD svd_H(H.transpose().getAsMatrix());
         svd_H.solve(A.transpose().getAsMatrix(), W.transpose().updAsMatrix());
         for (int i = 0; i < W.nrow(); ++i) {
@@ -320,10 +322,10 @@ double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A,
 
         // Compute error using the Frobenius norm.
         error = A - W * H;
-        normError = std::sqrt(error.scalarNormSqr()) / 
+        normError = std::sqrt(error.scalarNormSqr()) /
                            std::sqrt(A.nelt());
         deltaError = normError0 - normError;
-        log_info("Iteration {} | norm(error) = {} | change in norm(error) = {}", 
+        log_info("Iteration {} | norm(error) = {} | change in norm(error) = {}",
                 j, normError, deltaError);
 
         // Check for convergence.
@@ -336,11 +338,32 @@ double OpenSim::factorizeMatrixNonNegative(const SimTK::Matrix& A,
             log_info("");
             break;
         }
-    
+
         // Update variables.
         normError0 = normError;
         W0 = W;
     }
 
     return normError;
+}
+
+int OpenSim::choose(int n, int k) {
+    OPENSIM_THROW_IF(n < 0, Exception, "n must be non-negative.");
+    OPENSIM_THROW_IF(k < 0 || k > n, Exception, "k must be between 0 and n.");
+
+    // Use symmetry C(n,k) == C(n,n-k) to minimize loop iterations.
+    if (k > n - k) { k = n - k; }
+
+    int64_t result = 1;
+    for (int i = 0; i < k; ++i) {
+        // Check for overflow before multiplying.
+        OPENSIM_THROW_IF(result > std::numeric_limits<int64_t>::max() / (n - i),
+                Exception, "Intermediate overflow in binomial coefficient.");
+        result *= (n - i);
+        result /= (i + 1); // exact: result holds C(n,i), so product is divisible
+    }
+
+    OPENSIM_THROW_IF(result > std::numeric_limits<int>::max(), Exception,
+            "Binomial coefficient exceeds int range.");
+    return static_cast<int>(result);
 }

--- a/OpenSim/Common/CommonUtilities.h
+++ b/OpenSim/Common/CommonUtilities.h
@@ -84,9 +84,9 @@ SimTK::Vector createVectorLinspace(int length, double start, double end);
  * This function generates a vector of length `length`, where each element
  * is calculated based on the starting value and the specified step size.
  * The elements are computed as:
- * 
+ *
  * output[i] = start + i * step_size
- * 
+ *
  * for i = 0, 1, 2, ..., length-1.
  *
  * @tparam T The type of the elements in the output vector. This can be any
@@ -176,7 +176,7 @@ std::string detectDelimiter(
  *       See https://mathworks.com/help/matlab/ref/isuniform.html for more details.
  */
 /// @ingroup commonutil
-template <typename T> 
+template <typename T>
 std::pair<bool, T> isUniform(const std::vector<T>& x) {
 
     // Initialize step as NaN
@@ -217,7 +217,7 @@ std::pair<bool, T> isUniform(const std::vector<T>& x) {
         // Now find the minimum element among the positive numbers
         if (end != results.begin()) { // Check if there are any positive numbers
             step = *std::min_element(results.begin(), end);
-        } 
+        }
     }
 
     return {tf, step};
@@ -317,26 +317,32 @@ private:
 OSIMCOMMON_API SimTK::Matrix computeKNearestNeighbors(const SimTK::Matrix& x,
         const SimTK::Matrix& y, int k = 1);
 
-/// Use non-negative matrix factorization to decompose an matrix A (NxM) for a 
-/// selected number of factors 'K' into two matrices W (NxK) and H (KxM) such 
-/// that A = W * H. The alternating least squares (ALS) algorithm is used to 
-/// solve for W and H by minimizing the Frobenius norm of the error between A 
+/// Use non-negative matrix factorization to decompose an matrix A (NxM) for a
+/// selected number of factors 'K' into two matrices W (NxK) and H (KxM) such
+/// that A = W * H. The alternating least squares (ALS) algorithm is used to
+/// solve for W and H by minimizing the Frobenius norm of the error between A
 /// and W * H. The matrices W and H are scaled assuming that the rows of H
 /// have magnitudes as if all elements in H were equal to 0.5, which prevents
-/// individual factors from being very large or very small. The algorithm 
-/// terminates when the change in the error norm is less than the specified 
+/// individual factors from being very large or very small. The algorithm
+/// terminates when the change in the error norm is less than the specified
 /// tolerance or the maximum number of iterations is reached.
 ///
 /// @returns The final Frobenius norm of the error between A and W * H.
 ///
 /// Reference
 /// ---------
-/// Berry, M. W., et al. (2007). Algorithms and Applications for Approximate 
-/// Nonnegative Matrix Factorization. Computational Statistics & Data Analysis, 
+/// Berry, M. W., et al. (2007). Algorithms and Applications for Approximate
+/// Nonnegative Matrix Factorization. Computational Statistics & Data Analysis,
 /// 52(1), 155-173. doi:10.1016/j.csda.2006.11.006.
-OSIMCOMMON_API double factorizeMatrixNonNegative(const SimTK::Matrix& A, 
-        int numFactors, int maxIterations, double tolerance, 
+OSIMCOMMON_API double factorizeMatrixNonNegative(const SimTK::Matrix& A,
+        int numFactors, int maxIterations, double tolerance,
         SimTK::Matrix& W, SimTK::Matrix& H);
+
+/**
+ * Generate the number of possible combinations of `k` elements from a set
+ * of `n` total elements.
+ */
+OSIMCOMMON_API int choose(int n, int k);
 
 } // namespace OpenSim
 

--- a/OpenSim/Common/Test/testCommonUtilities.cpp
+++ b/OpenSim/Common/Test/testCommonUtilities.cpp
@@ -22,6 +22,7 @@
  * -------------------------------------------------------------------------- */
 
 #include <OpenSim/Common/CommonUtilities.h>
+#include <OpenSim/Common/Exception.h>
 
 #include <algorithm> // std::transform
 #include <limits> // std::numeric_limits
@@ -306,4 +307,46 @@ TEST_CASE("detectDelimiter") {
         auto delim = detectDelimiter(input, small_delimiters);
         REQUIRE(delim == "");
     }    
+}
+
+TEST_CASE("choose") {
+
+    using Catch::Matchers::ContainsSubstring;
+
+    SECTION("Invalid inputs") {
+        CHECK_THROWS_WITH(choose(-1, 0),
+                ContainsSubstring("n must be non-negative"));
+        CHECK_THROWS_WITH(choose(5, -1),
+                ContainsSubstring("k must be between 0 and n"));
+        CHECK_THROWS_WITH(choose(5, 6),
+                ContainsSubstring("k must be between 0 and n"));
+    }
+
+    SECTION("Valid inputs") {
+        CHECK(choose(5, 0) == 1);
+        CHECK(choose(5, 1) == 5);
+        CHECK(choose(5, 2) == 10);
+        CHECK(choose(5, 3) == 10);
+        CHECK(choose(5, 4) == 5);
+        CHECK(choose(5, 5) == 1);
+
+        CHECK(choose(10, 0) == 1);
+        CHECK(choose(10, 1) == 10);
+        CHECK(choose(10, 2) == 45);
+        CHECK(choose(10, 3) == 120);
+        CHECK(choose(10, 4) == 210);
+        CHECK(choose(10, 5) == 252);
+
+        CHECK(choose(25, 0) == 1);
+        CHECK(choose(25, 1) == 25);
+        CHECK(choose(25, 2) == 300);
+        CHECK(choose(25, 3) == 2300);
+        CHECK(choose(25, 4) == 12650);
+        CHECK(choose(25, 5) == 53130);
+    }
+
+    SECTION("Overflow checking") {
+        CHECK_THROWS_WITH(choose(150, 100), ContainsSubstring("overflow"));
+        CHECK_THROWS_WITH(choose(1000, 500), ContainsSubstring("overflow"));
+    }
 }


### PR DESCRIPTION
Partially addresses issue #4291

### Brief summary of changes

This change refactors `PolynomialPathFitter` to support future improvements as described in issue #4291.
- Moved the private helper function `choose()` to `CommonUtilities`.
- Remove all remaining private helper functions to an anonymous namespace in `PolynomialPathFitter.cpp`.
- Added the helper types `CoordinateMap` and `Settings` for passing configuration information to various parts of the path fitting pipeline.

Other minor changes include:
- Removed various instances of trailing whitespace in `CommonUtilities`. 

### Testing I've completed

Ran `testPolynomialPathFitter.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4302)
<!-- Reviewable:end -->
