### PR TITLE
Update Windows runner version in CI workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2025
+    runs-on: windows-2022
     name: Windows
 
     outputs:


### PR DESCRIPTION
Github windows action just changed default from vs 2022 to 2025, quickfix for build while we investigate upgrading to vs 2025-26

Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4340)
<!-- Reviewable:end -->
