### PR TITLE
[portability] Disable CasADi-dependent Moco tests when `OPENSIM_WITH_CASADI=OFF`

### DIFF
--- a/OpenSim/Moco/Test/CMakeLists.txt
+++ b/OpenSim/Moco/Test/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(Catch2 REQUIRED
 # Create an executable for the file ${TEST_NAME}.cpp, which depends on
 # libraries ${LIB_DEPENDENCIES}. Also create a CTest test for this executable.
 function(MocoAddTest)
-    set(options)
+    set(options REQUIRES_CASADI)
     set(oneValueArgs NAME)
     set(multiValueArgs LIB_DEPENDS RESOURCES)
     cmake_parse_arguments(MOCOTEST
@@ -30,6 +30,9 @@ function(MocoAddTest)
         list(APPEND test_args "~[mac]~[linux]~[mac/linux]~[linux/mac]~[unix]")
     endif()
     add_test(NAME ${MOCOTEST_NAME} COMMAND ${MOCOTEST_NAME} ${test_args})
+    if(MOCOTEST_REQUIRES_CASADI AND NOT OPENSIM_WITH_CASADI)
+        set_tests_properties(${MOCOTEST_NAME} PROPERTIES DISABLED TRUE)
+    endif()
     # Tests likely run faster if we parallelize the tests rather than the
     # individual problems.
     set_property(TEST ${MOCOTEST_NAME} APPEND PROPERTY
@@ -37,21 +40,21 @@ function(MocoAddTest)
     file(COPY ${MOCOTEST_RESOURCES} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endfunction()
 
-MocoAddTest(NAME testMocoInterface)
+MocoAddTest(NAME testMocoInterface REQUIRES_CASADI)
 
 MocoAddTest(NAME testMocoGoals)
 
 MocoAddTest(NAME testMocoParameters)
 
-MocoAddTest(NAME testMocoImplicit)
+MocoAddTest(NAME testMocoImplicit REQUIRES_CASADI)
 
-MocoAddTest(NAME testMocoConstraints)
+MocoAddTest(NAME testMocoConstraints REQUIRES_CASADI)
 
 MocoAddTest(NAME testMocoContact RESOURCES
         subject_20dof18musc_running.osim
         running_solution_full_stride.sto)
 
-MocoAddTest(NAME testMocoControllers)
+MocoAddTest(NAME testMocoControllers REQUIRES_CASADI)
 
 MocoAddTest(NAME testMocoActuators)
 
@@ -71,7 +74,7 @@ MocoAddTest(NAME testMocoTrack RESOURCES
         std_testMocoTrackGait10dof18musc_solution.sto
         )
 
-MocoAddTest(NAME testMocoAnalytic)
+MocoAddTest(NAME testMocoAnalytic REQUIRES_CASADI)
 
 MocoAddTest(NAME testMocoMetabolics RESOURCES
         testMocoMetabolics_hanging_muscle.osim

--- a/OpenSim/Moco/Test/CMakeLists.txt
+++ b/OpenSim/Moco/Test/CMakeLists.txt
@@ -6,8 +6,8 @@ find_package(Catch2 REQUIRED
 # Create an executable for the file ${TEST_NAME}.cpp, which depends on
 # libraries ${LIB_DEPENDENCIES}. Also create a CTest test for this executable.
 function(MocoAddTest)
-    set(options REQUIRES_CASADI)
-    set(oneValueArgs NAME)
+    set(options)
+    set(oneValueArgs NAME REQUIRES_CASADI)
     set(multiValueArgs LIB_DEPENDS RESOURCES)
     cmake_parse_arguments(MOCOTEST
             "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -15,11 +15,6 @@ function(MocoAddTest)
     # To organize targets in Visual Studio's Solution Explorer.
     set_target_properties(${MOCOTEST_NAME} PROPERTIES FOLDER "Moco/Tests")
     target_link_libraries(${MOCOTEST_NAME} osimMoco ${MOCOTEST_LIB_DEPENDS} Catch2::Catch2WithMain)
-    # Skip tests relying on MocoCasADiSolver if CasADi is not available.
-    if(NOT OPENSIM_WITH_CASADI)
-        list(APPEND test_args "~*MocoCasADiSolver*")
-        list(APPEND test_args "~[casadi]")
-    endif()
     if(APPLE)
         list(APPEND test_args "~[win]~[linux]~[win/linux]~[linux/win]")
     endif()
@@ -30,6 +25,10 @@ function(MocoAddTest)
         list(APPEND test_args "~[mac]~[linux]~[mac/linux]~[linux/mac]~[unix]")
     endif()
     add_test(NAME ${MOCOTEST_NAME} COMMAND ${MOCOTEST_NAME} ${test_args})
+    # Default to requiring CasADi unless the caller explicitly passes REQUIRES_CASADI FALSE.
+    if(NOT DEFINED MOCOTEST_REQUIRES_CASADI)
+        set(MOCOTEST_REQUIRES_CASADI TRUE)
+    endif()
     if(MOCOTEST_REQUIRES_CASADI AND NOT OPENSIM_WITH_CASADI)
         set_tests_properties(${MOCOTEST_NAME} PROPERTIES DISABLED TRUE)
     endif()
@@ -40,21 +39,21 @@ function(MocoAddTest)
     file(COPY ${MOCOTEST_RESOURCES} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 endfunction()
 
-MocoAddTest(NAME testMocoInterface REQUIRES_CASADI)
+MocoAddTest(NAME testMocoInterface)
 
 MocoAddTest(NAME testMocoGoals)
 
 MocoAddTest(NAME testMocoParameters)
 
-MocoAddTest(NAME testMocoImplicit REQUIRES_CASADI)
+MocoAddTest(NAME testMocoImplicit)
 
-MocoAddTest(NAME testMocoConstraints REQUIRES_CASADI)
+MocoAddTest(NAME testMocoConstraints)
 
 MocoAddTest(NAME testMocoContact RESOURCES
         subject_20dof18musc_running.osim
         running_solution_full_stride.sto)
 
-MocoAddTest(NAME testMocoControllers REQUIRES_CASADI)
+MocoAddTest(NAME testMocoControllers)
 
 MocoAddTest(NAME testMocoActuators)
 
@@ -74,9 +73,9 @@ MocoAddTest(NAME testMocoTrack RESOURCES
         std_testMocoTrackGait10dof18musc_solution.sto
         )
 
-MocoAddTest(NAME testMocoAnalytic REQUIRES_CASADI)
+MocoAddTest(NAME testMocoAnalytic)
 
-MocoAddTest(NAME testMocoMetabolics RESOURCES
+MocoAddTest(NAME testMocoMetabolics REQUIRES_CASADI FALSE RESOURCES
         testMocoMetabolics_hanging_muscle.osim
         )
 


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Replaces the Catch2 runtime filter approach in `OpenSim/Moco/Test/CMakeLists.txt`
with consistent CMake-level `DISABLED TRUE` for all Moco tests that require
CasADi. The `MocoAddTest` function gains a `REQUIRES_CASADI` one-value argument
that defaults to `TRUE`. Only `testMocoMetabolics` passes `REQUIRES_CASADI FALSE`
since it has no CasADi dependency. The previous `~[casadi]` and
`~*MocoCasADiSolver*` Catch2 filter arguments are removed from the function. The
`[casadi]` tags remain in the test source files for granular filtering when
CasADi is available.

## Why

The Catch2 filter approach ran a partial test suite when CasADi was absent,
either failing on untagged CasADi-dependent cases or producing near-empty runs.
Using CMake `DISABLED TRUE` makes the absence of CasADi a visible configuration
choice (CTest reports "Not Run") rather than a mix of skipped and failed tests.
Having a single consistent mechanism also avoids maintaining two parallel gating
strategies.

## How to test

Configure with `-DOPENSIM_WITH_CASADI=OFF` and run CTest. Confirm that all Moco
tests except `testMocoMetabolics` appear as "Not Run (Disabled)" and that
`testMocoMetabolics` runs and passes. Then configure with
`-DOPENSIM_WITH_CASADI=ON` and confirm that all twelve tests are enabled and run
normally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4360)
<!-- Reviewable:end -->
