### PR TITLE
Improvements to Moco and PolynomialPathFitter examples

### DIFF
--- a/Bindings/Java/Matlab/CMakeLists.txt
+++ b/Bindings/Java/Matlab/CMakeLists.txt
@@ -89,6 +89,14 @@ install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OpenSenseExample/Geometry/"
         DESTINATION
         "${OPENSIM_INSTALL_MATLABEXDIR}/Moco/exampleSquatToStand/exampleIMUTracking/Geometry/")
 
+# Copy Geometry folder for PolynomialPathFitter examples
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OpenSenseExample/Geometry/"
+        DESTINATION
+        "${OPENSIM_INSTALL_MATLABEXDIR}/PolynomialPathFitter/Geometry/")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/OpenSenseExample/Geometry/"
+        DESTINATION
+        "${OPENSIM_INSTALL_PYTHONEXDIR}/PolynomialPathFitter/Geometry/")
+
 # The configureOpenSim.m script contains paths into the OpenSim installation
 # that may be different on different platforms, so we configure it with CMake
 # variables.

--- a/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoInverse.m
+++ b/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoInverse.m
@@ -287,25 +287,34 @@ end
 
 % Use non-negative matrix factorization (NNMF) to extract a set of muscle
 % synergies for each leg.
-Al = leftControls.getMatrix().getAsMat();
-[Wl, Hl] = nnmf(Al, numSynergies);
+maxIterations = 100;
+tolerance = 1e-6;
 
-Ar = rightControls.getMatrix().getAsMat();
-[Wr, Hr] = nnmf(Ar, numSynergies);
-
-% Scale W and H assuming that the elements of H are all 0.5. This prevents
-% the synergy vector weights and synergy excitations from being very large 
-% or very small.
-scaleVec = 0.5*ones(1, length(leftControlNames));
-for i = 1:numSynergies
-    scale_l = norm(scaleVec) / norm(Hl(i, :));
-    Hl(i, :) = Hl(i, :) * scale_l;
-    Wl(:, i) = Wl(:, i) / scale_l;
-
-    scale_r = norm(scaleVec) / norm(Hr(i, :));
-    Hr(i, :) = Hr(i, :) * scale_r;
-    Wr(:, i) = Wr(:, i) / scale_r;
+leftControlsMat = leftControls.getMatrix();
+Al = Matrix(leftControlsMat.nrow(), leftControlsMat.ncol());
+for i = 1:leftControlsMat.nrow()
+    for j = 1:leftControlsMat.ncol()
+        Al.set(i-1, j-1, leftControlsMat.getElt(i-1, j-1));
+    end
 end
+
+Wl = Matrix();
+Hl = Matrix();
+opensimCommon.factorizeMatrixNonNegative(Al, numSynergies, ...
+    maxIterations, tolerance, Wl, Hl);
+
+rightControlsMat = rightControls.getMatrix();
+Ar = Matrix(rightControlsMat.nrow(), rightControlsMat.ncol());
+for i = 1:rightControlsMat.nrow()
+    for j = 1:rightControlsMat.ncol()
+        Ar.set(i-1, j-1, rightControlsMat.getElt(i-1, j-1));
+    end
+end
+
+Wr = Matrix();
+Hr = Matrix();
+opensimCommon.factorizeMatrixNonNegative(Ar, numSynergies, ...
+    maxIterations, tolerance, Wr, Hr);
 
 % Add a SynergyController for the left leg to the model.
 leftController = SynergyController();
@@ -322,7 +331,7 @@ end
 for i = 1:numSynergies  
     synergyVector = Vector(length(leftControlNames), 0.0);
     for j = 1:length(leftControlNames)
-        synergyVector.set(j-1, Hl(i, j));
+        synergyVector.set(j-1, Hl.getElt(i-1, j-1));
     end
     leftController.addSynergyVector(synergyVector);
 end
@@ -338,7 +347,7 @@ end
 for i = 1:numSynergies  
     synergyVector = Vector(length(rightControlNames), 0.0);
     for j = 1:length(rightControlNames)
