### PR TITLE
Fix crash dereferencing a nullptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ performance and stability in wrapping solutions.
 - Added `CoordinateLinearStopForce`, a force element for enforcing coordinate limits using a
 linear spring force and Hunt and Crossley-like damping. (#4329)
 - Updated `ExponentialCoordinateLimitForce` to use `Socket` to define the connection to a particular `Coordinate`. (#4329)
+- Fix crash deserializing xml files that are missing OpenSimDocument tags. (#4336)
 
 v4.5.2
 ======

--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -1595,10 +1595,11 @@ makeObjectFromFile(const std::string &aFileName)
         // properly
         IO::CwdChanger cwd = IO::CwdChanger::changeToParentOf(aFileName);
         newObject->_document = std::move(doc);
+        // doc is nullptr after this line
         if (newFormat) {
             newObject->updateFromXMLNode(*newObject->_document->getRootElement().element_begin(), newObject->_document->getDocumentVersion());
-        } else {
-            SimTK::Xml::Element e = doc->getRootElement();
+        } else { // Old format
+            SimTK::Xml::Element e = newObject->_document->getRootElement();
             newObject->updateFromXMLNode(e, 10500);
         }
 

--- a/OpenSim/Tools/Test/ikToolNoDocumentTag.xml
+++ b/OpenSim/Tools/Test/ikToolNoDocumentTag.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<InverseKinematicsTool>
+	<!--All properties of this object have their default values.-->
+</InverseKinematicsTool>

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -181,22 +181,14 @@ TEST_CASE("Serialize OpenSim objects") {
 }
 
 TEST_CASE("Test unrecognized types") {
-    bool caughtException = false;
-    try {
-        Object* newObject = Object::newInstanceOfType("Unrecognized");
-    } catch (Exception&) {
-        caughtException = true;
-    }
-    CHECK(caughtException);
+        REQUIRE_THROW(Object::newInstanceOfType("Unrecognized"));
+}
 }
 
 TEST_CASE("Test old format no enclosing tags") {
-    bool caughtException = false;
     { InverseKinematicsTool m; }
-    try {
-        OpenSim::Object* obj = OpenSim::Object::makeObjectFromFile("ikToolNoDocumentTag.xml");
-        std::cout << obj->getConcreteClassName() << std::endl;
-        REQUIRE(obj->getConcreteClassName() == "InverseKinematicsTool");
-    } catch (Exception&) { caughtException = true; }
-    CHECK(!caughtException);
+    
+    OpenSim::Object* obj = nullptr;
+    REQUIRE_NOTHROW(obj = OpenSim::Object::makeObjectFromFile("ikToolNoDocumentTag.xml"));
+    REQUIRE(obj->getConcreteClassName() == "InverseKinematicsTool");
 }

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -181,8 +181,7 @@ TEST_CASE("Serialize OpenSim objects") {
 }
 
 TEST_CASE("Test unrecognized types") {
-        REQUIRE_THROW(Object::newInstanceOfType("Unrecognized"));
-}
+        REQUIRE_THROWS(Object::newInstanceOfType("Unrecognized"));
 }
 
 TEST_CASE("Test old format no enclosing tags") {

--- a/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
+++ b/OpenSim/Tools/Test/testSerializeOpenSimObjects.cpp
@@ -31,6 +31,7 @@
 #include <OpenSim/Simulation/Model/ExponentialContactForce.h>
 
 #include <catch2/catch_all.hpp>
+#include <OpenSim/Tools/InverseKinematicsTool.h>
 
 using namespace OpenSim;
 using namespace std;
@@ -187,4 +188,15 @@ TEST_CASE("Test unrecognized types") {
         caughtException = true;
     }
     CHECK(caughtException);
+}
+
+TEST_CASE("Test old format no enclosing tags") {
+    bool caughtException = false;
+    { InverseKinematicsTool m; }
+    try {
+        OpenSim::Object* obj = OpenSim::Object::makeObjectFromFile("ikToolNoDocumentTag.xml");
+        std::cout << obj->getConcreteClassName() << std::endl;
+        REQUIRE(obj->getConcreteClassName() == "InverseKinematicsTool");
+    } catch (Exception&) { caughtException = true; }
+    CHECK(!caughtException);
 }


### PR DESCRIPTION
Fixes issue #4336 

### Brief summary of changes
Fix a crash dereferencing a smart pointer that was moved during deserializing xml files without enclosing OpenSimDocument tags.

### Testing I've completed
loaded files with old format, no enclosing tags

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4338)
<!-- Reviewable:end -->
