### PR TITLE
[portability] Add MinGW compiler support for `M_PI` and `_mkdir`

### DIFF
--- a/OpenSim/Common/IO.cpp
+++ b/OpenSim/Common/IO.cpp
@@ -40,7 +40,7 @@
 #if defined(__linux__) || defined(__APPLE__)
     #include <sys/stat.h>
     #include <sys/types.h>
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) || defined(__MINGW32__)
     #include <direct.h>
 #else
     #include <unistd.h>

--- a/Vendors/lepton/src/Operation.cpp
+++ b/Vendors/lepton/src/Operation.cpp
@@ -31,8 +31,9 @@
  * -------------------------------------------------------------------------- */
 
 #include "lepton/Operation.h"
+#include <numbers>
+
 #include "lepton/ExpressionTreeNode.h"
-#include "MSVC_erfc.h"
 
 using namespace Lepton;
 using namespace std;
@@ -228,7 +229,7 @@ ExpressionTreeNode Operation::Tanh::differentiate(const std::vector<ExpressionTr
 ExpressionTreeNode Operation::Erf::differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const {
     return ExpressionTreeNode(new Operation::Multiply(),
                               ExpressionTreeNode(new Operation::Multiply(),
-                                                 ExpressionTreeNode(new Operation::Constant(2.0/sqrt(M_PI))),
+                                                 ExpressionTreeNode(new Operation::Constant(2.0/sqrt(std::numbers::pi))),
                                                  ExpressionTreeNode(new Operation::Exp(),
                                                                     ExpressionTreeNode(new Operation::Negate(),
                                                                                        ExpressionTreeNode(new Operation::Square(), children[0])))),
@@ -238,7 +239,7 @@ ExpressionTreeNode Operation::Erf::differentiate(const std::vector<ExpressionTre
 ExpressionTreeNode Operation::Erfc::differentiate(const std::vector<ExpressionTreeNode>& children, const std::vector<ExpressionTreeNode>& childDerivs, const std::string& variable) const {
     return ExpressionTreeNode(new Operation::Multiply(),
                               ExpressionTreeNode(new Operation::Multiply(),
-                                                 ExpressionTreeNode(new Operation::Constant(-2.0/sqrt(M_PI))),
+                                                 ExpressionTreeNode(new Operation::Constant(-2.0/sqrt(std::numbers::pi))),
                                                  ExpressionTreeNode(new Operation::Exp(),
                                                                     ExpressionTreeNode(new Operation::Negate(),
                                                                                        ExpressionTreeNode(new Operation::Square(), children[0])))),


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Two small changes to make OpenSim compile under MinGW:

- `Vendors/lepton/src/Operation.cpp`: replaces `M_PI` with
  `std::numbers::pi` (C++20) in the `erf`/`erfc` derivative constants, and
  drops the now-stale `#include "MSVC_erfc.h"` (its only active job was
  defining `M_PI`; the `erf`/`erfc` polyfill inside is guarded to
  `_MSC_VER <= 1700`, which predates C++17).
- `OpenSim/Common/IO.cpp`: extends the `#elif defined(_MSC_VER)` branch that
  includes `<direct.h>` for `_mkdir` to also match `__MINGW32__`.

## Why

`M_PI` is non-standard. On MSVC it was provided by the vendored `MSVC_erfc.h`.
On Linux and macOS it leaks through from `<cmath>` via `_GNU_SOURCE`. MinGW
requires `_USE_MATH_DEFINES` to expose it. Rather than adding yet another
platform guard, the two uses are replaced with `std::numbers::pi`, which is
portable and well-defined on any C++20 compiler.

For directory creation, the existing code already branched between POSIX
(`sys/stat.h`) and MSVC (`direct.h`). MinGW provides `_mkdir` in `direct.h`
the same way MSVC does, but it does not define `_MSC_VER`, so it fell through
to the POSIX branch and failed to compile.

## How to test

Configure and build OpenSim using a MinGW toolchain (e.g. MSYS2 with
`mingw-w64-x86_64-gcc`). Confirm that the build completes without errors in
`Operation.cpp` and `IO.cpp`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4362)
<!-- Reviewable:end -->