-        synergyVector.set(j-1, Hr(i, j));
+        synergyVector.set(j-1, Hr.getElt(i-1, j-1));
     end
     rightController.addSynergyVector(synergyVector);
 end

--- a/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoTrack.m
+++ b/Bindings/Java/Matlab/examples/Moco/example3DWalking/exampleMocoTrack.m
@@ -208,7 +208,7 @@ solver.resetProblem(problem);
 
 % Solve!
 solution = study.solve();
-solution.write("exampleMocoTrack_muscle_driven_tracking_solution.sto");
+solution.write("exampleMocoTrack_muscle_driven_state_tracking_solution.sto");
 
 % Visualize the solution.
 study.visualize(solution);
@@ -261,30 +261,6 @@ problem = study.updProblem();
 effort = MocoControlGoal.safeDownCast(problem.updGoal("control_effort"));
 effort.setWeight(0.1);
 
-% Put larger individual weights on the pelvis CoordinateActuators, which act 
-% as the residual, or 'hand-of-god', forces which we would like to keep as small
-% as possible.
-effort.setWeightForControlPattern('.*pelvis.*', 10);
-
-% Constrain the states and controls to be periodic.
-periodicityGoal = MocoPeriodicityGoal("periodicity");
-model = modelProcessor.process();
-model.initSystem();
-for i = 0:model.getNumStateVariables()-1
-    currentStateName = string(model.getStateVariableNames().getitem(i));
-    if (~contains(currentStateName,"pelvis_tx/value"))
-        periodicityGoal.addStatePair(MocoPeriodicityGoalPair(currentStateName));
-    end
-end
-
-forceSet = model.getForceSet();
-for i = 0:forceSet.getSize()-1
-    forcePath = forceSet.get(i).getAbsolutePathString();
-    periodicityGoal.addControlPair(MocoPeriodicityGoalPair(forcePath));
-end
-
-problem.addGoal(periodicityGoal);
-
 % Add a joint moment tracking goal to the problem.
 jointMomentTracking = MocoGeneralizedForceTrackingGoal(...
         "joint_moment_tracking", 1e-2);
@@ -320,8 +296,8 @@ jointMomentTracking.setIgnoreConstrainedCoordinates(true);
 jointMomentTracking.setWeightForGeneralizedForcePattern(".*pelvis.*", 0);
 
 % Encourage better tracking of the ankle joint moments.
-jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_r_moment", 100);
-jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_l_moment", 100);
+jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_r_moment", 10);
+jointMomentTracking.setWeightForGeneralizedForce("ankle_angle_l_moment", 10);
 
 % Add the joint moment tracking goal to the problem.
 problem.addGoal(jointMomentTracking);
@@ -333,8 +309,8 @@ solver.set_optim_constraint_tolerance(1e-4);
 solver.resetProblem(problem);
 
 % Set the guess, if available.
-if (exist("exampleMocoTrack_muscle_driven_tracking_solution.sto", "file"))
-    solver.setGuessFile("exampleMocoTrack_muscle_driven_tracking_solution.sto");
+if (exist("exampleMocoTrack_muscle_driven_state_tracking_solution.sto", "file"))
+    solver.setGuessFile("exampleMocoTrack_muscle_driven_state_tracking_solution.sto");
 end
 
 % Solve!
@@ -342,6 +318,8 @@ solution = study.solve();
 solution.write("exampleMocoTrack_joint_moment_tracking_solution.sto");
 
 % Save the model to a file.
+model = modelProcessor.process();
+model.initSystem();
 model.print("exampleMocoTrack_model.osim");
 
 % Compute the joint moments and write them to a file.

--- a/Bindings/Python/examples/Moco/example3DWalking/exampleMocoInverse.py
+++ b/Bindings/Python/examples/Moco/example3DWalking/exampleMocoInverse.py
@@ -47,7 +47,7 @@ def solveMocoInverse():
     jointsToWeld.append("mtp_r")
     jointsToWeld.append("mtp_l")
     modelProcessor.append(osim.ModOpReplaceJointsWithWelds(jointsToWeld))
