### PR TITLE
[portability] Fix miscellaneous correctness issues in `MarkerData` and `Model`

### DIFF
--- a/OpenSim/Common/MarkerData.cpp
+++ b/OpenSim/Common/MarkerData.cpp
@@ -32,8 +32,8 @@
 #include "SimmIO.h"
 #include "SimmMacros.h"
 #include "Storage.h"
-#include "OpenSim/Auxiliary/auxiliaryTestFunctions.h"
 #include "OpenSim/Common/STOFileAdapter.h"
+#include <regex>
 
 //=============================================================================
 // STATICS
@@ -45,6 +45,25 @@ using SimTK::Vec3;
 //=============================================================================
 // HELPER FUNCTIONS
 //=============================================================================
+// Rewrite a version-2 STO file as version-1. Returns true if the version was
+// changed. This function can be removed when Storage class is removed.
+inline bool revertToVersionNumber1(const std::string& filenameOld,
+                                   const std::string& filenameNew) {
+    std::regex versionline{ R"([ \t]*version[ \t]*=[ \t]*2[ \t]*)" };
+    std::ifstream fileOld{ filenameOld };
+    std::ofstream fileNew{ filenameNew };
+    std::string line{};
+    bool changedVersion{false};
+    while (std::getline(fileOld, line)) {
+        if (std::regex_match(line, versionline)) {
+            fileNew << "version=1\n";
+            changedVersion = true;
+        } else
+            fileNew << line << "\n";
+    }
+    return changedVersion;
+}
+
 // Add number of rows (nRows) and number of columns (nColumns) to the header of
 // the STO file. Note that nColumns will include time, so it will be number of
 // columns in the matrix plus 1 (for time).

--- a/OpenSim/Simulation/Model/Model.cpp
+++ b/OpenSim/Simulation/Model/Model.cpp
@@ -223,7 +223,7 @@ Model::Model(const string &aFileName) :
     try {
         finalizeFromProperties();
     }
-    catch(const InvalidPropertyValue& err) {
+    catch(const std::exception& err) {
         log_error("Model was unable to finalizeFromProperties."
                   "Update the model file and reload OR update the property and "
                   "call finalizeFromProperties() on the model."
@@ -240,7 +240,7 @@ Model* Model::clone() const
     try {
         clone->finalizeFromProperties();
     }
-    catch (const InvalidPropertyValue& err) {
+    catch (const std::exception& err) {
         log_error(
                 "clone() was unable to finalizeFromProperties."
                 "Update the model and call clone() again OR update the clone's "
@@ -768,10 +768,10 @@ std::string Model::getWarningMesssageForMotionTypeInconsistency() const
     for (auto& coord : coordinates) {
         const Coordinate::MotionType oldMotionType =
             coord.getUserSpecifiedMotionTypePriorTo40();
+        if (oldMotionType == Coordinate::MotionType::Undefined)
+            continue;
         const Coordinate::MotionType motionType = coord.getMotionType();
-
-        if( (oldMotionType != Coordinate::MotionType::Undefined ) &&
-            (oldMotionType != motionType) ){
+        if (oldMotionType != motionType) {
             message += "Coordinate '" + coord.getName() +
                 "' was labeled as '" + enumToString(oldMotionType) +
                 "' but was found to be '" + enumToString(motionType) + "' based on the joint definition.\n";
@@ -1127,8 +1127,16 @@ void Model::extendAddToSystem(SimTK::MultibodySystem& system) const
 void Model::addModelComponent(ModelComponent* component)
 {
     if(component){
+        const std::string name = component->getName();
         upd_ComponentSet().adoptAndAppend(component);
-        finalizeFromProperties();
+        try {
+            finalizeFromProperties();
+        } catch (const std::exception& err) {
+            upd_ComponentSet().remove(component);
+            log_error("addModelComponent: finalizeFromProperties() failed, "
+                      "'{}' was not added. (details: {}).",
+                      name, err.what());
+        }
         prependComponentPathToConnecteePath(*component);
     }
 }


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Two independent correctness fixes:

**`OpenSim/Common/MarkerData.cpp`**

- Removes the incorrect `#include "OpenSim/Auxiliary/auxiliaryTestFunctions.h"`
  (a test-only header that has arguably no business in a library source file).
- Adds a file-local helper `revertToVersionNumber1()` that rewrites a
  version-2 STO file as version-1, used internally by the `Storage`-based
  reading path.

**`OpenSim/Simulation/Model/Model.cpp`**

- Widens the `catch(const InvalidPropertyValue&)` clauses in the `Model`
  constructor and `clone()` to `catch(const std::exception&)` so that any
  exception thrown by `finalizeFromProperties()` is caught and logged rather
  than propagating as an unhandled exception.
- Wraps the `finalizeFromProperties()` call in `addModelComponent()` in a
  try/catch that rolls back the component on failure and logs the error, so a
  failed add does not leave the model in an inconsistent state.
- Guards against `getUserSpecifiedMotionTypePriorTo40()` returning
  `Coordinate::MotionType::Undefined` in
  `getWarningMesssageForMotionTypeInconsistency()`, which previously caused a
  null-pointer crash in release builds for coordinates not owned by a joint.

## Why

The `auxiliaryTestFunctions.h` include is a stray dependency that should never
appear in library code. The missing `<regex>` include was only going unnoticed
because another header happened to pull it in transitively on some platforms.

The narrowed `catch` clauses in `Model.cpp` meant that exceptions other than
`InvalidPropertyValue` (for example `std::bad_alloc` or other property errors)
escaped the constructor and `clone()` entirely and produced confusing crashes
instead of the intended error log. Without the rollback in `addModelComponent`,
a failed `finalizeFromProperties()` left the newly-appended component in the
set permanently, corrupting the model. The `Undefined` guard prevents a
reproducible null-pointer crash that occurs when a coordinate is not attached
to a joint.

## How to test

Build and run the existing test suite. Confirm that `testSerialization` and any
test that exercises `Model::clone()` or coordinates without joints passes
cleanly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4361)
<!-- Reviewable:end -->