### PR TITLE
Implement `extendPreScale` and `extendPostScale` for `Scholz2015GoemetryPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ performance and stability in wrapping solutions.
 - `PolynomialPathFitter` now gracefully handles model configurations that lead to invalid path computations due to random sampling. (#4280)
 - Added `CantileverFreeBeamJoint`, a joint type providing a lightweight way for modeling flexible structures (e.g., the bending of the spinal column in a human or animal skeleton). (#4227)
 - Added `ExponentialCoordinateLimitForce`, a force element for enforcing coordinate limits using exponential spring functions. (#4231)
-
+- Implemented `extendPreScale` and `extendPostScale` for `Scholz2015GeometryPath`. Now, scaling a model using `Scholz2015GeometryPath` paths will update `Muscle` tendon slack lengths and optimal fiber lengths. (#4325)
 
 v4.5.2
 ======

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -1659,7 +1659,9 @@ bool Model::scale(SimTK::State& s, const ScaleSet& scaleSet,
 
     // Call postScale() on all ModelComponents owned by the model so that
     // components like muscles, ligaments, and path springs can update their
-    // properties based on their new path length.
+    // properties based on their new path length. Realize to velocity so that
+    // path state can be computed.
+    getMultibodySystem().realize(s, SimTK::Stage::Velocity);
     for (ModelComponent& comp : updComponentList<ModelComponent>())
         comp.postScale(s, scaleSet);
 

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -365,6 +365,18 @@ void Scholz2015GeometryPath::generateDecorations(
     });
 }
 
+void Scholz2015GeometryPath::extendPreScale(const SimTK::State& s,
+        const ScaleSet& scaleSet) {
+    Super::extendPreScale(s, scaleSet);
+    setPreScaleLength(s, getLength(s));
+}
+
+void Scholz2015GeometryPath::extendPostScale(const SimTK::State& s,
+        const ScaleSet& scaleSet) {
+    Super::extendPostScale(s, scaleSet);
+    getLength(s);
+}
+
 //=============================================================================
 // CONVENIENCE METHODS
 //=============================================================================

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -453,6 +453,8 @@ private:
     void generateDecorations(bool fixed, const ModelDisplayHints& hints,
             const SimTK::State& s,
             SimTK::Array_<SimTK::DecorativeGeometry>& geoms) const override;
+    void extendPreScale(const SimTK::State&, const ScaleSet&) override;
+    void extendPostScale(const SimTK::State&, const ScaleSet&) override;
 
     // CONVENIENCE METHODS
     void constructProperties();

--- a/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
+++ b/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
@@ -22,6 +22,7 @@
  * -------------------------------------------------------------------------- */
 
 #include <OpenSim/Actuators/ModelFactory.h>
+#include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Simulation/Control/PrescribedController.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
@@ -963,4 +964,53 @@ TEST_CASE("Changing contact geometry properties") {
     // Check that the path lengths are longer than the original lengths.
     CHECK(newLength1 > length1);
     CHECK(newLength2 > length2);
+}
+
+TEST_CASE("Scaling updates muscle properties") {
+
+    // Create a simple model with a slider joint actuated by a muscle.
+    Model model;
+    model.setName("isometric_muscle");
+    auto* body = new Body("body", 0.5, SimTK::Vec3(0), SimTK::Inertia(0));
+    model.addComponent(body);
+
+    auto* joint = new SliderJoint("joint",
+        model.getGround(), SimTK::Vec3(0), SimTK::Vec3(0),
+        *body, SimTK::Vec3(0.2, 0, 0), SimTK::Vec3(0));
+    auto& coord = joint->updCoordinate(SliderJoint::Coord::TranslationX);
+    coord.setName("slider");
+    model.addComponent(joint);
+
+    auto* muscle = new Millard2012EquilibriumMuscle();
+    muscle->setName("muscle");
+    muscle->set_path(Scholz2015GeometryPath());
+    muscle->set_optimal_fiber_length(0.1);
+    muscle->set_tendon_slack_length(0.1);
+    model.addComponent(muscle);
+
+    // Define the muscle path.
+    Scholz2015GeometryPath& path = muscle->updPath<Scholz2015GeometryPath>();
+    path.appendPathPoint(model.getGround(), SimTK::Vec3(0));
+    path.appendPathPoint(*body, SimTK::Vec3(0));
+
+    model.finalizeConnections();
+    SimTK::State state = model.initSystem();
+    model.realizePosition(state);
+
+    // Scale the model along the x-axis.
+    ScaleSet scaleSet;
+    Scale scale;
+    scale.setSegmentName("body");
+    scale.setScaleFactors(SimTK::Vec3(1.23, 1.0, 1.0));
+    scaleSet.cloneAndAppend(scale);
+    scaleSet.get(scaleSet.getSize() - 1).setName("body");
+    model.scale(state, scaleSet, true);
+    model.finalizeConnections();
+    model.initSystem();
+
+    // Check that the muscle's optimal fiber length and tendon slack length were
+    // scaled.
+    const auto& scaledMuscle = model.getComponent<Muscle>("/muscle");
+    CHECK(scaledMuscle.get_optimal_fiber_length() == 0.123);
+    CHECK(scaledMuscle.get_tendon_slack_length() == 0.123);
 }


### PR DESCRIPTION
Fixes issue #4311

### Brief summary of changes

Implements `extendPreScale` and `extendPostScale` for `Scholz2015GeometryPath`. This change required adding a stage realization call in `Model::scale()`, since `Scholz2015GeometryPath::extendPostScale()` requires calling `CableSpan::calcLength()` which in turn requires a valid `SimTK::State` cache.

### Testing I've completed
Added a unit test to `testScholz2015GeometryPath.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4325)
<!-- Reviewable:end -->
