### PR TITLE
Replace `spdlog` with `std::format` (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ the model's topology (e.g., `GeometryPath`) or via a user-defined list of coordi
   wide range of OSes (see pypa/manylinux for a compatibility table).
 - `OptimizationExample_Arm26` was removed from the repository. It runs slow and is numerically
   unstable (a forward integration to optimize a final velocity) across OSes/compilers.
+- Replaced `spdlog` and (transitively) `fmt` with `std::format`. If downstream codebases depended on
+  either of these libraries then they should integrate them downstream (which means you can now
+  pick the version yourself!).
 
 
 v4.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,6 @@ if(${OPENSIM_INSTALL_UNIX_FHS})
     set(OPENSIM_INSTALL_JAVASRCDIR "${CMAKE_INSTALL_DATAROOTDIR}/OpenSim/java")
     set(OPENSIM_INSTALL_APIEXDIR "${CMAKE_INSTALL_DOCDIR}/Code")
     set(OPENSIM_INSTALL_SIMBODYDIR ".")
-    set(OPENSIM_INSTALL_SPDLOGDIR ".")
     set(OPENSIM_INSTALL_CASADIDIR ".")
 
 else()
@@ -280,7 +279,6 @@ else()
     set(OPENSIM_INSTALL_JAVASRCDIR sdk/Java)
     set(OPENSIM_INSTALL_APIEXDIR Resources/Code)
     set(OPENSIM_INSTALL_SIMBODYDIR sdk/Simbody)
-    set(OPENSIM_INSTALL_SPDLOGDIR sdk/spdlog)
     set(OPENSIM_INSTALL_CASADIDIR sdk)
 
 endif()
@@ -564,10 +562,6 @@ else()
     unset(ezc3d_INCLUDE_DIR CACHE)
 endif()
 
-find_package(spdlog REQUIRED
-        HINTS "${OPENSIM_DEPENDENCIES_DIR}/spdlog")
-
-
 if(NOT SIMBODY_HOME AND OPENSIM_DEPENDENCIES_DIR)
     set(SIMBODY_HOME "${OPENSIM_DEPENDENCIES_DIR}/simbody")
 endif()
@@ -825,11 +819,6 @@ if(${OPENSIM_COPY_DEPENDENCIES})
         install(FILES ${ezc3d_desired_lib_files}
                 DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
-
-    # spdlog
-    # ------
-    install(DIRECTORY "${spdlog_DIR}/../../../"
-            DESTINATION "${OPENSIM_INSTALL_SPDLOGDIR}")
 endif()
 
 if(BUILD_PYTHON_WRAPPING AND OPENSIM_PYTHON_STANDALONE)

--- a/OpenSim/Actuators/PolynomialPathFitter.cpp
+++ b/OpenSim/Actuators/PolynomialPathFitter.cpp
@@ -34,6 +34,7 @@
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/SimbodyEngine/CoordinateCouplerConstraint.h>
 
+#include <format>
 #include <future>
 
 using namespace OpenSim;
@@ -114,7 +115,7 @@ TimeSeriesTable loadCoordinateValuesAndValidateModel(
     // Validate the coordinate values table
     std::vector<std::string> jointsToWeld;
     for (auto& coordinate : model.updComponentList<Coordinate>()) {
-        std::string valuePath = fmt::format("{}/value",
+        std::string valuePath = std::format("{}/value",
                 coordinate.getAbsolutePathString());
 
         // If the coordinate is locked, but the user provided a column for the
@@ -128,7 +129,7 @@ TimeSeriesTable loadCoordinateValuesAndValidateModel(
             }
         } else {
             OPENSIM_THROW_IF(!values.hasColumn(valuePath), Exception,
-                    fmt::format("Expected the coordinate values table to "
+                    std::format("Expected the coordinate values table to "
                                 "contain a column for '{}' (this coordinate is "
                                 "not locked), but it does not.",
                             coordinate.getAbsolutePathString()))
@@ -449,10 +450,10 @@ void computePathLengthsAndMomentArms(
     for (const auto& forcePath : forcePaths) {
         const auto& force = model.getComponent<Force>(forcePath);
         pathLengthLabels[ip++] =
-                fmt::format("{}_length", force.getAbsolutePathString());
+                std::format("{}_length", force.getAbsolutePathString());
         for (const auto& coordinate :
                 model.getComponentList<Coordinate>()) {
-            momentArmLabels[ima++] = fmt::format("{}_moment_arm_{}",
+            momentArmLabels[ima++] = std::format("{}_moment_arm_{}",
                     force.getAbsolutePathString(), coordinate.getName());
         }
     }
@@ -478,7 +479,7 @@ void filterSampledData(
     // Remove moment arm columns for coupled coordinates.
     for (const auto& couplerConstraint :
             model.getComponentList<CoordinateCouplerConstraint>()) {
-        auto momentArmLabel = fmt::format("_moment_arm_{}",
+        auto momentArmLabel = std::format("_moment_arm_{}",
                 couplerConstraint.getDependentCoordinateName());
         for (const auto& label : momentArms.getColumnLabels()) {
             if (label.find(momentArmLabel) != std::string::npos) {
@@ -887,7 +888,7 @@ Set<FunctionBasedPath> fitPolynomialCoefficients(
             // The path lengths for this force. This is the first N elements of
             // the 'b' vector.
             b(0, numTimes) = pathLengths.getDependentColumn(
-                    fmt::format("{}_length", forcePath));
+                    std::format("{}_length", forcePath));
 
             // The moment arms this force and coordinates associated with this
             // force. The moment arms are the remaining elements of the 'b'
@@ -898,12 +899,12 @@ Set<FunctionBasedPath> fitPolynomialCoefficients(
                 const std::string& coordinateName =
                         coordinatesNamesThisForce[ic];
                 b((ic+1)*numTimes, numTimes) = momentArms.getDependentColumn(
-                        fmt::format("{}_moment_arm_{}", forcePath,
+                        std::format("{}_moment_arm_{}", forcePath,
                                 coordinateName));
 
                 const SimTK::VectorView coordinateValuesThisCoordinate =
                         coordinateValues.getDependentColumn(
-                            fmt::format("{}/value",
+                            std::format("{}/value",
                                         coordinatePathsThisForce[ic]));
                 for (int itime = 0; itime < numTimes; ++itime) {
                     coordinatesThisForce.set(
@@ -1028,7 +1029,7 @@ void computeFittingErrors(
     auto printWarningMessage = [](const std::string& pathLengthOrMomentArm,
                                 double tolerance) {
         log_warn("-----------------------------------------------------------");
-        log_warn(fmt::format("The {} RMS error is greater than the prescribed "
+        log_warn(std::format("The {} RMS error is greater than the prescribed "
                              "tolerance of {:g} cm.",
                              pathLengthOrMomentArm, tolerance));
         log_warn("");
@@ -1070,7 +1071,7 @@ void computeFittingErrors(
         pathName = pathName.substr(0, pathName.length() - 5);
         log_info("'{}' path errors:", pathName);
 
-        const std::string lengthLabel = fmt::format("{}_length", pathName);
+        const std::string lengthLabel = std::format("{}_length", pathName);
         SimTK::Vector pathLength = pathLengths.getDependentColumn(lengthLabel);
         SimTK::Vector pathLengthFitted = pathLengthsFitted.getDependentColumn(
                 lengthLabel);
@@ -1089,7 +1090,7 @@ void computeFittingErrors(
                     modelFitted.getComponent<Coordinate>(coordinatePath);
             const std::string& coordinateName = coordinate.getName();
 
-            const std::string momentArmLabel = fmt::format(
+            const std::string momentArmLabel = std::format(
                 "{}_moment_arm_{}", pathName, coordinateName);
             SimTK::Vector momentArm = momentArms.getDependentColumn(
                     momentArmLabel);
@@ -1104,7 +1105,7 @@ void computeFittingErrors(
 
             if (momentArmRMSError > 10.0*momentArmTolerance) {
                 printWarningMessage(
-                        fmt::format("'{}' moment arm", coordinateName),
+                        std::format("'{}' moment arm", coordinateName),
                         momentArmTolerance);
             }
 
@@ -1227,7 +1228,7 @@ void PolynomialPathFitter::run() {
     coordinateBoundsMap.reserve(m_model.getNumCoordinates());
     coordinateRangeMap.reserve(m_model.getNumCoordinates());
     for (const auto& coordinate : m_model.getComponentList<Coordinate>()) {
-        std::string valuePath = fmt::format("{}/value",
+        std::string valuePath = std::format("{}/value",
                 coordinate.getAbsolutePathString());
         coordinateBoundsMap.insert({valuePath, globalBounds});
 
@@ -1258,7 +1259,7 @@ void PolynomialPathFitter::run() {
 
         bounds[0] = SimTK::convertDegreesToRadians(bounds[0]);
         bounds[1] = SimTK::convertDegreesToRadians(bounds[1]);
-        std::string valuePath = fmt::format("{}/value", coordinatePath);
+        std::string valuePath = std::format("{}/value", coordinatePath);
         coordinateBoundsMap[valuePath] = bounds;
     }
 
@@ -1355,10 +1356,10 @@ void PolynomialPathFitter::run() {
 
     // Print the information for each path.
     log_info("");
-    std::string pathName = fmt::format("{}path",
+    std::string pathName = std::format("{}path",
             std::string((int)(0.5*longestPathName)-2, ' '));
-    std::string fitName = fmt::format("{}polynomial fit", std::string(15, ' '));
-    std::string line = fmt::format("{:{}} | {:{}}", pathName, longestPathName,
+    std::string fitName = std::format("{}polynomial fit", std::string(15, ' '));
+    std::string line = std::format("{:{}} | {:{}}", pathName, longestPathName,
             fitName, 44);
     std::string separator(line.size(), '-');
     log_info(separator);
@@ -1375,7 +1376,7 @@ void PolynomialPathFitter::run() {
                 ++numNonZeroCoeffs;
             }
         }
-        line = fmt::format("{:{}} | order = {}, dimension = "
+        line = std::format("{:{}} | order = {}, dimension = "
                 "{}, coefficients = {}", path.getName(), longestPathName,
                 function.getOrder(), function.getDimension(), numNonZeroCoeffs);
         log_info(line);
@@ -1419,7 +1420,7 @@ void PolynomialPathFitter::run() {
     // Print the FunctionBasedPaths to file.
     std::string functionBasedPathsFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_FunctionBasedPathSet.xml",
+                    std::format("{}/{}_FunctionBasedPathSet.xml",
                             outputDir, m_model.getName()));
     log_info("Printing the FunctionBasedPaths to '{}'...",
             functionBasedPathsFileName);
@@ -1428,17 +1429,17 @@ void PolynomialPathFitter::run() {
     // Print the coordinate values to file.
     std::string coordinatesFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_coordinate_values.sto",
+                    std::format("{}/{}_coordinate_values.sto",
                             outputDir, m_model.getName()));
     std::string sampledCoordinatesFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_coordinate_values_sampled.sto",
+                    std::format("{}/{}_coordinate_values_sampled.sto",
                             outputDir, m_model.getName()));
     log_info("");
-    log_info(fmt::format("Printing original coordinate values to '{}'...",
+    log_info(std::format("Printing original coordinate values to '{}'...",
             coordinatesFileName));
     STOFileAdapter::write(m_values, coordinatesFileName);
-    log_info(fmt::format("Printing sampled coordinate values to '{}'...",
+    log_info(std::format("Printing sampled coordinate values to '{}'...",
             sampledCoordinatesFileName));
     STOFileAdapter::write(valuesSampled, sampledCoordinatesFileName);
 
@@ -1446,11 +1447,11 @@ void PolynomialPathFitter::run() {
     // data to file.
     std::string pathLengthsFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths.sto",
+                    std::format("{}/{}_path_lengths.sto",
                             outputDir, m_model.getName()));
     std::string momentArmsFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms.sto",
+                    std::format("{}/{}_moment_arms.sto",
                             outputDir, m_model.getName()));
     log_info("");
     log_info("Printing the path lengths to '{}'...",
@@ -1463,11 +1464,11 @@ void PolynomialPathFitter::run() {
     // data to file.
     std::string pathLengthsSampledFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_sampled.sto",
+                    std::format("{}/{}_path_lengths_sampled.sto",
                             outputDir, m_model.getName()));
     std::string momentArmsSampledFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_sampled.sto",
+                    std::format("{}/{}_moment_arms_sampled.sto",
                             outputDir, m_model.getName()));
 
     log_info("");
@@ -1482,11 +1483,11 @@ void PolynomialPathFitter::run() {
     // coordinate data to file.
     std::string pathLengthsFittedFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_fitted.sto",
+                    std::format("{}/{}_path_lengths_fitted.sto",
                             outputDir, m_model.getName()));
     std::string momentArmsFittedFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_fitted.sto",
+                    std::format("{}/{}_moment_arms_fitted.sto",
                             outputDir, m_model.getName()));
 
     log_info("");
@@ -1501,11 +1502,11 @@ void PolynomialPathFitter::run() {
     // coordinate data to file.
     std::string pathLengthsSampledFittedFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_path_lengths_sampled_fitted.sto",
+                    std::format("{}/{}_path_lengths_sampled_fitted.sto",
                             outputDir, m_model.getName()));
     std::string momentArmsSampledFittedFileName =
             SimTK::Pathname::getAbsolutePathname(
-                    fmt::format("{}/{}_moment_arms_sampled_fitted.sto",
+                    std::format("{}/{}_moment_arms_sampled_fitted.sto",
                             outputDir, m_model.getName()));
 
     log_info("");

--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -31,11 +31,12 @@
 #include "Exception.h"
 #include "Logger.h"
 #include "osimCommonDLL.h"
+
 #include <algorithm>
+#include <format>
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
-#include <spdlog/fmt/bundled/ostream.h>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -143,10 +144,7 @@ public:
      */
     friend std::ostream& operator<<(std::ostream& out, const Array& rhs)
     {
-        for (auto const& el : rhs._storage) {
-            out << " " << el;
-        }
-        return out;
+        return out << std::format("{}", rhs);
     }
 
     /**
@@ -601,9 +599,25 @@ private:
 }; //namespace
 
 #ifndef SWIG
-// fmt library serializers for OpenSim Array objects
-template <>
-struct fmt::formatter<OpenSim::Array<double>> : ostream_formatter {};
-#endif
+template<typename T>
+struct std::formatter<OpenSim::Array<T>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        return _inner.parse(ctx);
+    }
+
+    // Format the vector by iterating through elements and applying the specifier
+    template<class FormatContext>
+    auto format(const OpenSim::Array<T>& ary, FormatContext& ctx) const {
+        auto out = ctx.out();
+        for (int i = 0; i < ary.size(); ++i) {
+            out = std::format_to(out, " ");
+            out = _inner.format(ary[i], ctx);
+        }
+        return out;
+    }
+private:
+    std::formatter<T> _inner;
+};
+#endif // SWIG
 
 #endif // OPENSIM_ARRAY_H_

--- a/OpenSim/Common/Assertion.cpp
+++ b/OpenSim/Common/Assertion.cpp
@@ -23,6 +23,7 @@
 
 #include "Assertion.h"
 
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/Exception.h>
 #include <OpenSim/Common/Object.h>
 

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -16,7 +16,7 @@ OpenSimAddLibrary(
     KIT Common
     AUTHORS "Clay_Anderson-Ayman_Habib-Peter_Loan"
     # Clients of osimCommon need not link to ezc3d.
-    LINKLIBS PUBLIC ${Simbody_LIBRARIES} spdlog::spdlog osimLepton
+    LINKLIBS PUBLIC ${Simbody_LIBRARIES} osimLepton
              PRIVATE ${ezc3d_LIBRARY}
     INCLUDES ${INCLUDES}
     SOURCES ${SOURCES}

--- a/OpenSim/Common/CommonUtilities.cpp
+++ b/OpenSim/Common/CommonUtilities.cpp
@@ -190,7 +190,7 @@ SimTK::Real OpenSim::solveBisection(
                                       x.getContiguousScalarData() + x.size()),
                 residual, {"residual"});
         STOFileAdapter::write(
-                table, fmt::format("solveBisection_residual_{}.sto",
+                table, std::format("solveBisection_residual_{}.sto",
                                getFormattedDateTime()));
     }
     OPENSIM_THROW_IF(sameSign, Exception,

--- a/OpenSim/Common/Component.cpp
+++ b/OpenSim/Common/Component.cpp
@@ -26,6 +26,7 @@
 #include "Component.h"
 #include "OpenSim/Common/IO.h"
 #include "XMLDocument.h"
+#include "Detail/SimbodyFormatterShims.h"
 
 #include <regex>
 #include <unordered_map>
@@ -1907,7 +1908,7 @@ void Component::AddedStateVariable::
 
 
 void Component::printSocketInfo() const {
-    std::string str = fmt::format("Sockets for component {} of type [{}] along "
+    std::string str = std::format("Sockets for component {} of type [{}] along "
                                   "with connectee paths:", getName(),
                                   getConcreteClassName());
     if (getNumSockets() == 0)
@@ -1928,8 +1929,8 @@ void Component::printSocketInfo() const {
     for (const auto& it : _socketsTable) {
         const auto& socket = it.second;
         // Right-justify the connectee type names and socket names.
-        str = fmt::format("{:>{}} {:>{}} : ",
-                          fmt::format("[{}]", socket->getConnecteeTypeName()),
+        str = std::format("{:>{}} {:>{}} : ",
+                          std::format("[{}]", socket->getConnecteeTypeName()),
                           maxlenTypeName,
                           socket->getName(), maxlenSockName);
         if (socket->getNumConnectees() == 0) {
@@ -1940,14 +1941,14 @@ void Component::printSocketInfo() const {
                 connecteePaths.push_back(socket->getConnecteePath(i));
             }
             // Join the connectee paths with spaces in between.
-            str += fmt::format("{}", fmt::join(connecteePaths, " "));
+            str += std::format("{}", detail::join(connecteePaths, " "));
         }
         log_cout(str);
     }
 }
 
 void Component::printInputInfo() const {
-    std::string str = fmt::format("Inputs for component {} of type [{}] along "
+    std::string str = std::format("Inputs for component {} of type [{}] along "
                                   "with connectee paths:",
                                   getName(), getConcreteClassName());
     if (getNumInputs() == 0)
@@ -1967,8 +1968,8 @@ void Component::printInputInfo() const {
     for (const auto& it : _inputsTable) {
         const auto& input = it.second;
         // Right-justify the connectee type names and input names.
-        str = fmt::format("{:>{}} {:>{}} : ",
-                          fmt::format("[{}]", input->getConnecteeTypeName()),
+        str = std::format("{:>{}} {:>{}} : ",
+                          std::format("[{}]", input->getConnecteeTypeName()),
                           maxlenTypeName,
                           input->getName(), maxlenInputName);
         if (input->getNumConnectees() == 0 ||
@@ -1982,7 +1983,7 @@ void Component::printInputInfo() const {
                 // std::cout << " (alias: " << input.getAlias(i) << ") ";
             }
             // Join the connectee paths with spaces in between.
-            str += fmt::format("{}", fmt::join(connecteePaths, " "));
+            str += std::format("{}", detail::join(connecteePaths, " "));
         }
         log_cout(str);
     }
@@ -1996,7 +1997,7 @@ void Component::printOutputInfo(const bool includeDescendants) const {
 
     // Do not display header for Components with no outputs.
     if (getNumOutputs() > 0) {
-        std::string msg = fmt::format("Outputs from {} [{}]",
+        std::string msg = std::format("Outputs from {} [{}]",
                                       getAbsolutePathString(),
                                       getConcreteClassName());
         msg += "\n" + std::string(msg.size(), '=');
@@ -2011,7 +2012,7 @@ void Component::printOutputInfo(const bool includeDescendants) const {
         for(const auto& output : outputs) {
             const auto& name = output.second->getTypeName();
             log_cout("{:>{}}  {}",
-                     fmt::format("[{}]", output.second->getTypeName()),
+                     std::format("[{}]", output.second->getTypeName()),
                      maxlen, output.first);
         }
         log_cout("");

--- a/OpenSim/Common/Component.h
+++ b/OpenSim/Common/Component.h
@@ -2807,9 +2807,9 @@ public:
         for (const C& thisComp : compList) {
             const std::string thisClass = thisComp.getConcreteClassName();
             auto path = thisComp.getAbsolutePath();
-            log_cout(fmt::format(
+            log_cout(std::format(
                     "{:>{}}  {}/{}",
-                    fmt::format("[{}]", thisClass),
+                    std::format("[{}]", thisClass),
                     maxlen,
                     std::string((path.getNumPathLevels() - 1) * 4, ' '),
                     path.getComponentName()));

--- a/OpenSim/Common/ComponentSocket.cpp
+++ b/OpenSim/Common/ComponentSocket.cpp
@@ -23,6 +23,7 @@
 
 #include "ComponentSocket.h"
 #include "Component.h"
+#include "Detail/SimbodyFormatterShims.h"
 
 using namespace OpenSim;
 

--- a/OpenSim/Common/DebugUtilities.cpp
+++ b/OpenSim/Common/DebugUtilities.cpp
@@ -22,11 +22,12 @@
 #include "DebugUtilities.h"
 
 #include "Logger.h"
+
 #include <cstdlib>
 #include <exception>
+#include <format>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <stdexcept>
 
 namespace OpenSim {
@@ -34,7 +35,7 @@ namespace DebugUtilities {
 
 void Fatal_Error(const char* msg, const char* function, const char* file,
         unsigned int line) {
-    std::string str = fmt::format("Fatal Error: {} (function = {}, file = {}, "
+    std::string str = std::format("Fatal Error: {} (function = {}, file = {}, "
                                   "line = {})", msg, function, file, line);
     log_critical(str);
     throw std::runtime_error(str);

--- a/OpenSim/Common/Detail/JoinShim.h
+++ b/OpenSim/Common/Detail/JoinShim.h
@@ -1,0 +1,79 @@
+#ifndef OPENSIM_JOIN_SHIM_H
+#define OPENSIM_JOIN_SHIM_H
+
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim: JoinShim.h                                *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/// JoinShim is an internal header that provides a shim for C++23's
+/// `std::views::join`. It should only be used internally by OpenSim's
+/// library code (i.e. we can change/break this over time - beware).
+
+#include <format>
+#include <ranges>
+#include <string_view>
+
+namespace OpenSim::detail {
+
+    /// A shim for C++23's `std::views::join`.
+    template <std::ranges::input_range R>
+    struct join_view {
+        const R& range;
+        std::string_view separator;
+    };
+
+    /// A shim for C++23's `std::views::join`.
+    template <std::ranges::input_range R>
+    constexpr auto join(const R& r, std::string_view sep)
+    {
+        return join_view<R>{r, sep};
+    }
+}
+
+/// Formatter for `detail::join_view` shim (i.e. prints lists joined by delimiters).
+template <std::ranges::input_range R>
+struct std::formatter<OpenSim::detail::join_view<R>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        auto it = ctx.begin();
+        if (it != ctx.end() && *it != '}') {
+            throw std::format_error("invalid format for join_view");
+        }
+        return it;
+    }
+
+    template <class FormatContext>
+    auto format(const OpenSim::detail::join_view<R>& value, FormatContext& ctx) const {
+        auto out = ctx.out();
+
+        bool first = true;
+        for (const auto& elem : value.range) {
+            if (not first) {
+                out = std::ranges::copy(value.separator, out).out;
+            }
+            first = false;
+            out = std::format_to(out, "{}", elem);
+        }
+
+        return out;
+    }
+};
+
+#endif // OPENSIM_JOIN_SHIM_H

--- a/OpenSim/Common/Detail/OstreamFormatterShim.h
+++ b/OpenSim/Common/Detail/OstreamFormatterShim.h
@@ -1,0 +1,61 @@
+#ifndef OPENSIM_OSTREAM_FORMATTER_SHIM_H_
+#define OPENSIM_OSTREAM_FORMATTER_SHIM_H_
+/* -------------------------------------------------------------------------- *
+ *                      OpenSim: OstreamFormatterShim.h                       *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/// OstreamFormatterShim is an internal header that provides a shim for C++23's
+/// `std::ostream_formatter`. It should only be used internally by OpenSim's
+/// library code (i.e. we can change/break this over time - beware).
+
+#ifndef SWIG
+
+#include <format>
+#include <sstream>
+
+namespace OpenSim::detail {
+
+    /// A temporary shim for C++23's `std::ostream_formatter`.
+    struct ostream_formatter {
+        // Parses the format specifier (e.g., inside the {}).
+        // Since ostreams don't support std::format specifiers (like {:02d}),
+        // this ensures the format string is empty.
+        constexpr auto parse(std::format_parse_context& ctx) {
+            auto it = ctx.begin();
+            if (it != ctx.end() && *it != '}') {
+                throw std::format_error("ostream_formatter does not support format specifiers.");
+            }
+            return it;
+        }
+
+        // Formats the value by dumping it into a `std::stringstream`,
+        // then piping that string to the format context.
+        template <typename T, typename FormatContext>
+        auto format(const T& value, FormatContext& ctx) const {
+            std::ostringstream oss;
+            oss << value;
+            return std::format_to(ctx.out(), "{}", oss.str());
+        }
+    };
+}
+
+#endif  // ifndef SWIG
+#endif  // ifndef OPENSIM_OSTREAM_FORMATTER_SHIM_H_

--- a/OpenSim/Common/Detail/SimbodyFormatterShims.h
+++ b/OpenSim/Common/Detail/SimbodyFormatterShims.h
@@ -1,0 +1,78 @@
+#ifndef OPENSIM_SIMBODY_FORMATTER_SHIMS_H_
+#define OPENSIM_SIMBODY_FORMATTER_SHIMS_H_
+/* -------------------------------------------------------------------------- *
+ *                         OpenSim: FormatterShims.h                          *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/// SimbodyFormatterShim is an internal header that provides `std::formatter`
+/// support for Simbody's data types (e.g., SimTK::Vec3). It should only be used
+// internally by OpenSim's library code (i.e. we can change/break this over
+// time - beware).
+
+#ifndef SWIG
+
+#include <OpenSim/Common/Detail/OstreamFormatterShim.h>
+
+#include <SimTKcommon/SmallMatrix.h>             // for Vec3
+#include <SimTKcommon/internal/BigMatrix.h>      // for Vector
+#include <SimTKcommon/internal/MassProperties.h> // for Inertia
+#include <SimTKcommon/internal/Rotation.h>       // for Rotation
+#include <SimTKcommon/internal/String.h>         // for String
+#include <simbody/internal/common.h>             // for ConstraintIndex
+
+#include <format>
+
+/// A formatter for `SimTK::Vec`, where the format specifier is applied
+/// to each of its elements.
+template<int M, class ELT, int STRIDE>
+struct std::formatter<SimTK::Vec<M, ELT, STRIDE>> {
+    constexpr auto parse(std::format_parse_context& ctx) {
+        return _inner.parse(ctx);
+    }
+
+    template<class FormatContext>
+    auto format(const SimTK::Vec<M, ELT, STRIDE>& v, FormatContext& ctx) const -> decltype(ctx.out()) {
+        // This implementation should match upstream's:
+        //     `SimTK::operator<<(std::ostream&, SimTK::Vec<M, ELT, STRIDE>)`
+
+        auto out = ctx.out();
+        out = std::format_to(out, "~[");
+        if constexpr (M > 0) {
+            out = _inner.format(v[0], ctx);
+            for (int i = 1; i < M; ++i) {
+                out = std::format_to(out, ",");
+                out = _inner.format(v[i], ctx);
+            }
+        }
+        out = std::format_to(out, "]");
+        return out;
+    }
+private:
+    std::formatter<ELT> _inner;
+};
+template <> struct std::formatter<SimTK::String> : OpenSim::detail::ostream_formatter {};
+template <> struct std::formatter<SimTK::Vector> : OpenSim::detail::ostream_formatter {};
+template <> struct std::formatter<SimTK::Rotation> : OpenSim::detail::ostream_formatter {};
+template <> struct std::formatter<SimTK::Inertia> : OpenSim::detail::ostream_formatter {};
+template <> struct std::formatter<SimTK::ConstraintIndex> : OpenSim::detail::ostream_formatter {};
+
+#endif  // ifndef SWIG
+#endif  // ifndef OPENSIM_SIMBODY_FORMATTER_SHIMS_H_

--- a/OpenSim/Common/Exception.h
+++ b/OpenSim/Common/Exception.h
@@ -30,7 +30,8 @@
 
 // INCLUDES
 #include "osimCommonDLL.h"
-#include <spdlog/common.h>
+
+#include <format>
 #include <string>
 
 #ifdef SWIG
@@ -200,24 +201,24 @@ public:
 #ifndef SWIG
     /** Use this when you want to throw an Exception (with OPENSIM_THROW or
     OPENSIM_THROW_IF) and also provide a message that is formatted
-    using fmt::format() syntax. */
+    using std::format() syntax. */
     template <typename... Args>
     Exception(const std::string& file, size_t line, const std::string& func,
-            spdlog::format_string_t<Args...> fmt, Args&&... args)
+            std::format_string<Args...> fmt, Args&&... args)
             : Exception{file, line, func,
-                      fmt::format(fmt, std::forward<Args>(args)...)} {}
+                      std::format(fmt, std::forward<Args>(args)...)} {}
 
     /** The message created by this constructor will contain the class name and
     instance name of the provided Object, and also accepts a message formatted
-    using fmt::format() syntax. Use this when throwing an Exception directly.
+    using std::format() syntax. Use this when throwing an Exception directly.
     Use OPENSIM_THROW_FRMOBJ and OPENSIM_THROW_IF_FRMOBJ macros at throw sites.
     */
     template <typename... Args>
     Exception(const std::string& file, size_t line, const std::string& func,
-            const Object& obj, spdlog::format_string_t<Args...> fmt,
+            const Object& obj, std::format_string<Args...> fmt,
             Args&&... args)
             : Exception{file, line, func, obj,
-                      fmt::format(fmt, std::forward<Args>(args)...)} {}
+                      std::format(fmt, std::forward<Args>(args)...)} {}
 #endif
 
     virtual ~Exception() throw() {}

--- a/OpenSim/Common/ExpressionBasedFunction.cpp
+++ b/OpenSim/Common/ExpressionBasedFunction.cpp
@@ -41,7 +41,7 @@ public:
         for (const auto& variable : m_variables) {
             if (!uniqueVariables.insert(variable).second) {
                 OPENSIM_THROW(Exception, 
-                        fmt::format("Variable '{}' is defined more than once.", 
+                        std::format("Variable '{}' is defined more than once.",
                         variable));
             }
         }
@@ -72,7 +72,7 @@ public:
             if (msg.compare(0, 30, "No value specified for variable")) { 
                 std::string undefinedVar = msg.substr(32, msg.size() - 32);
                 OPENSIM_THROW(Exception, 
-                        fmt::format("Variable '{}' is not defined. Use "
+                        std::format("Variable '{}' is not defined. Use "
                         "setVariables() to explicitly define this variable. "
                         "Or, remove it from the expression.", undefinedVar));
             } else {

--- a/OpenSim/Common/GCVSplineSet.cpp
+++ b/OpenSim/Common/GCVSplineSet.cpp
@@ -163,7 +163,7 @@ Storage* GCVSplineSet::constructStorage(int aDerivOrder,double aDX) {
     if(aDerivOrder == 0) {
         name = getName() + "_GCVSpline";
     } else {
-        name = fmt::format("{}_GCVSpline_Deriv_{}", getName(), aDerivOrder);
+        name = std::format("{}_GCVSpline_Deriv_{}", getName(), aDerivOrder);
     }
     Storage *store = new Storage(nSteps,name);
 

--- a/OpenSim/Common/LogLevel.h
+++ b/OpenSim/Common/LogLevel.h
@@ -1,7 +1,7 @@
-#ifndef OPENSIM_LOGSINK_H_
-#define OPENSIM_LOGSINK_H_
+#ifndef OPENSIM_LOG_LEVEL_H_
+#define OPENSIM_LOG_LEVEL_H_
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  LogSink.h                                *
+ *                       OpenSim:  LogLevel.h                                 *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -22,54 +22,37 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <OpenSim/Common/LogLevel.h>
-#include <OpenSim/Common/LogMessage.h>
-#include <OpenSim/Common/osimCommonDLL.h>
-
-#include <string>
-
-// This file is not included in osimCommon.h. Only include
-// this file when deriving from LogSink.
 namespace OpenSim {
 
-/// Derive from this class to implement your own way of reporting logged
-/// messages.
-class OSIMCOMMON_API LogSink {
-public:
-    virtual ~LogSink() noexcept = default;
+    /// This enum lists the types of messages that should be logged, ordered
+    /// from least-severe to most-severe (or off).
+    enum class LogLevel {
+        /// Log as much as possible, including messages that describe the
+        /// software's behavior step by step. Note: OpenSim has very few Trace-level
+        /// messages.
+        Trace = 0,
 
-    /// Sinks `msg` into this `LogSink`.
-    void sink(const LogMessage& msg) {
-        sinkImpl(msg);
-        sinkImpl(msg.getPayload());
-    }
+        /// Log information that may be useful when debugging the operation of
+        /// the software to investigate unexpected results.
+        Debug = 1,
 
-    /// Tells this `LogSink` to flush any buffered content to its output.
-    void flush() { flushImpl(); }
+        /// Default.
+        Info = 2,
 
-    LogLevel getLevel() const { return level_; }
-    void setLevel(LogLevel logLevel) { level_ = logLevel; }
-    bool shouldLog(LogLevel logLevel) { return logLevel >= level_; }
+        /// Log warnings. Warnings are generated when the software will proceed
+        /// but the user should check their input.
+        Warn = 3,
 
-protected:
-    /// Implementors may override this function to provide their own
-    /// message sinking behavior.
-    virtual void sinkImpl(const LogMessage&) {}
+        /// Log all messages that require user intervention.
+        Error = 4,
 
-    /// Implementors may override this function to provide their own
-    /// message sinking behavior.
-    ///
-    /// Legacy shim: OpenSim 2019/11 to 2026/06 only provided this overload.
-    virtual void sinkImpl(const std::string& msg) {}
+        /// Only log critical errors.
+        Critical = 5,
 
-    /// Implementors may override this function to provide their own
-    /// message flushing behavior.
-    virtual void flushImpl() {}
+        /// Do not log any messages. Useful when running an optimization or
+        /// automated pipeline.
+        Off = 6,
+    };
+}
 
-private:
-    LogLevel level_ = LogLevel::Trace;
-};
-
-} // namespace OpenSim
-
-#endif // OPENSIM_LOGSINK_H_
+#endif

--- a/OpenSim/Common/LogMessage.h
+++ b/OpenSim/Common/LogMessage.h
@@ -1,7 +1,7 @@
-#ifndef OPENSIM_LOGSINK_H_
-#define OPENSIM_LOGSINK_H_
+#ifndef OPENSIM_LOG_MESSAGE_H_
+#define OPENSIM_LOG_MESSAGE_H_
 /* -------------------------------------------------------------------------- *
- *                         OpenSim:  LogSink.h                                *
+ *                       OpenSim:  LogMessage.h                               *
  * -------------------------------------------------------------------------- *
  * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
  * See http://opensim.stanford.edu and the NOTICE file for more information.  *
@@ -23,53 +23,42 @@
  * -------------------------------------------------------------------------- */
 
 #include <OpenSim/Common/LogLevel.h>
-#include <OpenSim/Common/LogMessage.h>
 #include <OpenSim/Common/osimCommonDLL.h>
 
+#include <chrono>
 #include <string>
+#include <string_view>
+#include <utility>
 
-// This file is not included in osimCommon.h. Only include
-// this file when deriving from LogSink.
 namespace OpenSim {
 
-/// Derive from this class to implement your own way of reporting logged
-/// messages.
-class OSIMCOMMON_API LogSink {
-public:
-    virtual ~LogSink() noexcept = default;
+    class OSIMCOMMON_API LogMessage final {
+    public:
+        using clock_type = std::chrono::system_clock;
+        using time_point_type = clock_type::time_point;
 
-    /// Sinks `msg` into this `LogSink`.
-    void sink(const LogMessage& msg) {
-        sinkImpl(msg);
-        sinkImpl(msg.getPayload());
-    }
+        LogMessage() = default;
 
-    /// Tells this `LogSink` to flush any buffered content to its output.
-    void flush() { flushImpl(); }
+        explicit LogMessage(
+            std::string loggerName,
+            LogLevel level,
+            std::string payload) :
+            _loggerName{std::move(loggerName)},
+            _level{level},
+            _payload{std::move(payload)}
+        {}
 
-    LogLevel getLevel() const { return level_; }
-    void setLevel(LogLevel logLevel) { level_ = logLevel; }
-    bool shouldLog(LogLevel logLevel) { return logLevel >= level_; }
+        std::string_view getLoggerName() const { return _loggerName; }
+        time_point_type getTime() const { return _time; }
+        LogLevel getLevel() const { return _level; }
+        const std::string& getPayload() const { return _payload; }
 
-protected:
-    /// Implementors may override this function to provide their own
-    /// message sinking behavior.
-    virtual void sinkImpl(const LogMessage&) {}
+    private:
+        std::string _loggerName;
+        time_point_type _time = clock_type::now();
+        LogLevel _level = LogLevel::Off;
+        std::string _payload;
+    };
+}
 
-    /// Implementors may override this function to provide their own
-    /// message sinking behavior.
-    ///
-    /// Legacy shim: OpenSim 2019/11 to 2026/06 only provided this overload.
-    virtual void sinkImpl(const std::string& msg) {}
-
-    /// Implementors may override this function to provide their own
-    /// message flushing behavior.
-    virtual void flushImpl() {}
-
-private:
-    LogLevel level_ = LogLevel::Trace;
-};
-
-} // namespace OpenSim
-
-#endif // OPENSIM_LOGSINK_H_
+#endif // OPENSIM_LOG_MESSAGE_H_

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -7,7 +7,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2019 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -22,269 +22,338 @@
 
 #include "Logger.h"
 
-#include "Exception.h"                       // for Exception, OPENSIM_THROW
-#include "IO.h"                              // for IO
-#include "LogSink.h"                         // for LogSink
-#include <algorithm>                         // for remove
-#include <spdlog/fmt/bundled/format.h>       // for format
-#include <spdlog/sinks/basic_file_sink.h>    // for basic_file_sink_mt, bas...
-#include <spdlog/sinks/sink.h>               // for sink
-#include <spdlog/sinks/stdout_color_sinks.h> // for stdout_color_mt
-#include <spdlog/spdlog.h>                   // for set_level, default_logger
-#include <vector>                            // for vector
+#include <OpenSim/Common/Exception.h>
+#include <OpenSim/Common/IO.h>
+#include <OpenSim/Common/LogLevel.h>
+#include <OpenSim/Common/LogMessage.h>
+#include <OpenSim/Common/LogSink.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <concepts>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace OpenSim;
 
-// Static initialization of default and cout loggers.
-//
-// There are objects from other compilation units that call into the default
-// (and probably cout) logger objects during static initialization so use the
-// "Construct On First Use" idiom to ensure that each logger is allocated and
-// completely initialized before that happens the first time.
-
-// Initialize a logger
-static std::shared_ptr<spdlog::logger> initializeLogger(
-    std::shared_ptr<spdlog::logger> l,
-    const char* pattern)
+namespace
 {
-    l->set_level(spdlog::level::info);
-    l->flush_on(spdlog::level::info);
-    l->set_pattern(pattern);
-    return l;
-}
+    // Used to ensure file sink auto-initialization happens once with no races.
+    constinit std::once_flag g_FileSinkAutoInitOnceFlag;
 
-// Return a reference to the static cout logger object, allocating and
-// initializing it on the first call.
-static spdlog::logger& coutLoggerInternal() {
-    static std::shared_ptr<spdlog::logger> l =
-      initializeLogger(spdlog::stdout_color_mt("cout"), "%v");
-    return *l;
-}
+    // Used when mutating `g_FileSink`.
+    constinit std::mutex g_FileSinkMutex;
 
-// Return a reference to the static default logger object, allocating and
-// initializing it on the first call.
-static spdlog::logger& defaultLoggerInternal() {
-    static std::shared_ptr<spdlog::logger> l =
-      initializeLogger(spdlog::default_logger(), "[%l] %v");
-    return *l;
-}
+    // Initialized at runtime.
+    class BasicFileSink;
+    constinit std::shared_ptr<BasicFileSink> g_FileSink;
 
-// the file log sink (e.g. `opensim.log`) is lazily initialized.
-//
-// it is only initialized when the first log message is about to be written to
-// it. Users *may* disable this functionality before the first log message is
-// written (or disable it statically, by setting OPENSIM_DISABLE_LOG_FILE)
-static std::shared_ptr<spdlog::sinks::basic_file_sink_mt> m_filesink = nullptr;
-
-// if a user manually calls `Logger::(remove|add)FileSink`, auto-initialization
-// should be disabled. Manual usage "overrides" lazy auto-initialization.
-static bool fileSinkAutoInitDisabled = false;
-
-// attempt to auto-initialize the file log, if applicable
-static bool initFileLoggingAsNeeded() {
-#ifdef OPENSIM_DISABLE_LOG_FILE
-// software builders may want to statically ensure that automatic file logging
-// *cannot* happen - even during static initialization. This compiler define
-// outright disables the behavior, which is important in Windows applications
-// that run multiple instances of OpenSim-linked binaries. In Windows, the
-// logs files collide and cause a "multiple processes cannot open the same
-// file" error).
-return true;
-#else
-    static bool initialized = []() {
-        if (fileSinkAutoInitDisabled) {
-            return true;
+    /// Returns a human-readable label for `level` (matches `LogLevel`).
+    std::string_view labelFor(LogLevel level) {
+        switch (level) {
+        case LogLevel::Off:      return "Off";
+        case LogLevel::Critical: return "Critical";
+        case LogLevel::Error:    return "Error";
+        case LogLevel::Warn:     return "Warn";
+        case LogLevel::Info:     return "Info";
+        case LogLevel::Debug:    return "Debug";
+        case LogLevel::Trace:    return "Trace";
+        default:
+            OPENSIM_THROW(Exception, "Internal error.");
         }
-        Logger::addFileSink();
-        return true;
-    }();
-
-    return initialized;
-#endif
-}
-
-// this function is only called when the caller is about to log something, so
-// it should perform lazy initialization of the file sink
-spdlog::logger& Logger::getCoutLogger() {
-    initFileLoggingAsNeeded();
-    return coutLoggerInternal();
-}
-
-// this function is only called when the caller is about to log something, so
-// it should perform lazy initialization of the file sink
-spdlog::logger& Logger::getDefaultLogger() {
-    initFileLoggingAsNeeded();
-    return defaultLoggerInternal();
-}
-
-static void addSinkInternal(std::shared_ptr<spdlog::sinks::sink> sink) {
-    coutLoggerInternal().sinks().push_back(sink);
-    defaultLoggerInternal().sinks().push_back(sink);
-}
-
-static void removeSinkInternal(const std::shared_ptr<spdlog::sinks::sink> sink)
-{
-    {
-        auto& sinks = defaultLoggerInternal().sinks();
-        auto new_end = std::remove(sinks.begin(), sinks.end(), sink);
-        sinks.erase(new_end, sinks.end());
     }
+
+    /// Returns a log-visible label for `level` (matches spdlog legacy labels).
+    std::string_view loggingLabelFor(LogLevel level) {
+        switch (level) {
+        case LogLevel::Off:      return "off";
+        case LogLevel::Critical: return "critical";
+        case LogLevel::Error:    return "error";
+        case LogLevel::Warn:     return "warn";
+        case LogLevel::Info:     return "info";
+        case LogLevel::Debug:    return "debug";
+        case LogLevel::Trace:    return "trace";
+        default:
+            OPENSIM_THROW(Exception, "Internal error.");
+        }
+    }
+
+    /// Parses `str` into a `LogLevel`. Throws if it cannot be parsed.
+    LogLevel parseLogLevel(std::string str) {
+        str = IO::Lowercase(str);
+        if (str == "off")      { return LogLevel::Off;      }
+        if (str == "critical") { return LogLevel::Critical; }
+        if (str == "error")    { return LogLevel::Error;    }
+        if (str == "warn")     { return LogLevel::Warn;     }
+        if (str == "info")     { return LogLevel::Info;     }
+        if (str == "debug")    { return LogLevel::Debug;    }
+        if (str == "trace")    { return LogLevel::Trace;    }
+
+        OPENSIM_THROW(Exception, "Expected log level to be Off, Critical, Error, Warn, Info, Debug, or Trace; got {}.", str);
+    }
+
+    /// Formats a `LogMessage` similarly to `spdlog`'s default pattern (legacy behavior)
+    std::string formatLikeSpdlog(const LogMessage& msg) {
+        namespace chrono = std::chrono;
+
+        static_assert(std::same_as<LogMessage::time_point_type, chrono::system_clock::time_point>);
+        const auto t = msg.getTime();
+        const auto seconds = chrono::floor<chrono::seconds>(t);
+        const auto millis = chrono::duration_cast<chrono::milliseconds>(t - seconds);
+
+        return std::format("[{:%Y-%m-%d %H:%M:%S}.{:03d}] [{}] [{}] {}\n",
+            seconds,
+            millis.count(),
+            msg.getLoggerName(),
+            loggingLabelFor(msg.getLevel()),
+            msg.getPayload()
+        );
+    }
+
+    /// A `LogSink` that writes log messages to `std::cout`.
+    class CoutSink final : public LogSink {
+        void sinkImpl(const LogMessage& msg) override {
+            std::cout << msg.getPayload() << '\n';
+        }
+
+        void flushImpl() override {
+            std::cout.flush();
+        }
+    };
+
+    /// A "default" `LogSink`: format matches OpenSim's legacy (spdlog) format.
+    class DefaultLogSink final : public LogSink {
+        void sinkImpl(const LogMessage& msg) override {
+            std::cout << '[' << loggingLabelFor(msg.getLevel()) << "] " << msg.getPayload() << '\n';
+        }
+
+        void flushImpl() override {
+            std::cout.flush();
+        }
+    };
+
+    /// A basic file `LogSink` that writes messages to the provided path.
+    class BasicFileSink final : public LogSink {
+    public:
+        explicit BasicFileSink(std::filesystem::path path) :
+            path_{std::move(path)}
+        {
+            if (!out_.is_open() || out_.fail()) {
+                OPENSIM_THROW(Exception, "Failed to open log file at '{}'", path_.string());
+            }
+        }
+
+        std::filesystem::path filename() const { return path_.filename(); }
+    private:
+        void sinkImpl(const LogMessage& msg) override {
+            out_ << formatLikeSpdlog(msg);
+        }
+        void flushImpl() override { out_.flush(); }
+
+        std::filesystem::path path_;
+        std::ofstream out_{path_};
+    };
+
+    /// Private implementation data for a logger.
+    class LoggerImpl final {
+    public:
+        template<typename T, typename... Args>
+        requires std::constructible_from<T, Args&&...>
+        static LoggerImpl with_sink(Args&&... args) {
+            return LoggerImpl{std::make_shared<T>(std::forward<Args>(args)...)};
+        }
+
+        LogLevel getLevel() const { return level_; }
+        void setLevel(LogLevel level) { level_ = level; }
+
+        bool shouldLog(LogLevel level) const {
+            const LogLevel cur = level_.load(std::memory_order_relaxed);
+            return level != LogLevel::Off and cur != LogLevel::Off and level >= cur;
+        }
+
+        void addSink(std::shared_ptr<LogSink> sink) {
+            std::lock_guard guard{mutex_};
+            sinks_.push_back(std::move(sink));
+        }
+
+        void removeSink(const std::shared_ptr<LogSink>& sink) {
+            std::lock_guard guard{mutex_};
+            std::erase(sinks_, sink);
+        }
+
+        void sinkMessage(const LogMessage& msg) {
+            if (not shouldLog(msg.getLevel())) {
+                return;
+            }
+
+            std::lock_guard guard{mutex_};
+
+            ++messagesSinceLastFlush;
+
+            const bool isHighSeverity =
+                msg.getLevel() >= LogLevel::Warn;
+
+            const bool shouldFlush =
+                isHighSeverity or
+                (messagesSinceLastFlush >= c_FlushInterval);
+
+            for (auto& sink : sinks_) {
+                if (sink->shouldLog(msg.getLevel())) {
+                    sink->sink(msg);
+                    if (shouldFlush) {
+                        sink->flush();
+                    }
+                }
+            }
+
+            if (shouldFlush) {
+                messagesSinceLastFlush = 0;
+            }
+        }
+
+        template<typename... Args>
+        requires std::constructible_from<LogMessage, std::string&&, Args&&...>
+        void sinkMessage(Args&&... args) {
+            sinkMessage(LogMessage{std::string{"OpenSim"}, std::forward<Args>(args)...});
+        }
+    private:
+        explicit LoggerImpl(std::shared_ptr<LogSink> sink) :
+            sinks_{std::move(sink)}
+        {}
+
+        std::mutex mutex_;
+        std::vector<std::shared_ptr<LogSink>> sinks_;
+        std::atomic<LogLevel> level_ = LogLevel::Info;
+        size_t messagesSinceLastFlush = 0;
+        static constexpr size_t c_FlushInterval = 16;
+    };
+
+    /// Returns a reference to the "global" logger state. Initialized on first-use.
+    LoggerImpl& getGlobalLogger() {
+        static LoggerImpl s_GlobalLogState = LoggerImpl::with_sink<DefaultLogSink>();
+        return s_GlobalLogState;
+    }
+
+    /// Returns a reference to the "cout" logger state. Initialized on first-use.
+    LoggerImpl& getCoutLogger() {
+        static LoggerImpl s_CoutLogState = LoggerImpl::with_sink<CoutSink>();
+        return s_CoutLogState;
+    }
+
+    /// Initializes the global file log
+    void initializeFileLoggingGlobally(
+        const std::string& filepath = "opensim.log")
     {
-        auto& sinks = coutLoggerInternal().sinks();
-        auto new_end = std::remove(sinks.begin(), sinks.end(), sink);
-        sinks.erase(new_end, sinks.end());
+        std::lock_guard guard{g_FileSinkMutex};
+
+        if (g_FileSink) {
+            getGlobalLogger().sinkMessage(
+                LogLevel::Warn,
+                std::format("Already logging to file '{}'; log file not added. Call removeFileSink() first.", g_FileSink->filename().string())
+            );
+            return;
+        }
+
+        // Check if file can be opened at the specified path if not return
+        // meaningful warning rather than bubble the exception up.
+        try {
+            g_FileSink = std::make_shared<BasicFileSink>(filepath);
+        }
+        catch (...) {
+            getGlobalLogger().sinkMessage(
+                LogLevel::Warn,
+                std::format("Can't open file '{}' for writing. Log file will not be created. Check that you have write permissions to the specified path.",
+                    filepath
+                )
+            );
+            return;
+        }
+        getGlobalLogger().addSink(g_FileSink);
+        getCoutLogger().addSink(g_FileSink);
+    }
+
+    void automaticallyInitializeFileLoggingGlobally()
+    {
+#ifndef OPENSIM_DISABLE_LOG_FILE
+        std::call_once(g_FileSinkAutoInitOnceFlag, [] { initializeFileLoggingGlobally(); });
+#endif
     }
 }
 
 void Logger::setLevel(Level level) {
-    switch (level) {
-    case Level::Off:
-        spdlog::set_level(spdlog::level::off);
-        break;
-    case Level::Critical:
-        spdlog::set_level(spdlog::level::critical);
-        break;
-    case Level::Error:
-        spdlog::set_level(spdlog::level::err);
-        break;
-    case Level::Warn:
-        spdlog::set_level(spdlog::level::warn);
-        break;
-    case Level::Info:
-        spdlog::set_level(spdlog::level::info);
-        break;
-    case Level::Debug:
-        spdlog::set_level(spdlog::level::debug);
-        break;
-    case Level::Trace:
-        spdlog::set_level(spdlog::level::trace);
-        break;
-    default:
-        OPENSIM_THROW(Exception, "Internal error.");
-    }
-    Logger::info("Set log level to {}.", getLevelString());
+    automaticallyInitializeFileLoggingGlobally();
+    getGlobalLogger().setLevel(level);
+    getCoutLogger().setLevel(level);
+    info("Set log level to {}.", getLevelString());
 }
 
 Logger::Level Logger::getLevel() {
-    switch (defaultLoggerInternal().level()) {
-    case spdlog::level::off: return Level::Off;
-    case spdlog::level::critical: return Level::Critical;
-    case spdlog::level::err: return Level::Error;
-    case spdlog::level::warn: return Level::Warn;
-    case spdlog::level::info: return Level::Info;
-    case spdlog::level::debug: return Level::Debug;
-    case spdlog::level::trace: return Level::Trace;
-    default:
-        OPENSIM_THROW(Exception, "Internal error.");
-    }
+    automaticallyInitializeFileLoggingGlobally();
+    return getGlobalLogger().getLevel();
 }
 
 void Logger::setLevelString(std::string str) {
-    Level level;
-    str = IO::Lowercase(str);
-    if (str == "off") level = Level::Off;
-    else if (str == "critical") level = Level::Critical;
-    else if (str == "error") level = Level::Error;
-    else if (str == "warn") level = Level::Warn;
-    else if (str == "info") level = Level::Info;
-    else if (str == "debug") level = Level::Debug;
-    else if (str == "trace") level = Level::Trace;
-    else {
-        OPENSIM_THROW(Exception,
-                "Expected log level to be Off, Critical, Error, "
-                "Warn, Info, Debug, or Trace; got {}.",
-                str);
-    }
-    setLevel(level);
+    setLevel(parseLogLevel(std::move(str)));
 }
 
 std::string Logger::getLevelString() {
-    const auto level = getLevel();
-    switch (level) {
-    case Level::Off: return "Off";
-    case Level::Critical: return "Critical";
-    case Level::Error: return "Error";
-    case Level::Warn: return "Warn";
-    case Level::Info: return "Info";
-    case Level::Debug: return "Debug";
-    case Level::Trace: return "Trace";
-    default:
-        OPENSIM_THROW(Exception, "Internal error.");
-    }
+    return std::string{labelFor(getLevel())};
 }
 
 bool Logger::shouldLog(Level level) {
-    spdlog::level::level_enum spdlogLevel;
-    switch (level) {
-    case Level::Off: spdlogLevel = spdlog::level::off; break;
-    case Level::Critical: spdlogLevel = spdlog::level::critical; break;
-    case Level::Error: spdlogLevel = spdlog::level::err; break;
-    case Level::Warn: spdlogLevel = spdlog::level::warn; break;
-    case Level::Info: spdlogLevel = spdlog::level::info; break;
-    case Level::Debug: spdlogLevel = spdlog::level::debug; break;
-    case Level::Trace: spdlogLevel = spdlog::level::trace; break;
-    default:
-        OPENSIM_THROW(Exception, "Internal error.");
-    }
-    return defaultLoggerInternal().should_log(spdlogLevel);
+    automaticallyInitializeFileLoggingGlobally();
+    return getGlobalLogger().shouldLog(level);
 }
 
 void Logger::addFileSink(const std::string& filepath) {
-    // this method is either called by the file log auto-initializer, which
-    // should now be disabled, or by downstream code trying to manually specify
-    // a file sink
-    //
-    // downstream callers would find it quite surprising if the auto-initializer
-    // runs *after* they manually specify a log, so just disable it
-    fileSinkAutoInitDisabled = true;
-    spdlog::logger& logger = defaultLoggerInternal();
-
-    if (m_filesink) {
-        logger.warn("Already logging to file '{}'; log file not added. Call "
-                    "removeFileSink() first.", m_filesink->filename());
-        return;
-    }
-
-    // check if file can be opened at the specified path if not return meaningful
-    // warning rather than bubble the exception up.
-    try {
-        m_filesink =
-                std::make_shared<spdlog::sinks::basic_file_sink_mt>(filepath);
-    }
-    catch (...) {
-        logger.warn("Can't open file '{}' for writing. Log file will not be created. "
-                    "Check that you have write permissions to the specified path.",
-                    filepath);
-        return;
-    }
-    addSinkInternal(m_filesink);
+    // This method is either called by the file log auto-initializer, which
+    // should now be disabled, or by downstream code trying to manually
+    // specify a file sink (and, therefore, auto-initialization should be
+    // disabled from now-on).
+    std::call_once(g_FileSinkAutoInitOnceFlag, []{});
+    initializeFileLoggingGlobally(filepath);
 }
 
 void Logger::removeFileSink() {
-    // if this method is called, then we are probably at a point in the
-    // application's lifetime where automatic log allocation is going to cause
-    // confusion.
-    //
-    // callers will be surpised if, after calling this method, auto
-    // initialization happens afterwards and the log file still exists - even
-    // if they called it to remove some manually-specified log
-    fileSinkAutoInitDisabled = true;
+    // This method is either called by the file log auto-initializer, which
+    // should now be disabled, or by downstream code trying to manually specify
+    // a file sink (and, therefore, auto-initialization should be disabled).
+    std::call_once(g_FileSinkAutoInitOnceFlag, []{});
 
-    if (m_filesink == nullptr) {
+    std::lock_guard guard{g_FileSinkMutex};
+    if (not g_FileSink) {
         return;
     }
-
-    removeSinkInternal(
-            std::static_pointer_cast<spdlog::sinks::sink>(m_filesink));
-    m_filesink.reset();
+    removeSink(g_FileSink);
+    g_FileSink.reset();
 }
 
-void Logger::addSink(const std::shared_ptr<LogSink> sink) {
-    addSinkInternal(std::static_pointer_cast<spdlog::sinks::sink>(sink));
+void Logger::addSink(std::shared_ptr<LogSink> sink) {
+    automaticallyInitializeFileLoggingGlobally();
+    getGlobalLogger().addSink(sink);
+    getCoutLogger().addSink(std::move(sink));
 }
 
-void Logger::removeSink(const std::shared_ptr<LogSink> sink) {
-    removeSinkInternal(std::static_pointer_cast<spdlog::sinks::sink>(sink));
+void Logger::removeSink(const std::shared_ptr<LogSink>& sink) {
+    automaticallyInitializeFileLoggingGlobally();
+    getGlobalLogger().removeSink(sink);
+    getCoutLogger().removeSink(sink);
 }
 
+void Logger::sinkMessage(LogLevel level, std::string&& payload) {
+    automaticallyInitializeFileLoggingGlobally();
+    getGlobalLogger().sinkMessage(level, std::move(payload));
+}
 
+void Logger::sinkCoutMessage(std::string&& payload) {
+    automaticallyInitializeFileLoggingGlobally();
+    getCoutLogger().sinkMessage(getCoutLogger().getLevel(), std::move(payload));
+}

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -9,7 +9,7 @@
  * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
  * through the Warrior Web program.                                           *
  *                                                                            *
- * Copyright (c) 2005-2019 Stanford University and the Authors                *
+ * Copyright (c) 2005-2026 Stanford University and the Authors                *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -22,28 +22,14 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "osimCommonDLL.h"              // for OSIMCOMMON_API
-#include <memory>                       // for shared_ptr
-#include <spdlog/common.h>              // for spdlog::format_string_t
-#include <spdlog/fmt/bundled/base.h>    // for formatter
-#include <spdlog/fmt/bundled/ostream.h> // for ostream_formatter
-#include <spdlog/logger.h>              // for logger
-#include <string>                       // for basic_string, string
-#include <string_view>                  // for std::string_view
-#include <utility>                      // for std::forward
+#include <OpenSim/Common/LogLevel.h>
+#include <OpenSim/Common/osimCommonDLL.h>
 
-#ifndef SWIG
-#include <SimTKcommon/SmallMatrix.h>             // for Vec3
-#include <SimTKcommon/internal/BigMatrix.h>      // for Vector
-#include <SimTKcommon/internal/MassProperties.h> // for Inertia
-#include <SimTKcommon/internal/Rotation.h>       // for Rotation
-
-// fmt library serializers for custom SimTK objects
-template <> struct fmt::formatter<SimTK::Vec3> : ostream_formatter {};
-template <> struct fmt::formatter<SimTK::Vector> : ostream_formatter {};
-template <> struct fmt::formatter<SimTK::Rotation> : ostream_formatter {};
-template <> struct fmt::formatter<SimTK::Inertia> : ostream_formatter {};
-#endif
+#include <format>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 
 namespace OpenSim {
 
@@ -59,35 +45,28 @@ class LogSink;
 ///
 class OSIMCOMMON_API Logger {
 public:
-    ///  This is a static singleton class: there is no way of constructing it
+    using Level = LogLevel;
+
+    /// This is a static singleton class: there is no way of constructing it.
     Logger() = delete;
 
-    /// This enum lists the types of messages that should be logged. These
-    /// levels match those of the spdlog logging library that OpenSim uses for
-    /// logging.
-    enum class Level {
-        /// Do not log any messages. Useful when running an optimization or
-        /// automated pipeline.
-        Off = 6,
-        /// Only log critical errors.
-        Critical = 5,
-        /// Log all messages that require user intervention.
-        Error = 4,
-        /// Log warnings. Warnings are generated when the software will proceed
-        /// but the user should check their input.
-        Warn = 3,
-        /// Default.
-        Info = 2,
-        /// Log information that may be useful when debugging the operation of
-        /// the
-        /// software to investigate unexpected results.
-        Debug = 1,
-        /// Log as much as possible, including messages that describe the
-        /// software's
-        /// behavior step by step. Note: OpenSim has very few Trace-level
-        /// messages.
-        Trace = 0
-    };
+#ifndef SWIG
+    /// Write `fmt` formatted with `args` at level `logLevel` to the log.
+    template<class... Args>
+    static void logMessage(LogLevel logLevel, std::format_string<Args...> fmt, Args&&... args)
+    {
+        if (not shouldLog(logLevel)) {
+            return;
+        }
+        sinkMessage(logLevel, std::format(fmt, std::forward<Args>(args)...));
+    }
+#endif  // SWIG
+
+    /// Write `message` at level `logLevel` to the log.
+    static void logMessage(LogLevel logLevel, std::string_view message)
+    {
+        logMessage(logLevel, "{}", message);
+    }
 
     /// Log messages of importance `level` and greater.
     /// For example, if the level is set to Info, then Critical, Error, Warn,
@@ -121,49 +100,36 @@ public:
     static bool shouldLog(Level level);
 
     /// @name Commands to log messages
-    /// Use these functions instead of using spdlog directly.
     /// @{
 #ifndef SWIG
     template <typename... Args>
-    static void critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Critical)) {
-            getDefaultLogger().critical(fmt, std::forward<Args>(args)...);
-        }
+    static void critical(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Critical, fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    static void error(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Error)) {
-            getDefaultLogger().error(fmt, std::forward<Args>(args)...);
-        }
+    static void error(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Error, fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    static void warn(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Warn)) {
-            getDefaultLogger().warn(fmt, std::forward<Args>(args)...);
-        }
+    static void warn(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Warn, fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    static void info(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Info)) {
-            getDefaultLogger().info(fmt, std::forward<Args>(args)...);
-        }
+    static void info(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Info, fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    static void debug(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Debug)) {
-            getDefaultLogger().debug(fmt, std::forward<Args>(args)...);
-        }
+    static void debug(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Debug, fmt, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    static void trace(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        if (shouldLog(Level::Trace)) {
-            getDefaultLogger().trace(fmt, std::forward<Args>(args)...);
-        }
+    static void trace(std::format_string<Args...> fmt, Args&&... args) {
+        logMessage(Level::Trace, fmt, std::forward<Args>(args)...);
     }
 
     /// Use this function to log messages that would normally be sent to
@@ -174,11 +140,15 @@ public:
     /// Besides such use cases, this function should be used sparingly to
     /// give users control over what gets logged.
     template <typename... Args>
-    static void cout(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-        getCoutLogger().log(
-                getCoutLogger().level(), fmt, std::forward<Args>(args)...);
+    static void cout(std::format_string<Args...> fmt, Args&&... args) {
+        sinkCoutMessage(std::format(fmt, std::forward<Args>(args)...));
     }
-#endif
+
+    static void cout(std::string_view msg) {
+        cout("{}", msg);
+    }
+#endif  // SWIG
+
     /// @}
 
     /// Log messages to a file at the level getLevel().
@@ -199,15 +169,16 @@ public:
     /// Start reporting messages to the provided sink.
     /// @note This function is not thread-safe. Do not invoke this function
     /// concurrently, or concurrently with addLogFile() or removeSink().
-    static void addSink(const std::shared_ptr<LogSink> sink);
+    static void addSink(std::shared_ptr<LogSink> sink);
 
     /// Remove a sink. If it doesn't exist, do nothing.
     /// @note This function is not thread-safe. Do not invoke this function
     /// concurrently, or concurrently with addLogFile() or addSink().
-    static void removeSink(const std::shared_ptr<LogSink> sink);
+    static void removeSink(const std::shared_ptr<LogSink>& sink);
+
 private:
-    static spdlog::logger& getCoutLogger();
-    static spdlog::logger& getDefaultLogger();
+    static void sinkMessage(LogLevel level, std::string&& payload);
+    static void sinkCoutMessage(std::string&&);
 };
 
 /// @name Logging functions
@@ -215,77 +186,77 @@ private:
 #ifndef SWIG
 /// @related Logger
 template <typename... Args>
-void log_critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::critical(fmt, std::forward<Args>(args)...);
+void log_critical(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Critical, fmt, std::forward<Args>(args)...);
+}
+/// @related Logger
+inline void log_critical(std::string_view msg) {
+    Logger::logMessage(LogLevel::Critical, msg);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_error(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::error(fmt, std::forward<Args>(args)...);
+void log_error(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Error, fmt, std::forward<Args>(args)...);
+}
+/// @related Logger
+inline void log_error(std::string_view msg) {
+    Logger::logMessage(LogLevel::Error, msg);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_warn(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::warn(fmt, std::forward<Args>(args)...);
+void log_warn(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Warn, fmt, std::forward<Args>(args)...);
+}
+/// @related Logger
+inline void log_warn(std::string_view msg) {
+    Logger::logMessage(LogLevel::Warn, msg);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_info(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::info(fmt, std::forward<Args>(args)...);
+void log_info(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Info, fmt, std::forward<Args>(args)...);
+}
+/// @related Logger
+inline void log_info(std::string_view msg) {
+    Logger::logMessage(LogLevel::Info, msg);
 }
 
 /// @related Logger
 template <typename... Args>
-void log_debug(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::debug(fmt, std::forward<Args>(args)...);
+void log_debug(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Debug, fmt, std::forward<Args>(args)...);
 }
+/// @related Logger
+inline void log_debug(std::string_view msg) {
+    Logger::logMessage(LogLevel::Debug, msg);
+}
+
 
 /// @related Logger
 template <typename... Args>
-void log_trace(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-    Logger::trace(fmt, std::forward<Args>(args)...);
+void log_trace(std::format_string<Args...> fmt, Args&&... args) {
+    Logger::logMessage(LogLevel::Trace, fmt, std::forward<Args>(args)...);
+}
+/// @related Logger
+inline void log_trace(std::string_view msg) {
+    Logger::logMessage(LogLevel::Trace, msg);
 }
 
 /// @copydoc Logger::cout()
 /// @related Logger
 template <typename... Args>
-void log_cout(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+void log_cout(std::format_string<Args...> fmt, Args&&... args) {
     Logger::cout(fmt, std::forward<Args>(args)...);
 }
-
-// Overloads for logging a single raw string message.
-
+/// @copydoc Logger::cout()
 /// @related Logger
-inline void log_critical(std::string_view msg) {
-    OpenSim::Logger::critical("{}", msg);
+inline void log_cout(std::string_view msg) {
+    Logger::cout(msg);
 }
 
-/// @related Logger
-inline void log_error(std::string_view msg) {
-    OpenSim::Logger::error("{}", msg);
-}
-
-/// @related Logger
-inline void log_warn(std::string_view msg) { OpenSim::Logger::warn("{}", msg); }
-
-/// @related Logger
-inline void log_info(std::string_view msg) { OpenSim::Logger::info("{}", msg); }
-
-/// @related Logger
-inline void log_debug(std::string_view msg) {
-    OpenSim::Logger::debug("{}", msg);
-}
-
-/// @related Logger
-inline void log_trace(std::string_view msg) {
-    OpenSim::Logger::trace("{}", msg);
-}
-
-/// @related Logger
-inline void log_cout(std::string_view msg) { OpenSim::Logger::cout("{}", msg); }
 #endif
 
 } // namespace OpenSim

--- a/OpenSim/Common/Object.h
+++ b/OpenSim/Common/Object.h
@@ -40,12 +40,13 @@
 #include "PropertySet.h"
 #include "PropertyTable.h"
 #include "osimCommonDLL.h"
+#include "Detail/JoinShim.h"
+
 #include <cstring>
 #include <map>
 #include <memory>
 #include <ostream>
 #include <set>
-#include <spdlog/fmt/ranges.h> // for fmt::join
 #include <string>
 
 // DISABLES MULTIPLE INSTANTIATION WARNINGS
@@ -1081,7 +1082,7 @@ void Object::checkPropertyValueIsInSet(
     for (int i = 0; i < p.size(); ++i) {
         const auto& value = p.getValue(i);
         if (set.find(value) == set.end()) {
-            std::string str = fmt::format("{}", fmt::join(set, ", "));
+            std::string str = std::format("{}", detail::join(set, ", "));
             OPENSIM_THROW_FRMOBJ(Exception,
                     "Property '{}' has invalid value {}; expected one of the "
                     "following: {}.", p.getName(), value, str);
@@ -1104,7 +1105,7 @@ void Object::checkPropertyValueIsInRangeOrSet(const Property<T>& p,
     for (int i = 0; i < p.size(); ++i) {
         const auto& value = p.getValue(i);
         if ((value < lower || value > upper) && set.find(value) == set.end()) {
-            std::string str = fmt::format("{}", fmt::join(set, ", "));
+            std::string str = std::format("{}", detail::join(set, ", "));
             OPENSIM_THROW_FRMOBJ(Exception,
                     "Property '{}' has invalid value {}; expected value to be "
                     "in range [{}, {}], or one of the following: {}.",
@@ -1400,7 +1401,7 @@ ObjectProperty<T>::readFromXMLElement
     int objectsFound = 0;
     SimTK::Xml::element_iterator iter = propertyElement.element_begin();
     for (; iter != propertyElement.element_end(); ++iter) {
-        const SimTK::String& objTypeTag = iter->getElementTag();
+        const std::string& objTypeTag = iter->getElementTag();
 
         const Object* registeredObj = 
             Object::getDefaultInstanceOfType(objTypeTag);

--- a/OpenSim/Common/Property.cpp
+++ b/OpenSim/Common/Property.cpp
@@ -25,6 +25,7 @@
 //============================================================================
 #include "Property.h"
 #include "Object.h"
+#include "Detail/SimbodyFormatterShims.h"
 #include <string>
 
 

--- a/OpenSim/Common/Reporter.h
+++ b/OpenSim/Common/Reporter.h
@@ -22,7 +22,8 @@
  * See the License for the specific language governing permissions and        *
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
-// INCLUDE
+
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/Component.h>
 #include <OpenSim/Common/TimeSeriesTable.h>
 
@@ -301,9 +302,9 @@ private:
 
                 // Time column.
                 if (row == numHeaderRows-1)
-                    msg += fmt::format("{:>{}}| ", "time", _width);
+                    msg += std::format("{:>{}}| ", "time", _width);
                 else
-                    msg += fmt::format("{:>{}}| ", "", _width);
+                    msg += std::format("{:>{}}| ", "", _width);
 
                 // Data columns.
                 for (auto idx = 0u; idx < input.getNumConnectees(); ++idx) {
@@ -311,7 +312,7 @@ private:
                     const std::string lbl =
                         std::string(numHeaderRows*_width - outName.size(), ' ')
                         + outName;
-                    msg += fmt::format("{}| ", lbl.substr(_width*row, _width));
+                    msg += std::format("{}| ", lbl.substr(_width*row, _width));
                 }
                 log_cout(msg);
             }
@@ -325,14 +326,13 @@ private:
 
         // TODO set width based on number of significant digits.
         std::string msg;
-        msg += fmt::format("{:>{}}| ", state.getTime(), _width);
+        msg += std::format("{:>{}}| ", state.getTime(), _width);
         for (const auto& chan : input.getChannels()) {
             const auto& value = chan->getValue(state);
             const auto& nSigFigs = chan->getOutput().getNumberOfSignificantDigits();
             // Print `value` right-justified in a column with width `_width`,
             // using `nSigFigs`: {:>{_width}.{nSigFigs}g}
-            msg += fmt::format(fmt::runtime("{:>{}.{}g}| "), value, _width,
-                    nSigFigs);
+            msg += std::format("{:>{}.{}g}| ", value, _width, nSigFigs);
         }
         log_cout(msg);
 

--- a/OpenSim/Common/XMLDocument.cpp
+++ b/OpenSim/Common/XMLDocument.cpp
@@ -32,6 +32,8 @@
 #include "Assertion.h"
 #include "XMLDocument.h"
 #include "Object.h"
+#include "Detail/SimbodyFormatterShims.h"
+
 #include <functional>
 
 

--- a/OpenSim/Examples/Moco/example3DWalking/example3DWalking.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/example3DWalking.cpp
@@ -23,6 +23,8 @@
 #include <OpenSim/Actuators/CoordinateActuator.h>
 #include <OpenSim/Actuators/Millard2012EquilibriumMuscle.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 /// This example demonstrates how to solve 3D walking optimization problems 
@@ -216,19 +218,19 @@ void runTrackingStudy(Model model, bool muscleDriven) {
     // Solve!
     // ------
     MocoSolution solution = study.solve();
-    solution.write(fmt::format("example3DWalking_{}_solution.sto", study_name));
+    solution.write(std::format("example3DWalking_{}_solution.sto", study_name));
 
     // Print the model.
     Model modelSolution = modelProcessor.process();
     modelSolution.initSystem();
-    modelSolution.print(fmt::format(
+    modelSolution.print(std::format(
             "example3DWalking_{}_model.osim", study_name));
 
     // Extract the ground reaction forces.
     TimeSeriesTable externalForcesTableFlat = createExternalLoadsTableForGait(
             modelSolution, solution, contactForcesRight, contactForcesLeft);
     STOFileAdapter::write(externalForcesTableFlat,
-            fmt::format("example3DWalking_{}_ground_reactions.sto", study_name));
+            std::format("example3DWalking_{}_ground_reactions.sto", study_name));
 
     // Visualize the solution.
     study.visualize(solution);

--- a/OpenSim/Examples/Moco/example3DWalking/exampleMocoInverse.cpp
+++ b/OpenSim/Examples/Moco/example3DWalking/exampleMocoInverse.cpp
@@ -30,6 +30,8 @@
 #include <OpenSim/Simulation/Control/SynergyController.h>
 #include <OpenSim/Moco/osimMoco.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 /// Solve the basic muscle redundancy problem with MocoInverse.
@@ -302,12 +304,12 @@ void solveMocoInverseWithSynergies(int numSynergies = 5) {
     auto& effort = dynamic_cast<MocoControlGoal&>(
             problem.updGoal("excitation_effort"));
     for (int i = 0; i < numSynergies; ++i) {
-        std::string nameLeft = fmt::format("/controllerset/"
+        std::string nameLeft = std::format("/controllerset/"
                 "synergy_controller_left_leg/synergy_excitation_{}", i);
         problem.setInputControlInfo(nameLeft, {0, 1.0});
         effort.setWeightForControl(nameLeft, 10);
 
-        std::string nameRight = fmt::format("/controllerset/"
+        std::string nameRight = std::format("/controllerset/"
                 "synergy_controller_right_leg/synergy_excitation_{}", i);
         problem.setInputControlInfo(nameRight, {0, 1.0});
         effort.setWeightForControl(nameRight, 10);
@@ -328,7 +330,7 @@ void solveMocoInverseWithSynergies(int numSynergies = 5) {
     solution.insertStatesTrajectory(coordinateSpeeds);
 
     // Write the solution to a Storage file.
-    solution.write(fmt::format("example3DWalking_MocoInverseWith{}Synergies_"
+    solution.write(std::format("example3DWalking_MocoInverseWith{}Synergies_"
             "solution.sto", numSynergies));
 }
 

--- a/OpenSim/Moco/About.cpp
+++ b/OpenSim/Moco/About.cpp
@@ -22,9 +22,10 @@
 
 #include "About.h"
 
-#include <stdio.h>
-
 #include <OpenSim/Common/Logger.h>
+
+#include <format>
+#include <string>
 
 #define STR(var) #var
 #define MAKE_VERSION_STRING(maj, min, build) STR(maj.min.build)
@@ -45,7 +46,7 @@ namespace OpenSim {
 static const char* OpenSimMocoVersion = GET_OPENSIM_MOCO_VERSION_STRING;
 
 std::string GetMocoVersionAndDate() {
-    return fmt::format("version {}, build date {} {}", OpenSimMocoVersion,
+    return std::format("version {}, build date {} {}", OpenSimMocoVersion,
             __TIME__, __DATE__);
 }
 

--- a/OpenSim/Moco/Components/ActuatorInputController.cpp
+++ b/OpenSim/Moco/Components/ActuatorInputController.cpp
@@ -75,7 +75,7 @@ ActuatorInputController::getInputControlLabels() const {
                 // Use the control name format based on
                 // SimulationUtilities::createControlNamesFromModel().
                 labels.push_back(
-                        fmt::format("{}_{}", actu.getAbsolutePathString(), j));
+                        std::format("{}_{}", actu.getAbsolutePathString(), j));
             }
         } else {
             // Scalar actuator.

--- a/OpenSim/Moco/Components/ControlDistributor.cpp
+++ b/OpenSim/Moco/Components/ControlDistributor.cpp
@@ -108,7 +108,7 @@ ControlDistributor::addControlDistributorAndConnectInputControllers(
         }
         const auto labels = controller.getInputControlLabels();
         for (const auto& label : labels) {
-            std::string inputControlName = fmt::format(
+            std::string inputControlName = std::format(
                     "{}/{}", controller.getAbsolutePathString(), label);
             controlDistributorUPtr->addControl(inputControlName);
             controlDistributorUPtr->finalizeFromProperties();

--- a/OpenSim/Moco/MocoBounds.h
+++ b/OpenSim/Moco/MocoBounds.h
@@ -24,6 +24,9 @@
 #include <OpenSim/Common/Property.h>
 #include <OpenSim/Common/Array.h>
 
+#include <format>
+#include <ostream>
+
 namespace OpenSim {
 
 class MocoPhase;
@@ -107,16 +110,6 @@ private:
 
 };
 
-inline std::ostream& operator<<(
-        std::ostream& stream, const MocoBounds& bounds) {
-    if (bounds.isEquality()) {
-        stream << bounds.getLower();
-    } else {
-        stream << "[" << bounds.getLower() << ", " << bounds.getUpper() << "]";
-    }
-    return stream;
-}
-
 /// Used for specifying the bounds on a variable at the start of a phase.
 class OSIMMOCO_API MocoInitialBounds : public MocoBounds {
 OpenSim_DECLARE_CONCRETE_OBJECT(MocoInitialBounds, MocoBounds);
@@ -135,12 +128,40 @@ OpenSim_DECLARE_CONCRETE_OBJECT(MocoFinalBounds, MocoBounds);
 } // namespace OpenSim
 
 #ifndef SWIG
-// fmt library serializers for custom Moco objects
-template <> struct fmt::formatter<OpenSim::MocoBounds> : ostream_formatter {};
-template <>
-struct fmt::formatter<OpenSim::MocoInitialBounds> : ostream_formatter {};
-template <>
-struct fmt::formatter<OpenSim::MocoFinalBounds> : ostream_formatter {};
+template<>
+struct std::formatter<OpenSim::MocoBounds> {
+    // Parse format specifiers intended for the bound values (e.g., {:.2f})
+    constexpr auto parse(std::format_parse_context& ctx) {
+        return _inner.parse(ctx);
+    }
+
+    // Format the MocoBounds matching the original conditional layout
+    template<class FormatContext>
+    auto format(const OpenSim::MocoBounds& bounds, FormatContext& ctx) const -> decltype(ctx.out()) {
+        auto out = ctx.out();
+
+        if (bounds.isEquality()) {
+            out = _inner.format(bounds.getLower(), ctx);
+        } else {
+            out = std::format_to(out, "[");
+            out = _inner.format(bounds.getLower(), ctx);
+            out = std::format_to(out, ", ");
+            out = _inner.format(bounds.getUpper(), ctx);
+            out = std::format_to(out, "]");
+        }
+
+        return out;
+    }
+
+private:
+    std::formatter<double> _inner;
+};
+template<> struct std::formatter<OpenSim::MocoInitialBounds> : std::formatter<OpenSim::MocoBounds> {};
+template<> struct std::formatter<OpenSim::MocoFinalBounds> : std::formatter<OpenSim::MocoBounds> {};
 #endif
+
+inline std::ostream& operator<<(std::ostream& lhs, const OpenSim::MocoBounds& rhs) {
+    return lhs << std::format("{}", rhs);
+}
 
 #endif // OPENSIM_MOCOBOUNDS_H

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCProblem.cpp
@@ -27,6 +27,8 @@
 #include <OpenSim/Moco/MocoTrajectory.h>
 #include "MocoCasOCProblem.h"
 
+#include <format>
+
 using OpenSim::Exception;
 
 namespace CasOC {
@@ -47,7 +49,7 @@ std::vector<std::string>
 Problem::createKinematicConstraintEquationNamesImpl() const {
     std::vector<std::string> names(getNumKinematicConstraintEquations());
     for (int i = 0; i < getNumKinematicConstraintEquations(); ++i) {
-        names[i] = fmt::format("kinematic_constraint_{:03d}", i);
+        names[i] = std::format("kinematic_constraint_{:03d}", i);
     }
     return names;
 }

--- a/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/CasOCTranscription.cpp
@@ -1489,7 +1489,7 @@ void Transcription::printConstraintValues(const Iterate& it,
                     const double L1 = max;
                     const double time_of_max = it.times(argmax).scalar();
 
-                    std::string label = fmt::format("{}_{}", pc.name, ieq);
+                    std::string label = std::format("{}_{}", pc.name, ieq);
                     ss << std::setfill('0') << std::setw(2) << ipc << ":"
                            << std::setfill(' ') << std::setw(maxNameLength)
                            << label << spacer << std::setprecision(2)

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasADiSolver.cpp
@@ -398,11 +398,11 @@ MocoSolution MocoCasADiSolver::solveImpl() const {
         casSolution = casSolver->solve(casGuess);
     } catch(const Exception& ex) {
         OPENSIM_THROW_FRMOBJ(Exception,
-            fmt::format("MocoCasADiSolver failed internally with message: {}",
+            std::format("MocoCasADiSolver failed internally with message: {}",
                 ex.getMessage()));
     } catch(const casadi::CasadiException& ex) {
         OPENSIM_THROW_FRMOBJ(Exception,
-            fmt::format("MocoCasADiSolver failed internally with message: {}",
+            std::format("MocoCasADiSolver failed internally with message: {}",
                 ex.what()));
     } catch (...) {
         OPENSIM_THROW_FRMOBJ(Exception, "MocoCasADiSolver failed internally.");

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.cpp
@@ -282,6 +282,6 @@ MocoCasOCProblem::MocoCasOCProblem(const MocoCasADiSolver& mocoCasADiSolver,
     }
 
     m_fileDeletionThrower = std::make_unique<FileDeletionThrower>(
-            fmt::format("delete_this_to_stop_optimization_{}_{}.txt",
+            std::format("delete_this_to_stop_optimization_{}_{}.txt",
                     problemRep.getName(), m_formattedTimeString));
 }

--- a/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
+++ b/OpenSim/Moco/MocoCasADiSolver/MocoCasOCProblem.h
@@ -644,7 +644,7 @@ private:
     void intermediateCallbackWithIterateImpl(
             const CasOC::Iterate& iterate) const override {
         std::string filename =
-                fmt::format("MocoCasADiSolver_{}_trajectory{:06d}.sto",
+                std::format("MocoCasADiSolver_{}_trajectory{:06d}.sto",
                         m_formattedTimeString, iterate.iteration);
         convertToMocoTrajectory(iterate).write(filename);
     }

--- a/OpenSim/Moco/MocoConstraintInfo.cpp
+++ b/OpenSim/Moco/MocoConstraintInfo.cpp
@@ -38,18 +38,12 @@ std::vector<std::string> MocoConstraintInfo::getConstraintLabels() const {
 }
 
 void MocoConstraintInfo::printDescription() const {
-    std::string str = fmt::format("  {}. {}. number of scalar equations: {}",
-            getName(), getConcreteClassName(), getNumEquations());
-
-    const std::vector<MocoBounds> bounds = getBounds();
-    std::vector<std::string> boundsStr;
-    for (const auto& bound : bounds) {
-        std::stringstream ss;
-        ss << bound;
-        boundsStr.push_back(ss.str());
-    }
-    str += fmt::format(". bounds: {}", fmt::join(boundsStr, ", "));
-    log_info(str);
+    log_info("  {}. {}. number of scalar equations: {}. bounds: {}",
+        getName(),
+        getConcreteClassName(),
+        getNumEquations(),
+        detail::join(getBounds(), ", ")
+    );
 }
 
 void MocoConstraintInfo::constructProperties() {

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.cpp
@@ -78,7 +78,7 @@ void MocoExpressionBasedParameterGoal::initializeOnModelImpl(const Model& model)
         if (msg.compare(0, 30, "No value specified for variable")) {
             std::string undefinedVar = msg.substr(32, msg.size() - 32);
             OPENSIM_THROW_FRMOBJ(Exception, 
-                    fmt::format("Parameter variable '{}' is not defined. Use "
+                    std::format("Parameter variable '{}' is not defined. Use "
                     "addParameter() to explicitly define this variable. Or, "
                     "remove it from the expression.", undefinedVar));
         } else {
@@ -102,8 +102,7 @@ double MocoExpressionBasedParameterGoal::getPropertyValue(int i) const {
         return static_cast<const Property<SimTK::Vec6>*>(propRef.get())
                                                      ->getValue()[elt];
     }
-    OPENSIM_THROW_FRMOBJ(Exception, fmt::format(fmt::runtime(
-            "Property at index {} is not of a recognized type."), i));
+    OPENSIM_THROW_FRMOBJ(Exception, std::format("Property at index {} is not of a recognized type.", i));
 }
 
 void MocoExpressionBasedParameterGoal::calcGoalImpl(

--- a/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoExpressionBasedParameterGoal.h
@@ -51,7 +51,7 @@ auto* spring2_parameter = mp.addParameter("spring2_stiffness", "spring2",
 auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>();
 double STIFFNESS = 100.0;
 // minimum is when p + q = STIFFNESS
-spring_goal->setExpression(fmt::format("square(p+q-{})", STIFFNESS));
+spring_goal->setExpression(std::format("square(p+q-{})", STIFFNESS));
 spring_goal->addParameter(*spring1_parameter, "p");
 spring_goal->addParameter(*spring2_parameter, "q");
 @endcode

--- a/OpenSim/Moco/MocoGoal/MocoGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.cpp
@@ -20,6 +20,8 @@
 
 #include <OpenSim/Moco/Components/ControlDistributor.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 MocoGoal::MocoGoal() {
@@ -40,10 +42,10 @@ MocoGoal::MocoGoal(std::string name, double weight)
 
 void MocoGoal::printDescription() const {
     const auto mode = getModeAsString();
-    std::string str = fmt::format("  {}. {}, enabled: {}, mode: {}",
+    std::string str = std::format("  {}. {}, enabled: {}, mode: {}",
             getName(), getConcreteClassName(), get_enabled(), mode);
     if (mode == "cost") {
-        str += fmt::format(", weight: {}", get_weight());
+        str += std::format(", weight: {}", get_weight());
     }
     log_info(str);
     printDescriptionImpl();

--- a/OpenSim/Moco/MocoGoal/MocoGoal.h
+++ b/OpenSim/Moco/MocoGoal/MocoGoal.h
@@ -517,7 +517,7 @@ private:
     void checkMode(const std::string& mode) const {
         OPENSIM_THROW_IF_FRMOBJ(mode != "cost" && mode != "endpoint_constraint",
                 Exception,
-                fmt::format(
+                std::format(
                         "Expected mode to be 'cost' or 'endpoint_constraint' "
                         "but got {}.",
                         mode));

--- a/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoJointReactionGoal.cpp
@@ -162,7 +162,7 @@ void MocoJointReactionGoal::printDescriptionImpl() const {
     for (int i = 0; i < (int)measures.size(); i++) {
         measures[i] = get_reaction_measures(i);
     }
-    log_info("        reaction measures: {}", fmt::join(measures, ", "));
+    log_info("        reaction measures: {}", detail::join(measures, ", "));
 
-    log_info("        reaction weights: {}", fmt::join(m_measureWeights, ", "));
+    log_info("        reaction weights: {}", detail::join(m_measureWeights, ", "));
 }

--- a/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOrientationTrackingGoal.cpp
@@ -26,6 +26,8 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/StatesTrajectory.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
@@ -87,11 +89,11 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
         auto columns = statesTableToUse.getColumnLabels();
         for (int i = 0; i < coords.getSize(); ++i) {
             const Coordinate& coord = coords.get(i);
-            std::string path = fmt::format("{}/value", coord.getAbsolutePathString());
+            std::string path = std::format("{}/value", coord.getAbsolutePathString());
             OPENSIM_THROW_IF(
                 std::find(columns.begin(), columns.end(), path) == columns.end(),
                 Exception,
-                fmt::format("Expected the states reference table to contain "
+                std::format("Expected the states reference table to contain "
                             "columns for all coordinate values in the model, "
                             "but {} was not found.", path));
         }
@@ -169,7 +171,7 @@ void MocoOrientationTrackingGoal::initializeOnModelImpl(const Model& model)
                 mat.updElt(irow, icol++) = e[ie];
                 if (!irow) {
                     colLabels.push_back(
-                            fmt::format("{}/quaternion_e{}", label, ie));
+                            std::format("{}/quaternion_e{}", label, ie));
                 }
             }
         }

--- a/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoOutputGoal.cpp
@@ -103,7 +103,7 @@ void MocoOutputBase::initializeOnModelBase() const {
         m_useCompositeOutputValue = true;
         initializeComposite();
     } else if (get_operation() != "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("An operation was provided "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("An operation was provided "
                 "but a second Output path was not provided. Either provide no "
                 "operation with a single Output, or provide a value to both "
                 "setOperation() and setSecondOutputPath()."));
@@ -120,11 +120,11 @@ void MocoOutputBase::initializeComposite() const {
     } else if (get_operation() == "division") {
         m_operation = Division;
     } else if (get_operation() == "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("A second Output path was "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("A second Output path was "
                 "provided, but no operation was provided. Use setOperation() to"
                 "provide an operation"));
     } else {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Invalid operation: '{}', must "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("Invalid operation: '{}', must "
                 "be 'addition', 'subtraction', 'multiplication', or 'division'.",
                 get_operation()));
     }
@@ -236,28 +236,28 @@ double MocoOutputBase::calcCompositeOutputValue(const SimTK::State& state) const
 
 void MocoOutputBase::printDescriptionImpl() const {
     // Output path.
-    std::string str = fmt::format("        output: {}", getOutputPath());
+    std::string str = std::format("        output: {}", getOutputPath());
 
     if (m_useCompositeOutputValue) {
-        str += fmt::format("\n        second output: {}", getSecondOutputPath());
+        str += std::format("\n        second output: {}", getSecondOutputPath());
         // Operation.
-        str += fmt::format("\n        operation: {}", get_operation());
+        str += std::format("\n        operation: {}", get_operation());
     }
 
     // Output type.
-    str += fmt::format(", type: {}", getDataTypeString(m_data_type));
+    str += std::format(", type: {}", getDataTypeString(m_data_type));
 
     // Output index (if relevant).
     if (getOutputIndex() != -1) {
-        str += fmt::format(", index: {}", getOutputIndex());
+        str += std::format(", index: {}", getOutputIndex());
     }
 
     // Exponent.
-    str += fmt::format(", exponent: {}", getExponent());
+    str += std::format(", exponent: {}", getExponent());
 
     // Bounds (if endpoint constraint).
     if (getModeIsEndpointConstraint()) {
-        str += fmt::format(", bounds: {}", getConstraintInfo().getBounds()[0]);
+        str += std::format(", bounds: {}", getConstraintInfo().getBounds()[0]);
     }
 
     log_info(str);
@@ -303,7 +303,7 @@ void MocoOutputExtremumGoal::initializeOnModelImpl(const Model& output) const {
     OPENSIM_THROW_IF_FRMOBJ(
             get_smoothing_factor() < 0.2 || get_smoothing_factor() > 1.0,
             Exception,
-            fmt::format("Expected the smoothing factor must be in the range "
+            std::format("Expected the smoothing factor must be in the range "
                     "[0.2, 1.0], but received {}.", get_smoothing_factor()));
 
     OPENSIM_THROW_IF_FRMOBJ(m_minimizeVectorNorm == 1 &&

--- a/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
+++ b/OpenSim/Moco/MocoGoal/MocoTranslationTrackingGoal.cpp
@@ -24,6 +24,8 @@
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/StatesTrajectory.h>
 
+#include <format>
+
 using namespace OpenSim;
 using SimTK::Vec3;
 
@@ -61,7 +63,7 @@ void MocoTranslationTrackingGoal::initializeOnModelImpl(const Model& model)
                 OPENSIM_THROW_IF_FRMOBJ(std::find(labels.begin(), labels.end(),
                                                 path) == labels.end(),
                         Exception,
-                        fmt::format(
+                        std::format(
                                 "Expected frame_paths to match one of the "
                                 "column labels in the translation reference, "
                                 "but frame path '{}' not found in the "

--- a/OpenSim/Moco/MocoOutputBoundConstraint.cpp
+++ b/OpenSim/Moco/MocoOutputBoundConstraint.cpp
@@ -21,6 +21,8 @@
 #include <OpenSim/Common/GCVSpline.h>
 #include <OpenSim/Simulation/SimulationUtilities.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 void MocoOutputBoundConstraint::constructProperties() {
@@ -169,7 +171,7 @@ void MocoOutputBoundConstraint::initializeOnModelImpl(
         m_useCompositeOutputValue = true;
         initializeComposite();
     } else if (get_operation() != "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("An operation was provided "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("An operation was provided "
                 "but a second Output path was not provided. Either provide no "
                 "operation with a single Output, or provide a value to both "
                 "setOperation() and setSecondOutputPath()."));
@@ -186,11 +188,11 @@ void MocoOutputBoundConstraint::initializeComposite() const {
     } else if (get_operation() == "division") {
         m_operation = Division;
     } else if (get_operation() == "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("A second Output path was "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("A second Output path was "
                 "provided, but no operation was provided. Use setOperation() to"
                 "provide an operation"));
     } else {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Invalid operation: '{}', must "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("Invalid operation: '{}', must "
                 "be 'addition', 'subtraction', 'multiplication', or 'division'.",
                 get_operation()));
     }

--- a/OpenSim/Moco/MocoOutputConstraint.cpp
+++ b/OpenSim/Moco/MocoOutputConstraint.cpp
@@ -102,7 +102,7 @@ void MocoOutputConstraint::initializeOnModelImpl(const Model&,
         m_useCompositeOutputValue = true;
         initializeComposite();
     } else if (get_operation() != "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("An operation was provided "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("An operation was provided "
                 "but a second Output path was not provided. Either provide no "
                 "operation with a single Output, or provide a value to both "
                 "setOperation() and setSecondOutputPath()."));
@@ -119,11 +119,11 @@ void MocoOutputConstraint::initializeComposite() const {
     } else if (get_operation() == "division") {
         m_operation = Division;
     } else if (get_operation() == "") {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("A second Output path was "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("A second Output path was "
                 "provided, but no operation was provided. Use setOperation() to"
                 "provide an operation"));
     } else {
-        OPENSIM_THROW_FRMOBJ(Exception, fmt::format("Invalid operation: '{}', must "
+        OPENSIM_THROW_FRMOBJ(Exception, std::format("Invalid operation: '{}', must "
                 "be 'addition', 'subtraction', 'multiplication', or 'division'.",
                 get_operation()));
     }
@@ -246,24 +246,24 @@ double MocoOutputConstraint::calcCompositeOutputValue(const SimTK::State& state)
 
 void MocoOutputConstraint::printDescriptionImpl() const {
     // Output path.
-    std::string str = fmt::format("        output: {}", getOutputPath());
+    std::string str = std::format("        output: {}", getOutputPath());
 
     if (m_useCompositeOutputValue) {
-        str += fmt::format("\n        second output: {}", getSecondOutputPath());
+        str += std::format("\n        second output: {}", getSecondOutputPath());
         // Operation.
-        str += fmt::format("\n        operation: {}", get_operation());
+        str += std::format("\n        operation: {}", get_operation());
     }
 
     // Output type.
-    str += fmt::format(", type: {}", getDataTypeString(m_data_type));
+    str += std::format(", type: {}", getDataTypeString(m_data_type));
 
     // Output index (if relevant).
     if (getOutputIndex() != -1) {
-        str += fmt::format(", index: {}", getOutputIndex());
+        str += std::format(", index: {}", getOutputIndex());
     }
 
     // Exponent.
-    str += fmt::format(", exponent: {}", getExponent());
+    str += std::format(", exponent: {}", getExponent());
 
     log_info(str);
 }

--- a/OpenSim/Moco/MocoParameter.cpp
+++ b/OpenSim/Moco/MocoParameter.cpp
@@ -20,6 +20,8 @@
 #include "MocoUtilities.h"
 #include <OpenSim/Simulation/Model/Model.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 MocoParameter::MocoParameter() {
@@ -137,12 +139,12 @@ void MocoParameter::printDescription() const {
         propertyElementStr = "n/a";
     } else {
         propertyElementStr =
-                fmt::format("{}", getProperty_property_element().getValue());
+                std::format("{}", getProperty_property_element().getValue());
     }
 
     log_info("  {}. model property name: {}. component paths: {}. "
              "property element: {}. bounds: {}",
-            getName(), getPropertyName(), fmt::join(componentPaths, ", "),
+            getName(), getPropertyName(), detail::join(componentPaths, ", "),
             propertyElementStr, getBounds());
 }
 

--- a/OpenSim/Moco/MocoProblem.cpp
+++ b/OpenSim/Moco/MocoProblem.cpp
@@ -22,6 +22,8 @@
 
 #include <OpenSim/Simulation/SimulationUtilities.h>
 
+#include <format>
+
 using namespace OpenSim;
 
 // ============================================================================
@@ -122,7 +124,7 @@ void MocoPhase::printControlNamesWithSubstring(const std::string& substring) {
             } else {
                 for (int i = 0; i < actu.numControls(); ++i) {
                     controlsToExclude.push_back(
-                            fmt::format("{}_{}", actuPath, i));
+                            std::format("{}_{}", actuPath, i));
                 }
             }
         }

--- a/OpenSim/Moco/MocoProblemRep.cpp
+++ b/OpenSim/Moco/MocoProblemRep.cpp
@@ -35,7 +35,7 @@
 
 using namespace OpenSim;
 
-template <> struct fmt::formatter<SimTK::ConstraintIndex> : ostream_formatter {};
+
 
 const std::vector<std::string> MocoProblemRep::m_disallowedJoints(
         {"FreeJoint", "BallJoint", "EllipsoidJoint", "ScapulothoracicJoint"});
@@ -170,7 +170,7 @@ void MocoProblemRep::initialize() {
                 actuatorController->connectInput_controls(channel, actuPath);
             } else {
                 for (int i = 0; i < actu.numControls(); ++i) {
-                    std::string controlName = fmt::format("{}_{}", actuPath, i);
+                    std::string controlName = std::format("{}_{}", actuPath, i);
                     controlDistributor.addControl(controlName);
                     controlDistributor.finalizeFromProperties();
                     const auto& output = 
@@ -361,7 +361,7 @@ void MocoProblemRep::initialize() {
             std::vector<MocoVariableInfo> multInfos;
             for (int i = 0; i < mp; ++i) {
                 std::string name =
-                        fmt::format("cid{}_p{}", static_cast<int>(cid), i);
+                        std::format("cid{}_p{}", static_cast<int>(cid), i);
                 kc_perr_names.push_back(name);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
@@ -369,7 +369,7 @@ void MocoProblemRep::initialize() {
             }
             for (int i = 0; i < mv; ++i) {
                 std::string name =
-                        fmt::format("cid{}_v{}", static_cast<int>(cid), i);
+                        std::format("cid{}_v{}", static_cast<int>(cid), i);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
                 kc_verr_names.push_back(name);
@@ -377,7 +377,7 @@ void MocoProblemRep::initialize() {
             }
             for (int i = 0; i < ma; ++i) {
                 std::string name =
-                        fmt::format("cid{}_a{}", static_cast<int>(cid), i);
+                        std::format("cid{}_a{}", static_cast<int>(cid), i);
                 MocoVariableInfo info("lambda_" + name, multBounds,
                         multInitBounds, multFinalBounds);
                 kc_aerr_names.push_back(name);
@@ -469,7 +469,7 @@ void MocoProblemRep::initialize() {
         for (const auto& output : outputsBound) {
             const auto nameStart = output->getName().find("_") + 1;
             const auto stateName = output->getName().substr(nameStart);
-            const auto statePath = fmt::format(
+            const auto statePath = std::format(
                     "{}/{}", component.getAbsolutePathString(), stateName);
             // If this is indeed a state and no info has been provided for it,
             // use the state bounds from the output.

--- a/OpenSim/Moco/MocoTrajectory.cpp
+++ b/OpenSim/Moco/MocoTrajectory.cpp
@@ -699,15 +699,15 @@ void MocoTrajectory::generateControlsFromModelControllers(
 
 void MocoTrajectory::trimToIndices(int newStartIndex, int newFinalIndex) {
     OPENSIM_THROW_IF(newFinalIndex < newStartIndex, Exception,
-            fmt::format("Expected newFinalIndex to be greater than "
+            std::format("Expected newFinalIndex to be greater than "
                         "newStartIndex, but received {} and {} for "
                         "newStartIndex and newFinalIndex, respectively.",
                         newStartIndex, newFinalIndex));
     OPENSIM_THROW_IF(newStartIndex < 0, Exception,
-            fmt::format("Expected newStartIndex to be greater than or equal to"
+            std::format("Expected newStartIndex to be greater than or equal to"
                         "0, but received {}.", newStartIndex));
     OPENSIM_THROW_IF(newFinalIndex > getNumTimes()-1, Exception,
-            fmt::format("Expected newFinalIndex to be less than or equal to"
+            std::format("Expected newFinalIndex to be less than or equal to"
                         "the current final index {}, but received {}.",
                         getNumTimes()-1, newFinalIndex));
 

--- a/OpenSim/Moco/MocoUtilities.cpp
+++ b/OpenSim/Moco/MocoUtilities.cpp
@@ -94,7 +94,7 @@ void OpenSim::prescribeControlsToModel(
     for (auto& controller : model.updComponentList<InputController>()) {
         const auto& labels = controller.getInputControlLabels();
         for (const auto& label : labels) {
-            std::string inputControlName = fmt::format("{}/{}", 
+            std::string inputControlName = std::format("{}/{}",
                     controller.getAbsolutePathString(), label);
 
             const auto inputControl = 
@@ -433,7 +433,7 @@ TimeSeriesTable OpenSim::calcGeneralizedForces(Model model,
     for (int j = 0; j < static_cast<int>(coordinates.size()); ++j) {
         const auto& coordinate = coordinates[j];
         udots.updCol(j) = accelerationsTable.getDependentColumn(
-                fmt::format("{}|acceleration",
+                std::format("{}|acceleration",
                             coordinate->getAbsolutePathString()));
     }
 

--- a/OpenSim/Moco/MocoVariableInfo.cpp
+++ b/OpenSim/Moco/MocoVariableInfo.cpp
@@ -19,6 +19,8 @@
 #include "MocoVariableInfo.h"
 #include "MocoUtilities.h"
 
+#include <format>
+
 using namespace OpenSim;
 
 MocoVariableInfo::MocoVariableInfo() {
@@ -65,14 +67,14 @@ void MocoVariableInfo::validate() const {
 
 void MocoVariableInfo::printDescription() const {
     const auto bounds = getBounds();
-    std::string str = fmt::format("  {}. bounds: {}", getName(), bounds);
+    std::string str = std::format("  {}. bounds: {}", getName(), bounds);
     const auto initial = getInitialBounds();
     if (initial.isSet()) {
-        str += fmt::format(" initial: {}", initial);
+        str += std::format(" initial: {}", initial);
     }
     const auto final = getFinalBounds();
     if (final.isSet()) {
-        str += fmt::format(" final: {}", final);
+        str += std::format(" final: {}", final);
     }
     log_info(str);
 }

--- a/OpenSim/Moco/Test/testMocoAnalytic.cpp
+++ b/OpenSim/Moco/Test/testMocoAnalytic.cpp
@@ -205,7 +205,7 @@ TEMPLATE_TEST_CASE("Linear tangent steering",
 
     MocoSolution solution = study.solve().unseal();
     solution.write(
-            fmt::format("testMocoAnalytic_LinearTangentSteering_{}_solution.sto",
+            std::format("testMocoAnalytic_LinearTangentSteering_{}_solution.sto",
                     transcription_scheme));
 
     const SimTK::Vector time = solution.getTime();

--- a/OpenSim/Moco/Test/testMocoConstraints.cpp
+++ b/OpenSim/Moco/Test/testMocoConstraints.cpp
@@ -881,7 +881,7 @@ TEST_CASE("DoublePendulum tests, Posa2016 method - MocoCasADiSolver",
     bool enforce_constraint_derivatives = GENERATE(true, false);
     std::string dynamics_mode = GENERATE(as<std::string>{}, 
             "explicit", "implicit");
-    std::string section = fmt::format(
+    std::string section = std::format(
             "enforce derivatives: {}, dynamics_mode: {}", 
             enforce_constraint_derivatives, dynamics_mode);
 
@@ -907,7 +907,7 @@ TEST_CASE("DoublePendulum tests, Bordalba2023 method", "[casadi]") {
             "legendre-gauss-radau-3");
     std::string dynamics_mode = GENERATE(as<std::string>{}, 
             "explicit", "implicit");
-    std::string section = fmt::format("scheme: {}, dynamics_mode: {}", 
+    std::string section = std::format("scheme: {}, dynamics_mode: {}",
             scheme, dynamics_mode);
 
     // Trapezoidal rule requires more mesh intervals to keep slack variables 

--- a/OpenSim/Moco/Test/testMocoGoals.cpp
+++ b/OpenSim/Moco/Test/testMocoGoals.cpp
@@ -1403,7 +1403,7 @@ TEST_CASE("MocoExpressionBasedParameterGoal - MocoCasADiSolver") {
                                           "stiffness", MocoBounds(0, 100));
         auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>();
         // minimum is when p = 0.5*STIFFNESS
-        spring_goal->setExpression(fmt::format("(p-{})^2", 0.5*STIFFNESS));
+        spring_goal->setExpression(std::format("(p-{})^2", 0.5*STIFFNESS));
         spring_goal->addParameter(*parameter, "p");
 
         auto& ms = study.initCasADiSolver();
@@ -1424,7 +1424,7 @@ TEST_CASE("MocoExpressionBasedParameterGoal - MocoCasADiSolver") {
                                           "stiffness", MocoBounds(0, 100));
         auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>();
         // minimum is when p + q = STIFFNESS
-        spring_goal->setExpression(fmt::format("square( p+q-{} )", STIFFNESS));
+        spring_goal->setExpression(std::format("square( p+q-{} )", STIFFNESS));
         spring_goal->addParameter(*parameter, "p");
         spring_goal->addParameter(*parameter2, "q");
 
@@ -1446,7 +1446,7 @@ TEST_CASE("MocoExpressionBasedParameterGoal - MocoCasADiSolver") {
                                           "stiffness", MocoBounds(0, 100));
 
         auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>(
-                "stiffness", 1, fmt::format("(p+q-{})^2", STIFFNESS));
+                "stiffness", 1, std::format("(p+q-{})^2", STIFFNESS));
         spring_goal->addParameter(*parameter, "p");
 
         CHECK_THROWS(study.initCasADiSolver()); // missing q
@@ -1460,7 +1460,7 @@ TEST_CASE("MocoExpressionBasedParameterGoal - MocoCasADiSolver") {
                                           "stiffness", MocoBounds(0, 100));
 
         auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>(
-                "stiffness", 1, fmt::format("(p-{})^2", STIFFNESS));
+                "stiffness", 1, std::format("(p-{})^2", STIFFNESS));
         spring_goal->addParameter(*parameter, "p");
         // second parameter is ignored
         spring_goal->addParameter(*parameter2, "a");
@@ -1474,7 +1474,7 @@ TEST_CASE("MocoExpressionBasedParameterGoal - MocoCasADiSolver") {
         auto* parameter2 = mp.addParameter("spring2_stiffness", "spring2",
                                           "stiffness", MocoBounds(0, 100));
         auto* spring_goal = mp.addGoal<MocoExpressionBasedParameterGoal>();
-        spring_goal->setExpression(fmt::format("square( p+q-{} )", STIFFNESS));
+        spring_goal->setExpression(std::format("square( p+q-{} )", STIFFNESS));
         spring_goal->addParameter(*parameter, "p");
         spring_goal->addParameter(*parameter2, "q");
         // set as endpoint constraint

--- a/OpenSim/Moco/Test/testMocoInterface.cpp
+++ b/OpenSim/Moco/Test/testMocoInterface.cpp
@@ -1746,7 +1746,7 @@ void testSlidingMass(const std::string& transcriptionScheme) {
             transcriptionScheme, N);
     MocoSolution solution = study.solve();
     solution.write(
-            fmt::format("testMocoInterface_testSlidingMass_{}_solution.sto",
+            std::format("testMocoInterface_testSlidingMass_{}_solution.sto",
                     transcriptionScheme));
     int numTimes;
     if (transcriptionScheme == "trapezoidal") {

--- a/OpenSim/Simulation/Control/InputController.cpp
+++ b/OpenSim/Simulation/Control/InputController.cpp
@@ -88,7 +88,7 @@ void InputController::extendConnectToModel(Model& model) {
                 // Use the control name format based on
                 // SimulationUtilities::createControlNamesFromModel().
                 m_controlNames.push_back(
-                        fmt::format("{}_{}", actu.getAbsolutePathString(), j));
+                        std::format("{}_{}", actu.getAbsolutePathString(), j));
                 auto it = std::find(modelControlNames.begin(),
                         modelControlNames.end(), m_controlNames.back());
                 m_controlIndexes.push_back(

--- a/OpenSim/Simulation/Control/SynergyController.cpp
+++ b/OpenSim/Simulation/Control/SynergyController.cpp
@@ -63,7 +63,7 @@ SynergyController::operator=(SynergyController&& other) = default;
 std::vector<std::string> SynergyController::getInputControlLabels() const {
     std::vector<std::string> labels;
     for (int i = 0; i < getProperty_synergy_vectors().size(); ++i) {
-        labels.push_back(fmt::format("synergy_excitation_{}", i));
+        labels.push_back(std::format("synergy_excitation_{}", i));
     }
     return labels;
 }
@@ -95,7 +95,7 @@ void SynergyController::extendConnectToModel(Model& model) {
 void SynergyController::addSynergyVector(const SimTK::Vector& vector) {
     int index = getProperty_synergy_vectors().size();
     append_synergy_vectors(
-            SynergyVector(fmt::format("synergy_vector_{}", index), vector));
+            SynergyVector(std::format("synergy_vector_{}", index), vector));
 }
 
 void SynergyController::updSynergyVector(int index, 

--- a/OpenSim/Simulation/Manager/Manager.cpp
+++ b/OpenSim/Simulation/Manager/Manager.cpp
@@ -28,6 +28,7 @@
 
 #include "Manager.h"
 
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Common/Array.h>
 #include <OpenSim/Simulation/Model/Model.h>

--- a/OpenSim/Simulation/Model/AbstractTool.cpp
+++ b/OpenSim/Simulation/Model/AbstractTool.cpp
@@ -790,7 +790,7 @@ std::string AbstractTool::getNextAvailableForceName(const std::string prefix) co
     bool found = false;
     while (!found) {
         candidate++;
-        candidateName = fmt::format("{}_{}", prefix, candidate);
+        candidateName = std::format("{}_{}", prefix, candidate);
         if (_model) {
             if (_model->getForceSet().contains(candidateName))
                 continue;

--- a/OpenSim/Simulation/Model/ExpressionBasedPathForce.cpp
+++ b/OpenSim/Simulation/Model/ExpressionBasedPathForce.cpp
@@ -133,7 +133,7 @@ double ExpressionBasedPathForce::computeMomentArm(const SimTK::State& s,
 
 OpenSim::Array<std::string> ExpressionBasedPathForce::getRecordLabels() const {
     OpenSim::Array<std::string> labels("");
-    labels.append(fmt::format("{}_tension", getName()));
+    labels.append(std::format("{}_tension", getName()));
     return labels;
 }
 

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -105,7 +105,7 @@ const Function& FunctionBasedPath::getMomentArmFunction(
 {
     auto it = _coordinateIndices.find(coordinatePath);
     OPENSIM_THROW_IF_FRMOBJ(it == _coordinateIndices.end(), Exception,
-            fmt::format("Path does not depend on Coordinate '{}'.",
+            std::format("Path does not depend on Coordinate '{}'.",
                     coordinatePath))
     return get_moment_arm_functions(it->second);
 }
@@ -300,7 +300,7 @@ void FunctionBasedPath::extendFinalizeFromProperties() {
                       uniqueCoordinatePaths.end(),
                     coordinatePath) != uniqueCoordinatePaths.end()) {
             OPENSIM_THROW_FRMOBJ(Exception,
-                    fmt::format("Coordinate '{}' was provided more than once.",
+                    std::format("Coordinate '{}' was provided more than once.",
                             coordinatePath))
         }
         uniqueCoordinatePaths.push_back(coordinatePath);
@@ -308,7 +308,7 @@ void FunctionBasedPath::extendFinalizeFromProperties() {
 
     OPENSIM_THROW_IF_FRMOBJ(getLengthFunction().getArgumentSize() !=
             getProperty_coordinate_paths().size(), Exception,
-            fmt::format("Expected the number of arguments in 'length_function' "
+            std::format("Expected the number of arguments in 'length_function' "
                         "({}) to equal the number of coordinates ({}).",
                         getLengthFunction().getArgumentSize(),
                         getProperty_coordinate_paths().size()))
@@ -323,7 +323,7 @@ void FunctionBasedPath::extendFinalizeFromProperties() {
     } else {
         OPENSIM_THROW_IF_FRMOBJ(getProperty_moment_arm_functions().size() !=
                                 getProperty_coordinate_paths().size(), Exception,
-                fmt::format("Expected the number of moment arm functions ({}) "
+                std::format("Expected the number of moment arm functions ({}) "
                             "to equal the number of coordinates ({}).",
                         getProperty_moment_arm_functions().size(),
                         getProperty_coordinate_paths().size()))
@@ -332,7 +332,7 @@ void FunctionBasedPath::extendFinalizeFromProperties() {
             OPENSIM_THROW_IF_FRMOBJ(
                     get_moment_arm_functions(i).getArgumentSize() !=
                             getProperty_coordinate_paths().size(), Exception,
-                    fmt::format("Expected the number of arguments in "
+                    std::format("Expected the number of arguments in "
                                 "'moment_arm_functions[{}]' ({}) to equal the "
                                 "number of coordinates ({}).",
                             i, get_moment_arm_functions(i).getArgumentSize(),
@@ -346,7 +346,7 @@ void FunctionBasedPath::extendFinalizeFromProperties() {
         OPENSIM_THROW_IF_FRMOBJ(
                 getLengtheningSpeedFunction().getArgumentSize() !=
                 2*getProperty_coordinate_paths().size(), Exception,
-                fmt::format("Expected the number of arguments in "
+                std::format("Expected the number of arguments in "
                             "'speed_function' ({}) to equal to twice the "
                             "number of coordinates ({}).",
                         getLengtheningSpeedFunction().getArgumentSize(),
@@ -371,7 +371,7 @@ void FunctionBasedPath::extendConnectToModel(Model& model) {
         const auto& coordinatePath = get_coordinate_paths(i);
         OPENSIM_THROW_IF_FRMOBJ(!model.hasComponent<Coordinate>(coordinatePath),
                 Exception,
-                fmt::format("Coordinate '{}' does not exist in the model.",
+                std::format("Coordinate '{}' does not exist in the model.",
                         coordinatePath))
 
         _coordinates.emplace_back(

--- a/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
+++ b/OpenSim/Simulation/OpenSense/IMUPlacer.cpp
@@ -26,8 +26,8 @@
 //=============================================================================
 #include "IMUPlacer.h"
 
-#include "OpenSenseUtilities.h"
-
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
+#include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
 #include <OpenSim/Simulation/InverseKinematicsSolver.h>
 #include <OpenSim/Simulation/MarkersReference.h>
 #include <OpenSim/Simulation/Model/Model.h>

--- a/OpenSim/Simulation/SimbodyEngine/Body.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Body.cpp
@@ -25,8 +25,11 @@
 // INCLUDES
 //=============================================================================
 #include "Body.h"
+
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/ScaleSet.h>
-#include "simbody/internal/MobilizedBody.h"
+
+#include <simbody/internal/MobilizedBody.h>
 
 //=============================================================================
 // STATICS

--- a/OpenSim/Simulation/SimbodyEngine/ConstantCurvatureJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/ConstantCurvatureJoint.cpp
@@ -53,7 +53,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
     SimTK::Vec3 pos = q;
     const double bound = (M_PI / 2) - 0.01;
     if (pos(0) > bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! X rotation reached position "
                 "{}, which is above upper bound {}. This will lead "
@@ -64,7 +64,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
         pos(0) = bound;
     }
     if (pos(0) < -bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! X rotation reached position "
                 "{}, which is below lower bound {}. This will lead "
@@ -75,7 +75,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
         pos(0) = -bound;
     }
     if (pos(1) > bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! Z rotation reached position "
                 "{}, which is above upper bound {}. This will lead "
@@ -86,7 +86,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
         pos(1) = bound;
     }
     if (pos(1) < -bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! Z rotation reached position "
                 "{}, which is below lower bound {}. This will lead "
@@ -97,7 +97,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
         pos(1) = -bound;
     }
     if (pos(2) > bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! Y rotation reached position "
                 "{}, which is above upper bound {}. This will lead "
@@ -108,7 +108,7 @@ SimTK::Vec3 OpenSim::ConstantCurvatureJoint::clamp(const SimTK::Vec3& q) {
         pos(2) = bound;
     }
     if (pos(2) < -bound) {
-        log_warn(fmt::format(
+        log_warn(std::format(
                 "WARNING! ConstantCurvatureJoint position outside of "
                 "its supported range! Y rotation reached position "
                 "{}, which is below lower bound {}. This will lead "

--- a/OpenSim/Simulation/SimbodyEngine/Constraint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Constraint.cpp
@@ -254,7 +254,7 @@ Array<std::string> Constraint::getRecordLabels() const
     }
 
     for(int i=0; i<ncm; ++i){
-        labels.append(fmt::format("{}_mobility_F{}", getName(), i));
+        labels.append(std::format("{}_mobility_F{}", getName(), i));
     }
     
     return labels;

--- a/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/Test/testJoints.cpp
@@ -1797,7 +1797,7 @@ TEST_CASE("testCantileverFreeBeamJoint") {
 
     // Rename the hip coordinates for the cantilever-free beam joint.
     for (int i = 0; i < hip->numCoordinates(); i++) {
-        hip->upd_coordinates(i).setName(fmt::format("hip_q{}", i));
+        hip->upd_coordinates(i).setName(std::format("hip_q{}", i));
     }
 
     // Add the thigh body, which now also contains the hip joint, to the model.

--- a/OpenSim/Simulation/SimulationUtilities.cpp
+++ b/OpenSim/Simulation/SimulationUtilities.cpp
@@ -370,7 +370,7 @@ std::unordered_map<std::string, int> OpenSim::createSystemControlIndexMap(
             if (nc == 1) {
                 controlIndices[actuPath] = i;
             } else {
-                controlIndices[fmt::format("{}_{}", actuPath, j)] = i;
+                controlIndices[std::format("{}_{}", actuPath, j)] = i;
             }
             ++i;
         }
@@ -456,7 +456,7 @@ void OpenSim::appendCoupledCoordinateValues(TimeSeriesTable& table,
         const Coordinate& coordinate = coordinateSet.get(
                 couplerConstraint.getDependentCoordinateName());
         const std::string& coupledCoordinatePath =
-                fmt::format("{}/value", coordinate.getAbsolutePathString());
+                std::format("{}/value", coordinate.getAbsolutePathString());
         if (table.hasColumn(coupledCoordinatePath)) {
             if (overwriteExistingColumns) {
                 table.removeColumn(coupledCoordinatePath);
@@ -473,7 +473,7 @@ void OpenSim::appendCoupledCoordinateValues(TimeSeriesTable& table,
             const Coordinate& independentCoordinate = coordinateSet.get(
                     independentCoordinateNames[i]);
             independentCoordinatePaths.push_back(
-                    fmt::format("{}/value",
+                    std::format("{}/value",
                         independentCoordinate.getAbsolutePathString()));
             OPENSIM_THROW_IF(
                     !table.hasColumn(independentCoordinatePaths.back()),
@@ -522,7 +522,7 @@ void OpenSim::appendCoordinateValueDerivativesAsSpeeds(TimeSeriesTable& table,
             if (!model.hasComponent<Coordinate>(valuePath)) {
                 continue;
             }
-            speedPath = fmt::format("{}/speed", valuePath);
+            speedPath = std::format("{}/speed", valuePath);
         } else {
             continue;
         }

--- a/OpenSim/Simulation/Test/testReportersWithModel.cpp
+++ b/OpenSim/Simulation/Test/testReportersWithModel.cpp
@@ -24,6 +24,7 @@
 
 #include <OpenSim/Common/LogSink.h>
 #include <OpenSim/Common/Logger.h>
+#include <OpenSim/Common/LogMessage.h>
 #include <OpenSim/Common/Reporter.h>
 #include <OpenSim/Simulation/Manager/Manager.h>
 #include <OpenSim/Simulation/Model/Model.h>
@@ -31,9 +32,22 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <string>
+
 using namespace std;
 using namespace SimTK;
 using namespace OpenSim;
+
+namespace {
+    class StringLogSink : public LogSink {
+    public:
+        const std::string& getString() const { return m_Buffer; }
+    private:
+        void sinkImpl(const LogMessage& logMessage) { m_Buffer += logMessage.getPayload(); }
+
+        std::string m_Buffer;
+    };
+}
 
 TEST_CASE("testConsoleReporterLabels") {
     // Create a model consisting of a falling ball.

--- a/OpenSim/Simulation/Test/testSimulationUtilities.cpp
+++ b/OpenSim/Simulation/Test/testSimulationUtilities.cpp
@@ -186,15 +186,15 @@ TEST_CASE("findJointsBetweenPhysicalFrames") {
         const PhysicalFrame* prevBody = &ground;
         for (int i = 0; i < numLinks; ++i) {
             const std::string istr = std::to_string(i);
-            auto* bi = new OpenSim::Body(fmt::format("b{}_{}", istr, name),
+            auto* bi = new OpenSim::Body(std::format("b{}_{}", istr, name),
                 1, Vec3(0), Inertia(1));
             model.addBody(bi);
 
-            auto* ji = new PinJoint(fmt::format("j{}_{}", istr, name),
+            auto* ji = new PinJoint(std::format("j{}_{}", istr, name),
                     *prevBody, Vec3(0), Vec3(0),
                     *bi, Vec3(-1, 0, 0), Vec3(0));
             auto& qi = ji->updCoordinate();
-            qi.setName(fmt::format("q{}_{}", istr, name));
+            qi.setName(std::format("q{}_{}", istr, name));
             model.addJoint(ji);
 
             prevBody = bi;

--- a/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
+++ b/OpenSim/Tests/Wrapping/testGeometryPathWrapping.cpp
@@ -466,7 +466,7 @@ TEST_CASE("findIndependentCoordinates") {
 
     SECTION("hip muscles") {
         const std::string muscle_name = GENERATE("iliopsoas_r", "glut_max_r");
-        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const std::string muscle_path = std::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
         CHECK(coords.size() == 1);
@@ -475,7 +475,7 @@ TEST_CASE("findIndependentCoordinates") {
 
     SECTION("hip/knee biarticular muscles") {
         const std::string muscle_name = GENERATE("rect_fem_r", "hamstrings_r");
-        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const std::string muscle_path = std::format("/forceset/{}", muscle_name);
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
@@ -486,7 +486,7 @@ TEST_CASE("findIndependentCoordinates") {
 
     SECTION("knee muscles") {
         const std::string muscle_name = GENERATE("vasti_r", "bifemsh_r");
-        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const std::string muscle_path = std::format("/forceset/{}", muscle_name);
         const auto& muscle = model.getComponent<Muscle>(muscle_path);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
@@ -505,7 +505,7 @@ TEST_CASE("findIndependentCoordinates") {
 
     SECTION("ankle muscles") {
         const std::string muscle_name = GENERATE("tib_ant_r", "soleus_r");
-        const std::string muscle_path = fmt::format("/forceset/{}", muscle_name);
+        const std::string muscle_path = std::format("/forceset/{}", muscle_name);
         const auto& path = model.getComponent<Muscle>(muscle_path).getPath();
         auto coords = path.findIndependentCoordinates(state);
         CHECK(coords.size() == 1);

--- a/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
+++ b/OpenSim/Tests/Wrapping/testScholz2015GeometryPath.cpp
@@ -745,28 +745,28 @@ TEST_CASE("Touchdown and liftoff") {
         const SimTK::Vec3& sceneOffset) {
 
         auto* originBody = new Body(
-            fmt::format("{}_origin_body", name), 1.0, SimTK::Vec3(0),
+            std::format("{}_origin_body", name), 1.0, SimTK::Vec3(0),
             SimTK::Inertia(1.0));
         model.addComponent(originBody);
-        auto* originJoint = new FreeJoint(fmt::format("{}_origin_joint", name),
+        auto* originJoint = new FreeJoint(std::format("{}_origin_joint", name),
             model.getGround(), sceneOffset + originShift, SimTK::Vec3(0),
             *originBody, SimTK::Vec3(0), SimTK::Vec3(0));
         model.addComponent(originJoint);
 
         // Termination body and joint.
         auto* terminationBody = new Body(
-            fmt::format("{}_termination_body", name), 1.0, SimTK::Vec3(0),
+            std::format("{}_termination_body", name), 1.0, SimTK::Vec3(0),
             SimTK::Inertia(1.0));
         model.addComponent(terminationBody);
         auto* terminationJoint = new FreeJoint(
-            fmt::format("{}_termination_joint", name),
+            std::format("{}_termination_joint", name),
             model.getGround(), sceneOffset + terminationShift, SimTK::Vec3(0),
             *terminationBody, SimTK::Vec3(0), SimTK::Vec3(0));
         model.addComponent(terminationJoint);
 
         // Create the path object.
         Scholz2015GeometryPath* path = new Scholz2015GeometryPath();
-        path->setName(fmt::format("{}_path", name));
+        path->setName(std::format("{}_path", name));
         path->appendPathPoint(*originBody, SimTK::Vec3(0.));
         path->appendObstacle(obstacle, SimTK::Vec3(SimTK::NaN));
         path->appendPathPoint(*terminationBody, SimTK::Vec3(0.));

--- a/OpenSim/Tools/CMC.cpp
+++ b/OpenSim/Tools/CMC.cpp
@@ -30,7 +30,9 @@
 // INCLUDES
 //=============================================================================
 #include "CMC.h"
+
 #include "VectorFunctionForActuators.h"
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/RootSolver.h>
 #include <OpenSim/Simulation/Control/ControlConstant.h>
 #include <OpenSim/Simulation/Control/ControlLinear.h>

--- a/OpenSim/Tools/CMCTool.cpp
+++ b/OpenSim/Tools/CMCTool.cpp
@@ -26,6 +26,7 @@
 #include "ActuatorForceTarget.h"
 #include "ActuatorForceTargetFast.h"
 #include "VectorFunctionForActuators.h"
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Common/GCVSplineSet.h>

--- a/OpenSim/Tools/RRATool.cpp
+++ b/OpenSim/Tools/RRATool.cpp
@@ -27,6 +27,7 @@
 #include "ActuatorForceTargetFast.h"
 #include "AnalyzeTool.h"
 #include "VectorFunctionForActuators.h"
+#include <OpenSim/Common/Detail/SimbodyFormatterShims.h>
 #include <OpenSim/Common/Assertion.h>
 #include <OpenSim/Common/IO.h>
 #include <OpenSim/Simulation/Model/Model.h>

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,7 +18,6 @@ configure_package_config_file(
         CMAKE_INSTALL_LIBDIR
         OPENSIM_INSTALL_CMAKEDIR
         OPENSIM_INSTALL_SIMBODYDIR
-        OPENSIM_INSTALL_SPDLOGDIR
     )
 
 # Version file.

--- a/cmake/OpenSimConfig.cmake.in
+++ b/cmake/OpenSimConfig.cmake.in
@@ -86,22 +86,17 @@ set(@CMAKE_PROJECT_NAME@_JAR_FILE
 # Dependencies
 # ------------
 if (@OPENSIM_COPY_DEPENDENCIES@) # OPENSIM_COPY_DEPENDENCIES
-    # Find the copies of Simbody and spdlog within the OpenSim installation.
-    # We define _SIMBODY_PATH and _SPDLOG_PATH before find_package(Simbody)
+    # Find the copies of Simbody within the OpenSim installation.
+    # We define _SIMBODY_PATH before find_package(Simbody)
     # because finding Simbody redefines the PACKAGE_PREFIX_DIR variable
-    # that appears in this file after configuring, thereby incorrectly
-    # causing CMake to look for spdlog within Simbody's installation.
+    # that appears in this file after configuring.
     set(_SIMBODY_PATH "@PACKAGE_OPENSIM_INSTALL_SIMBODYDIR@")
-    set(_SPDLOG_PATH "@PACKAGE_OPENSIM_INSTALL_SPDLOGDIR@")
     find_package(Simbody @SIMBODY_VERSION_TO_USE@ REQUIRED
         PATHS "${_SIMBODY_PATH}" NO_MODULE NO_DEFAULT_PATH)
-    find_package(spdlog REQUIRED
-        PATHS "${_SPDLOG_PATH}" NO_MODULE NO_DEFAULT_PATH)
 else()
     # Find the correct version anywhere on the machine.
     include(CMakeFindDependencyMacro)
     find_dependency(Simbody @SIMBODY_VERSION_TO_USE@)
-    find_dependency(spdlog)
 endif()
 
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -198,18 +198,6 @@ AddDependency(NAME       simbody
                          -DBUILD_TESTING:BOOL=OFF
                          ${SIMBODY_EXTRA_CMAKE_ARGS})
 
-set(SPDLOG_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
-AddDependency(NAME       spdlog
-              DEFAULT    ON
-              GIT_URL    https://github.com/gabime/spdlog.git
-              GIT_TAG    v1.15.3
-              CMAKE_ARGS -DSPDLOG_BUILD_BENCH:BOOL=OFF
-                         -DSPDLOG_BUILD_TESTS:BOOL=OFF
-                         -DSPDLOG_BUILD_EXAMPLE:BOOL=OFF
-                         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-                         -DCMAKE_CXX_FLAGS:STRING=${SPDLOG_CXX_FLAGS})
-
 AddDependency(NAME       catch2
               DEFAULT    ON
               GIT_URL    https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
The aim of this PR is to switch OpenSim over to `std::format`, so that it can drop its dependency on `spdlog` (and, transitively, `fmt`).

OpenSim doesn't need the high-performance super logging provided by `spdlog` and having it as a dependency that's visible via headers causes problems downstream when those downstream projects also include `spdlog` (but a different version, etc.)

### CHANGELOG.md (choose one)

- no need to update because...
- TODO: updated, because it changes the C++ API

Note: this is breaking because downstream code may have integrated against the spdlog-based logger APIs etc. However, it'll be a compile-time error for the (presumably small number of) downstream C++ codebases. While I was in the area, I also took the liberty of adding a `LogMessage` consumer to the `LogSink` API  (non-breaking) so that downstream loggers can see the name/level/time of the message in addition to its payload.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4367)
<!-- Reviewable:end -->
