### PR TITLE
[portability] Disable plugin example tests when `BUILD_API_ONLY=ON`

### DIFF
--- a/OpenSim/Tests/AnalysisPluginExample/CMakeLists.txt
+++ b/OpenSim/Tests/AnalysisPluginExample/CMakeLists.txt
@@ -35,3 +35,6 @@ set_target_properties(${TEST_TARGET} PROPERTIES
 add_test(NAME ${TEST_TARGET}
          COMMAND opensim-cmd -L $<TARGET_FILE:${TEST_TARGET}> run-tool
                  subject01_Setup_AnalysisPluginTemplate.xml)
+if(BUILD_API_ONLY)
+    set_tests_properties(${TEST_TARGET} PROPERTIES DISABLED TRUE)
+endif()

--- a/OpenSim/Tests/BodyDragExample/CMakeLists.txt
+++ b/OpenSim/Tests/BodyDragExample/CMakeLists.txt
@@ -45,3 +45,8 @@ add_test(NAME ${TEST_TARGET}_Example2
          COMMAND opensim-cmd -L $<TARGET_FILE:${TEST_TARGET}> run-tool
          forward.xml
          WORKING_DIRECTORY ${TEST_DIR})
+
+if(BUILD_API_ONLY)
+    set_tests_properties(${TEST_TARGET}_Example1 ${TEST_TARGET}_Example2
+            PROPERTIES DISABLED TRUE)
+endif()


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Adds `if(BUILD_API_ONLY) set_tests_properties(... PROPERTIES DISABLED TRUE) endif()`
after the `add_test` calls in:

- `OpenSim/Tests/AnalysisPluginExample/CMakeLists.txt` (one test)
- `OpenSim/Tests/BodyDragExample/CMakeLists.txt` (two tests)

## Why

Both tests invoke `opensim-cmd` at runtime to load a plugin DLL. When
`BUILD_API_ONLY=ON` the `Applications` subdirectory is skipped and `opensim-cmd`
is never built, so CTest cannot launch the test process and reports the tests as
"Not Run", which counts as a failure. The plugin DLLs themselves are still built
because both `CMakeLists.txt` files use `add_library(... SHARED ...)` unconditionally,
so the only missing piece is the launcher.

Using `if(TARGET opensim-cmd)` to conditionally register the tests would be the
more idiomatic approach, but `OpenSim/Tests` is processed before `Applications`
in the root `CMakeLists.txt`, so the target does not exist yet at configure time
when the test directories are visited. The explicit `BUILD_API_ONLY` check is
therefore the correct solution here.

## How to test

Configure with `-DBUILD_API_ONLY=ON` and run CTest. Confirm that
`testAnalysisPluginExample`, `testBodyDragExample_Example1`, and
`testBodyDragExample_Example2` appear as "Not Run (Disabled)" rather than as
failures. Then configure without `BUILD_API_ONLY` and confirm that all three
tests run normally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4359)
<!-- Reviewable:end -->
