### PR TITLE
Add utility to append two TimeSeriesTable(s) and produce a new one.

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -433,7 +433,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/opensim_dependencies_install
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('dependencies/*') }}
+        key: ${{ runner.os }}-${{ github.job }}-dependencies-${{ hashFiles('dependencies/*') }}
 
     - name: Build dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -635,16 +635,16 @@ class TestTables {
         // Append a row to the table.
         RowVector row = new RowVector(4, 1);
         System.out.println(table);
-        // Append another row to the table.        
+        // Append another row to the table.
         row.set(0, 2); row.set(1, 2); row.set(2, 2); row.set(3, 2);
         table.appendRow(0.2, row);
-        // Make second table
+        // Create a second table.
         TimeSeriesTable table2 = new TimeSeriesTable();
         table2.setColumnLabels(labels);
         RowVector row3 = new RowVector(4, 1);
         row3.set(0, 3); row3.set(1, 3); row3.set(2, 3); row3.set(3, 3);
         table2.appendRow(0.3, row3);
-        // combine
+        // Concatenate the tables.
         TimeSeriesTable combined = TableUtilities.concatenateTable(table, table2);
         System.out.println(combined);
         assert combined.getNumRows()             == 2;

--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -645,7 +645,7 @@ class TestTables {
         row3.set(0, 3); row3.set(1, 3); row3.set(2, 3); row3.set(3, 3);
         table2.appendRow(0.3, row3);
         // Concatenate the tables.
-        TimeSeriesTable combined = TableUtilities.concatenateTable(table, table2);
+        TimeSeriesTable combined = TableUtilities.concatenate(table, table2);
         System.out.println(combined);
         assert combined.getNumRows()             == 2;
         assert combined.getColumnLabels().size() == 4;

--- a/Bindings/Java/tests/TestTables.java
+++ b/Bindings/Java/tests/TestTables.java
@@ -627,6 +627,32 @@ class TestTables {
         System.out.println(tableFlat);
     }
 
+    public static void test_TimeSeriesTableConcatenate() {
+        TimeSeriesTable table = new TimeSeriesTable();
+        StdVectorString labels = new StdVectorString();
+        labels.add("0"); labels.add("1"); labels.add("2"); labels.add("3");
+        table.setColumnLabels(labels);
+        // Append a row to the table.
+        RowVector row = new RowVector(4, 1);
+        System.out.println(table);
+        // Append another row to the table.        
+        row.set(0, 2); row.set(1, 2); row.set(2, 2); row.set(3, 2);
+        table.appendRow(0.2, row);
+        // Make second table
+        TimeSeriesTable table2 = new TimeSeriesTable();
+        table2.setColumnLabels(labels);
+        RowVector row3 = new RowVector(4, 1);
+        row3.set(0, 3); row3.set(1, 3); row3.set(2, 3); row3.set(3, 3);
+        table2.appendRow(0.3, row3);
+        // combine
+        TimeSeriesTable combined = TableUtilities.concatenateTable(table, table2);
+        System.out.println(combined);
+        assert combined.getNumRows()             == 2;
+        assert combined.getColumnLabels().size() == 4;
+        assert combined.getRowAtIndex(0).get(0) == 2;
+        assert combined.getRowAtIndex(1).get(3) == 3;
+    }
+
     public static void test_TimeSeriesTableVec3() {
         TimeSeriesTableVec3 table = new TimeSeriesTableVec3();
         // Set column labels.
@@ -802,6 +828,7 @@ class TestTables {
         test_DataTable();
         test_DataTableVec3();
         test_TimeSeriesTable();
+        test_TimeSeriesTableConcatenate();
         test_TimeSeriesTableVec3();
         test_FlattenWithIK();
         test_vector_rowvector();

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -389,6 +389,9 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
 %shared_ptr(OpenSim::TimeSeriesTableVec3)
 
+%template(concatenateTableVec3) OpenSim::TableUtilities::concatenateTable<SimTK::Vec3>;
+%template(concatenateTable) OpenSim::TableUtilities::concatenateTable<double>;
+
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)
 %shared_ptr(OpenSim::DelimFileAdapter)

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -389,8 +389,10 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 %template(StdVectorEvent) std::vector<OpenSim::Event>;
 %shared_ptr(OpenSim::TimeSeriesTableVec3)
 
-%template(concatenateTableVec3) OpenSim::TableUtilities::concatenateTable<SimTK::Vec3>;
-%template(concatenateTable) OpenSim::TableUtilities::concatenateTable<double>;
+%template(concatenateVec3) OpenSim::TableUtilities::concatenate<SimTK::Vec3>;
+%template(concatenate) OpenSim::TableUtilities::concatenate<double>;
+%template(concatenateRotation) OpenSim::TableUtilities::concatenate<SimTK:::Rotation_<double> >;
+%template(concatenateQuaternion) OpenSim::TableUtilities::concatenate<SimTK::Quaternion_<double> >;
 
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)

--- a/Bindings/common.i
+++ b/Bindings/common.i
@@ -391,8 +391,9 @@ DATATABLE_CLONE(double, SimTK::Rotation_<double>)
 
 %template(concatenateVec3) OpenSim::TableUtilities::concatenate<SimTK::Vec3>;
 %template(concatenate) OpenSim::TableUtilities::concatenate<double>;
-%template(concatenateRotation) OpenSim::TableUtilities::concatenate<SimTK:::Rotation_<double> >;
-%template(concatenateQuaternion) OpenSim::TableUtilities::concatenate<SimTK::Quaternion_<double> >;
+// Current version of SWIG 4.2 fails to digest SimTK::Rotation or SimTK::Rotation_<double>
+//%template(concatenateRotation) OpenSim::TableUtilities::concatenate<SimTK:::Rotation >;
+%template(concatenateQuaternion) OpenSim::TableUtilities::concatenate<SimTK::Quaternion >;
 
 %shared_ptr(OpenSim::DataAdapter)
 %shared_ptr(OpenSim::FileAdapter)

--- a/OpenSim/Common/TableUtilities.h
+++ b/OpenSim/Common/TableUtilities.h
@@ -135,21 +135,18 @@ public:
     static TimeSeriesTable_<SimTK::Vec3> convertRotationsToEulerAngles(
             const TimeSeriesTable_<SimTK::Rotation>& rotTable);
 
-    /// Stitch to TimeSeriesTables and produce a new one
-    /// Useful for stitching results segmented by AddBiomechanics
-    /// Assumes secondTable time is greater than last time of firstTable
-    /// Checks that headers are consistent otherwise throws
+    /// Utility to concatenate two TimeSeriesTables into a new table.
+    /// Requires that both tables contain elements of the same type and
+    /// have the same number of columns with the same labels. The initial
+    /// time point in the second table must be greater than the final
+    /// time in the first table.
     template <typename T>
-    static TimeSeriesTable_<T> concatenateTable(
+    static TimeSeriesTable_<T> concatenate(
         const TimeSeriesTable_<T>& firstTable,
         const TimeSeriesTable_<T>& secondTable) {
-        // Checks to perform
-        // Same type, size, labels
-        // times do not overlap so can be merged
-        // initially we can use appendRow but eventually use in memory Matrices
-        // with resizeKeep so cost is not quadratic in regrowth To stitch tables
-        // into a new one, create a clone before calling this function, then
-        // repeatedly concatenate
+        // Check that both tables have the same number of columns with
+        // equal column labels. Verify that the combined time vectors will
+        // be monotonically increasing.
         const auto& labels = firstTable.getColumnLabels();
         const auto& times = firstTable.getIndependentColumn();
         const auto& data = firstTable.getMatrix();
@@ -173,11 +170,11 @@ public:
         int nCols = firstTable.getNumColumns();
         int nTotalRows = nRows1 + nRows2;
 
-        // 1. merge time vectors
+        // Merge the time vectors.
         std::vector<double> mergedTimes(times);
         mergedTimes.insert(mergedTimes.end(), secondTimes.begin(), secondTimes.end());
 
-        // 2. Merge data
+        // Merge the data.
         SimTK::Matrix_<T> mergedMatrix(nTotalRows, nCols);
         mergedMatrix.updBlock(0, 0, nRows1, nCols) = data;
         mergedMatrix.updBlock(nRows1, 0, nRows2, nCols) = secondData;

--- a/OpenSim/Common/TableUtilities.h
+++ b/OpenSim/Common/TableUtilities.h
@@ -156,14 +156,17 @@ public:
         const auto& secondData = secondTable.getMatrix();
 
         OPENSIM_THROW_IF(labels.size() != secondLabels.size(), Exception,
-                "Cannot concatentate tables of inconsistent column labels..");
+                "Cannot concatentate tables with inconsistent column labels.");
         OPENSIM_THROW_IF(!(labels == secondLabels), Exception,
-                "Cannot concatentate tables of inconsistent column labels..");
+                "Cannot concatentate tables with inconsistent column labels.");
         OPENSIM_THROW_IF(data.ncol() != secondData.ncol(), Exception,
                 "Cannot concatentate tables of inconsistent number of "
                 "columns..");
         OPENSIM_THROW_IF(times[times.size() - 1] > secondTimes[0], Exception,
-                "Cannot concatentate tables of not increasing times..");
+                "Expected the final time point of the second point to be "
+                "greater than the last time point of the first table, "
+                "but concatenating the tables "
+                "led to time vector that is not monotonically increasing.");
 
         int nRows1 = firstTable.getNumRows();
         int nRows2 = secondTable.getNumRows();

--- a/OpenSim/Common/TableUtilities.h
+++ b/OpenSim/Common/TableUtilities.h
@@ -135,6 +135,56 @@ public:
     static TimeSeriesTable_<SimTK::Vec3> convertRotationsToEulerAngles(
             const TimeSeriesTable_<SimTK::Rotation>& rotTable);
 
+    /// Stitch to TimeSeriesTables and produce a new one
+    /// Useful for stitching results segmented by AddBiomechanics
+    /// Assumes secondTable time is greater than last time of firstTable
+    /// Checks that headers are consistent otherwise throws
+    template <typename T>
+    static TimeSeriesTable_<T> concatenateTable(
+        const TimeSeriesTable_<T>& firstTable,
+        const TimeSeriesTable_<T>& secondTable) {
+        // Checks to perform
+        // Same type, size, labels
+        // times do not overlap so can be merged
+        // initially we can use appendRow but eventually use in memory Matrices
+        // with resizeKeep so cost is not quadratic in regrowth To stitch tables
+        // into a new one, create a clone before calling this function, then
+        // repeatedly concatenate
+        const auto& labels = firstTable.getColumnLabels();
+        const auto& times = firstTable.getIndependentColumn();
+        const auto& data = firstTable.getMatrix();
+
+        const auto& secondLabels = secondTable.getColumnLabels();
+        const auto& secondTimes = secondTable.getIndependentColumn();
+        const auto& secondData = secondTable.getMatrix();
+
+        OPENSIM_THROW_IF(labels.size() != secondLabels.size(), Exception,
+                "Cannot concatentate tables of inconsistent column labels..");
+        OPENSIM_THROW_IF(!(labels == secondLabels), Exception,
+                "Cannot concatentate tables of inconsistent column labels..");
+        OPENSIM_THROW_IF(data.ncol() != secondData.ncol(), Exception,
+                "Cannot concatentate tables of inconsistent number of "
+                "columns..");
+        OPENSIM_THROW_IF(times[times.size() - 1] > secondTimes[0], Exception,
+                "Cannot concatentate tables of not increasing times..");
+
+        int nRows1 = firstTable.getNumRows();
+        int nRows2 = secondTable.getNumRows();
+        int nCols = firstTable.getNumColumns();
+        int nTotalRows = nRows1 + nRows2;
+
+        // 1. merge time vectors
+        std::vector<double> mergedTimes(times);
+        mergedTimes.insert(mergedTimes.end(), secondTimes.begin(), secondTimes.end());
+
+        // 2. Merge data
+        SimTK::Matrix_<T> mergedMatrix(nTotalRows, nCols);
+        mergedMatrix.updBlock(0, 0, nRows1, nCols) = data;
+        mergedMatrix.updBlock(nRows1, 0, nRows2, nCols) = secondData;
+
+        return TimeSeriesTable_<T>(mergedTimes, mergedMatrix, labels);
+    }
+
 private:
     static int findStateLabelIndexInternal(const std::string* begin,
             const std::string* end, const std::string& desired);

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -1132,7 +1132,7 @@ TEST_CASE("TableUtilities::concatenate") {
     CHECK_THROWS_WITH(
         TableUtilities::concatenate<Vec3>(tableVec3Append, tableVec3),
             Catch::Matchers::ContainsSubstring(
-                    "Cannot concatentate tables of not increasing times"));
+                    "led to time vector that is not monotonically increasing."));
 
     tableVec3Append.setColumnLabels({"col0", "col1", "col3"});
     // Check that concatenating tables with inconsistent columns throws an
