### PR TITLE
Add `ExponentialContactForce` examples

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -618,7 +618,7 @@ jobs:
         make --jobs 4 install
         cd $GITHUB_WORKSPACE
         mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ubuntu22.zip opensim-core-${{ steps.configure.outputs.version }}
+        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ubuntu24.zip opensim-core-${{ steps.configure.outputs.version }}
         mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
 
     - name: Build wheel

--- a/Bindings/Java/Matlab/examples/ExponentialContactForce/exampleExponentialContactForce.m
+++ b/Bindings/Java/Matlab/examples/ExponentialContactForce/exampleExponentialContactForce.m
@@ -1,0 +1,101 @@
+% -------------------------------------------------------------------------- %
+%                 OpenSim:  exampleExponentialContactForce.m                 %
+% -------------------------------------------------------------------------- %
+% The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  %
+% See http://opensim.stanford.edu and the NOTICE file for more information.  %
+% OpenSim is developed at Stanford University and supported by the US        %
+% National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    %
+% through the Warrior Web program.                                           %
+%                                                                            %
+% Copyright (c) 2026 Stanford University and the Authors                     %
+% Author(s): Nicholas Bianco, F. C. Anderson                                 %
+%                                                                            %
+% Licensed under the Apache License, Version 2.0 (the "License"); you may    %
+% not use this file except in compliance with the License. You may obtain a  %
+% copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         %
+%                                                                            %
+% Unless required by applicable law or agreed to in writing, software        %
+% distributed under the License is distributed on an "AS IS" BASIS,          %
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   %
+% See the License for the specific language governing permissions and        %
+% limitations under the License.                                             %
+% -------------------------------------------------------------------------- %
+
+% This example demonstrates how to simulate a bouncing block using the
+% ExponentialContactForce class.
+%
+% ExponentialContactForce uses a normal force model based on exponential
+% spring functions. The exponential springs avoid expensive contact
+% detection algorithms by always applying a normal force to the body,
+% becoming negligibly small as soon as the body is more than a few
+% centimeters above the contact plane. Additional speed up is achieved
+% through a spring-based frictional model that includes a
+% velocity-dependent damping term and a position-dependent elastic term,
+% the latter eliminating drift entirely to maintain large integration step
+% sizes.
+
+import org.opensim.modeling.*
+
+% Create a model with a single body representing a block that can move
+% relative to the ground via a free joint.
+model = Model();
+model.setName('bouncing_block');
+
+% Block body.
+block = Body();
+block.setName('block');
+block.set_mass(10.0);
+block.set_mass_center(Vec3(0));
+block.setInertia(Inertia(1));
+% Block geometry.
+block.attachGeometry(Brick(Vec3(0.1)));
+
+% Ground-to-block free joint.
+freeJoint = FreeJoint('free_joint', ...
+    model.getGround(), Vec3(0), Vec3(0), ...
+    block, Vec3(0), Vec3(0));
+model.addBody(block);
+model.addJoint(freeJoint);
+
+% Create the transform that defines the ground plane for the contact
+% force. The transform rotates about the x-axis by -90 degrees so that
+% the positive z-axis of the contact plane (i.e., the normal direction)
+% aligns with the positive y-axis of the ground frame, which is the
+% upward direction in OpenSim.
+floorRotation = Rotation(-pi/2, Vec3(1, 0, 0));
+floorTransform = Transform(floorRotation, Vec3(0, 0, 0));
+
+% Add an ExponentialContactForce at each corner of the block.
+hs = 0.1; % half the side length of the block
+corners = { ...
+    Vec3( hs, -hs,  hs), Vec3( hs, -hs, -hs), ...
+    Vec3(-hs, -hs, -hs), Vec3(-hs, -hs,  hs), ...
+    Vec3( hs,  hs,  hs), Vec3( hs,  hs, -hs), ...
+    Vec3(-hs,  hs, -hs), Vec3(-hs,  hs,  hs)};
+for i = 1:8
+    esf = ExponentialContactForce(floorTransform, block, corners{i});
+    esf.setName(['ExpSprForce' num2str(i - 1)]);
+    model.addForce(esf);
+end
+
+% Finalize the model and initialize the system.
+model.finalizeConnections();
+state = model.initSystem();
+
+% Set the block initial conditions.
+freeJoint.get_coordinates(3).setValue(state, -1.5);      % tx
+freeJoint.get_coordinates(4).setValue(state, 2.0 * hs);  % ty
+freeJoint.get_coordinates(5).setValue(state,  1.0);      % tz
+freeJoint.get_coordinates(3).setSpeedValue(state, -1.0); % tx speed
+freeJoint.get_coordinates(2).setSpeedValue(state, 2*pi); % rz speed (wz)
+
+% Simulate the model.
+manager = Manager(model);
+manager.setIntegratorAccuracy(1e-4);
+manager.initialize(state);
+manager.setWriteToStorage(true);
+state = manager.integrate(5.0);
+
+% Visualize the results.
+statesTable = manager.getStatesTable();
+VisualizerUtilities.showMotion(model, statesTable);

