### PR TITLE
Have doxygen ignore some headers that cause parsing errors downstream

### DIFF
--- a/OpenSim/Actuators/ModelOperators.h
+++ b/OpenSim/Actuators/ModelOperators.h
@@ -18,12 +18,13 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+/** \cond DO_NOT_DOCUMENT */
 #include "ModelProcessor.h"
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Common/GCVSplineSet.h>
 #include <OpenSim/Simulation/Model/ExternalLoads.h>
 #include "OpenSim/Simulation/TableProcessor.h"
-
+/** \endcond */
 namespace OpenSim {
 
 /// Turn off activation dynamics for all muscles in the model.
@@ -53,7 +54,7 @@ public:
     }
 };
 
-/** Scale the max isometric force for all muscles in the model. */
+/// Scale the max isometric force for all muscles in the model.
 class OSIMACTUATORS_API ModOpScaleMaxIsometricForce : public ModelOperator {
     OpenSim_DECLARE_CONCRETE_OBJECT(ModOpScaleMaxIsometricForce, ModelOperator);
     OpenSim_DECLARE_PROPERTY(scale_factor, double,
@@ -76,7 +77,7 @@ public:
     }
 };
 
-/** Remove all muscles contained in the model's ForceSet. */
+/// Remove all muscles contained in the model's ForceSet.
 class OSIMACTUATORS_API ModOpRemoveMuscles : public ModelOperator {
     OpenSim_DECLARE_CONCRETE_OBJECT(ModOpRemoveMuscles, ModelOperator);
 


### PR DESCRIPTION
Fixes issue #4167

### Brief summary of changes
Forced doxygen to ignore some includes that are irrelevant for doxygen generation

### Testing I've completed
generated Doxygen that has all classes

### Looking for feedback on...
I tried to dig deeper into which header file was culprit but they all seemed to contribute somehow. 

### CHANGELOG.md (choose one)

- no need to update because internal?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4304)
<!-- Reviewable:end -->