-    # Add CoordinateActuators to the pelvis coordinates. 
+    # Add CoordinateActuators to the pelvis coordinates.
     modelProcessor.append(osim.ModOpAddResiduals(250.0, 50.0, 1.0))
     modelProcessor.append(osim.ModOpIgnoreTendonCompliance())
     modelProcessor.append(osim.ModOpReplaceMusclesWithDeGrooteFregly2016())
@@ -104,7 +104,7 @@ def solveMocoInverseWithEMG():
     jointsToWeld.append("mtp_r")
     jointsToWeld.append("mtp_l")
     modelProcessor.append(osim.ModOpReplaceJointsWithWelds(jointsToWeld))
-    # Add CoordinateActuators to the pelvis coordinates. 
+    # Add CoordinateActuators to the pelvis coordinates.
     modelProcessor.append(osim.ModOpAddResiduals(250.0, 50.0, 1.0))
     modelProcessor.append(osim.ModOpIgnoreTendonCompliance())
     modelProcessor.append(osim.ModOpReplaceMusclesWithDeGrooteFregly2016())
@@ -195,7 +195,7 @@ def solveMocoInverseWithSynergies(numSynergies=5):
     jointsToWeld.append("mtp_r")
     jointsToWeld.append("mtp_l")
     modelProcessor.append(osim.ModOpReplaceJointsWithWelds(jointsToWeld))
-    # Add CoordinateActuators to the pelvis coordinates. 
+    # Add CoordinateActuators to the pelvis coordinates.
     modelProcessor.append(osim.ModOpAddResiduals(250.0, 50.0, 1.0))
     modelProcessor.append(osim.ModOpIgnoreTendonCompliance())
     modelProcessor.append(osim.ModOpIgnoreActivationDynamics())
@@ -220,7 +220,7 @@ def solveMocoInverseWithSynergies(numSynergies=5):
                 rightControlNames.append(actu.getAbsolutePathString())
             elif name.endswith('_l'):
                 leftControlNames.append(actu.getAbsolutePathString())
-    
+
     controls = prevSolution.exportToControlsTable()
     leftControls = osim.TimeSeriesTable(controls.getIndependentColumn())
     rightControls = osim.TimeSeriesTable(controls.getIndependentColumn())
@@ -231,20 +231,20 @@ def solveMocoInverseWithSynergies(numSynergies=5):
 
     # SynergyController
     # -----------------
-    # SynergyController defines the controls for actuators connected to the 
-    # controller using a linear combination of time-varying synergy control 
-    # signals (i.e., "synergy excitations") and a set of vectors containing 
+    # SynergyController defines the controls for actuators connected to the
+    # controller using a linear combination of time-varying synergy control
+    # signals (i.e., "synergy excitations") and a set of vectors containing
     # weights for each actuator representing the contribution of each synergy
-    # excitation to the total control signal for that actuator 
+    # excitation to the total control signal for that actuator
     # (i.e., "synergy vectors").
     #
     # If 'N' is the number of time points in the trajectory, 'M' is the number
-    # of actuators connected to the controller, and 'K' is the number of   
+    # of actuators connected to the controller, and 'K' is the number of
     # synergies in the controller, then:
     # - The synergy excitations are a matrix 'W' of size N x K.
     # - The synergy vectors are a matrix 'H' of size K x M.
     # - The controls for the actuators are computed A = W * H.
-    #  
+    #
     # SynergyController is a concrete implementation of InputController, which
     # means that it uses Input control signals as the synergy excitations.
     # Moco automatically detects InputController%s in a model provided to a
@@ -255,30 +255,28 @@ def solveMocoInverseWithSynergies(numSynergies=5):
 
     # Use non-negative matrix factorization (NNMF) to extract a set of muscle
     # synergies for each leg.
