### PR TITLE
[portability] Fix static initialization order of Object type-registry maps

### DIFF
--- a/OpenSim/Common/Object.cpp
+++ b/OpenSim/Common/Object.cpp
@@ -49,9 +49,18 @@ using SimTK::Transform;
 //=============================================================================
 // STATICS
 //=============================================================================
-ArrayPtrs<Object>           Object::_registeredTypes;
-std::map<string,Object*>    Object::_mapTypesToDefaultObjects;
-std::map<string,string>     Object::_renamedTypesMap;
+ArrayPtrs<Object>& Object::_registeredTypes() {
+    static ArrayPtrs<Object> instance;
+    return instance;
+}
+std::map<string,Object*>& Object::_mapTypesToDefaultObjects() {
+    static std::map<string,Object*> instance;
+    return instance;
+}
+std::map<string,string>& Object::_renamedTypesMap() {
+    static std::map<string,string> instance;
+    return instance;
+}
 
 bool                        Object::_serializeAllDefaults=false;
 const string                Object::DEFAULT_NAME(ObjectDEFAULT_NAME);
@@ -503,25 +512,25 @@ registerType(const Object& aObject)
     log_debug("Object.registerType: {}.", type);
 
     // REPLACE IF A MATCHING TYPE IS ALREADY REGISTERED
-    for(int i=0; i <_registeredTypes.size(); ++i) {
-        Object *object = _registeredTypes.get(i);
+    for(int i=0; i <_registeredTypes().size(); ++i) {
+        Object *object = _registeredTypes().get(i);
         if(object->getConcreteClassName() == type) {
             log_debug("Object.registerType: replacing registered object of "
                       "type {} with a new default object of the same type.",
                       type);
             Object* defaultObj = aObject.clone();
             defaultObj->setName(DEFAULT_NAME);
-            _registeredTypes.set(i,defaultObj);
-            _mapTypesToDefaultObjects[type]= defaultObj;
+            _registeredTypes().set(i,defaultObj);
+            _mapTypesToDefaultObjects()[type]= defaultObj;
             return;
-        } 
+        }
     }
 
     // REGISTERING FOR THE FIRST TIME -- APPEND
     Object* defaultObj = aObject.clone();
     defaultObj->setName(DEFAULT_NAME);
-    _registeredTypes.append(defaultObj);
-    _mapTypesToDefaultObjects[type]= defaultObj;
+    _registeredTypes().append(defaultObj);
+    _mapTypesToDefaultObjects()[type]= defaultObj;
 }
 
 /*static*/ void Object::
@@ -530,16 +539,16 @@ renameType(const std::string& oldTypeName, const std::string& newTypeName)
     if(oldTypeName == newTypeName)
         return; 
 
-    std::map<std::string,Object*>::const_iterator p = 
-        _mapTypesToDefaultObjects.find(newTypeName);
+    std::map<std::string,Object*>::const_iterator p =
+        _mapTypesToDefaultObjects().find(newTypeName);
 
-    if (p == _mapTypesToDefaultObjects.end())
+    if (p == _mapTypesToDefaultObjects().end())
         throw OpenSim::Exception(
             "Object::renameType(): illegal attempt to rename object type "
             + oldTypeName + " to " + newTypeName + " which is unregistered.",
             __FILE__, __LINE__);
 
-    _renamedTypesMap[oldTypeName] = newTypeName;
+    _renamedTypesMap()[oldTypeName] = newTypeName;
 }
 
 /*static*/ const Object* Object::
