### PR TITLE
Add warm start option to `Scholz2015GeometryPath`

### DIFF
--- a/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
+++ b/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
@@ -78,6 +78,11 @@ path.appendObstacle(obstacle, contact_hint);
 % adding, it defines the insertion of the path.
 path.appendPathPoint(model.getBodySet().get('b1'), Vec3(-0.5, 0.1, 0.));
 
+% Enable warm starts in the wrapping solver. At each time step, the
+% wrapping solver will use the solution from the previous time step as an
+% initial guess for the current time step.
+path.setUseWarmStart(true);
+
 % Initialize the system.
 state = model.initSystem();
 model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2);

--- a/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
+++ b/Bindings/Java/Matlab/examples/Wrapping/exampleScholz2015GeometryPath.m
@@ -81,6 +81,11 @@ path.appendObstacle(obstacle, contact_hint);
 % adding, it defines the insertion of the path.
 path.appendPathPoint(model.getBodySet().get('b1'), Vec3(-0.5, 0.1, 0.));
 
+% Enable warm starts in the wrapping solver. At each time step, the
+% wrapping solver will use the solution from the previous time step as an
+% initial guess for the current time step.
+path.setUseWarmStart(true);
+
 % Initialize the system.
 state = model.initSystem();
 model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2);

--- a/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
+++ b/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
@@ -76,6 +76,11 @@ path.appendObstacle(obstacle, contact_hint)
 # adding, it defines the insertion of the path.
 path.appendPathPoint(model.getBodySet().get('b1'), osim.Vec3(-0.5, 0.1, 0.))
 
+# Enable warm starts in the wrapping solver. At each time step, the
+# wrapping solver will use the solution from the previous time step as an
+# initial guess for the current time step.
+path.setUseWarmStart(True)
+
 # Initialize the system.
 state = model.initSystem()
 model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2)

--- a/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
+++ b/Bindings/Python/examples/Wrapping/exampleScholz2015GeometryPath.py
@@ -79,6 +79,11 @@ path.appendObstacle(obstacle, contact_hint)
 # adding, it defines the insertion of the path.
 path.appendPathPoint(model.getBodySet().get('b1'), osim.Vec3(-0.5, 0.1, 0.))
 
