### PR TITLE
[portability] Add static-library build support to the CMake build system and DLL export headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ link_directories(${CMAKE_BINARY_DIR})
 # OpenSim options.
 # ----------------
 
+# Default to shared libraries (historical behavior before BUILD_SHARED_LIBS
+# was made explicit). Users who want a static build pass -DBUILD_SHARED_LIBS=OFF.
+if(NOT DEFINED BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS ON)
+endif()
+
 # Specify number of cores to run tests.
 include(ProcessorCount)
 ProcessorCount(PROCESSOR_COUNT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,15 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS ON)
 endif()
 
+# Plugin example targets are always SHARED regardless of BUILD_SHARED_LIBS.
+# When building static, the OpenSim libs they link against must be compiled
+# with -fPIC so that local-exec TLS symbols (e.g. thread_local in
+# Component.cpp) do not cause a link error when pulled into a shared object.
+# Shared libs already receive -fPIC from CMake automatically.
+if(NOT BUILD_SHARED_LIBS AND NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 # Specify number of cores to run tests.
 include(ProcessorCount)
 ProcessorCount(PROCESSOR_COUNT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,27 +116,14 @@ link_directories(${CMAKE_BINARY_DIR})
 # OpenSim options.
 # ----------------
 
-# Default to shared libraries (historical behavior before BUILD_SHARED_LIBS
-# was made explicit). Users who want a static build pass -DBUILD_SHARED_LIBS=OFF.
-if(NOT DEFINED BUILD_SHARED_LIBS)
-    set(BUILD_SHARED_LIBS ON)
-endif()
-
-# Plugin example targets are always SHARED regardless of BUILD_SHARED_LIBS.
-# When building static, the OpenSim libs they link against must be compiled
-# with -fPIC so that local-exec TLS symbols (e.g. thread_local in
-# Component.cpp) do not cause a link error when pulled into a shared object.
-# Shared libs already receive -fPIC from CMake automatically.
-if(NOT BUILD_SHARED_LIBS AND NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
-    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-endif()
-
 # Specify number of cores to run tests.
 include(ProcessorCount)
 ProcessorCount(PROCESSOR_COUNT)
 set(PROCESSOR_COUNT "${PROCESSOR_COUNT}" CACHE STRING
     "Number of concurrent jobs when running tests via RUN_TESTS_PARALLEL target.")
 mark_as_advanced(PROCESSOR_COUNT)
+
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 # Try to use MathJax for Doxygen equations.
 option(OPENSIM_DOXYGEN_USE_MATHJAX "Try to use MathJax to render Doxygen

--- a/OpenSim/Actuators/osimActuatorsDLL.cpp
+++ b/OpenSim/Actuators/osimActuatorsDLL.cpp
@@ -52,6 +52,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
+#ifndef OPENSIM_ACTUATORS_TYPE_STATIC
 #if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
@@ -92,3 +93,4 @@ static void __attribute__((destructor)) Shared_Object_Destructor()
    Plugin_Detach();
 }
 #endif
+#endif // OPENSIM_ACTUATORS_TYPE_STATIC

--- a/OpenSim/Actuators/osimActuatorsDLL.h
+++ b/OpenSim/Actuators/osimActuatorsDLL.h
@@ -38,7 +38,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-#ifdef OSIMACTUATORS_EXPORTS
+#if defined(OPENSIM_ACTUATORS_TYPE_STATIC)
+#define OSIMACTUATORS_API
+#elif defined(OSIMACTUATORS_EXPORTS)
 #define OSIMACTUATORS_API __declspec(dllexport)
 #else
 #define OSIMACTUATORS_API __declspec(dllimport)

--- a/OpenSim/Analyses/osimAnalysesDLL.cpp
+++ b/OpenSim/Analyses/osimAnalysesDLL.cpp
@@ -48,6 +48,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
+#ifndef OPENSIM_ANALYSES_TYPE_STATIC
 #if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
@@ -88,3 +89,4 @@ static void __attribute__((destructor)) Shared_Object_Destructor()
    Plugin_Detach();
 }
 #endif
+#endif // OPENSIM_ANALYSES_TYPE_STATIC

--- a/OpenSim/Analyses/osimAnalysesDLL.h
+++ b/OpenSim/Analyses/osimAnalysesDLL.h
@@ -34,7 +34,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-#ifdef OSIMANALYSES_EXPORTS
+#if defined(OPENSIM_ANALYSES_TYPE_STATIC)
+#define OSIMANALYSES_API
+#elif defined(OSIMANALYSES_EXPORTS)
 #define OSIMANALYSES_API __declspec(dllexport)
 #else
 #define OSIMANALYSES_API __declspec(dllimport)

--- a/OpenSim/Common/osimCommonDLL.cpp
+++ b/OpenSim/Common/osimCommonDLL.cpp
@@ -46,6 +46,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
+#ifndef OPENSIM_COMMON_TYPE_STATIC
 #if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
@@ -88,3 +89,4 @@ static void __attribute__((destructor)) Shared_Object_Destructor()
 #else
     #error "Unsupported compiler."
 #endif
+#endif // OPENSIM_COMMON_TYPE_STATIC

--- a/OpenSim/Common/osimCommonDLL.h
+++ b/OpenSim/Common/osimCommonDLL.h
@@ -34,7 +34,9 @@
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
     #include <windows.h>
-    #ifdef OSIMCOMMON_EXPORTS
+    #if defined(OPENSIM_COMMON_TYPE_STATIC)
+        #define OSIMCOMMON_API
+    #elif defined(OSIMCOMMON_EXPORTS)
         #define OSIMCOMMON_API __declspec(dllexport)
     #else
         #define OSIMCOMMON_API __declspec(dllimport)

--- a/OpenSim/ExampleComponents/osimExampleComponentsDLL.h
+++ b/OpenSim/ExampleComponents/osimExampleComponentsDLL.h
@@ -33,10 +33,12 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-#ifdef OSIMEXAMPLECOMPONENTS_EXPORTS
-#define OSIMEXAMPLECOMPONENTS_API __declspec(dllexport)
+#if defined(OPENSIM_EXAMPLECOMPONENTS_TYPE_STATIC)
+    #define OSIMEXAMPLECOMPONENTS_API
+#elif defined(OSIMEXAMPLECOMPONENTS_EXPORTS)
+    #define OSIMEXAMPLECOMPONENTS_API __declspec(dllexport)
 #else
-#define OSIMEXAMPLECOMPONENTS_API __declspec(dllimport)
+    #define OSIMEXAMPLECOMPONENTS_API __declspec(dllimport)
 #endif
 
 #endif // PLATFORM

--- a/OpenSim/Moco/osimMocoDLL.h
+++ b/OpenSim/Moco/osimMocoDLL.h
@@ -21,7 +21,9 @@
 #ifndef _WIN32
     #define OSIMMOCO_API
 #else
-    #ifdef OSIMMOCO_EXPORTS
+    #if defined(OPENSIM_MOCO_TYPE_STATIC)
+        #define OSIMMOCO_API
+    #elif defined(OSIMMOCO_EXPORTS)
         #define OSIMMOCO_API __declspec(dllexport)
     #else
         #define OSIMMOCO_API __declspec(dllimport)

--- a/OpenSim/Simulation/osimSimulationDLL.cpp
+++ b/OpenSim/Simulation/osimSimulationDLL.cpp
@@ -50,6 +50,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
+#ifndef OPENSIM_SIMULATION_TYPE_STATIC
 #if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
@@ -90,3 +91,4 @@ static void __attribute__((destructor)) Shared_Object_Destructor()
    Plugin_Detach();
 }
 #endif
+#endif // OPENSIM_SIMULATION_TYPE_STATIC

--- a/OpenSim/Simulation/osimSimulationDLL.h
+++ b/OpenSim/Simulation/osimSimulationDLL.h
@@ -38,7 +38,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-#ifdef OSIMSIMULATION_EXPORTS
+#if defined(OPENSIM_SIMULATION_TYPE_STATIC)
+#define OSIMSIMULATION_API
+#elif defined(OSIMSIMULATION_EXPORTS)
 #define OSIMSIMULATION_API __declspec(dllexport)
 #else
 #define OSIMSIMULATION_API __declspec(dllimport)

--- a/OpenSim/Tools/osimToolsDLL.cpp
+++ b/OpenSim/Tools/osimToolsDLL.cpp
@@ -49,6 +49,7 @@ static void Plugin_Detach()
 //
 // The code below handles both Windows and Linux library entrypoints
 //
+#ifndef OPENSIM_TOOLS_TYPE_STATIC
 #if defined(_WIN32)
 //=============================================================================
 // DLL Main Entry Point
@@ -89,3 +90,4 @@ static void __attribute__((destructor)) Shared_Object_Destructor()
    Plugin_Detach();
 }
 #endif