-    from sklearn.decomposition import NMF
-    import numpy as np
-    nmf = NMF(n_components=numSynergies, init='random', random_state=0)
-    
-    Al = leftControls.getMatrix().to_numpy()
-    Wl = nmf.fit_transform(Al)
-    Hl = nmf.components_
+    maxIterations = 100
+    tolerance = 1e-6
 
-    Ar = rightControls.getMatrix().to_numpy()
-    Wr = nmf.fit_transform(Ar)
-    Hr = nmf.components_
+    leftControlsMat = leftControls.getMatrix()
+    Al = osim.Matrix(leftControlsMat.nrow(), leftControlsMat.ncol())
+    for i in range(leftControlsMat.nrow()):
+        for j in range(leftControlsMat.ncol()):
+            Al.set(i, j, leftControlsMat.getElt(i, j))
 
-    # Scale W and H assuming that the elements of H are all 0.5. This prevents the 
-    # synergy vector weights and synergy excitations from being very large or very
-    # small.
-    scaleVec = 0.5*np.ones(Hl.shape[1])
-    for i in range(numSynergies):
-        scale_l = np.linalg.norm(scaleVec) / np.linalg.norm(Hl[i, :])
-        Hl[i, :] *= scale_l
-        Wl[:, i] /= scale_l
+    Wl = osim.Matrix()
+    Hl = osim.Matrix()
+    osim.factorizeMatrixNonNegative(Al, numSynergies, maxIterations, tolerance, Wl, Hl)
 
-        scale_r = np.linalg.norm(scaleVec) / np.linalg.norm(Hr[i, :])
-        Hr[i, :] *= scale_r
-        Wr[:, i] /= scale_r
+    rightControlsMat = rightControls.getMatrix()
+    Ar = osim.Matrix(rightControlsMat.nrow(), rightControlsMat.ncol())
+    for i in range(rightControlsMat.nrow()):
+        for j in range(rightControlsMat.ncol()):
+            Ar.set(i, j, rightControlsMat.getElt(i, j))
+
+    Wr = osim.Matrix()
+    Hr = osim.Matrix()
+    osim.factorizeMatrixNonNegative(Ar, numSynergies, maxIterations, tolerance, Wr, Hr)
 
     # Add a SynergyController for the left leg to the model.
     leftController = osim.SynergyController()
@@ -289,12 +287,12 @@ def solveMocoInverseWithSynergies(numSynergies=5):
         leftController.addActuator(
                 osim.Muscle.safeDownCast(model.getComponent(name)))
     # Adding a synergy vector increases the number of synergies in the
-    # controller by one. This means that the number of Input control 
+    # controller by one. This means that the number of Input control
     # signals expected by the controller is also increased by one.
-    for i in range(numSynergies):  
-        synergyVector = osim.Vector(Hl.shape[1], 0.0)
-        for j in range(Hl.shape[1]):
-            synergyVector.set(j, Hl[i, j])
+    for i in range(numSynergies):
+        synergyVector = osim.Vector(Hl.ncol(), 0.0)
+        for j in range(Hl.ncol()):
+            synergyVector.set(j, Hl.getElt(i, j))
         leftController.addSynergyVector(synergyVector)
     model.addController(leftController)
 
@@ -305,9 +303,9 @@ def solveMocoInverseWithSynergies(numSynergies=5):
         rightController.addActuator(
                 osim.Muscle.safeDownCast(model.getComponent(name)))
     for i in range(numSynergies):
-        synergyVector = osim.Vector(Hr.shape[1], 0.0)
-        for j in range(Hr.shape[1]):
-            synergyVector.set(j, Hr[i, j])
+        synergyVector = osim.Vector(Hr.ncol(), 0.0)
+        for j in range(Hr.ncol()):
+            synergyVector.set(j, Hr.getElt(i, j))
         rightController.addSynergyVector(synergyVector)
     model.addController(rightController)
     model.finalizeConnections()
@@ -325,21 +323,21 @@ def solveMocoInverseWithSynergies(numSynergies=5):
 
     # Initialize the MocoInverse study and set the control bounds for the
     # muscle synergies excitations. 'setInputControlInfo()' is equivalent to
