### PR TITLE
[portability] Add missing `fmt::formatter` specialization for `SimTK::ConstraintIndex`

### DIFF
--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -35,6 +35,8 @@
 
 using namespace OpenSim;
 
+template <> struct fmt::formatter<SimTK::ConstraintIndex> : ostream_formatter {};
+
 const std::vector<std::string> MocoProblemRep::m_disallowedJoints(
         {"FreeJoint", "BallJoint", "EllipsoidJoint", "ScapulothoracicJoint"});
 


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Adds `template <> struct fmt::formatter<SimTK::ConstraintIndex> : ostream_formatter {};`
in `OpenSim/Moco/MocoProblemRep.cpp` so that `ConstraintIndex` values can be
passed directly to `fmt` or `spdlog` log calls.

## Why

`fmt` requires a registered `fmt::formatter` specialization for every type used
as a format argument. This requirement became a hard compile error in newer
versions of `fmt` (around v9), which tightened enforcement of the formatter
concept. `SimTK::ConstraintIndex` lacks a specialization but is passed to a log
call in `MocoProblemRep.cpp`, producing a static assertion failure on affected
fmt versions. The `ostream_formatter` base satisfies the requirement for any
type that already has an `operator<<` overload.

## How to test

Build OpenSim against a recent version of fmt (v9 or later) and confirm that
`MocoProblemRep.cpp` compiles without a formatter-related static assertion
failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4363)
<!-- Reviewable:end -->
