### PR TITLE
Add `CoordinateLinearStopForce`

### DIFF
--- a/Bindings/OpenSimHeaders_simulation.h
+++ b/Bindings/OpenSimHeaders_simulation.h
@@ -24,6 +24,7 @@
 #include <OpenSim/Simulation/Model/PrescribedForce.h>
 #include <OpenSim/Simulation/Model/CoordinateLimitForce.h>
 #include <OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.h>
+#include <OpenSim/Simulation/Model/CoordinateLinearStopForce.h>
 #include <OpenSim/Simulation/Model/ExternalForce.h>
 #include <OpenSim/Simulation/Model/ContactGeometry.h>
 #include <OpenSim/Simulation/Model/ContactHalfSpace.h>

--- a/Bindings/simulation.i
+++ b/Bindings/simulation.i
@@ -118,6 +118,7 @@ OpenSim::ModelComponentSet<OpenSim::Controller>;
 %include <OpenSim/Simulation/Model/PrescribedForce.h>
 %include <OpenSim/Simulation/Model/CoordinateLimitForce.h>
 %include <OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.h>
+%include <OpenSim/Simulation/Model/CoordinateLinearStopForce.h>
 
 %include <OpenSim/Simulation/Model/ContactGeometry.h>
 %template(SetContactGeometry) OpenSim::Set<OpenSim::ContactGeometry, OpenSim::ModelComponent>;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ performance and stability in wrapping solutions.
 - Added `CantileverFreeBeamJoint`, a joint type providing a lightweight way for modeling flexible structures (e.g., the bending of the spinal column in a human or animal skeleton). (#4227)
 - Added `ExponentialCoordinateLimitForce`, a force element for enforcing coordinate limits using exponential spring functions. (#4231)
 - Implemented `extendPreScale` and `extendPostScale` for `Scholz2015GeometryPath`. Now, scaling a model using `Scholz2015GeometryPath` paths will update `Muscle` tendon slack lengths and optimal fiber lengths. (#4325)
+- Added `CoordinateLinearStopForce`, a force element for enforcing coordinate limits using a
+linear spring force and Hunt and Crossley-like damping. (#4329)
+- Updated `ExponentialCoordinateLimitForce` to use `Socket` to define the connection to a particular `Coordinate`. (#4329)
 
 v4.5.2
 ======

--- a/OpenSim/Simulation/AssemblySolver.cpp
+++ b/OpenSim/Simulation/AssemblySolver.cpp
@@ -102,7 +102,7 @@ void AssemblySolver::setupGoals(SimTK::State &s)
         const Coordinate& coord = modelCoordSet[i];
         if(coord.getClamped(s)){
             _assembler->restrictQ(coord.getBodyIndex(),
-                    SimTK::MobilizerQIndex(coord.getMobilizerQIndex()),
+                    coord.getMobilizerQIndex(),
                     coord.getRangeMin(), coord.getRangeMax());
         }
     }
@@ -116,17 +116,17 @@ void AssemblySolver::setupGoals(SimTK::State &s)
             CoordinateReference *coordRef = p;
             const Coordinate &coord = modelCoordSet.get(coordRef->getName());
             if(coord.getLocked(s)){
-                _assembler->lockQ(coord.getBodyIndex(), SimTK::MobilizerQIndex(coord.getMobilizerQIndex()));
+                _assembler->lockQ(coord.getBodyIndex(), coord.getMobilizerQIndex());
                 //No longer need the lock on
                 coord.setLocked(s, false);
-                
+
                 //Get rid of the corresponding reference too
                 _coordinateReferencesp.erase(p);
                 p--; //decrement since erase automatically points to next in the list
             }
             else if(!(coord.get_is_free_to_satisfy_constraints())) {
                 // Make this reference and its current value a goal of the Assembler
-                SimTK::QValue *coordGoal = new SimTK::QValue(coord.getBodyIndex(), SimTK::MobilizerQIndex(coord.getMobilizerQIndex()),
+                SimTK::QValue *coordGoal = new SimTK::QValue(coord.getBodyIndex(), coord.getMobilizerQIndex(),
                                                          coordRef->getValue(s) );
                 // keep a handle to the goal so we can update
                 _coordinateAssemblyConditions.push_back(coordGoal);

--- a/OpenSim/Simulation/Model/CoordinateLinearStopForce.cpp
+++ b/OpenSim/Simulation/Model/CoordinateLinearStopForce.cpp
@@ -1,0 +1,127 @@
+/* -------------------------------------------------------------------------- *
+ *                     OpenSim:  CoordinateLinearStop.cpp                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2026 Stanford University and the Authors                     *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "CoordinateLinearStopForce.h"
+
+#include <OpenSim/Simulation/Model/Model.h>
+
+using namespace OpenSim;
+
+//=============================================================================
+// CONSTRUCTOR(S)
+//=============================================================================
+CoordinateLinearStopForce::CoordinateLinearStopForce() {
+    constructProperties();
+}
+
+CoordinateLinearStopForce::CoordinateLinearStopForce(
+        const Coordinate& coordinate, double stiffness,
+        double damping, double lowerLimit, double upperLimit) {
+    constructProperties();
+    connectSocket_coordinate(coordinate);
+    set_stiffness(stiffness);
+    set_damping(damping);
+    set_lower_limit(lowerLimit);
+    set_upper_limit(upperLimit);
+}
+
+void CoordinateLinearStopForce::constructProperties() {
+    constructProperty_stiffness(0.0);
+    constructProperty_damping(0.0);
+    constructProperty_upper_limit(0.0);
+    constructProperty_lower_limit(0.0);
+}
+
+//=============================================================================
+// MODEL COMPONENT INTERFACE
+//=============================================================================
+void CoordinateLinearStopForce::extendAddToSystem(
+        SimTK::MultibodySystem& system) const {
+    Super::extendAddToSystem(system);
+
+    OPENSIM_THROW_IF_FRMOBJ(get_stiffness() < 0.0, Exception,
+        "Expected a non-negative stiffness, but received {}.", get_stiffness());
+    OPENSIM_THROW_IF_FRMOBJ(get_damping() < 0.0, Exception,
+        "Expected a non-negative damping, but received {}.", get_damping());
+    OPENSIM_THROW_IF_FRMOBJ(get_lower_limit() > get_upper_limit(), Exception,
+        "Expected lower limit to be less than or equal to upper limit, but "
+        "received {} and {}, respectively.", get_lower_limit(),
+        get_upper_limit());
+
+    const Coordinate& coord = getConnectee<Coordinate>("coordinate");
+    const SimTK::MobilizedBody& mobod =
+        system.getMatterSubsystem().getMobilizedBody(coord.getBodyIndex());
+    SimTK::GeneralForceSubsystem& forces = _model->updForceSubsystem();
+    SimTK::Force::MobilityLinearStop stop(forces, mobod,
+        coord.getMobilizerQIndex(), get_stiffness(), get_damping(),
+        get_lower_limit(), get_upper_limit());
+
+    CoordinateLinearStopForce* mutableThis =
+        const_cast<CoordinateLinearStopForce*>(this);
+    mutableThis->_index = stop.getForceIndex();
+}
+
+//=============================================================================
+// FORCE INTERFACE
+//=============================================================================
+double CoordinateLinearStopForce::computePotentialEnergy(
+        const SimTK::State& state) const {
+    return getMobilityLinearStop().calcPotentialEnergyContribution(state);
+}
+
+//=============================================================================
+// REPORTING
+//=============================================================================
+Array<std::string> CoordinateLinearStopForce::getRecordLabels() const {
+    OpenSim::Array<std::string> labels("");
+    labels.append(getName());
+    labels.append("PotentialEnergy");
+    return labels;
+}
+
+Array<double> CoordinateLinearStopForce::getRecordValues(
+        const SimTK::State& state) const {
+    const SimTK::Force::MobilityLinearStop& stop = getMobilityLinearStop();
+    SimTK::Vector_<SimTK::SpatialVec> bodyForces(0);
+    SimTK::Vector_<SimTK::Vec3> particleForces(0);
+    SimTK::Vector mobilityForces(0);
+    stop.calcForceContribution(state, bodyForces, particleForces,
+        mobilityForces);
+
+    OpenSim::Array<double> values(0.0, 0, 2);
+    const Coordinate& coord = getConnectee<Coordinate>("coordinate");
+    values.append(mobilityForces[coord.getMobilizerQIndex()]);
+    values.append(computePotentialEnergy(state));
+    return values;
+}
+
+//=============================================================================
+// HELPERS
+//=============================================================================
+const SimTK::Force::MobilityLinearStop&
+CoordinateLinearStopForce::getMobilityLinearStop() const {
+    SimTK_ASSERT(_index.isValid(), "Invalid Force index.");
+    const auto& forceSubsys = getModel().getForceSubsystem();
+    const SimTK::Force& abstractForce = forceSubsys.getForce(_index);
+    return static_cast<const SimTK::Force::MobilityLinearStop&>(abstractForce);
+}

--- a/OpenSim/Simulation/Model/CoordinateLinearStopForce.h
+++ b/OpenSim/Simulation/Model/CoordinateLinearStopForce.h
@@ -1,0 +1,136 @@
+#ifndef OPENSIM_COORDINATE_LINEAR_STOP_FORCE_H
+#define OPENSIM_COORDINATE_LINEAR_STOP_FORCE_H
+/* -------------------------------------------------------------------------- *
+ *                  OpenSim:  CoordinateLinearStopForce.h                     *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2026 Stanford University and the Authors                     *
+ * Author(s): Nicholas Bianco                                                 *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "Force.h"
+
+#include "simbody/internal/Force_MobilityLinearStop.h"
+
+namespace OpenSim {
+
+/**
+ * Generate a compliant stop force that acts to keep a coordinate within
+ * specified bounds. This force element generates no force when the coordinate
+ * is in bounds, but when either the lower or upper bound is exceeded
+ * it generates a generalized force opposing further violation of the bound. The
+ * generated force is composed of a stiffness force (or torque, or generalized
+ * force) that is linear in the violation of the bound, and damping that is
+ * linear in the rate qdot. Internally, this class encapsulates the Simbody
+ * force element SimTK::MobilityLinearStop.
+ *
+ * @note CoordinateLinearStopForce currently works only for coordinates q whose
+ * time derivatives qdot are just the corresponding generalized speed u. That is
+ * the case for translational mobilities, pin, universal, and gimbal mobilizers
+ * but not free or ball mobilizers.
+ *
+ * \section Theory
+ *
+ * Given a coordinate q and lower and upper limits q_low and q_up, the
+ * generalized force generated here is:
+ * <pre>
+ *        ⎧           0,               q_low ≤ q ≤ q_up
+ *   f =  ⎨ min(0, -k·x·(1 + d·qdot)), q > q_up,  x = q - q_up  (x > 0, f ≤ 0)
+ *        ⎩ max(0, -k·x·(1 - d·qdot)), q < q_low, x = q - q_low (x < 0, f ≥ 0)
+ * </pre>
+ * where k is a stiffness parameter and d is a damping coefficient.
+ *
+ * Damping occurs both during compression and expansion, but the max() and
+ * min() functions in the above equations prevent "sticking" behavior, i.e.,
+ * damping will never generate a force that opposes motion back toward
+ * the limit. Unlike CoordinateLimitForce and ExponentialCoordinateLimitForce,
+ * this force does not have a smooth transition from zero to the applied force
+ * as the coordinate exceeds its limit. Finally, it uses a Hunt and
+ * Crossley-like damping model where the damping force is zero when you first
+ * touch the stop.
+ */
+class OSIMSIMULATION_API CoordinateLinearStopForce : public Force {
+    OpenSim_DECLARE_CONCRETE_OBJECT(CoordinateLinearStopForce, Force);
+public:
+//=============================================================================
+// SOCKETS
+//=============================================================================
+    OpenSim_DECLARE_SOCKET(coordinate, Coordinate,
+            "The coordinate to which this stop force is applied.");
+
+//=============================================================================
+// PROPERTIES
+//=============================================================================
+    OpenSim_DECLARE_PROPERTY(stiffness, double,
+        "The stiffness coefficient of the stop force (N-m/rad for rotational, "
+        "N/m for translational).");
+    OpenSim_DECLARE_PROPERTY(damping, double,
+        "The damping coefficient of the stop force (N-m/(rad/s) for "
+        "rotational, N/(m/s) for translational).");
+    OpenSim_DECLARE_PROPERTY(upper_limit, double,
+        "Upper coordinate limit (rad for rotational, m for translational).");
+    OpenSim_DECLARE_PROPERTY(lower_limit, double,
+        "Lower coordinate limit (rad for rotational, m for translational).");
+
+//=============================================================================
+// METHODS
+//=============================================================================
+
+    /**
+     * Default constructor.
+     */
+    CoordinateLinearStopForce();
+
+    /**
+     * Convenience constructor.
+     *
+     * @param[in] coordinate The coordinate to which this stop force is applied.
+     * @param[in] stiffness The stiffness coefficient of the stop force
+     * (N-m/rad for rotational, N/m for translational).
+     * @param[in] damping The damping coefficient of the stop force
+     * (N-m/(rad/s) for rotational, N/(m/s) for translational).
+     * @param[in] lowerLimit The lower limit of the coordinate range of motion
+     * (rad for rotational, m for translational).
+     * @param[in] upperLimit The upper limit of the coordinate range of motion
+     * (rad for rotational, m for translational).
+     */
+    CoordinateLinearStopForce(const Coordinate& coordinate,
+        double stiffness, double damping, double lowerLimit, double upperLimit);
+
+    // FORCE INTERFACE
+    double computePotentialEnergy(const SimTK::State& state) const override;
+
+    // REPORTING
+    Array<std::string> getRecordLabels() const override;
+    Array<double> getRecordValues(const SimTK::State& state) const override;
+
+protected:
+    // MODEL COMPONENT INTERFACE
+    void extendAddToSystem(SimTK::MultibodySystem& system) const override;
+
+private:
+    void constructProperties();
+
+    // HELPERS
+    const SimTK::Force::MobilityLinearStop& getMobilityLinearStop() const;
+
+}; // class CoordinateLinearStopForce
+
+} // namespace OpenSim
+
+#endif // OPENSIM_COORDINATE_LINEAR_STOP_FORCE_H

--- a/OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.cpp
+++ b/OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.cpp
@@ -39,11 +39,11 @@ ExponentialCoordinateLimitForce::ExponentialCoordinateLimitForce() {
 }
 
 ExponentialCoordinateLimitForce::ExponentialCoordinateLimitForce(
-    const std::string& coordinateNameOrPath, double lowerLimit,
-    double upperLimit, const SimTK::Vec2& lowerShapeParameters,
-    const SimTK::Vec2& upperShapeParameters) {
+        const Coordinate& coordinate, double lowerLimit, double upperLimit,
+        const SimTK::Vec2& lowerShapeParameters,
+        const SimTK::Vec2& upperShapeParameters) {
     constructProperties();
-    set_coordinate(coordinateNameOrPath);
+    connectSocket_coordinate(coordinate);
     set_lower_limit(lowerLimit);
     set_upper_limit(upperLimit);
     set_lower_shape_parameters(lowerShapeParameters);
@@ -51,7 +51,6 @@ ExponentialCoordinateLimitForce::ExponentialCoordinateLimitForce(
 }
 
 void ExponentialCoordinateLimitForce::constructProperties() {
-    constructProperty_coordinate("");
     constructProperty_lower_limit(0.0);
     constructProperty_upper_limit(0.0);
     constructProperty_lower_shape_parameters(SimTK::Vec2(0.0, 0.0));
@@ -72,25 +71,14 @@ void ExponentialCoordinateLimitForce::extendConnectToModel(Model& aModel) {
     OPENSIM_THROW_IF_FRMOBJ(s_upper[0] <= 0 || s_upper[1] <= 0,
         Exception, "Expected both upper shape parameters to be positive "
         "values, but received ({}, {}).", s_upper[0], s_upper[1]);
-
-    const auto& coordinateNameOrPath = get_coordinate();
-    if (_model->getCoordinateSet().contains(coordinateNameOrPath)) {
-        _coord = &_model->getCoordinateSet().get(coordinateNameOrPath);
-    } else if (_model->hasComponent<Coordinate>(coordinateNameOrPath)) {
-        _coord = &_model->getComponent<Coordinate>(coordinateNameOrPath);
-    } else {
-        OPENSIM_THROW_FRMOBJ(Exception,
-            "Received '{}' from property 'coordinate', but no coordinate "
-            "with this name or path was found in the model.",
-            coordinateNameOrPath);
-    }
 }
 
 //=============================================================================
 // COMPUTATIONS
 //=============================================================================
 double ExponentialCoordinateLimitForce::calcForce(const SimTK::State& s) const {
-    double q = _coord->getValue(s);
+    const Coordinate& coord = getConnectee<Coordinate>("coordinate");
+    double q = coord.getValue(s);
 
     const SimTK::Vec2& s_lower = get_lower_shape_parameters();
     const SimTK::Vec2& s_upper = get_upper_shape_parameters();
@@ -103,7 +91,8 @@ double ExponentialCoordinateLimitForce::calcForce(const SimTK::State& s) const {
 
 double ExponentialCoordinateLimitForce::computePotentialEnergy(
         const SimTK::State& s) const {
-    double q = _coord->getValue(s);
+    const Coordinate& coord = getConnectee<Coordinate>("coordinate");
+    double q = coord.getValue(s);
 
     const SimTK::Vec2& s_lower = get_lower_shape_parameters();
     const SimTK::Vec2& s_upper = get_upper_shape_parameters();
@@ -120,7 +109,9 @@ double ExponentialCoordinateLimitForce::computePotentialEnergy(
 //=============================================================================
 void ExponentialCoordinateLimitForce::implProduceForces(const SimTK::State& s,
         ForceConsumer& forceConsumer) const {
-    forceConsumer.consumeGeneralizedForce(s, *_coord, calcForce(s));
+    const Coordinate& coord = getConnectee<Coordinate>("coordinate");
+    double q = coord.getValue(s);
+    forceConsumer.consumeGeneralizedForce(s, coord, calcForce(s));
 }
 
 //=============================================================================

--- a/OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.h
+++ b/OpenSim/Simulation/Model/ExponentialCoordinateLimitForce.h
@@ -65,12 +65,15 @@ namespace OpenSim {
 class OSIMSIMULATION_API ExponentialCoordinateLimitForce : public ForceProducer {
 OpenSim_DECLARE_CONCRETE_OBJECT(ExponentialCoordinateLimitForce, ForceProducer);
 public:
+//=============================================================================
+// SOCKETS
+//=============================================================================
+    OpenSim_DECLARE_SOCKET(coordinate, Coordinate,
+            "The coordinate to which the limit forces are applied.");
+
 //==============================================================================
 // PROPERTIES
 //==============================================================================
-    OpenSim_DECLARE_PROPERTY(coordinate, std::string,
-        "The name or full path of the coordinate to which the limit forces are "
-        "applied.");
     OpenSim_DECLARE_PROPERTY(lower_limit, double,
         "The lower limit of the coordinate range of motion.");
     OpenSim_DECLARE_PROPERTY(upper_limit, double,
@@ -93,8 +96,8 @@ public:
     /**
      * Convenience constructor.
      *
-     * @param[in] coordinateNameOrPath The name or full path of the coordinate
-     * to which the limit forces are applied.
+     * @param[in] coordinate The coordinate to which the limit forces are
+     * applied.
      * @param[in] lowerLimit The lower limit of the coordinate range of motion.
      * @param[in] upperLimit The upper limit of the coordinate range of motion.
      * @param[in] lowerShapeParameters The shape parameters for the exponential
@@ -103,8 +106,8 @@ public:
      * function that models the upper limit force.
      */
     ExponentialCoordinateLimitForce(
-        const std::string& coordinateNameOrPath, double lowerLimit,
-        double upperLimit, const SimTK::Vec2& lowerShapeParameters,
+        const Coordinate& coordinate, double lowerLimit, double upperLimit,
+        const SimTK::Vec2& lowerShapeParameters,
         const SimTK::Vec2& upperShapeParameters);
 
     // COMPUTATIONS
@@ -125,8 +128,6 @@ private:
 
     // HELPERS
     void constructProperties();
-
-    SimTK::ReferencePtr<const Coordinate> _coord;
 
 };  // class ExponentialCoordinateLimitForce
 

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -45,6 +45,7 @@
 #include "Model/ContactHalfSpace.h"
 #include "Model/ContactMesh.h"
 #include "Model/CoordinateLimitForce.h"
+#include "Model/CoordinateLinearStopForce.h"
 #include "Model/CoordinateSet.h"
 #include "Model/ElasticFoundationForce.h"
 #include "Model/ExponentialContactForce.h"
@@ -258,6 +259,7 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( ContactEllipsoid() );
     Object::registerType( ContactTorus() );
     Object::registerType( CoordinateLimitForce() );
+    Object::registerType( CoordinateLinearStopForce() );
     Object::registerType( SmoothSphereHalfSpaceForce() );
     Object::registerType( ExponentialContactForce() );
     Object::registerType( MeyerFregly2016Force() );

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.cpp
@@ -193,7 +193,7 @@ void Coordinate::extendAddToSystem(SimTK::MultibodySystem& system) const
         lock(system.updMatterSubsystem(),
              funcOwner.release(),   // give up ownership
              _bodyIndex,
-             SimTK::MobilizerQIndex(_mobilizerQIndex));
+             _mobilizerQIndex);
 
     // Save the index so we can access the SimTK::Constraint later
     mutableThis->_lockedConstraintIndex = lock.getConstraintIndex();
@@ -204,7 +204,7 @@ void Coordinate::extendAddToSystem(SimTK::MultibodySystem& system) const
                 _model->updMatterSubsystem(),
                 get_prescribed_function().createSimTKFunction(),
                 _bodyIndex,
-                SimTK::MobilizerQIndex(_mobilizerQIndex));
+                _mobilizerQIndex);
         mutableThis->_prescribedConstraintIndex = prescribe.getConstraintIndex();
     }
     else if(get_prescribed()){

--- a/OpenSim/Simulation/SimbodyEngine/Coordinate.h
+++ b/OpenSim/Simulation/SimbodyEngine/Coordinate.h
@@ -222,7 +222,9 @@ public:
 
     /** @name Advanced Access to underlying Simbody system resources */
     /**@{**/
-    int getMobilizerQIndex() const { return _mobilizerQIndex; };
+    SimTK::MobilizerQIndex getMobilizerQIndex() const {
+        return _mobilizerQIndex;
+    };
     SimTK::MobilizedBodyIndex getBodyIndex() const { return _bodyIndex; };
     /**@}**/
 

--- a/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.cpp
@@ -278,13 +278,13 @@ void CoordinateCouplerConstraint::extendAddToSystem(SimTK::MultibodySystem& syst
         // Error checking was handled in extendConnectToModel()
         const Coordinate& aCoordinate = getModel().getCoordinateSet().get(independentCoordNames[i]);
         mob_bodies.push_back(aCoordinate._bodyIndex);
-        mob_qs.push_back(SimTK::MobilizerQIndex(aCoordinate._mobilizerQIndex));
+        mob_qs.push_back(aCoordinate._mobilizerQIndex);
     }
 
     // Last coordinate in the coupler is the dependent coordinate
     const Coordinate& aCoordinate = getModel().getCoordinateSet().get(get_dependent_coordinate_name());
     mob_bodies.push_back(aCoordinate._bodyIndex);
-    mob_qs.push_back(SimTK::MobilizerQIndex(aCoordinate._mobilizerQIndex));
+    mob_qs.push_back(aCoordinate._mobilizerQIndex);
 
     if (!mob_qs.size() && (mob_qs.size() != mob_bodies.size())) {
         errorMessage = "CoordinateCouplerConstraint:: requires at least one body and coordinate." ;

--- a/OpenSim/Simulation/SimbodyEngine/Joint.h
+++ b/OpenSim/Simulation/SimbodyEngine/Joint.h
@@ -339,8 +339,8 @@ protected:
 
     void setChildMobilizedBodyIndex(SimTK::MobilizedBodyIndex index) const;
     void setCoordinateMobilizedBodyIndex(Coordinate *aCoord, SimTK::MobilizedBodyIndex index) const {aCoord->_bodyIndex = index;}
-    void setCoordinateMobilizerQIndex(Coordinate *aCoord, int index) const
-        { aCoord->_mobilizerQIndex = SimTK::MobilizerQIndex(index);}
+    void setCoordinateMobilizerQIndex(Coordinate *aCoord, SimTK::MobilizerQIndex index) const
+        { aCoord->_mobilizerQIndex = index;}
     void setCoordinateModel(Coordinate *aCoord, Model *aModel) const {aCoord->_model = aModel;}
 
     /** Updating XML formating to latest revision */

--- a/OpenSim/Simulation/Test/testForces.cpp
+++ b/OpenSim/Simulation/Test/testForces.cpp
@@ -39,6 +39,7 @@
 //     13. ExpressionBasedPathForce
 //     14. Blankevoort1991Ligament
 //     15. ExponentialCoordinateLimitForce
+//     16. CoordinateLinearStopForce
 //
 //     Add tests here as Forces are added to OpenSim
 //
@@ -2436,8 +2437,8 @@ TEST_CASE("testExponentialCoordinateLimitForce") {
     SimTK::Vec2 shape(50.0, 75.0);
     double lowerLimit = 0.1;
     double upperLimit = 2.0;
-    auto* limitForce = new ExponentialCoordinateLimitForce("height", lowerLimit,
-        upperLimit, shape, shape);
+    auto* limitForce = new ExponentialCoordinateLimitForce(sliderCoord,
+        lowerLimit, upperLimit, shape, shape);
     limitForce->setName("height_limit_force");
     model.addForce(limitForce);
 
@@ -2550,5 +2551,194 @@ TEST_CASE("testExponentialCoordinateLimitForce") {
         double PE = energyFunction(3.0);
         REQUIRE_THAT(eclf.computePotentialEnergy(state),
             Catch::Matchers::WithinAbs(PE, 1e-6));
+    }
+}
+
+TEST_CASE("testCoordinateLinearStopForce") {
+
+    // Create the model.
+    Model model;
+    model.setName("CoordinateLinearStopForceTest");
+    model.setGravity(gravity_vec);
+
+    // Add a ball body.
+    double mass = 1.0;
+    Body* ball = new Body("ball", mass, Vec3(0),
+        mass * SimTK::Inertia::sphere(0.25));
+    ball->attachGeometry(new Sphere(0.25));
+    model.addBody(ball);
+
+    // Add a slider joint.
+    const Ground& ground = model.getGround();
+    SliderJoint* slider = new SliderJoint("slider",
+            ground, Vec3(0), Vec3(0, 0, SimTK::Pi / 2),
+            *ball, Vec3(0), Vec3(0, 0, SimTK::Pi / 2));
+    auto& sliderCoord = slider->updCoordinate();
+    sliderCoord.setName("height");
+    model.addJoint(slider);
+
+    // Add a CoordinateLinearStopForce to the model.
+    double stiffness = 1000.0;
+    double damping = 10.0;
+    double lowerLimit = 0.1;
+    double upperLimit = 2.0;
+    auto* stopForce = new CoordinateLinearStopForce(sliderCoord,
+        stiffness, damping, lowerLimit, upperLimit);
+    stopForce->setName("height_stop_force");
+    model.addForce(stopForce);
+
+    // Finalize the model.
+    model.finalizeConnections();
+    model.print("CoordinateLinearStopForceTest.osim");
+
+    auto forceFunction = [stiffness, lowerLimit, upperLimit](double q) {
+        if (q < lowerLimit) {
+            return -stiffness * (q - lowerLimit);  // positive
+        } else if (q > upperLimit) {
+            return -stiffness * (q - upperLimit);  // negative
+        }
+        return 0.0;
+    };
+
+    auto energyFunction = [stiffness, lowerLimit, upperLimit](double q) {
+        if (q < lowerLimit) {
+            double x = q - lowerLimit;
+            return 0.5 * stiffness * x * x;
+        } else if (q > upperLimit) {
+            double x = q - upperLimit;
+            return 0.5 * stiffness * x * x;
+        }
+        return 0.0;
+    };
+
+    // Test cases.
+    // -----------
+    SECTION("Serialization and deserialization") {
+        Model loadedModel("CoordinateLinearStopForceTest.osim");
+        CHECK(loadedModel == model);
+    }
+
+    SECTION("Copying") {
+        auto copiedModel = std::unique_ptr<Model>{model.clone()};
+        CHECK(*copiedModel == model);
+    }
+
+    SECTION("Within range") {
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        height.setValue(state, 1.0);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+    }
+
+    SECTION("At lower limit") {
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        height.setValue(state, lowerLimit);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+    }
+
+    SECTION("At upper limit") {
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        height.setValue(state, upperLimit);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(0.0, 1e-6));
+    }
+
+    SECTION("Exceeding lower limit") {
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        height.setValue(state, 0.0);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(forceFunction(0.0), 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(energyFunction(0.0), 1e-6));
+    }
+
+    SECTION("Exceeding upper limit") {
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        height.setValue(state, 3.0);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(forceFunction(3.0), 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(energyFunction(3.0), 1e-6));
+    }
+
+    SECTION("Damping when exceeding lower limit") {
+        // Moving further below the lower limit (qdot < 0) amplifies the force.
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        double q = 0.0;
+        double qdot = -0.5;
+        height.setValue(state, q);
+        height.setSpeedValue(state, qdot);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        // f = max(0, -k*x*(1 - d*qdot)), x = q - q_low < 0
+        double x = q - lowerLimit;
+        double expectedF = -stiffness * x * (1.0 - damping * qdot);
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(expectedF, 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(energyFunction(q), 1e-6));
+    }
+
+    SECTION("Damping when exceeding upper limit") {
+        // Moving further above the upper limit (qdot > 0) amplifies the force.
+        const Coordinate& height = model.getCoordinateSet()[0];
+        SimTK::State state = model.initSystem();
+        double q = 3.0;
+        double qdot = 0.5;
+        height.setValue(state, q);
+        height.setSpeedValue(state, qdot);
+        model.realizeAcceleration(state);
+        const auto& clsf = model.getComponent<CoordinateLinearStopForce>(
+                "/forceset/height_stop_force");
+
+        // f = min(0, -k*x*(1 + d*qdot)), x = q - q_up > 0
+        double x = q - upperLimit;
+        double expectedF = -stiffness * x * (1.0 + damping * qdot);
+        auto values = clsf.getRecordValues(state);
+        REQUIRE_THAT(values[0],
+            Catch::Matchers::WithinAbs(expectedF, 1e-6));
+        REQUIRE_THAT(clsf.computePotentialEnergy(state),
+            Catch::Matchers::WithinAbs(energyFunction(q), 1e-6));
     }
 }

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -71,6 +71,7 @@
 #include "Model/ExpressionBasedBushingForce.h"
 #include "Model/CoordinateLimitForce.h"
 #include "Model/ExponentialCoordinateLimitForce.h"
+#include "Model/CoordinateLinearStopForce.h"
 #include "Model/ExternalLoads.h"
 #include "Model/PathActuator.h"
 #include "Model/ActuatorPowerProbe.h"


### PR DESCRIPTION
Fixes issue #4250

### Brief summary of changes

Adds the new force element `CoordinateLinearStopForce`, an OpenSim wrapper for Simbody's `SimTK::MobilityLinearStop`. 

### Testing I've completed

Added testing to `testForces.cpp`.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4329)
<!-- Reviewable:end -->
