### PR TITLE
Add basic CMakePresets.json with dev-default and dev-minimal presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,57 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "base",
+            "description": "Base build configuration for all presets",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "OPENSIM_DEPENDENCIES_DIR": "${sourceDir}/build/dependencies/${presetName}/install"
+            }
+        },
+        {
+            "name": "dev-default",
+            "description": "Recommended development configuration that builds everything a typical release contains",
+            "inherits": ["base"],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "OPENSIM_WITH_CASADI": "ON",
+                "BUILD_JAVA_WRAPPING": "ON",
+                "BUILD_PYTHON_WRAPPING": "ON",
+                "OPENSIM_C3D_PARSER": "ezc3d"
+            }
+        },
+        {
+            "name": "dev-minimal",
+            "description": "Minimal development configuration that builds OpenSim without Moco, ezc3d, and bindings",
+            "inherits": ["dev-default"],
+            "cacheVariables": {
+                "OPENSIM_WITH_CASADI": "OFF",
+                "BUILD_JAVA_WRAPPING": "OFF",
+                "BUILD_PYTHON_WRAPPING": "OFF",
+                "OPENSIM_C3D_PARSER": "None"
+            }
+        }
+    ],
+    "buildPresets": [
+        { "name": "dev-default", "configurePreset": "dev-default" },
+        { "name": "dev-minimal", "configurePreset": "dev-minimal" }
+    ],
+    "workflowPresets": [
+        {
+            "name": "dev-default",
+            "steps": [
+                { "type": "configure", "name": "dev-default" },
+                { "type": "build",     "name": "dev-default" }
+            ]
+        },
+        {
+            "name": "dev-minimal",
+            "steps": [
+                { "type": "configure", "name": "dev-minimal" },
+                { "type": "build",     "name": "dev-minimal" }
+            ]
+        }
+    ]
+}

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -1,0 +1,54 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "base",
+            "description": "Base build configuration for all presets",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../build/dependencies/${presetName}",
+            "installDir": "${sourceDir}/../build/dependencies/${presetName}/install",
+            "cacheVariables": {
+                "CMAKE_INSTALL_PREFIX": "${sourceDir}/../build/dependencies/${presetName}/install"
+            }
+        },
+        {
+            "name": "dev-default",
+            "description": "Recommended development configuration that builds all dependencies that a typical release requires",
+            "inherits": ["base"],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "OPENSIM_WITH_CASADI": "ON",
+                "SUPERBUILD_ezc3d": "ON"
+            }
+        },
+        {
+            "name": "dev-minimal",
+            "description": "Minimal development configuration that only build the dependencies necessary for a minimal build (no Moco, no ezc3d)",
+            "inherits": ["dev-default"],
+            "cacheVariables": {
+                "OPENSIM_WITH_CASADI": "OFF",
+                "SUPERBUILD_ezc3d": "OFF"
+            }
+        }
+    ],
+    "buildPresets": [
+        { "name": "dev-default", "configurePreset": "dev-default" },
+        { "name": "dev-minimal", "configurePreset": "dev-minimal" }
+    ],
+    "workflowPresets": [
+        {
+            "name": "dev-default",
+            "steps": [
+                { "type": "configure", "name": "dev-default" },
+                { "type": "build",     "name": "dev-default" }
+            ]
+        },
+        {
+            "name": "dev-minimal",
+            "steps": [
+                { "type": "configure", "name": "dev-minimal" },
+                { "type": "build",     "name": "dev-minimal" }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds a `CMakePresets.json` file for `dependencies/` and the root project.

The utility of a `CMakePresets.json` file is that major IDEs and text editors natively support them. E.g. with this preset, setting up a development environment is a matter of first building the dependencies:

```bash
cd dependencies/ && cmake --workflow --preset dev-default && cd -

# Or, if you want a little more control, you can override generators, cache variables, etc.
cd dependencies/ && cmake -G Ninja --preset dev-minimal && cmake --build --preset dev-minimal  && cd -
```

Once the dependencies are built, they're installed in a location that the corresponding preset in `./CMakePresets.json` already knows about (and sets `OPENSIM_DEPENDENCIES_DIR` etc. for). So you can then (e.g.):

- Open the directory in CLion, select the `dev-default`/`dev-minimal` configuration from the popup, or the CMake section of CLion
- Open the directory in Visual Studio, it will list available configurations in the dropdown next to the run button

Selecting a preset should automatically find the locally-installed dependencies. Because there's a hard-coded path relationship between the `dependencies/` build and the root one.

## Notes

- `dev-default` is a full-fat development build that builds Moco, ezc3d, and the bindings. It's assumed that the default development build should try and build the same elements as the release build (e.g. so developers can run the same test suites etc. before PRing)
- `dev-minimal` is a minimal development build that skips Moco, ezc3d, and the bindings. It's for pure-C++ developers (e.g. myself, for OpenSim Creator + OPynSim) that are only looking to make a few non-API-changing edits to the core OpenSim codebase.
- Both the dependencies and main build build+install into `build/`. This is a pretty standard setup and means that all build artifacts can be deleted in one step (i.e. `rm -rf build/`). The structure is such that the installation folders for the dependencies are nested inside the dependencies build directory. The unusual layout of the installation directory (e.g. install/ipopt/include, install/casadi/lib, etc.) is a legacy thing and should probably be looked at separately (standard installation behavior is to unify everything into an FSH-style install tree).
- The naming reflects a long-term goal for the change. I would recommend porting OpenSim's release builds to the presets, those could be called (e.g.) `ci-msvc-amd64-release` and similar. Simbody already has something like this if you need inspiration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4354)
<!-- Reviewable:end -->
