### PR TITLE
Treat SimTK String as std;;string across the swig interface.

### DIFF
--- a/Bindings/preliminaries.i
+++ b/Bindings/preliminaries.i
@@ -3,6 +3,10 @@
 %include "typemaps.i"
 %include "std_string.i"
 
+namespace SimTK {
+    typedef std::string String;
+}
+
 %include "std_vector.i"
 %template(StdVectorUnsigned) std::vector<unsigned>;
 %template(StdVectorInt)      std::vector<int>;

--- a/Bindings/simbody.i
+++ b/Bindings/simbody.i
@@ -1,5 +1,8 @@
 %feature("director") SimTK::DecorativeGeometryImplementation;
 
+%apply std::string          { SimTK::String };
+%apply const std::string&   { const SimTK::String& };
+
 %include <SimTKcommon.h>
 
 %include <SimTKcommon/Constants.h>
@@ -278,6 +281,7 @@ namespace SimTK {
 }
 %include <SWIGSimTK/common.h>
 %include <SWIGSimTK/Array.h>
+
 namespace SimTK {
 %template(SimTKArrayString) SimTK::Array_<std::string>;
 %template(SimTKArrayDouble) SimTK::Array_<double>;
@@ -321,6 +325,7 @@ namespace SimTK {
 %include <SWIGSimTK/SimbodyMatterSubsystem.h>
 
 %rename(SimTKVisualizer) SimTK::Visualizer;
+
 %include <simbody/internal/Visualizer.h>
 
 // Wrap SimTK::Visualizer and InputSilo to put geometry in Visualizer and


### PR DESCRIPTION
Fixes issue #4324 
### Brief summary of changes

This PR tells SWIG to treat SimTK::String as an std::string across the interface. Due to the fact that SimTK::String has an implicit conversion this should not cause problems. Besides no old interfaces are affected, only methods with SimTK::String in signature are now available to scripting.

### Testing I've completed
Check signature of SWIG generated java files and they looked correct/usable.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- will update once testing is complete

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4335)
<!-- Reviewable:end -->