@@ -1140,6 +1140,6 @@ TEST_CASE("TableUtilities::concatenate") {
     CHECK_THROWS_WITH(
             TableUtilities::concatenate<Vec3>(tableVec3, tableVec3Append),
             Catch::Matchers::ContainsSubstring(
-                "Cannot concatentate tables of inconsistent column labels"));
+                "Cannot concatentate tables with inconsistent column labels."));
 
 }

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -1115,7 +1115,7 @@ TEST_CASE("TableUtilities::concatenate") {
     tableVec3Append.appendRow(0.5, {{5, 5, 5}, {1, 1, 1}, {2, 2, 2}});
     tableVec3Append.appendRow(0.6, {{6, 6, 6}, {3, 3, 3}, {7, 8, 9}});
 
-    auto combined = TableUtilities::concatenateTable<Vec3>(tableVec3, tableVec3Append);
+    auto combined = TableUtilities::concatenate<Vec3>(tableVec3, tableVec3Append);
     CHECK(combined.getNumRows() == 6);
     CHECK(combined.getNumColumns() == 3);
     auto& times = combined.getIndependentColumn();
@@ -1127,13 +1127,19 @@ TEST_CASE("TableUtilities::concatenate") {
     CHECK(lastElement[1] == 8);
     CHECK(lastElement[2] == 9);
 
-    // Check can't concatenate tableVec3 with itself since time will not be increasing
-    SimTK_TEST_MUST_THROW(TableUtilities::concatenateTable<Vec3>(
-            tableVec3Append, tableVec3););
+    // Check that concatenating tableVec3 with itself throws since the time
+    // vector will not be monotonically increasing
+    CHECK_THROWS_WITH(
+        TableUtilities::concatenate<Vec3>(tableVec3Append, tableVec3),
+            Catch::Matchers::ContainsSubstring(
+                    "Cannot concatentate tables of not increasing times"));
 
     tableVec3Append.setColumnLabels({"col0", "col1", "col3"});
-    // check throw if column labels mismatch
-    SimTK_TEST_MUST_THROW(TableUtilities::concatenateTable<Vec3>(
-            tableVec3, tableVec3Append););
+    // Check that concatenating tables with inconsistent columns throws an
+    // exception.
+    CHECK_THROWS_WITH(
+            TableUtilities::concatenate<Vec3>(tableVec3, tableVec3Append),
+            Catch::Matchers::ContainsSubstring(
+                "Cannot concatentate tables of inconsistent column labels"));
 
 }

--- a/OpenSim/Common/Test/testDataTable.cpp
+++ b/OpenSim/Common/Test/testDataTable.cpp
@@ -1100,3 +1100,40 @@ TEST_CASE("TimeSeriesTable trim methods") {
         CHECK(table.getNumRows() == 1);
     }
 }