+# Enable warm starts in the wrapping solver. At each time step, the
+# wrapping solver will use the solution from the previous time step as an
+# initial guess for the current time step.
+path.setUseWarmStart(True)
+
 # Initialize the system.
 state = model.initSystem()
 model.updVisualizer().updSimbodyVisualizer().setBackgroundTypeByInt(2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ the model's topology (e.g., `GeometryPath`) or via a user-defined list of coordi
 - Updated to `ezc3d` version 1.7.2 which offers a bunch a new features, but more importantly some bug fixes since the last used version.
 - `PolynomialPathFitter` now detects which coordinates should belong to a path based on the model topology by finding the joints that lie between the path's origin and insertion, and computes moment arms only for these coordinates.
 The property `moment_arm_threshold` has been removed, and the methods `get/setMomentArmThreshold()` have been deprecated. (#4352)
+- Added the property `use_warm_start` and accessors `set/getWarmStart()` in `Scholz2015GeometryPath` to enable toggling on and off warm starts, where the wrapping solver from the previous time step is an initial guess for the path at the next time step. Now, `Scholz2015GeometryPath` by default has warm starts disabled meaning that paths are always computed from wrap obstacle contact hints (previously, warm starts were always enabled). (#4342)
 
 
 v4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ performance and stability in wrapping solutions.
 - The Matlab and Python versions of the muscle-synergy example in `exampleMocoInverse` now use `CommonUtilities::factorizeMatrixNonNegative()` to perform muscle synergy analysis, now consistent with the C++ version of the example. (#4323)
 - Made simplifications to the joint moment tracking example in exampleMocoTrack to improve performance. (#4323)
 - Reference solution files are now included for `exampleMocoTrack` and `example3DWalking`. (#4323)
+- Added the property `use_warm_start` and accessors `set/getWarmStart()` in `Scholz2015GeometryPath` to enable toggling on and off warm starts, where the wrapper solver from the previous time step as an initial guess for the path at the next time step. By default, `Scholz2015GeometryPath` now has warm starts disabled, meaning that paths are always computed from wrap obstacle contact hints (previously, warm starts were always enabled). (#4342)
 
 
 v4.5.2

--- a/OpenSim/Examples/Wrapping/exampleScholz2015GeometryPath.cpp
+++ b/OpenSim/Examples/Wrapping/exampleScholz2015GeometryPath.cpp
@@ -82,6 +82,11 @@ int main() {
     path.appendPathPoint(model.getComponent<Body>("/bodyset/b1"),
             SimTK::Vec3(-0.5, 0.1, 0.));
 
+    // Enable warm starts in the wrapping solver. At each time step, the
+    // wrapping solver will use the solution from the previous time step as an
+    // initial guess for the current time step.
+    path.setUseWarmStart(true);
+
     // Initialize the system.
     SimTK::State state = model.initSystem();
     model.updVisualizer().updSimbodyVisualizer().setBackgroundType(

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  * Author(s): Nicholas Bianco                                                 *
  * Contributor(s): Pepijn van den Bos, Andreas Scholz                         *
  *                                                                            *
@@ -188,6 +188,17 @@ int Scholz2015GeometryPath::getNumObstacles() const {
 
 int Scholz2015GeometryPath::getNumPathElements() const {
     return getProperty_path_elements().size();
+}
+
+void Scholz2015GeometryPath::setUseWarmStart(bool useWarmStart) {
+    if (_index.isValid()) {
+        updCableSpan().setUseWarmStart(useWarmStart);
+    }
+    set_use_warm_start(useWarmStart);
+}
+
+bool Scholz2015GeometryPath::getUseWarmStart() const {
+    return get_use_warm_start();
 }
 
 //=============================================================================
@@ -396,6 +407,7 @@ void Scholz2015GeometryPath::extendAddToSystem(
     cable.setCurveSegmentAccuracy(1e-10);
     cable.setSolverMaxIterations(50);
     cable.setAlgorithm(SimTK::CableSpanAlgorithm::Scholz2015);
+    cable.setUseWarmStart(get_use_warm_start());
     _index = cable.getIndex();
 }
 
@@ -452,6 +464,7 @@ void Scholz2015GeometryPath::extendPostScale(const SimTK::State& s,
 //=============================================================================
 void Scholz2015GeometryPath::constructProperties() {
     constructProperty_path_elements();
+    constructProperty_use_warm_start(false);
 }
 
 const Scholz2015GeometryPathObstacle* Scholz2015GeometryPath::getObstacle(

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.cpp
@@ -190,6 +190,17 @@ int Scholz2015GeometryPath::getNumPathElements() const {
     return getProperty_path_elements().size();
 }
 
+void Scholz2015GeometryPath::setUseWarmStart(bool useWarmStart) {
+    if (_index.isValid()) {
+        updCableSpan().setUseWarmStart(useWarmStart);
+    }
+    set_use_warm_start(useWarmStart);
+}
+
+bool Scholz2015GeometryPath::getUseWarmStart() const {
+    return get_use_warm_start();
+}
+
 //=============================================================================
 // ABSTRACT PATH INTERFACE
 //=============================================================================
@@ -396,6 +407,7 @@ void Scholz2015GeometryPath::extendAddToSystem(
     cable.setCurveSegmentAccuracy(1e-10);
     cable.setSolverMaxIterations(50);
     cable.setAlgorithm(SimTK::CableSpanAlgorithm::Scholz2015);
+    cable.setUseWarmStart(get_use_warm_start());
     _index = cable.getIndex();
 }
 
@@ -452,6 +464,7 @@ void Scholz2015GeometryPath::extendPostScale(const SimTK::State& s,
 //=============================================================================
 void Scholz2015GeometryPath::constructProperties() {
     constructProperty_path_elements();
+    constructProperty_use_warm_start(false);
 }
 
 const Scholz2015GeometryPathObstacle* Scholz2015GeometryPath::getObstacle(

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -162,8 +162,7 @@ public:
  * can touchdown on the obstacle if the surface obstructs the straight line
  * segment again.
  *
- * The path is computed as an optimization problem using the previous optimal
- * path as the warm start. This is done by computing natural geodesic
+ * The path is computed as an optimization problem by computing natural geodesic
  * corrections for each curve segment to compute the locally shortest path,
  * as described in the following publication:
  *
@@ -172,7 +171,10 @@ public:
  *     System Dynamics 36, 195–219.
  *
  * The overall path is locally the shortest, allowing winding over an obstacle
- * multiple times, without flipping to the other side.
+ * multiple times, without flipping to the other side. The wrapping solver can
+ * optionally use the solution from the previous time step as a warm start to
+ * improve performance during forward dynamics simulations (see method
+ * `getUseWarmStart()` for more information).
  *
  * This class encapsulates `SimTK::CableSpan`, the Simbody implementation of
  * this algorithm. For the full details concerning this class, see the Simbody
@@ -425,6 +427,28 @@ public:
      */
     int getNumPathElements() const;
 
+     /**
+     * Set whether the path uses the solution from the previous time step as a
+     * warm start for the wrapping solver.
+     *
+     * Enable this setting when performing forward dyanmics simulations or any
+     * simulation where path solutions will be computed sequentially in time
+     * reasonable small time steps. In other scenarios where the configuration
+     * of the model, and therefore path solutions, may change rapidly, it is
+     * recommended to disable this setting to avoid inconsistent path solutions.
+     * If false, the path will always be computed from the curve contact hints
+     * when realizing to SimTK::Stage::Position. Default: false.
+     */
+    void setUseWarmStart(bool useWarmStart);
+
+    /**
+     * Get whether the path uses the solution from the previous time step as a
+     * warm start for the wrapping solver.
+     *
+     * @see setUseWarmStart()
+     */
+    bool getUseWarmStart() const;
+
     // @}
 
     //** @name `AbstractGeometryPath` interface */
@@ -466,6 +490,11 @@ private:
     // PROPERTIES
     OpenSim_DECLARE_LIST_PROPERTY(path_elements, Scholz2015GeometryPathElement,
         "The list of elements (path points or obstacles) defining the path.");
+    OpenSim_DECLARE_PROPERTY(use_warm_start, bool,
+        "Whether to use the path solution from the previous time step as a "
+        "warm start for the wrapping solver. If false, the path will always be "
+        "computed from the curve contact hints when realizing to "
+        "SimTK::Stage::Position. Default: false.");
 
     // MODEL COMPONENT INTERFACE
     void extendConnectToModel(Model& model) override;

--- a/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
+++ b/OpenSim/Simulation/Model/Scholz2015GeometryPath.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2025 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  * Author(s): Nicholas Bianco                                                 *
  * Contributor(s): Pepijn van den Bos, Andreas Scholz                         *
  *                                                                            *
@@ -34,7 +34,7 @@
 namespace OpenSim {
 
 /**
- * \section Scholz2015GeometryPathPoint
+ * \section Scholz2015GeometryPathElement
  * An abstract class representing an element in a `Scholz2015GeometryPath`.
  *
  * Concrete implementations of this class should represent geometric elements
@@ -144,7 +144,7 @@ public:
 //=============================================================================
 
 /**
- * \section Scholz2015GeometryPath
+ * @section Scholz2015GeometryPath
  * A concrete class representing a geometric path object defined by a list of
  * path points and wrapping obstacles.
  *
@@ -162,8 +162,7 @@ public:
  * can touchdown on the obstacle if the surface obstructs the straight line
  * segment again.
  *
- * The path is computed as an optimization problem using the previous optimal
- * path as the warm start. This is done by computing natural geodesic
+ * The path is computed as an optimization problem by computing natural geodesic
  * corrections for each curve segment to compute the locally shortest path,
  * as described in the following publication:
  *
@@ -172,13 +171,21 @@ public:
  *     System Dynamics 36, 195–219.
  *
  * The overall path is locally the shortest, allowing winding over an obstacle
- * multiple times, without flipping to the other side.
+ * multiple times, without flipping to the other side. By default, path
+ * solutions are computed from scratch using the user-specified "contact hints"
+ * associated with each wrap obstacle (see @ref appending_obstacles for
+ * details). Alternatively, the wrapping solver can use the most recently
+ * computed solution (e.g., from a previous time step in a forward integration)
+ * as a warm start to improve performance (see method `getUseWarmStart()` for
+ * more information). In other scenarios where the configuration of the model,
+ * and therefore path solutions, may change rapidly, it is recommended to
+ * disable this warm starts to avoid inconsistent path solutions.
  *
  * This class encapsulates `SimTK::CableSpan`, the Simbody implementation of
  * this algorithm. For the full details concerning this class, see the Simbody
  * API documentation.
  *
- * ## Constructing a Scholz2015GeometryPath
+ * @subsection construction Constructing a Scholz2015GeometryPath
  *
  * The simplest valid path consists of two path points: an origin and an
  * insertion point:
@@ -219,7 +226,7 @@ public:
  * each `PathPoint` was appended, the `Socket` connections would be broken when
  * the `Scholz2015GeometryPath` is copied into the `PathSpring`.
  *
- * ## Appending Wrap Obstacles
+ * @subsection appending_obstacles Appending Wrap Obstacles
  *
  * Wrap obstacles are defined by `ContactGeometry` objects which encapsulate
  * a wrapping geometry, the `PhysicalFrame` that the geometry is attached to,
@@ -259,7 +266,7 @@ public:
  *         SimTK::Vec3(-0.5, 0.1, 0.));
  * \endcode
  *
- * ## Path Ordering
+ * @subsection path_ordering Path Ordering
  *
  * The order in which obstacles and path points are appended to the path is
  * important. For example, consider the path we constructed above:
@@ -296,7 +303,7 @@ public:
  * behavior. Note also that both of the path examples above are valid, since
  * each begins and ends with a path point.
  *
- * ## Changing Obstacle Properties
+ * @subsection obstacle_properties Changing Obstacle Properties
  *
  * The properties of a `ContactGeometry` obstacle can be changed after it has
  * been appended to the path. However, if `ContactGeometry` properties are
@@ -425,6 +432,28 @@ public:
      */
     int getNumPathElements() const;
 
+     /**
+     * Set whether the path uses the most recently computed solution as a warm
+     * start for the wrapping solver.
+     *
+     * Enable this setting when performing forward dynamics simulations or any
+     * simulation where path solutions will be computed sequentially in time
+     * (using reasonably small time steps). In other scenarios where the
+     * configuration of the model, and therefore path solutions, may change
+     * rapidly, it is recommended to disable this setting to avoid inconsistent
+     * path solutions. If false, the path will always be computed from the curve
+     * contact hints when realizing to SimTK::Stage::Position. Default: false.
+     */
+    void setUseWarmStart(bool useWarmStart);
+
+    /**
+     * Get whether the path uses the most recently computed solution as a warm
+     * start for the wrapping solver.
+     *
+     * @see setUseWarmStart()
+     */
+    bool getUseWarmStart() const;
+
     // @}
 
     //** @name `AbstractGeometryPath` interface */
@@ -466,6 +495,11 @@ private:
     // PROPERTIES
     OpenSim_DECLARE_LIST_PROPERTY(path_elements, Scholz2015GeometryPathElement,
         "The list of elements (path points or obstacles) defining the path.");
+    OpenSim_DECLARE_PROPERTY(use_warm_start, bool,
+        "Whether to use the most recently computed soluation as a warm start "
+        "for the wrapping solver. If false, the path will always be computed "
+        "from the curve contact hints when realizing to SimTK::Stage::Position. "
+        "Default: false.");
 
     // MODEL COMPONENT INTERFACE
     void extendConnectToModel(Model& model) override;

--- a/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
+++ b/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
@@ -23,6 +23,7 @@
 
 #include <OpenSim/Actuators/ModelFactory.h>
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
+#include <OpenSim/Common/CommonUtilities.h>
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Simulation/Control/PrescribedController.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
@@ -31,6 +32,8 @@
 #include <OpenSim/Simulation/Model/Scholz2015GeometryPath.h>
 #include <OpenSim/Simulation/SimbodyEngine/SliderJoint.h>
 #include <OpenSim/Simulation/SimbodyEngine/FreeJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/PinJoint.h>
+#include <OpenSim/Simulation/SimbodyEngine/WeldJoint.h>
 
 #include <OpenSim/Simulation/VisualizerUtilities.h>
 
@@ -146,6 +149,7 @@ TEST_CASE("Suspended pendulum") {
 
     // Set the path's origin and insertion.
     Scholz2015GeometryPath& path = actu->updPath<Scholz2015GeometryPath>();
+    path.setUseWarmStart(true);
     path.appendPathPoint(model.getGround(), SimTK::Vec3(-0.1, 0, 0));
 
     // Check that pendulum is at rest with the expected length.
@@ -596,6 +600,7 @@ TEST_CASE("Path with all surfaces and a via point") {
 
     // Create the path object.
     Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
+    path->setUseWarmStart(true);
     path->appendPathPoint(*originBody, SimTK::Vec3(0.));
 
     // Add the first torus obstacle.
@@ -1013,4 +1018,127 @@ TEST_CASE("Scaling updates muscle properties") {
     const auto& scaledMuscle = model.getComponent<Muscle>("/muscle");
     CHECK(scaledMuscle.get_optimal_fiber_length() == 0.123);
     CHECK(scaledMuscle.get_tendon_slack_length() == 0.123);
+}
+
+TEST_CASE("Disabling warm starts unifies moment arm calculations") {
+    using DataPoints = std::vector<std::pair<double, double>>;
+
+    // A simple pendulum model with a path wrapping over an ellipsoid obstacle.
+    // The model is designed so that, depending on the choice of the default
+    // value for the 'angle' coordinate, moment arm calculations may differ when
+    // using the warm start feature of Scholz2015GeometryPath.
+    auto buildModel = [](bool warmStart, double defaultAngle) {
+        Model model;
+        model.setName("pendulum");
+
+        // Define the pendulum bodies: base and head.
+        auto* base = new Body("pendulum_base", 1.0, SimTK::Vec3(0),
+                SimTK::Inertia(1));
+        model.addBody(base);
+        auto* head = new Body("pendulum_head", 1.0, SimTK::Vec3(0),
+                SimTK::Inertia(1));
+        model.addBody(head);
+
+        // Base welded 1.5 m above ground.
+        auto* weld = new WeldJoint("ground_base",
+                model.getGround(), SimTK::Vec3(0, 1.5, 0), SimTK::Vec3(0),
+                *base, SimTK::Vec3(0), SimTK::Vec3(0));
+        model.addJoint(weld);
+
+        // Add a PinJoint between the base and head driven by the coordinate
+        // 'angle'.
+        auto* pin = new PinJoint("base_to_head",
+                *base, SimTK::Vec3(0), SimTK::Vec3(0),
+                *head, SimTK::Vec3(0, 1, 0), SimTK::Vec3(0));
+        auto& angle = pin->updCoordinate();
+        angle.setName("angle");
+        angle.setRangeMin(-0.5);
+        angle.setRangeMax(0.5);
+        angle.setDefaultValue(defaultAngle);
+        model.addJoint(pin);
+
+        // Attach a contact ellipsoid to the base which the muscle path will
+        // wrap over.
+        auto* ellipsoid = new ContactEllipsoid(
+                SimTK::Vec3(0.1, 0.1, 0.5),
+                SimTK::Vec3(-0.01, -0.25, -0.035),
+                SimTK::Vec3(0.25, -0.29, 0.075),
+                *base);
+        ellipsoid->setName("ellipsoid");
+        model.addComponent(ellipsoid);
+
+        // Add muscle with a path between the head and base, wrapping over the
+        // ellipsoid.
+        auto* muscle = new Millard2012EquilibriumMuscle();
+        muscle->setName("muscle");
+        muscle->set_path(Scholz2015GeometryPath());
+        model.addForce(muscle);
+        auto& path = muscle->updPath<Scholz2015GeometryPath>();
+        path.appendPathPoint(*head, SimTK::Vec3(0));
+        path.appendObstacle(*ellipsoid, SimTK::Vec3(0.10, 0, 0));
+        path.appendPathPoint(*base, SimTK::Vec3(0));
+        path.setUseWarmStart(warmStart);
+        return model;
+    };
+
+    // Sweep over the range of motion of the 'angle' coordinate, computing the
+    // moment arm of the muscle path at each point. This replicates the
+    // behavior of OpenSim Creator's moment arm plotting functionality, where
+    // the underlying bug was originally discovered.
+    auto computeDataPoints = [&](bool warmStart, double defaultAngle)
+            -> DataPoints {
+        Model model = buildModel(warmStart, defaultAngle);
+        SimTK::State state = model.initSystem();
+        const Coordinate& coordinate =
+                model.getComponent<Coordinate>("/jointset/base_to_head/angle");
+        const Muscle& muscle = model.getComponent<Muscle>("/forceset/muscle");
+        const double start = coordinate.getRangeMin();
+        const double end = coordinate.getRangeMax();
+        SimTK::Vector x = createVectorLinspace(202, start, end);
+        DataPoints data_points;
+        for (int i = 0; i < x.size(); ++i) {
+            coordinate.setValue(state, x[i]);
+            model.equilibrateMuscles(state);
+            model.realizeReport(state);
+            const double y = muscle.getPath().computeMomentArm(state,
+                coordinate);
+            data_points.emplace_back(x[i], y);
+        }
+        return data_points;
+    };
+
+    // Compare two sets of data points sampled at the same coordinate values,
+    // checking that the moment arm agrees at every point across the range of
+    // motion.
+    auto compareDataPoints = [](const DataPoints& lhs, const DataPoints& rhs,
+            double tolerance, bool useWarmStart = false) {
+        REQUIRE(lhs.size() == rhs.size());
+        SimTK::Vector error(static_cast<int>(lhs.size()), 0.0);
+        for (int i = 0; i < static_cast<int>(lhs.size()); ++i) {
+            error[i] = std::abs(lhs[i].second - rhs[i].second);
+        }
+
+        // If using a warm start, we expect the error to be non-zero (i.e., the
+        // moment arm curves different) when using different default values for
+        // 'angle'.
+        if (useWarmStart) {
+            CHECK_THAT(error.norm(),
+                       !Catch::Matchers::WithinAbs(0.0, tolerance));
+        } else {
+            CHECK_THAT(error.norm(),
+                       Catch::Matchers::WithinAbs(0.0, tolerance));
+        }
+
+        CAPTURE(error);
+    };
+
+    // Test that the moment arm curves are identical when using different
+    // default values for the 'angle' coordinate, when warm starts are disabled.
+    // Conversely, when warm starts are enabled, the moment arm curves should
+    // differ depending on the default value of 'angle'.
+    bool useWarmStart = GENERATE(false, true);
+    CAPTURE(useWarmStart);
+    auto lhs = computeDataPoints(useWarmStart, 0.0);
+    auto rhs = computeDataPoints(useWarmStart, 0.45);
+    compareDataPoints(lhs, rhs, 1e-6, useWarmStart);
 }

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -193,7 +193,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    80a3f10a6daa26c8aaf18f2c672cf385b227e62c
+              GIT_TAG    bb7b30c9b76497782eb34d19fa39b8689121a349
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -190,7 +190,7 @@ AddDependency(NAME       ezc3d
 AddDependency(NAME       simbody
               DEFAULT    ON
               GIT_URL    https://github.com/simbody/simbody.git
-              GIT_TAG    80a3f10a6daa26c8aaf18f2c672cf385b227e62c
+              GIT_TAG    bb7b30c9b76497782eb34d19fa39b8689121a349
               CMAKE_ARGS -DBUILD_EXAMPLES:BOOL=OFF
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})


### PR DESCRIPTION
Fixes issue #4330 

### Brief summary of changes

This change adds the property `use_warm_start` and associated accessors `Scholz2015GeometryPath::set/getWarmStart()` to enable toggling on and off warm starts, where the underlying `SimTK::CableSpan` will use the path solution from the previous time step as an initial guess for the path at the next time step.

Note: requires https://github.com/simbody/simbody/pull/858 to be merged first.

### Testing I've completed

Added tests to `testScholz2015GeometryPath.cpp` to check that disabling warm starts fixes inconsistencies in moment arm calculations.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4342)
<!-- Reviewable:end -->
