### PR TITLE
Loosen SWIG required version to 4.1.0

### DIFF
--- a/Bindings/CMakeLists.txt
+++ b/Bindings/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(BUILD_PYTHON_WRAPPING OR BUILD_JAVA_WRAPPING)
-    find_package(SWIG 4.1.1 REQUIRED)
+    find_package(SWIG 4.1.0 REQUIRED)
 endif()
 
 # Flags are both Python and Java bindings will use.


### PR DESCRIPTION
This makes it easier to build opensim-core on Ubuntu24. Ubuntu24 provides a `swig4.1` package via `apt`, but it ships `4.1.0`. With this change, getting a bindings-building version of OpenSim on Ubuntu24 is a matter of:

```bash
sudo apt-get install swig4.1
sudo update-alternatives --install /usr/bin/swig swig /usr/bin/swig4.1 50
# configure and build OpenSim etc.
```

The loosening doesn't seem like it would be fatal. The change list is minor (note: Ubuntu24 ships with Python 3.12):

```text
Version 4.4.1 (7 Dec 2025)
==========================

2025-12-03: jschueller
            [Python] #3285 Fix builds with python>=3.13 and Py_LIMITED_API<3.13.

2025-11-14: jschueller
            [Python] #3280 Add override specifier to SwigPyIterator methods for c++11
            and later.

2025-11-06: degasus
	    #3284 Fix -fsanitize=undefined problem in the SWIG runtime code.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4356)
<!-- Reviewable:end -->