@@ -550,12 +559,12 @@ getDefaultInstanceOfType(const std::string& objectTypeTag) {
     // First apply renames if any.
 
     // Avoid an infinite loop if there is a cycle in the rename table.
-    const int MaxRenames = (int)_renamedTypesMap.size();
+    const int MaxRenames = (int)_renamedTypesMap().size();
     int renameCount = 0;
     while(true) {
         std::map<std::string,std::string>::const_iterator newNamep =
-            _renamedTypesMap.find(actualName);
-        if (newNamep == _renamedTypesMap.end())
+            _renamedTypesMap().find(actualName);
+        if (newNamep == _renamedTypesMap().end())
             break; // actualName has not been renamed
 
         if (++renameCount > MaxRenames) {
@@ -569,9 +578,9 @@ getDefaultInstanceOfType(const std::string& objectTypeTag) {
     }
 
     // Look up the "actualName" default object and return it.
-    std::map<std::string,Object*>::const_iterator p = 
-        _mapTypesToDefaultObjects.find(actualName);
-    if (p != _mapTypesToDefaultObjects.end())
+    std::map<std::string,Object*>::const_iterator p =
+        _mapTypesToDefaultObjects().find(actualName);
+    if (p != _mapTypesToDefaultObjects().end())
         return p->second;
 
     // The requested object was not registered. That's OK normally but is
@@ -619,9 +628,9 @@ newInstanceOfType(const std::string& objectTypeTag)
 /*static*/ void Object::
 getRegisteredTypenames(Array<std::string>& rTypeNames)
 {
-    std::map<string,Object*>::const_iterator p = 
-        _mapTypesToDefaultObjects.begin();
-    for (; p != _mapTypesToDefaultObjects.end(); ++p)
+    std::map<string,Object*>::const_iterator p =
+        _mapTypesToDefaultObjects().begin();
+    for (; p != _mapTypesToDefaultObjects().end(); ++p)
         rTypeNames.append(p->first);
     // Renamed type names don't appear in the registeredTypes map, unless
     // they were separately registered.
@@ -1405,11 +1414,11 @@ PrintPropertyInfo(ostream &aOStream,
 
     if(aClassName=="") {
         // NO CLASS
-        int size = _registeredTypes.getSize();
+        int size = _registeredTypes().getSize();
         ss<<"REGISTERED CLASSES ("<<size<<")\n";
         Object *obj;
         for(int i=0;i<size;i++) {
-            obj = _registeredTypes.get(i);
+            obj = _registeredTypes().get(i);
             if(obj==NULL) continue;
             ss<<obj->getConcreteClassName()<<endl;
         }

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -485,8 +485,8 @@ public:
     getRegisteredObjectsOfGivenType(ArrayPtrs<T>& rArray) {
         rArray.setSize(0);
         rArray.setMemoryOwner(false);
-        for(int i=0; i<_registeredTypes.getSize(); i++) {
-            T* obj = dynamic_cast<T*>(_registeredTypes[i]);
+        for(int i=0; i<_registeredTypes().getSize(); i++) {
+            T* obj = dynamic_cast<T*>(_registeredTypes()[i]);
             if (obj) rArray.append(obj);
         }
     }
@@ -874,22 +874,22 @@ private:
     // Each object type only appears once in this array. Renamed types usually
     // do not have separate registered objects; they are just used to locate 
     // one of the current ones.
-    static ArrayPtrs<Object>                    _registeredTypes;
+    static ArrayPtrs<Object>&                    _registeredTypes();
 
-    // Map from concrete object class name string to a default object of that 
-    // type kept in the above array of registered types. Renamed types are *not* 
-    // normally entered here; the names are mapped separately using the map 
+    // Map from concrete object class name string to a default object of that
+    // type kept in the above array of registered types. Renamed types are *not*
+    // normally entered here; the names are mapped separately using the map
     // below.
-    static std::map<std::string,Object*>        _mapTypesToDefaultObjects;
+    static std::map<std::string,Object*>&        _mapTypesToDefaultObjects();
 
     // Map types that have been renamed to their new names, which can
-    // then be used to find them in the default object map. This lets us 
+    // then be used to find them in the default object map. This lets us
     // recognize the old names while converting to the new ones internally
-    // so that they will be updated when written out. It also allows one 
+    // so that they will be updated when written out. It also allows one
     // to map one registered type to a different one programmatically, because
     // we'll look up the name in the rename table first prior to searching
     // the registered types list.
-    static std::map<std::string,std::string>    _renamedTypesMap;
+    static std::map<std::string,std::string>&    _renamedTypesMap();
 
     // Global flag to indicate if all registered objects are to be written in 
     // a "defaults" section.


### PR DESCRIPTION
> **Series note:** This PR is one of a set of portability and correctness fixes
> extracted from a build2 port of opensim-core. All changes fix genuine issues
> in the upstream codebase and none is build2-specific. Each PR is
> self-contained and can be reviewed and merged independently. The full set
> covers: superbuild MSVC runtime forwarding, MinGW compiler support, Windows
> DLL export correctness, spdlog and fmt API alignment, static-library build
> support (CMake build system, type-registration SIOF, SimTK constant SIOF,
> LoadOpenSimLibrary removal), and test configuration gating.
> Final full static build (including `Simbody` dependency) requires `Simbody` PR [860](https://github.com/simbody/simbody/pull/860).

## What

Converts the three static data members of `Object`
(`_registeredTypes`, `_mapTypesToDefaultObjects`, `_renamedTypesMap`) from
plain static members to function-local statics returned by accessor functions
(`Object.h`, `Object.cpp`). All call sites are updated accordingly.

## Why

In a static-library build, the `RegisterTypes_osim*` translation units run
their global constructors to populate the type registry before the translation
unit that defines the three static arrays has been initialized. Reading or
writing an uninitialized `std::map` or `ArrayPtrs` in this window produces
undefined behaviour and typically silently corrupts the registry, causing
subsequent `Object::newInstanceOfType` calls to return null.

Converting to function-local statics (the "construct on first use" idiom)
guarantees that each container is fully constructed the first time any code
touches it, regardless of the order in which translation units are initialized.
The fix has no runtime cost beyond the first call and no effect on the public
API.

## How to test

Build OpenSim as a static library (`-DBUILD_SHARED_LIBS=OFF`) and run the full
test suite. Confirm that tests which rely on type registration (for example
`testSerialization` and `testModelInterface`) pass and that no assertion fires
inside `Object::registerType` or `Object::newInstanceOfType`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4364)
<!-- Reviewable:end -->