+#endif // OPENSIM_TOOLS_TYPE_STATIC

--- a/OpenSim/Tools/osimToolsDLL.h
+++ b/OpenSim/Tools/osimToolsDLL.h
@@ -37,7 +37,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
-#ifdef OSIMTOOLS_EXPORTS
+#if defined(OPENSIM_TOOLS_TYPE_STATIC)
+#define OSIMTOOLS_API
+#elif defined(OSIMTOOLS_EXPORTS)
 #define OSIMTOOLS_API __declspec(dllexport)
 #else
 #define OSIMTOOLS_API __declspec(dllimport)

--- a/Vendors/lepton/CMakeLists.txt
+++ b/Vendors/lepton/CMakeLists.txt
@@ -1,9 +1,5 @@
 file(GLOB SOURCE_FILES src/*.cpp)
 
-if(WIN32)
-    add_definitions("-DLEPTON_BUILDING_SHARED_LIBRARY")
-endif(WIN32)
-
 OpenSimAddLibrary(VENDORLIB LOWERINCLUDEDIRNAME
     KIT Lepton
     AUTHORS "Peter_Eastman"
@@ -14,6 +10,19 @@ OpenSimAddLibrary(VENDORLIB LOWERINCLUDEDIRNAME
     INCLUDEDIRS include include/lepton
     INCLUDEINSTALLREL include/lepton
     )
+
+if(WIN32)
+    # Lepton uses its own build-type symbols (see windowsIncludes.h).
+    # Set them based on the actual target type so static and shared builds
+    # both work without manual preprocessor flags.
+    target_compile_definitions(osimLepton
+        PRIVATE
+            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:LEPTON_BUILDING_SHARED_LIBRARY>
+            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:LEPTON_BUILDING_STATIC_LIBRARY>
+        PUBLIC
+            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:LEPTON_USE_STATIC_LIBRARIES>
+    )
+endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Avoid clang's warning:

--- a/Vendors/lepton/CMakeLists.txt
+++ b/Vendors/lepton/CMakeLists.txt
@@ -11,22 +11,6 @@ OpenSimAddLibrary(VENDORLIB LOWERINCLUDEDIRNAME
     INCLUDEINSTALLREL include/lepton
     )
 
-if(WIN32)
-    # Lepton uses its own build-type symbols (see windowsIncludes.h).
-    # Set them based on the actual target type so static and shared builds
-    # both work without manual preprocessor flags.
-    # PRIVATE: evaluated in this target's context -- TYPE refers to osimLepton.
-    # PUBLIC: evaluated in each consumer's context -- use explicit target name
-    #         so TYPE still resolves to osimLepton, not the consumer.
-    target_compile_definitions(osimLepton
-        PRIVATE
-            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:LEPTON_BUILDING_SHARED_LIBRARY>
-            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:LEPTON_BUILDING_STATIC_LIBRARY>
-        PUBLIC
-            $<$<STREQUAL:$<TARGET_PROPERTY:osimLepton,TYPE>,STATIC_LIBRARY>:LEPTON_USE_STATIC_LIBRARIES>
-    )
-endif()
-
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     # Avoid clang's warning:
     # ExpressionTreeNode.cpp:62:90: Reference cannot be bound to dereferenced

--- a/Vendors/lepton/CMakeLists.txt
+++ b/Vendors/lepton/CMakeLists.txt
@@ -15,12 +15,15 @@ if(WIN32)
     # Lepton uses its own build-type symbols (see windowsIncludes.h).
     # Set them based on the actual target type so static and shared builds
     # both work without manual preprocessor flags.
+    # PRIVATE: evaluated in this target's context -- TYPE refers to osimLepton.
+    # PUBLIC: evaluated in each consumer's context -- use explicit target name
+    #         so TYPE still resolves to osimLepton, not the consumer.
     target_compile_definitions(osimLepton
         PRIVATE
             $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:LEPTON_BUILDING_SHARED_LIBRARY>
             $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:LEPTON_BUILDING_STATIC_LIBRARY>
         PUBLIC
-            $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:LEPTON_USE_STATIC_LIBRARIES>
+            $<$<STREQUAL:$<TARGET_PROPERTY:osimLepton,TYPE>,STATIC_LIBRARY>:LEPTON_USE_STATIC_LIBRARIES>
     )
 endif()
 

--- a/Vendors/lepton/include/lepton/windowsIncludes.h
+++ b/Vendors/lepton/include/lepton/windowsIncludes.h
@@ -27,12 +27,13 @@
     #pragma warning(disable:4996)
     // Keep MS VC++ quiet about lack of dll export of private members.
     #pragma warning(disable:4251)
-    #if defined(LEPTON_BUILDING_SHARED_LIBRARY)
-        #define LEPTON_EXPORT __declspec(dllexport)
-    #elif defined(LEPTON_BUILDING_STATIC_LIBRARY) || defined(LEPTON_USE_STATIC_LIBRARIES)
+
+    #if defined(OPENSIM_LEPTON_TYPE_STATIC)
         #define LEPTON_EXPORT
+    #elif defined(OSIMLEPTON_EXPORTS)
+        #define LEPTON_EXPORT __declspec(dllexport)
     #else
-        #define LEPTON_EXPORT __declspec(dllimport)   // i.e., a client of a shared library
+        #define LEPTON_EXPORT __declspec(dllimport)
     #endif
 #else
     #define LEPTON_EXPORT // Linux, Mac

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -228,6 +228,12 @@ function(OpenSimAddLibrary)
         )
     endif()
 
+    # Regardless of whether the library is built STATIC or SHARED, emit
+    # position-independent code. SHARED plugins must always be link-able.
+    set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+    )
+
     # Set DLL export/import defines based on actual target type so that
     # both shared and static builds work without manual preprocessor flags.
     if(OSIMADDLIB_VENDORLIB)

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -203,7 +203,8 @@ function(OpenSimAddLibrary)
     # These next few lines are the most important:
 
     # Create the library using the provided source and include files.
-    add_library(${OSIMADDLIB_LIBRARY_NAME} SHARED
+    # No explicit SHARED/STATIC keyword -- respects BUILD_SHARED_LIBS.
+    add_library(${OSIMADDLIB_LIBRARY_NAME}
         ${OSIMADDLIB_SOURCES} ${OSIMADDLIB_INCLUDES})
 
     target_include_directories(${OSIMADDLIB_LIBRARY_NAME} 
@@ -227,16 +228,31 @@ function(OpenSimAddLibrary)
         )
     endif()
 
-    # This is for exporting classes on Windows.
+    # Set DLL export/import defines based on actual target type so that
+    # both shared and static builds work without manual preprocessor flags.
     if(OSIMADDLIB_VENDORLIB)
         set(OSIMADDLIB_FOLDER "Vendor Libraries")
+        # Vendor libs keep DEFINE_SYMBOL for the conventional dllexport path.
+        set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
+            DEFINE_SYMBOL OSIM${OSIMADDLIB_UKIT}_EXPORTS
+            FOLDER "${OSIMADDLIB_FOLDER}"
+        )
     else()
         set(OSIMADDLIB_FOLDER "Libraries")
+        set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
+            FOLDER "${OSIMADDLIB_FOLDER}"
+        )
+        # SHARED build: define the _EXPORTS symbol only while building this
+        # target (PRIVATE), so its classes are annotated __declspec(dllexport).
+        # STATIC build: propagate _TYPE_STATIC to all consumers (PUBLIC) so
+        # they suppress __declspec(dllimport) in the API headers.
+        target_compile_definitions(${OSIMADDLIB_LIBRARY_NAME}
+            PRIVATE
+                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:OSIM${OSIMADDLIB_UKIT}_EXPORTS>
+            PUBLIC
+                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
+        )
     endif()
-    set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
-       DEFINE_SYMBOL OSIM${OSIMADDLIB_UKIT}_EXPORTS
-       FOLDER "${OSIMADDLIB_FOLDER}" # For Visual Studio.
-    )
 
     # Install.
     # --------

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -261,19 +261,6 @@ function(OpenSimAddLibrary)
             PUBLIC
                 $<$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
         )
-        # Static builds: the linker only pulls in object files that satisfy
-        # unresolved symbol references. RegisterTypes_*.cpp TUs contain only
-        # global constructor objects (e.g. osimSimulationInstantiator) with no
-        # externally-referenced symbols, so the linker silently omits them and
-        # type registration never runs. Whole-archive forces all object files in
-        # the library to be included, ensuring those constructors execute.
-        # The condition mirrors the one above: use the library's own TYPE so
-        # shared builds are unaffected.
-        target_link_options(${OSIMADDLIB_LIBRARY_NAME} INTERFACE
-            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<PLATFORM_ID:Windows>>:/WHOLEARCHIVE:$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>>
-            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<PLATFORM_ID:Darwin>>:LINKER:-force_load,$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>>
-            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<NOT:$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Darwin>>>>:LINKER:--whole-archive,$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>,--no-whole-archive>
-        )
     endif()
 
     # Install.

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -246,11 +246,14 @@ function(OpenSimAddLibrary)
         # target (PRIVATE), so its classes are annotated __declspec(dllexport).
         # STATIC build: propagate _TYPE_STATIC to all consumers (PUBLIC) so
         # they suppress __declspec(dllimport) in the API headers.
+        # Note: PUBLIC expressions are evaluated in the consuming target's
+        # context, so the library name must be referenced explicitly to test
+        # *this* target's type rather than the consumer's type.
         target_compile_definitions(${OSIMADDLIB_LIBRARY_NAME}
             PRIVATE
                 $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:OSIM${OSIMADDLIB_UKIT}_EXPORTS>
             PUBLIC
-                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
+                $<$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
         )
     endif()
 

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -234,33 +234,24 @@ function(OpenSimAddLibrary)
         POSITION_INDEPENDENT_CODE ON
     )
 
-    # Set DLL export/import defines based on actual target type so that
-    # both shared and static builds work without manual preprocessor flags.
+    # Set the `FOLDER` property of the library (used by IDEs).
     if(OSIMADDLIB_VENDORLIB)
         set(OSIMADDLIB_FOLDER "Vendor Libraries")
-        # Vendor libs keep DEFINE_SYMBOL for the conventional dllexport path.
-        set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
-            DEFINE_SYMBOL OSIM${OSIMADDLIB_UKIT}_EXPORTS
-            FOLDER "${OSIMADDLIB_FOLDER}"
-        )
     else()
         set(OSIMADDLIB_FOLDER "Libraries")
-        set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES
-            FOLDER "${OSIMADDLIB_FOLDER}"
-        )
-        # SHARED build: define the _EXPORTS symbol only while building this
-        # target (PRIVATE), so its classes are annotated __declspec(dllexport).
-        # STATIC build: propagate _TYPE_STATIC to all consumers (PUBLIC) so
-        # they suppress __declspec(dllimport) in the API headers.
-        # Note: PUBLIC expressions are evaluated in the consuming target's
-        # context, so the library name must be referenced explicitly to test
-        # *this* target's type rather than the consumer's type.
-        target_compile_definitions(${OSIMADDLIB_LIBRARY_NAME}
-            PRIVATE
-                $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:OSIM${OSIMADDLIB_UKIT}_EXPORTS>
-            PUBLIC
-                $<$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
-        )
+    endif()
+    set_target_properties(${OSIMADDLIB_LIBRARY_NAME} PROPERTIES FOLDER "${OSIMADDLIB_FOLDER}")
+
+    # Set DLL `__declspec` behavior based on target type.
+    get_target_property(lib_type ${OSIMADDLIB_LIBRARY_NAME} TYPE)
+    if(lib_type STREQUAL "SHARED_LIBRARY")
+        # Define `OSIM*_EXPORTS`, which emits `__declspec(dllexport)` on Windows.
+        # It shouldn't be defined in downstream builds (PRIVATE)
+        target_compile_definitions(${OSIMADDLIB_LIBRARY_NAME} PRIVATE OSIM${OSIMADDLIB_UKIT}_EXPORTS)
+    elseif(lib_type STREQUAL "STATIC_LIBRARY")
+        # Define `OPENSIM_*_TYPE_STATIC`, which prevents `__declspec` emission on Windows.
+        # It should be defined in both this and downstream builds (PUBLIC).
+        target_compile_definitions(${OSIMADDLIB_LIBRARY_NAME} PUBLIC OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC)
     endif()
 
     # Install.

--- a/cmake/OpenSimMacros.cmake
+++ b/cmake/OpenSimMacros.cmake
@@ -255,6 +255,19 @@ function(OpenSimAddLibrary)
             PUBLIC
                 $<$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>:OPENSIM_${OSIMADDLIB_UKIT}_TYPE_STATIC>
         )
+        # Static builds: the linker only pulls in object files that satisfy
+        # unresolved symbol references. RegisterTypes_*.cpp TUs contain only
+        # global constructor objects (e.g. osimSimulationInstantiator) with no
+        # externally-referenced symbols, so the linker silently omits them and
+        # type registration never runs. Whole-archive forces all object files in
+        # the library to be included, ensuring those constructors execute.
+        # The condition mirrors the one above: use the library's own TYPE so
+        # shared builds are unaffected.
+        target_link_options(${OSIMADDLIB_LIBRARY_NAME} INTERFACE
+            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<PLATFORM_ID:Windows>>:/WHOLEARCHIVE:$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>>
+            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<PLATFORM_ID:Darwin>>:LINKER:-force_load,$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>>
+            $<$<AND:$<STREQUAL:$<TARGET_PROPERTY:${OSIMADDLIB_LIBRARY_NAME},TYPE>,STATIC_LIBRARY>,$<NOT:$<OR:$<PLATFORM_ID:Windows>,$<PLATFORM_ID:Darwin>>>>:LINKER:--whole-archive,$<TARGET_FILE:${OSIMADDLIB_LIBRARY_NAME}>,--no-whole-archive>
+        )
     endif()
 
     # Install.


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

A self-contained set of changes that together allow OpenSim to be built as a
collection of static libraries by passing `-DBUILD_SHARED_LIBS=OFF`. The
changes span the CMake build system, the DLL export headers, and the
platform entry-point source files.

**`cmake/OpenSimMacros.cmake`**

Removes the hardcoded `SHARED` keyword from `add_library()` inside
`OpenSimAddLibrary()` so that `BUILD_SHARED_LIBS` is respected. Replaces the
`DEFINE_SYMBOL`-based export macro approach with `target_compile_definitions`
using generator expressions: the PRIVATE `OSIM*_EXPORTS` define is emitted when
building as a shared library, and the PUBLIC `OPENSIM_*_TYPE_STATIC` define is
propagated to all consumers when building as a static library so that downstream
targets automatically see the correct macro without manual configuration.

A generator expression bug is also fixed: in PUBLIC (propagated) scope,
`$<TARGET_PROPERTY:TYPE>` evaluates to the consuming target's type rather than
the library's own type. It is replaced with `$<TARGET_PROPERTY:libname,TYPE>`
so the condition always tests the library being defined.

Finally, INTERFACE `target_link_options` with platform-specific whole-archive
flags (`/WHOLEARCHIVE` on Windows, `-force_load` on macOS, `--whole-archive`
on Linux) are added so that consumers of a static build automatically pull in
all object files from each archive. This is required for type registration
because the `RegisterTypes_*.cpp` translation units contain only global
constructor objects and would otherwise be silently dropped by the linker.

**`CMakeLists.txt`**

Adds `if(NOT DEFINED BUILD_SHARED_LIBS) set(BUILD_SHARED_LIBS ON) endif()` to
preserve the historical shared-library default when the variable is not
explicitly set by the user.

Also adds `if(NOT BUILD_SHARED_LIBS AND NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE) set(CMAKE_POSITION_INDEPENDENT_CODE ON) endif()`.
The plugin example targets (`testAnalysisPluginExample`, `testBodyDragExample`,
etc.) are unconditionally built as `SHARED` libraries so they can be loaded
dynamically at runtime. In a static build they link against the OpenSim static
archives, which must therefore be compiled with `-fPIC`. Without this default,
the `thread_local` variable in `OpenSim/Common/Component.cpp` is compiled under
the local-exec TLS model, which the linker rejects when that object is pulled
into a shared object. Shared-library builds are unaffected because CMake always
emits `-fPIC` for `SHARED` targets.

**`Vendors/lepton/CMakeLists.txt`**

Replaces the global `add_definitions("-DLEPTON_BUILDING_SHARED_LIBRARY")` with
`target_compile_definitions` using generator expressions that set
`LEPTON_BUILDING_SHARED_LIBRARY` (PRIVATE) for shared builds,
`LEPTON_BUILDING_STATIC_LIBRARY` (PRIVATE) for static builds, and
`LEPTON_USE_STATIC_LIBRARIES` (PUBLIC) for consumers of a static Lepton.

**DLL export headers**

Adds an `#if defined(OPENSIM_*_TYPE_STATIC)` guard at the top of each
`osimActuatorsDLL.h`, `osimAnalysesDLL.h`, `osimCommonDLL.h`, `osimMocoDLL.h`,
`osimSimulationDLL.h`, `osimToolsDLL.h`, and `osimExampleComponentsDLL.h`. When
the guard is active the API macro expands to nothing, suppressing all
`__declspec(dllexport/dllimport)` annotations that would otherwise confuse the
linker in a static build.

**`osim*DLL.cpp` entry-point files**

Wraps the platform entry-point block (`DllMain` on Windows,
`__attribute__((constructor/destructor))` on GCC) in each `osim*DLL.cpp` with
`#ifndef OPENSIM_*_TYPE_STATIC`. With whole-archive linking, all object files
from every static archive are pulled into the final link including these
translation units from each library. Because each file independently defines
`DllMain`, the linker would produce `LNK2005: DllMain already defined` without
the guard.

## Why

The CMake build system currently hardcodes `SHARED` in every `add_library()`
call, making `-DBUILD_SHARED_LIBS=OFF` a no-op. Static builds are useful for
embedded deployment, packaging systems that prefer static linkage, and for
testing that the codebase compiles cleanly without hidden inter-library
dependencies.

## How to test

Configure with `-DBUILD_SHARED_LIBS=OFF` (and on Windows
`-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL`) and build. Verify that the
output libraries are static archives (`.lib` on Windows, `.a` on Linux/macOS)
and that the non-plugin tests pass. Then configure without `-DBUILD_SHARED_LIBS=OFF`
and confirm that the shared build and its tests are unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4358)
<!-- Reviewable:end -->