--- a/Bindings/Python/examples/ExponentialContactForce/exampleExponentialContactForce.py
+++ b/Bindings/Python/examples/ExponentialContactForce/exampleExponentialContactForce.py
@@ -1,0 +1,104 @@
+# -------------------------------------------------------------------------- #
+#               OpenSim:  exampleExponentialContactForce.py                  #
+# -------------------------------------------------------------------------- #
+# The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  #
+# See http://opensim.stanford.edu and the NOTICE file for more information.  #
+# OpenSim is developed at Stanford University and supported by the US        #
+# National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    #
+# through the Warrior Web program.                                           #
+#                                                                            #
+# Copyright (c) 2026 Stanford University and the Authors                     #
+# Author(s): Nicholas Bianco, F. C. Anderson                                 #
+#                                                                            #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may    #
+# not use this file except in compliance with the License. You may obtain a  #
+# copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         #
+#                                                                            #
+# Unless required by applicable law or agreed to in writing, software        #
+# distributed under the License is distributed on an "AS IS" BASIS,          #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   #
+# See the License for the specific language governing permissions and        #
+# limitations under the License.                                             #
+# -------------------------------------------------------------------------- #
+
+# This example demonstrates how to simulate a bouncing block using the
+# ExponentialContactForce class.
+#
+# ExponentialContactForce uses a normal force model based on exponential
+# spring functions. The exponential springs avoid expensive contact
+# detection algorithms by always applying a normal force to the body,
+# becoming negligibly small as soon as the body is more than a few
+# centimeters above the contact plane. Additional speed up is achieved
+# through a spring-based frictional model that includes a
+# velocity-dependent damping term and a position-dependent elastic term,
+# the latter eliminating drift entirely to maintain large integration step
+# sizes.
+
+import math
+import opensim as osim
+
+# Create a model with a single body representing a block that can move
+# relative to the ground via a free joint.
+model = osim.Model()
+model.setName('bouncing_block')
+
+# Block body.
+block = osim.Body()
+block.setName('block')
+block.set_mass(10.0)
+block.set_mass_center(osim.Vec3(0))
+block.setInertia(osim.Inertia(1))
+# Block geometry.
+block.attachGeometry(osim.Brick(osim.Vec3(0.1)))
+
+# Ground-to-block free joint.
+free_joint = osim.FreeJoint('free_joint',
+    model.getGround(), osim.Vec3(0), osim.Vec3(0),
+    block, osim.Vec3(0), osim.Vec3(0))
+model.addBody(block)
+model.addJoint(free_joint)
+
+# Create the transform that defines the ground plane for the contact force.
+# The transform rotates about the x-axis by -90 degrees so that the
+# positive z-axis of the contact plane (i.e., the normal direction)
+# aligns with the positive y-axis of the ground frame, which is the
+# upward direction in OpenSim.
+floor_rotation = osim.Rotation()
+floor_rotation.setRotationFromAngleAboutX(-math.pi / 2.0)
+floor_transform = osim.Transform(floor_rotation, osim.Vec3(0, 0, 0))
+
+# Add an ExponentialContactForce at each corner of the block.
+hs = 0.1  # half the side length of the block
+corners = [
+    osim.Vec3( hs, -hs,  hs), osim.Vec3( hs, -hs, -hs),
+    osim.Vec3(-hs, -hs, -hs), osim.Vec3(-hs, -hs,  hs),
+    osim.Vec3( hs,  hs,  hs), osim.Vec3( hs,  hs, -hs),
+    osim.Vec3(-hs,  hs, -hs), osim.Vec3(-hs,  hs,  hs),
+]
+for i, corner in enumerate(corners):
+    esf = osim.ExponentialContactForce(floor_transform, block, corner)
+    esf.setName(f'ExpSprForce{i}')
+    model.addForce(esf)
+
+# Finalize the model and initialize the system.
+model.finalizeConnections()
+state = model.initSystem()
+
+# Set the block initial conditions.
+# free_joint = osim.FreeJoint.safeDownCast(model.getJointSet().get('free_joint'))
+free_joint.get_coordinates(3).setValue(state, -1.5);           # tx
+free_joint.get_coordinates(4).setValue(state, 2.0 * hs);       # ty
+free_joint.get_coordinates(5).setValue(state,  1.0);           # tz
+free_joint.get_coordinates(3).setSpeedValue(state, -1.0);      # tx speed
+free_joint.get_coordinates(2).setSpeedValue(state, 2*math.pi); # rz speed (wz)
+
+# Simulate the model.
+manager = osim.Manager(model)
+manager.setIntegratorAccuracy(1e-4)
+manager.initialize(state)
+manager.setWriteToStorage(True)
+state = manager.integrate(5.0)
+
+# Visualize the results.
+states_table = manager.getStatesTable()
+osim.VisualizerUtilities.showMotion(model, states_table)

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -126,8 +126,6 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/ElasticFoundationForce.h>
 %include <OpenSim/Simulation/Model/HuntCrossleyForce.h>
 %include <OpenSim/Simulation/Model/SmoothSphereHalfSpaceForce.h>