+
+
+TEST_CASE("TableUtilities::concatenate") {
+    TimeSeriesTable_<Vec3> tableVec3{};
+    tableVec3.setColumnLabels({"col0", "col1", "col2"});
+    tableVec3.appendRow(0.1, {{1, 1, 1}, {2, 2, 2}, {3, 3, 3}});
+    tableVec3.appendRow(0.2, {{2, 2, 2}, {1, 1, 1}, {2, 2, 2}});
+    tableVec3.appendRow(0.3, {{3, 3, 3}, {3, 3, 3}, {1, 1, 1}});
+
+    TimeSeriesTable_<Vec3> tableVec3Append{};
+    tableVec3Append.setColumnLabels({"col0", "col1", "col2"});
+    tableVec3Append.appendRow(0.4, {{4, 4 ,4}, {2, 2, 2}, {3, 3, 3}});
+    tableVec3Append.appendRow(0.5, {{5, 5, 5}, {1, 1, 1}, {2, 2, 2}});
+    tableVec3Append.appendRow(0.6, {{6, 6, 6}, {3, 3, 3}, {7, 8, 9}});
+
+    auto combined = TableUtilities::concatenateTable<Vec3>(tableVec3, tableVec3Append);
+    CHECK(combined.getNumRows() == 6);
+    CHECK(combined.getNumColumns() == 3);
+    auto& times = combined.getIndependentColumn();
+    for (int iRow = 0; iRow < 6; ++iRow) { 
+        CHECK(times[iRow] == Approx(0.1 * (iRow+1))); 
+    }
+    auto lastElement = combined.getMatrix().getElt(5, 2);
+    CHECK(lastElement[0] == 7);
+    CHECK(lastElement[1] == 8);
+    CHECK(lastElement[2] == 9);
+
+    // Check can't concatenate tableVec3 with itself since time will not be increasing
+    SimTK_TEST_MUST_THROW(TableUtilities::concatenateTable<Vec3>(
+            tableVec3Append, tableVec3););
+
+    tableVec3Append.setColumnLabels({"col0", "col1", "col3"});
+    // check throw if column labels mismatch
+    SimTK_TEST_MUST_THROW(TableUtilities::concatenateTable<Vec3>(
+            tableVec3, tableVec3Append););
+
+}


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Added utility to concatenate two tables and create a new one, useful for stitching segments

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4328)
<!-- Reviewable:end -->