-    # 'setControlInfo()', but reserved for Input control variables. Note that 
-    # while we make a distinction between "control" variables and 
+    # 'setControlInfo()', but reserved for Input control variables. Note that
+    # while we make a distinction between "control" variables and
     # "Input control" variables in the API, the optimal control problem
     # constructed by Moco treats them both as algebraic variables.
     study = inverse.initialize()
     problem = study.updProblem()
 
-    # We will also increase the weight on the synergy excitations in the 
-    # control effort cost term. MocoControlGoal, and other MocoGoals, that 
+    # We will also increase the weight on the synergy excitations in the
+    # control effort cost term. MocoControlGoal, and other MocoGoals, that
     # depend on control variables have options configuring cost terms with
     # Input control values.
     effort = osim.MocoControlGoal.safeDownCast(
             problem.updGoal("excitation_effort"))
     for i in range(numSynergies):
-        nameLeft = (f'/controllerset/synergy_controller_left_leg' 
+        nameLeft = (f'/controllerset/synergy_controller_left_leg'
                     f'/synergy_excitation_{i}')
         problem.setInputControlInfo(nameLeft, [0, 1.0])
         effort.setWeightForControl(nameLeft, 10)
@@ -367,7 +365,7 @@ def solveMocoInverseWithSynergies(numSynergies=5):
     solutionFile = (f'example3DWalking_MocoInverseWith'
                     f'{numSynergies}Synergies_solution.sto')
     solution.write(solutionFile)
-    
+
     # Generate a report comparing MocoInverse solutions with and without
     # muscle synergies.
     output = (f'example3DWalking_MocoInverseWith'
@@ -379,7 +377,7 @@ def solveMocoInverseWithSynergies(numSynergies=5):
                                 colors=['black', 'red'])
     # The PDF is saved to the working directory.
     report.generate()
-    
+
 
 # Solve the basic muscle redundancy problem with MocoInverse.
 solveMocoInverse()

--- a/Bindings/Python/examples/Moco/example3DWalking/exampleMocoTrack.py
+++ b/Bindings/Python/examples/Moco/example3DWalking/exampleMocoTrack.py
@@ -64,7 +64,7 @@ def torqueDrivenMarkerTracking():
     track.setMarkersReferenceFromTRC("markers_walk.trc")
 
     # Increase the global marker tracking weight, which is the weight
-    # associated with the internal MocoMarkerTrackingCost term.
+    # associated with the internal MocoMarkerTrackingGoal term.
     track.set_markers_global_tracking_weight(10)
 
     # Set the marker weights based on the IKTaskSet from the dataset.
@@ -177,7 +177,7 @@ def muscleDrivenStateTracking():
     
     # Solve!
     solution = study.solve()
-    solution.write('exampleMocoTrack_muscle_driven_tracking_solution.sto')
+    solution.write('exampleMocoTrack_muscle_driven_state_tracking_solution.sto')
 
     # Visualize the solution.
     study.visualize(solution)
@@ -226,27 +226,6 @@ def muscleDrivenJointMomentTracking():
     effort = osim.MocoControlGoal.safeDownCast(problem.updGoal("control_effort"))
     effort.setWeight(0.1)
 
-    # Put larger individual weights on the pelvis CoordinateActuators, which act 
-    # as the residual, or 'hand-of-god', forces which we would like to keep as small
-    # as possible.
-    effort.setWeightForControlPattern('.*pelvis.*', 10)
-
-    # Constrain the states and controls to be periodic.
-    periodicityGoal = osim.MocoPeriodicityGoal('periodicity')
-    model = modelProcessor.process()
-    model.initSystem()
-    for i in range(model.getNumStateVariables()):
-        currentStateName = str(model.getStateVariableNames().getitem(i))
-        if 'pelvis_tx/value' not in currentStateName:
-            periodicityGoal.addStatePair(osim.MocoPeriodicityGoalPair(currentStateName))
-        
-    forceSet = model.getForceSet()
-    for i in range(forceSet.getSize()):
-        forcePath = forceSet.get(i).getAbsolutePathString()
-        periodicityGoal.addControlPair(osim.MocoPeriodicityGoalPair(forcePath))
-    
-    problem.addGoal(periodicityGoal)
-
     # Add a joint moment tracking goal to the problem.
     jointMomentTracking = osim.MocoGeneralizedForceTrackingGoal(
             'joint_moment_tracking', 1e-2)
@@ -282,8 +261,8 @@ def muscleDrivenJointMomentTracking():
     jointMomentTracking.setWeightForGeneralizedForcePattern('.*pelvis.*', 0)
 
     # Encourage better tracking of the ankle joint moments.
-    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_r_moment', 100)
-    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_l_moment', 100)
+    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_r_moment', 10)
+    jointMomentTracking.setWeightForGeneralizedForce('ankle_angle_l_moment', 10)
 
     # Add the joint moment tracking goal to the problem.
     problem.addGoal(jointMomentTracking)
@@ -295,14 +274,16 @@ def muscleDrivenJointMomentTracking():
     solver.resetProblem(problem)
 
     # Set the guess, if available.
-    if os.path.exists('exampleMocoTrack_muscle_driven_tracking_solution.sto'):
-        solver.setGuessFile('exampleMocoTrack_muscle_driven_tracking_solution.sto')
+    if os.path.exists('exampleMocoTrack_muscle_driven_state_tracking_solution.sto'):
+        solver.setGuessFile('exampleMocoTrack_muscle_driven_state_tracking_solution.sto')
     
     # Solve!
     solution = study.solve()
     solution.write('exampleMocoTrack_joint_moment_tracking_solution.sto')
 
     # Save the model to a file.
+    model = modelProcessor.process()
+    model.initSystem()
     model.printToXML('exampleMocoTrack_model.osim')
 
     # Compute the joint moments and write them to a file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ performance and stability in wrapping solutions.
 - Implemented `extendPreScale` and `extendPostScale` for `Scholz2015GeometryPath`. Now, scaling a model using `Scholz2015GeometryPath` paths will update `Muscle` tendon slack lengths and optimal fiber lengths. (#4325)
 - Fix crash deserializing xml files that are missing OpenSimDocument tags. (#4336)
 - Added `exampleExponentialContactForce`, including C++, Matlab, and Python variants. (#4318)
+- The Matlab and Python versions of the muscle-synergy example in `exampleMocoInverse` now use `CommonUtilities::factorizeMatrixNonNegative()` to perform muscle synergy analysis, now consistent with the C++ version of the example. (#4323)
+- Made simplifications to the joint moment tracking example in exampleMocoTrack to improve performance. (#4323)
+- Reference solution files are now included for `exampleMocoTrack` and `example3DWalking`. (#4323)
 
 
 v4.5.2

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoTrack.cpp
@@ -168,7 +168,6 @@ void muscleDrivenStateTracking() {
     }
     for (const auto& muscle : model.getComponentList<Muscle>()) {
         periodicityGoal->addStatePair(muscle.getStateVariableNames()[0]);
-        periodicityGoal->addControlPair(muscle.getAbsolutePathString());
     }
     for (const auto& actu : model.getComponentList<Actuator>()) {
         periodicityGoal->addControlPair(actu.getAbsolutePathString());
@@ -226,37 +225,9 @@ void muscleDrivenJointMomentTracking() {
 
     // Get a reference to the MocoControlCost that is added to every MocoTrack
     // problem by default and set the overall weight to 0.1.
-    MocoControlGoal& effort = 
+    MocoControlGoal& effort =
             dynamic_cast<MocoControlGoal&>(problem.updGoal("control_effort"));
     effort.setWeight(0.1);
-
-    // Put larger individual weights on the pelvis CoordinateActuators, which act 
-    // as the residual, or 'hand-of-god', forces which we would like to keep as small
-    // as possible.
-    effort.setWeightForControlPattern(".*pelvis.*", 10);
-
-    // Constrain the states and controls to be periodic.
-    auto* periodicityGoal = problem.addGoal<MocoPeriodicityGoal>("periodicity");
-    Model model = modelProcessor.process();
-    model.initSystem();
-    for (const auto& coord : model.getComponentList<Coordinate>()) {
-        if (!IO::EndsWith(coord.getName(), "_tx")) {
-            // Add a state pair for the coordinate value.
-            periodicityGoal->addStatePair(coord.getStateVariableNames()[0]);
-        }
-        // Add a state pair for the coordinate speed.
-        periodicityGoal->addStatePair(coord.getStateVariableNames()[1]);
-    }
-    for (const auto& muscle : model.getComponentList<Muscle>()) {
-        // Add a control pair for the muscle excitation.
-        periodicityGoal->addControlPair(muscle.getAbsolutePathString());
-        // Add a state pair for the muscle activation.
-        periodicityGoal->addStatePair(muscle.getStateVariableNames()[0]);
-    }
-    for (const auto& actu : model.getComponentList<Actuator>()) {
-        // Add a control pair for the actuator control.
-        periodicityGoal->addControlPair(actu.getAbsolutePathString());
-    }
 
     // Add a joint moment tracking goal to the problem.
     auto* jointMomentTracking = 
@@ -293,9 +264,9 @@ void muscleDrivenJointMomentTracking() {
 
     // Encourage better tracking of the ankle joint moments.
     jointMomentTracking->setWeightForGeneralizedForce(
-            "ankle_angle_r_moment", 100);
+            "ankle_angle_r_moment", 10);
     jointMomentTracking->setWeightForGeneralizedForce(
-            "ankle_angle_l_moment", 100);
+            "ankle_angle_l_moment", 10);
     
     // Update the solver problem and tolerances.
     auto& solver = study.updSolver<MocoCasADiSolver>();
@@ -304,9 +275,10 @@ void muscleDrivenJointMomentTracking() {
     solver.resetProblem(problem);
 
     // Set the guess, if available.
-    if (IO::FileExists("exampleMocoTrack_muscle_driven_tracking_solution.sto")) {
+    if (IO::FileExists(
+            "exampleMocoTrack_muscle_driven_state_tracking_solution.sto")) {
         solver.setGuessFile(
-                "exampleMocoTrack_muscle_driven_tracking_solution.sto");
+                "exampleMocoTrack_muscle_driven_state_tracking_solution.sto");
     }
 
     // Solve!
@@ -314,6 +286,8 @@ void muscleDrivenJointMomentTracking() {
     solution.write("exampleMocoTrack_joint_moment_tracking_solution.sto");
 
     // Save the model to a file.
+    Model model = modelProcessor.process();
+    model.initSystem();
     model.print("exampleMocoTrack_model.osim");
 
     // Compute the joint moments and write them to a file.

--- a/OpenSim/Moco/Test/testMocoImplicit.cpp
+++ b/OpenSim/Moco/Test/testMocoImplicit.cpp
@@ -138,7 +138,7 @@ MocoSolution solveDoublePendulumSwingup(const std::string& dynamics_mode) {
 //}
 
 TEMPLATE_TEST_CASE("Similar solutions between implicit and explicit dynamics",
-        "[linux/win][implicit]", MocoCasADiSolver) {
+        "[win][implicit]", MocoCasADiSolver) {
     
     GIVEN("solutions to implicit and explicit problems") {
 


### PR DESCRIPTION
Note: this was already merged to `opensim_46` via https://github.com/opensim-org/opensim-core/pull/4323, but was not yet merged to `main`.

### Brief summary of changes

- Added Geometry folder to PolynomialPathFitter examples
- Use CommonUtilities::factorizeMatrixNonNegative() across MocoInverse examples
- Made adjustments to joint moment tracking example in exampleMocoTrack to improve performance
- Include reference solution files for exampleMocoTrack and example3DWalking
- Trimmed whitespace in various places
- Drive-by: disabled an inconsistently failing Moco implicit dynamics test on Linux

### Testing I've completed

Tested all examples locally.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4345)
<!-- Reviewable:end -->