-%include <OpenSim/Simulation/Model/MeyerFregly2016Force.h>
-%include <OpenSim/Simulation/Model/ExponentialContactForce.h>
 
 %include <OpenSim/Simulation/Model/Actuator.h>
 %template(SetActuators) OpenSim::Set<OpenSim::Actuator, OpenSim::Object>;
@@ -154,6 +152,11 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %template(SetMarkers) OpenSim::Set<OpenSim::Marker, OpenSim::ModelComponent>;
 %template(ModelComponentSetMarkers) OpenSim::ModelComponentSet<OpenSim::Marker>;
 %include <OpenSim/Simulation/Model/MarkerSet.h>
+
+// These contact force elements depend on Station, so we
+// need to include them after Station.
+%include <OpenSim/Simulation/Model/MeyerFregly2016Force.h>
+%include <OpenSim/Simulation/Model/ExponentialContactForce.h>
 
 // WrapObject is included up above.
 %include <OpenSim/Simulation/Wrap/WrapSphere.h>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ performance and stability in wrapping solutions.
 - Fixed an issue in `PolynomialPathFitter` where the process would segfault if too few coordinate samples were used. (#4280)
 - Fixed an issue in `PolynomialPathFitter` where the process assign threads to model forces without a wrapping path. (#4280)
 - `PolynomialPathFitter` now gracefully handles model configurations that lead to invalid path computations due to random sampling. (#4280)
+- Added `exampleExponentialContactForce`, including C++, Matlab, and Python variants. (#4318)
 
 
 v4.5.2

--- a/OpenSim/Examples/CMakeLists.txt
+++ b/OpenSim/Examples/CMakeLists.txt
@@ -27,6 +27,7 @@ if(BUILD_API_EXAMPLES)
     add_subdirectory(Moco)
     add_subdirectory(Wrapping)
     add_subdirectory(PolynomialPathFitter)
+    add_subdirectory(ExponentialContactForce)
 
 else()
 

--- a/OpenSim/Examples/ExponentialContactForce/CMakeLists.txt
+++ b/OpenSim/Examples/ExponentialContactForce/CMakeLists.txt
@@ -1,0 +1,1 @@
+OpenSimAddExampleCXX(NAME exampleExponentialContactForce SUBDIR ExponentialContactForce)

--- a/OpenSim/Examples/ExponentialContactForce/exampleExponentialContactForce.cpp
+++ b/OpenSim/Examples/ExponentialContactForce/exampleExponentialContactForce.cpp
@@ -1,0 +1,112 @@
+/* -------------------------------------------------------------------------- *
+ *                OpenSim:  exampleExponentialContactForce.cpp                *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2026 Stanford University and the Authors                     *
+ * Author(s): Nicholas Bianco, F. C. Anderson                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+// This example demonstrates how to simulate a bouncing block using the
+// ExponentialContactForce class.
+//
+// ExponentialContactForce uses a normal force model based on exponential spring
+// functions. The exponential springs avoid expensive contact detection
+// algorithms by always applying a normal force to the body, becoming
+// negligible small as soon as the body is more than a few centimeters above
+// the contact plane. Addtional speed up is achieved through a spring-based
+// frictional model that includes a velocity-dependent damping term and a
+// position-dependent elastic term, the latter eliminating drift entirely
+// to maintain large integration step sizes.
+
+#include <OpenSim/OpenSim.h>
+
+using namespace OpenSim;
+
+int main() {
+
+    // Create a model with a single body representing a block that can move
+    // relative to the ground via a free joint.
+    Model model;
+    model.setName("bouncing_block");
+
+    // Block body.
+    Body* block = new Body();
+    block->setName("block");
+    block->set_mass(10.0);
+    block->set_mass_center(SimTK::Vec3(0));
+    block->setInertia(SimTK::Inertia(1.0));
+    // Block geometry.
+    Brick* blockGeometry = new Brick(SimTK::Vec3(0.1));
+    block->attachGeometry(blockGeometry);
+
+    // Ground-to-block free joint.
+    FreeJoint* free = new FreeJoint("free_joint",
+        model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
+        *block, SimTK::Vec3(0), SimTK::Vec3(0));
+    model.addBody(block);
+    model.addJoint(free);
+
+    // Create the transform that defines the ground plane for the contact force.
+    // The transform rotates about the x-axis by -90 degrees so that the
+    // positive z-axis of the contact plane (i.e., the normal direction)
+    // aligns with the positive y-axis of the ground frame, which is the upward
+    // direction in OpenSim.
+    const SimTK::Rotation floorRotation(-SimTK::Pi/2.0, SimTK::XAxis);
+    const SimTK::Transform floorTransform(floorRotation, SimTK::Vec3(0.));
+
+    // Add an ExponentialContactForce at each corner of the block.
+    const double hs = 0.1; // half the side length of the block
+    SimTK::Vector_<SimTK::Vec3> corners(8, SimTK::Vec3(0));
+    corners[0] = SimTK::Vec3( hs, -hs,  hs);
+    corners[1] = SimTK::Vec3( hs, -hs, -hs);
+    corners[2] = SimTK::Vec3(-hs, -hs, -hs);
+    corners[3] = SimTK::Vec3(-hs, -hs,  hs);
+    corners[4] = SimTK::Vec3( hs,  hs,  hs);
+    corners[5] = SimTK::Vec3( hs,  hs, -hs);
+    corners[6] = SimTK::Vec3(-hs,  hs, -hs);
+    corners[7] = SimTK::Vec3(-hs,  hs,  hs);
+    for (int i = 0; i < 8; ++i) {
+        auto* esf = new ExponentialContactForce(floorTransform, *block,
+            corners[i]);
+        esf->setName("ExpSprForce" + std::to_string(i));
+        model.addForce(esf);
+    }
+
+    // Finalize the model and initialize the system.
+    model.finalizeConnections();
+    SimTK::State state = model.initSystem();
+
+    // Set the block initial conditions.
+    SimTK::Vec3 pos(-1.5, 2.0 * hs, 1.0);
+    SimTK::Vec3 vel(-1.0, 0.0, 0.0);
+    SimTK::Vec3 angvel(0.0, 0.0, 2.0 * SimTK::Pi);
+    block->getMobilizedBody().setQToFitTranslation(state, pos);
+    block->getMobilizedBody().setUToFitLinearVelocity(state, vel);
+    block->getMobilizedBody().setUToFitAngularVelocity(state, angvel);
+
+    // Simulate the model.
+    Manager manager(model);
+    manager.setIntegratorAccuracy(1e-4);
+    manager.initialize(state);
+    manager.setWriteToStorage(true);
+    state = manager.integrate(5.0);
+
+    // Visualize the results.
+    TimeSeriesTable statesTable = manager.getStatesTable();
+    VisualizerUtilities::showMotion(model, statesTable);
+}

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -47,6 +47,7 @@
 #include "Model/HuntCrossleyForce.h"
 #include "Model/SmoothSphereHalfSpaceForce.h"
 #include "Model/MeyerFregly2016Force.h"
+#include "Model/ExponentialContactForce.h"
 #include "Model/Ligament.h"
 #include "Model/Blankevoort1991Ligament.h"
 #include "Model/JointSet.h"
@@ -136,6 +137,7 @@
 #include "OpenSense/OpenSenseUtilities.h"
 #include "OpenSense/IMU.h"
 #include "SimulationUtilities.h"
+#include "VisualizerUtilities.h"
 
 #include "RegisterTypes_osimSimulation.h"   // to expose RegisterTypes_osimSimulation
 

--- a/doc/doxyfile_shared.in
+++ b/doc/doxyfile_shared.in
@@ -967,11 +967,15 @@ EXAMPLE_PATH           = "@PROJECT_SOURCE_DIR@/OpenSim/Examples/ExampleSimpleElb
                          "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/Moco" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/PolynomialPathFitter" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/Wrapping" \
+                         "@PROJECT_SOURCE_DIR@/Bindings/Java/Matlab/examples/ExponentialContactForce" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/Moco" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/PolynomialPathFitter" \
                          "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/Wrapping" \
+                         "@PROJECT_SOURCE_DIR@/Bindings/Python/examples/ExponentialContactForce" \
                          "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Moco" \
-                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Wrapping"
+                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/PolynomialPathFitter" \
+                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/Wrapping" \
+                         "@PROJECT_SOURCE_DIR@/OpenSim/Examples/ExponentialContactForce"
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and


### PR DESCRIPTION
Fixes issue #4314 

### Brief summary of changes

- Added `exampleExponentialContactForce.cpp` and equivalent Matlab and Python examples.
- Moved the inclusion of `ExponentialContactForce` after `Station` in the bindings, so that `Station` is properly wrapped when calling `ExponentialContactForce::getStation()`.
- Added `ExponentialContactForce.h` and `VisualizerUtilities.h` to `osimSimulation.h`, so that they are available via the `OpenSim.h` header.
- Drive-by: fixed an inconsistency in the Ubuntu 24 CI job.

### Testing I've completed
- Tested all examples locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4318)
<!-- Reviewable:end -->
