### PR TITLE
Minor patch to `.gitignore` so `.cache` folder is ignored propertly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,9 @@ CMakeLists.txt.user
 *~
 *.swp
 *.swo
-.cache/  # When using clangd-based LSPs
+
+# When using clangd-based LSPs
+.cache/
 
 # editor: Visual Studio
 .vs/


### PR DESCRIPTION
Minor follow-up to #4355.

### Brief summary of changes
Locally, my `.cache/clangd` folder was not being ignored properly with the recent `.gitignore` change. Moving the comment above the entry seems to fix it. 

### CHANGELOG.md (choose one)

- no need to update because...minor gitignore change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4365)
<!-- Reviewable:end -->
