### PR TITLE
[PoC] Make file logging configurable/opt-in at runtime

### DIFF
--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -166,7 +166,6 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
         DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3)
 
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
@@ -300,7 +299,6 @@ jobs:
         DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_LIBDIR=lib)
         DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
         DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
         printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
         cmake "${DEP_CMAKE_ARGS[@]}"
         make --jobs 4

--- a/Applications/Analyze/analyze.cpp
+++ b/Applications/Analyze/analyze.cpp
@@ -49,6 +49,10 @@ int main(int argc,char **argv)
     //----------------------
     try {
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     // DEPRECATION NOTICE
     const std::string deprecationNotice = R"(
     THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.

--- a/Applications/CMC/cmc.cpp
+++ b/Applications/CMC/cmc.cpp
@@ -47,6 +47,10 @@ int main(int argc,char **argv)
     try {
     //----------------------
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     //LoadOpenSimLibrary("osimSdfastEngine");
     //LoadOpenSimLibrary("osimSimbodyEngine");
 

--- a/Applications/Forward/forward.cpp
+++ b/Applications/Forward/forward.cpp
@@ -54,6 +54,10 @@ int main(int argc,char **argv)
     try {
     //----------------------
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     //LoadOpenSimLibrary("osimSdfastEngine");
 
     // DEPRECATION NOTICE

--- a/Applications/ID/id.cpp
+++ b/Applications/ID/id.cpp
@@ -51,6 +51,10 @@ int main(int argc,char **argv)
     try {
     //----------------------
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     //LoadOpenSimLibrary("osimSdfastEngine");
 
     // DEPRECATION NOTICE

--- a/Applications/IK/ik.cpp
+++ b/Applications/IK/ik.cpp
@@ -57,6 +57,10 @@ int main(int argc,char **argv)
     try {
     //----------------------
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     // DEPRECATION NOTICE
     const std::string deprecationNotice = R"(
     THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.

--- a/Applications/RRA/rra.cpp
+++ b/Applications/RRA/rra.cpp
@@ -47,6 +47,10 @@ int main(int argc,char **argv)
     try {
     //----------------------
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     // DEPRECATION NOTICE
     const std::string deprecationNotice = R"(
     THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.

--- a/Applications/Scale/scale.cpp
+++ b/Applications/Scale/scale.cpp
@@ -53,6 +53,10 @@ int main(int argc,char **argv)
     //TODO: put these options on the command line
     //LoadOpenSimLibrary("osimSimbodyEngine");
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     // DEPRECATION NOTICE
     const std::string deprecationNotice = R"(
     THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.

--- a/Applications/opensense/opensense.cpp
+++ b/Applications/opensense/opensense.cpp
@@ -70,6 +70,10 @@ int main(int argc, char **argv)
     // Surrounding try block
     //----------------------
     try {
+        // The OpenSim library no longer creates 'opensim.log' on its own; opt
+        // in here so this application's logging behavior is unchanged.
+        Logger::addFileSink();
+
         //----------------------
         // PARSE COMMAND LINE
         string option = "";

--- a/Applications/opensim-cmd/opensim-cmd.cpp
+++ b/Applications/opensim-cmd/opensim-cmd.cpp
@@ -28,6 +28,7 @@
 #include "opensim-cmd_viz.h"
 #include "parse_arguments.h"
 #include <Vendors/docopt/docopt.h>
+#include <fstream>
 #include <iostream>
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/version.h>
@@ -41,13 +42,16 @@ static const char HELP[] =
 R"(OpenSim: musculoskeletal modeling and simulation.
 
 Usage:
-  opensim-cmd [--library=<path>]... [--log=<level>] <command> [<args>...]
+  opensim-cmd [--library=<path>]... [--log=<level>]
+              [--log-file=<path>] [--no-log-file] <command> [<args>...]
   opensim-cmd -h | --help
   opensim-cmd -V | --version
 
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
   -h, --help     Show this help description.
   -V, --version  Show the version number.
 
@@ -70,6 +74,12 @@ Description of options:
   o, log      Control the verbosity of OpenSim's console output.
               Levels: off, critical, error, warn, info, debug, trace.
               Default: info.
+  log-file    Also write log messages to the given file. By default,
+              opensim-cmd writes to 'opensim.log' in the current directory.
+              If the given file cannot be opened for writing, opensim-cmd
+              reports an error and exits.
+  no-log-file Disable writing log messages to a file (even if a different
+              --log-file is specified).
 
 Examples:
   opensim-cmd run-tool InverseDynamics_Setup.xml
@@ -79,6 +89,8 @@ Examples:
   opensim-cmd -L C:\Plugins\osimMyCustomForce.dll run-tool CMC_setup.xml
   opensim-cmd --library ../plugins/libosimMyPlugin.so print-xml MyCustomTool
   opensim-cmd --library=libosimMyCustomForce.dylib --log=debug info MyCustomForce
+  opensim-cmd --no-log-file run-tool CMC_setup.xml
+  opensim-cmd --log-file=run.log run-tool CMC_setup.xml
 
 )";
 
@@ -112,6 +124,25 @@ int main(int argc, const char** argv) {
             true, // show help if requested
             "OpenSim " + GetVersionAndDate(),
             true); // take options first; necessary for nested commands.
+
+    // File logging.
+    // -------------
+    // Writes log messages to a file unless --no-log-file is given.
+    if (!args["--no-log-file"].asBool()) {
+        const bool explicitLogFile = static_cast<bool>(args["--log-file"]);
+        const std::string logFilePath = explicitLogFile
+                ? args["--log-file"].asString() : "opensim.log";
+        // Check and error if requested path isn't writable
+        if (explicitLogFile) {
+            std::ofstream logFileProbe(logFilePath, std::ios_base::app);
+            if (!logFileProbe) {
+                log_error("Could not open log file '{}' for writing.",
+                        logFilePath);
+                return EXIT_FAILURE;
+            }
+        }
+        Logger::addFileSink(logFilePath);
+    }
 
     // Load the specified libraries.
     // -----------------------------

--- a/Applications/opensim-cmd/opensim-cmd_info.h
+++ b/Applications/opensim-cmd/opensim-cmd_info.h
@@ -38,6 +38,8 @@ Usage:
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
 
 Description:
   If you do not supply any arguments, you get a list of all registered

--- a/Applications/opensim-cmd/opensim-cmd_print-xml.h
+++ b/Applications/opensim-cmd/opensim-cmd_print-xml.h
@@ -38,6 +38,8 @@ Usage:
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
 
 Description:
   The argument <tool-or-class> can be the name of a Tool

--- a/Applications/opensim-cmd/opensim-cmd_run-tool.h
+++ b/Applications/opensim-cmd/opensim-cmd_run-tool.h
@@ -38,6 +38,8 @@ Usage:
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
 
 Description:
   The Tool to run is detected from the setup file you provide. Supported tools

--- a/Applications/opensim-cmd/opensim-cmd_update-file.h
+++ b/Applications/opensim-cmd/opensim-cmd_update-file.h
@@ -38,6 +38,8 @@ Usage:
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
 
 Description:
   In an OpenSim XML file, the XML file format version appears as

--- a/Applications/opensim-cmd/opensim-cmd_viz.h
+++ b/Applications/opensim-cmd/opensim-cmd_viz.h
@@ -41,6 +41,8 @@ Usage:
 Options:
   -L <path>, --library <path>  Load a plugin.
   -o <level>, --log <level>  Logging level.
+  --log-file <path>  Write log messages to a file (default: opensim.log).
+  --no-log-file  Do not write a log file; overrides --log-file.
   -g <path>, --geometry <path> Search for geometry mesh files in this path.
   -m <path>, --model <model-file> Visualize data based on a model.
   -a <layout>, --layout <layout> Visualize orientations in a circle, line, etc.

--- a/Applications/opensim-cmd/test/CMakeLists.txt
+++ b/Applications/opensim-cmd/test/CMakeLists.txt
@@ -1,9 +1,9 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 OpenSimAddTests(
     TESTPROGRAMS testCommandLineInterface.cpp
-    # Don't need OpenSim since we only interact with OpenSim through the
-    # command line tool. But we use Simbody for its Testing.h.
-    LINKLIBS SimTKcommon
+    LINKLIBS Catch2::Catch2WithMain
     )
 
 add_dependencies(testCommandLineInterface opensim-cmd)

--- a/Applications/opensim-cmd/test/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/test/testCommandLineInterface.cpp
@@ -21,21 +21,26 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include <SimTKcommon/Testing.h>
+#include <catch2/catch_all.hpp>
+#include <cstdio>
 #include <cstdlib>
-#include <iostream>
-#include <memory>
-#include <regex>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
 // We do *not* include OpenSim headers, since we are only interacting with
-// OpenSim through its command-line interface. But we do use Simbody's testing
-// macros.
+// OpenSim through its command-line interface. We use the Catch2 testing
+// framework (which also provides main() via Catch2::Catch2WithMain).
 
 // These tests are fairly weak, and are mostly about syntax.
 // We do not test *all* possible commands here, since some commands would
 // invoke a long computation (e.g., CMC). We mostly just test incorrect input.
-// Also, we only test the console output and return code of the commands; we
-// don't test the actual purpose of the commands (e.g., if a command was
-// supposed to write a file, we don't check that the file was written).
+// Aside from the log-file test below, we only check the console output and
+// return code of the commands; we don't test the actual purpose of the
+// commands (e.g., if a command was supposed to write a file, we don't check
+// that the file was written).
+
+using namespace Catch::Matchers;
 
 // OSIM_CLI_PATH is a preprocessor definition that is defined when compiling
 // this executable.
@@ -103,138 +108,31 @@ CommandOutput system_output(std::string command) {
     return CommandOutput(returncode, result);
 }
 
-class StartsWith {
-public:
-    StartsWith(std::string prefix) : prefixStr(prefix) {}
-    bool check(const std::string& str) const {
-        return std::equal(prefixStr.begin(), prefixStr.end(), str.begin());
-    }
-    const std::string prefixStr;
-};
-
-class ContainsSubstring {
-public:
-    ContainsSubstring(std::string substr) : substring(substr) {}
-    bool check(const std::string& str) const {
-        return str.find(substring) != std::string::npos;
-    }
-    const std::string substring;
-};
-
-// Checks that the command produces exactly the expected output.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const std::string& expectedOutput) {
-    const bool outputIsEqual = (output == expectedOutput);
-    if (!outputIsEqual) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following output:\n" + output +
-            "\nExpected:\n" + expectedOutput;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command output starts with a given string.
-// Created this because profiling indicated regexes were making the test slow;
-// ended up not being true.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const StartsWith& expectedOutput) {
-    if (!expectedOutput.check(output)) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following output:\n" + output +
-                          "\nExpected it to start with:\n" +
-                          expectedOutput.prefixStr;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command output ends with a given string.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const ContainsSubstring& expectedOutput) {
-    if (!expectedOutput.check(output)) {
-        std::string msg = "When testing arguments '" + arguments +
-                          "' got the following output:\n" + output +
-                          "\nExpected it to contain:\n" +
-                          expectedOutput.substring;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command's output matches the given regular expression.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const std::regex& expectedOutput) {
-    if (!std::regex_match(output, expectedOutput)) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following unexpected output:\n" + output;
-        throw std::runtime_error(msg);
-    }
-}
-
-template <typename T>
-void testCommand(const std::string& arguments,
-                 int expectedReturnCode,
-                 const T& expectedOutput) {
+// Run opensim-cmd with the given arguments and check that its console output
+// satisfies `outputMatcher` (any Catch2 string matcher, e.g. ContainsSubstring,
+// StartsWith, Matches) and that it returns `expectedReturnCode`.
+void testCommand(const std::string& arguments, int expectedReturnCode,
+                 const MatcherBase<std::string>& outputMatcher) {
     CommandOutput out = system_output(COMMAND + " " + arguments);
-
-    checkCommandOutput(arguments, out.output, expectedOutput);
-
-    const bool returnCodeIsCorrect = (out.returncode == expectedReturnCode);
-    if (!returnCodeIsCorrect) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got return code '" + std::to_string(out.returncode) +
-            "' but expected '" + std::to_string(expectedReturnCode) + "'.";
-        throw std::runtime_error(msg);
-    }
+    INFO("Arguments: " << arguments);
+    INFO("Output:\n" << out.output);
+    CHECK_THAT(out.output, outputMatcher);
+    CHECK(out.returncode == expectedReturnCode);
 }
 
-void testNoCommand() {
-    // Help.
-    // =====
-    {
-        std::regex output("OpenSim: musculoskeletal" + RE_ANY +
-                          "Pass -h or --help" + RE_ANY);
-        testCommand("", EXIT_SUCCESS, output);
-        testCommand("-h", EXIT_SUCCESS, output);
-        testCommand("--help", EXIT_SUCCESS, output);
-    }
-
-    // Version.
-    // ========
-    {
-        std::regex output("OpenSim version (?:.*), build date (?:.*)\n");
-        testCommand("-V", EXIT_SUCCESS, output);
-        testCommand("--version", EXIT_SUCCESS, output);
-    }
-
-    // Library option.
-    // ===============
-    // Syntax errors.
-    testCommand("-L", EXIT_FAILURE,
-            ContainsSubstring("-L requires an argument"));
-    testCommand("--library", EXIT_FAILURE,
-            ContainsSubstring("--library requires an argument"));
-    // Must specify a command; can't only list a library to load.
-    {
-        ContainsSubstring output("Arguments did not match expected patterns");
-        // All of these are otherwise valid options for specify libraries to
-        // load.
-        testCommand("-L x", EXIT_FAILURE, output);
-        testCommand("--library x", EXIT_FAILURE, output);
-        testCommand("-L=x", EXIT_FAILURE, output);
-        testCommand("--library=y", EXIT_FAILURE, output);
-        testCommand("-L x --library y -L z", EXIT_FAILURE, output);
-        testCommand("-L=x --library=y -L=z", EXIT_FAILURE, output);
-    }
-
-    // Unrecognized command.
-    // =====================
-    std::string str_bleepbloop("'bleepbloop' is not an opensim-cmd command. "
-                               "See 'opensim-cmd --help'.\n");
-    testCommand("bleepbloop", EXIT_FAILURE,
-            ContainsSubstring(str_bleepbloop));
+// Some tests need a file to operate on, and use print-xml to create it. Those
+// commands are setup, not the thing under test, so a failure here is fatal:
+// carrying on would fail the commands that follow for reasons that have nothing
+// to do with what they are checking.
+void requirePrintedFile(const std::string& classOrTool,
+                        const std::string& filepath) {
+    const std::string arguments = "print-xml " + classOrTool + " " + filepath;
+    CommandOutput out = system_output(COMMAND + " " + arguments);
+    INFO("Arguments: " << arguments);
+    INFO("Output:\n" << out.output);
+    REQUIRE_THAT(out.output,
+            ContainsSubstring("Printing '" + filepath + "'.\n"));
+    REQUIRE(out.returncode == EXIT_SUCCESS);
 }
 
 // http://stackoverflow.com/questions/5343190/how-do-i-replace-all-instances-of-a-string-with-another-string
@@ -248,6 +146,25 @@ std::string replaceString(std::string subject, const std::string& search,
     return subject;
 }
 
+// Removes the given files on destruction so that a test cleans up after itself
+// even when an assertion fails. Catch2 does not provide a temporary-file
+// fixture, and this test intentionally does not link osimCommon (whose
+// FileRemover lives), so we use a small self-contained std::filesystem guard.
+class ScopedFileRemover {
+public:
+    explicit ScopedFileRemover(std::vector<std::string> paths)
+            : m_paths(std::move(paths)) {}
+    ~ScopedFileRemover() {
+        for (const auto& path : m_paths) {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    }
+private:
+    std::vector<std::string> m_paths;
+};
+
+// Exercises the plugin-loading (--library) option, shared by all subcommands.
 void testLoadPluginLibraries(const std::string& subcommand) {
 
     const auto cmd = subcommand + " -h";
@@ -255,7 +172,7 @@ void testLoadPluginLibraries(const std::string& subcommand) {
     // Nonexistent file.
     // =================
     {
-        std::regex output(RE_ANY + "(Failed to load library x)\n");
+        auto output = Matches(RE_ANY + "(Failed to load library x)\n");
         // These are all valid ways of specifying libraries.
         testCommand("-L x " + cmd, EXIT_FAILURE, output);
         testCommand("-Lx " + cmd, EXIT_FAILURE, output);
@@ -280,7 +197,7 @@ void testLoadPluginLibraries(const std::string& subcommand) {
         expectLib = replaceString(expectLib, "/", "\\");
     #endif
     {
-        StartsWith output("[info] Loaded library " + expectLib);
+        auto output = StartsWith("[info] Loaded library " + expectLib);
         testCommand("-L " + lib + " " + cmd, EXIT_SUCCESS, output);
         testCommand("-L" + lib + " " + cmd, EXIT_SUCCESS, output);
         testCommand("--library " + lib + " " + cmd, EXIT_SUCCESS, output);
@@ -304,198 +221,302 @@ void testLoadPluginLibraries(const std::string& subcommand) {
     }
 }
 
-void testRunTool() {
-    // Help.
-    // =====
-    {
-        StartsWith output("Run a tool ");
+TEST_CASE("opensim-cmd with no (or a bad) command", "[opensim-cmd]") {
+    SECTION("Help") {
+        auto output = Matches("OpenSim: musculoskeletal" + RE_ANY +
+                              "Pass -h or --help" + RE_ANY);
+        testCommand("", EXIT_SUCCESS, output);
+        testCommand("-h", EXIT_SUCCESS, output);
+        testCommand("--help", EXIT_SUCCESS, output);
+    }
+
+    SECTION("Version") {
+        auto output = Matches("OpenSim version (?:.*), build date (?:.*)\n");
+        testCommand("-V", EXIT_SUCCESS, output);
+        testCommand("--version", EXIT_SUCCESS, output);
+    }
+
+    SECTION("Options that require an argument") {
+        testCommand("-L", EXIT_FAILURE,
+                ContainsSubstring("-L requires an argument"));
+        testCommand("--library", EXIT_FAILURE,
+                ContainsSubstring("--library requires an argument"));
+        testCommand("--log-file", EXIT_FAILURE,
+                ContainsSubstring("--log-file requires an argument"));
+    }
+
+    SECTION("Options alone are not enough; a command is required") {
+        auto output =
+                ContainsSubstring("Arguments did not match expected patterns");
+        // All of these are otherwise valid ways to specify libraries to load.
+        testCommand("-L x", EXIT_FAILURE, output);
+        testCommand("--library x", EXIT_FAILURE, output);
+        testCommand("-L=x", EXIT_FAILURE, output);
+        testCommand("--library=y", EXIT_FAILURE, output);
+        testCommand("-L x --library y -L z", EXIT_FAILURE, output);
+        testCommand("-L=x --library=y -L=z", EXIT_FAILURE, output);
+        // Likewise for the log-file options. Parsing fails before opensim-cmd
+        // gets as far as opening a log file, so no file is created here.
+        testCommand("--log-file x", EXIT_FAILURE, output);
+        testCommand("--log-file=x", EXIT_FAILURE, output);
+        testCommand("--no-log-file", EXIT_FAILURE, output);
+    }
+
+    SECTION("Unrecognized command") {
+        std::string str_bleepbloop(
+                "'bleepbloop' is not an opensim-cmd command. "
+                "See 'opensim-cmd --help'.\n");
+        testCommand("bleepbloop", EXIT_FAILURE,
+                ContainsSubstring(str_bleepbloop));
+    }
+}
+
+TEST_CASE("opensim-cmd run-tool", "[opensim-cmd]") {
+    SECTION("Help") {
+        auto output = StartsWith("Run a tool ");
         testCommand("run-tool -h", EXIT_SUCCESS, output);
         testCommand("run-tool -help", EXIT_SUCCESS, output);
     }
 
-    // Error messages.
-    // ===============
-    testCommand("run-tool", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("run-tool putes.xml", EXIT_FAILURE,
-            StartsWith("[error] SimTK Exception thrown at"));
-    // We use print-xml to create a setup file that we can try to run.
-    // (We are not really trying to test print-xml right now.)
-    testCommand("print-xml cmc testruntool_cmc_setup.xml", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'testruntool_cmc_setup.xml'.\n"));
-    // This fails because this setup file doesn't have much in it.
-    testCommand("run-tool testruntool_cmc_setup.xml", EXIT_FAILURE,
-            std::regex(RE_ANY + "(No model file was specified)" + RE_ANY));
-    // Similar to the previous two commands, except for scaling
-    // (since ScaleTool goes through a different branch of the code).
-    testCommand("print-xml scale testruntool_scale_setup.xml", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'testruntool_scale_setup.xml'.\n"));
-    // This fails because this setup file doesn't have much in it.
-    testCommand("run-tool testruntool_scale_setup.xml", EXIT_FAILURE,
-            std::regex(RE_ANY + "(Preparing to run ScaleTool.)" + RE_ANY +
-                       "(Processing subject default)" + RE_ANY));
-    // Now we'll try loading a valid OpenSim XML file that is *not* a Tool
-    // setup file, and we get a helpful error.
-    // (We are not really trying to test print-xml right now.)
-    testCommand("print-xml Model testruntool_Model.xml", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'testruntool_Model.xml'.\n"));
-    testCommand("run-tool testruntool_Model.xml", EXIT_FAILURE,
-            ContainsSubstring("The provided file 'testruntool_Model.xml' "
-                              "does not define an OpenSim Tool. "
-                              "Did you intend to load a plugin?\n"));
+    SECTION("Syntax errors") {
+        testCommand("run-tool", EXIT_FAILURE,
+                ContainsSubstring("Arguments did not match expected patterns"));
+        testCommand("run-tool putes.xml", EXIT_FAILURE,
+                StartsWith("[error] SimTK Exception thrown at"));
+    }
 
-    // Library option.
-    // ===============
-    testLoadPluginLibraries("run-tool");
+    SECTION("A setup file without a model") {
+        // We use print-xml to create a setup file that we can try to run.
+        // (We are not really trying to test print-xml right now.)
+        requirePrintedFile("cmc", "testruntool_cmc_setup.xml");
+        // This fails because this setup file doesn't have much in it.
+        testCommand("run-tool testruntool_cmc_setup.xml", EXIT_FAILURE,
+                Matches(RE_ANY + "(No model file was specified)" + RE_ANY));
+    }
+
+    SECTION("A scale setup file without a model") {
+        // Similar to the previous section, except for scaling (since ScaleTool
+        // goes through a different branch of the code).
+        requirePrintedFile("scale", "testruntool_scale_setup.xml");
+        testCommand("run-tool testruntool_scale_setup.xml", EXIT_FAILURE,
+                Matches(RE_ANY + "(Preparing to run ScaleTool.)" + RE_ANY +
+                        "(Processing subject default)" + RE_ANY));
+    }
+
+    SECTION("A valid OpenSim XML file that is not a Tool setup file") {
+        // We get a helpful error rather than something cryptic.
+        requirePrintedFile("Model", "testruntool_Model.xml");
+        testCommand("run-tool testruntool_Model.xml", EXIT_FAILURE,
+                ContainsSubstring("The provided file 'testruntool_Model.xml' "
+                                  "does not define an OpenSim Tool. "
+                                  "Did you intend to load a plugin?\n"));
+    }
+
+    SECTION("Library option") {
+        testLoadPluginLibraries("run-tool");
+    }
 }
 
-void testPrintXML() {
-    // Help.
-    // =====
-    {
-        StartsWith output("Print a template XML file ");
+TEST_CASE("opensim-cmd print-xml", "[opensim-cmd]") {
+    SECTION("Help") {
+        auto output = StartsWith("Print a template XML file ");
         testCommand("print-xml -h", EXIT_SUCCESS, output);
         testCommand("print-xml -help", EXIT_SUCCESS, output);
     }
 
-    // Error messages.
-    // ===============
-    testCommand("print-xml", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("print-xml x y z", EXIT_FAILURE,
-            ContainsSubstring("Unexpected argument: print-xml, x, y, z"));
-    testCommand("print-xml bleepbloop", EXIT_FAILURE,
-            ContainsSubstring("There is no tool or registered concrete class "
-                              "named 'bleepbloop'.\nDid you intend to load a "
-                              "plugin (with --library)?\n"));
-    testCommand("print-xml bleepbloop y", EXIT_FAILURE,
-            ContainsSubstring("There is no tool or registered concrete class "
-                              "named 'bleepbloop'.\nDid you intend to load a "
-                              "plugin (with --library)?\n"));
+    SECTION("Error messages") {
+        testCommand("print-xml", EXIT_FAILURE,
+                ContainsSubstring("Arguments did not match expected patterns"));
+        testCommand("print-xml x y z", EXIT_FAILURE,
+                ContainsSubstring("Unexpected argument: print-xml, x, y, z"));
+        auto noSuchClass =
+                ContainsSubstring("There is no tool or registered concrete "
+                                  "class named 'bleepbloop'.\nDid you intend "
+                                  "to load a plugin (with --library)?\n");
+        testCommand("print-xml bleepbloop", EXIT_FAILURE, noSuchClass);
+        testCommand("print-xml bleepbloop y", EXIT_FAILURE, noSuchClass);
+    }
 
-    // Successful input.
-    // =================
-    testCommand("print-xml cmc", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
-    testCommand("print-xml Millard2012EquilibriumMuscle", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_Millard2012EquilibriumMuscle.xml'.\n"));
-    testCommand("print-xml cmc default_cmc_setup.xml", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_cmc_setup.xml'.\n"));
+    SECTION("Successful input") {
+        testCommand("print-xml cmc", EXIT_SUCCESS,
+                ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
+        testCommand("print-xml Millard2012EquilibriumMuscle", EXIT_SUCCESS,
+                ContainsSubstring(
+                        "Printing 'default_Millard2012EquilibriumMuscle.xml'."
+                        "\n"));
+        testCommand("print-xml cmc default_cmc_setup.xml", EXIT_SUCCESS,
+                ContainsSubstring("Printing 'default_cmc_setup.xml'.\n"));
+    }
 
-    // Tool names are case-insensitive.
-    // ================================
-    testCommand("print-xml CmC", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
-    testCommand("print-xml FORwarD", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_Setup_ForwardTool.xml'.\n"));
-    testCommand("print-xml Analyze default_analyze_setup.xml", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'default_analyze_setup.xml'.\n"));
+    SECTION("Tool names are case-insensitive") {
+        testCommand("print-xml CmC", EXIT_SUCCESS,
+                ContainsSubstring("Printing 'default_Setup_CMCTool.xml'.\n"));
+        testCommand("print-xml FORwarD", EXIT_SUCCESS,
+                ContainsSubstring(
+                        "Printing 'default_Setup_ForwardTool.xml'.\n"));
+        testCommand("print-xml Analyze default_analyze_setup.xml", EXIT_SUCCESS,
+                ContainsSubstring("Printing 'default_analyze_setup.xml'.\n"));
+    }
 
-    // Library option.
-    // ===============
-    testLoadPluginLibraries("print-xml");
+    SECTION("Library option") {
+        testLoadPluginLibraries("print-xml");
+    }
 }
 
-void testInfo() {
-    // Help.
-    // =====
-    {
-        StartsWith output("Show description ");
+TEST_CASE("opensim-cmd info", "[opensim-cmd]") {
+    SECTION("Help") {
+        auto output = StartsWith("Show description ");
         testCommand("info -h", EXIT_SUCCESS, output);
         testCommand("info -help", EXIT_SUCCESS, output);
     }
 
-    // Error messages.
-    // ===============
-    testCommand("info x", EXIT_FAILURE,
-            ContainsSubstring("No registered class with name 'x'. "
-                              "Did you intend to load a plugin?\n"));
-    testCommand("info x y", EXIT_FAILURE,
-            ContainsSubstring("No registered class with name 'x'. "
-                              "Did you intend to load a plugin?\n"));
-    testCommand("info Body y", EXIT_FAILURE,
-            ContainsSubstring("No property with name 'y' found in "
-                              "class 'Body'.\n"));
+    SECTION("Error messages") {
+        auto noSuchClass =
+                ContainsSubstring("No registered class with name 'x'. "
+                                  "Did you intend to load a plugin?\n");
+        testCommand("info x", EXIT_FAILURE, noSuchClass);
+        testCommand("info x y", EXIT_FAILURE, noSuchClass);
+        testCommand("info Body y", EXIT_FAILURE,
+                ContainsSubstring("No property with name 'y' found in "
+                                  "class 'Body'.\n"));
+    }
 
-    // Successful input.
-    // =================
-    testCommand("info", EXIT_SUCCESS, StartsWith("REGISTERED CLASSES "));
-    testCommand("info PathSpring", EXIT_SUCCESS,
-            StartsWith("\nPROPERTIES FOR PathSpring"));
-    testCommand("info Body mass", EXIT_SUCCESS,
-            ContainsSubstring("\nBody.mass\nThe mass of the body (kg)\n"));
+    SECTION("Successful input") {
+        testCommand("info", EXIT_SUCCESS, StartsWith("REGISTERED CLASSES "));
+        testCommand("info PathSpring", EXIT_SUCCESS,
+                StartsWith("\nPROPERTIES FOR PathSpring"));
+        testCommand("info Body mass", EXIT_SUCCESS,
+                ContainsSubstring("\nBody.mass\nThe mass of the body (kg)\n"));
+    }
 
-    // Library option.
-    // ===============
-    testLoadPluginLibraries("info");
+    SECTION("Library option") {
+        testLoadPluginLibraries("info");
+    }
 }
 
-void testUpdateFile() {
-    // Help.
-    // =====
-    {
-        StartsWith output("Update an .osim, .xml ");
+TEST_CASE("opensim-cmd update-file", "[opensim-cmd]") {
+    SECTION("Help") {
+        auto output = StartsWith("Update an .osim, .xml ");
         testCommand("update-file -h", EXIT_SUCCESS, output);
         testCommand("update-file -help", EXIT_SUCCESS, output);
     }
 
-    // Error messages.
-    // ===============
+    SECTION("Syntax errors") {
+        auto noMatch =
+                ContainsSubstring("Arguments did not match expected patterns");
+        testCommand("update-file", EXIT_FAILURE, noMatch);
+        testCommand("update-file x", EXIT_FAILURE, noMatch);
+        testCommand("update-file x.doc", EXIT_FAILURE, noMatch);
+        testCommand("update-file x.xml", EXIT_FAILURE, noMatch);
+        testCommand("update-file x y", EXIT_FAILURE,
+                ContainsSubstring(
+                        "Input file 'x' does not have an extension.\n"));
+        testCommand("update-file x.doc y", EXIT_FAILURE,
+                ContainsSubstring("Input file 'x.doc' has an unrecognized "
+                                  "extension.\n"));
+    }
 
-    // Syntax errors.
-    testCommand("update-file", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("update-file x", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("update-file x.doc", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("update-file x.xml", EXIT_FAILURE,
-            ContainsSubstring("Arguments did not match expected patterns"));
-    testCommand("update-file x y", EXIT_FAILURE,
-            ContainsSubstring("Input file 'x' does not have an extension.\n"));
-    testCommand("update-file x.doc y", EXIT_FAILURE,
-            ContainsSubstring("Input file 'x.doc' has an unrecognized "
-                              "extension.\n"));
+    SECTION("File does not exist") {
+        testCommand("update-file x.xml y", EXIT_FAILURE,
+                Matches(RE_ANY + "(?:Loading input file 'x.xml')" + RE_ANY +
+                        "(?:Could not make object from file 'x.xml'.\n" +
+                        "Did you intend to load a plugin (with --library)?)" +
+                        RE_ANY));
+        testCommand("update-file x.osim y", EXIT_FAILURE,
+                Matches(RE_ANY + "(?:Loading input file 'x.osim')" + RE_ANY +
+                        "(?:Could not make object from file 'x.osim'.\n" +
+                        "Did you intend to load a plugin (with --library)?)" +
+                        RE_ANY));
+        testCommand("update-file x.sto y", EXIT_FAILURE,
+                Matches(RE_ANY + "(Loading input file 'x.sto')" + RE_ANY +
+                        "(Storage: Failed to open file 'x.sto')" + RE_ANY));
+    }
 
-    // File does not exist.
-    testCommand("update-file x.xml y", EXIT_FAILURE,
-            std::regex(RE_ANY + "(?:Loading input file 'x.xml')" + RE_ANY +
-                       "(?:Could not make object from file 'x.xml'.\n" +
-                       "Did you intend to load a plugin (with --library)?)" +
-                       RE_ANY));
-    testCommand("update-file x.osim y", EXIT_FAILURE,
-            std::regex(RE_ANY + "(?:Loading input file 'x.osim')" + RE_ANY +
-                       "(?:Could not make object from file 'x.osim'.\n" +
-                       "Did you intend to load a plugin (with --library)?)" +
-                       RE_ANY));
-    testCommand("update-file x.sto y", EXIT_FAILURE,
-            std::regex(RE_ANY + "(Loading input file 'x.sto')" + RE_ANY +
-                       "(Storage: Failed to open file 'x.sto')" + RE_ANY));
+    SECTION("Successful input") {
+        // We use print-xml to create a file that we can try to update.
+        // (We are not really trying to test print-xml right now.)
+        requirePrintedFile("Model", "testupdatefile_Model.osim");
+        testCommand("update-file testupdatefile_Model.osim "
+                    "testupdatefile_Model_updated.osim", EXIT_SUCCESS,
+                    Matches(RE_ANY + "(Loading input file "
+                            "'testupdatefile_Model.osim'.\n)" +
+                            RE_ANY + "(Printing updated file to "
+                            "'testupdatefile_Model_updated.osim'.\n)" +
+                            RE_ANY));
+    }
 
-    // Successful input.
-    // =================
-    // We use print-xml to create a file that we can try to update.
-    // (We are not really trying to test print-xml right now.)
-    testCommand("print-xml Model testupdatefile_Model.osim", EXIT_SUCCESS,
-            ContainsSubstring("Printing 'testupdatefile_Model.osim'.\n"));
-    testCommand("update-file testupdatefile_Model.osim "
-                "testupdatefile_Model_updated.osim", EXIT_SUCCESS,
-                std::regex(RE_ANY + "(Loading input file "
-                           "'testupdatefile_Model.osim'.\n)" +
-                           RE_ANY + "(Printing updated file to "
-                           "'testupdatefile_Model_updated.osim'.\n)" + RE_ANY));
-
-    // Library option.
-    // ===============
-    testLoadPluginLibraries("update-file");
+    SECTION("Library option") {
+        testLoadPluginLibraries("update-file");
+    }
 }
 
-int main() {
-    SimTK_START_TEST("testCommandLineInterface");
-        SimTK_SUBTEST(testNoCommand);
-        SimTK_SUBTEST(testRunTool);
-        SimTK_SUBTEST(testPrintXML);
-        SimTK_SUBTEST(testInfo);
-        SimTK_SUBTEST(testUpdateFile);
-    SimTK_END_TEST();
+TEST_CASE("opensim-cmd log file options", "[opensim-cmd]") {
+    // The osimCommon library never creates a log file on its own; opensim-cmd
+    // decides the file-logging policy at runtime. We use print-xml as a simple
+    // command that succeeds and emits log output. opensim-cmd's addFileSink()
+    // creates (opens) the log file immediately, so checking that the file
+    // exists is enough.
+    const std::string cmd = "print-xml cmc testlogfile_cmc_setup.xml";
+    const auto printed =
+            ContainsSubstring("Printing 'testlogfile_cmc_setup.xml'.\n");
+
+    // Remove the files these commands may create when this test case goes out
+    // of scope (i.e., after every SECTION), so the cases are self-cleaning and
+    // independent even if an assertion fails. The last entry is the XML file
+    // that `cmd` prints; the rest are the log files under test.
+    ScopedFileRemover cleanup({"opensim.log", "testlogfile_custom.log",
+                               "testlogfile_spaced.log", "overridden.log",
+                               "testlogfile_cmc_setup.xml"});
+    // Clear any 'opensim.log' left behind by the other test cases so the
+    // negative checks below are meaningful.
+    std::error_code ec;
+    std::filesystem::remove("opensim.log", ec);
+
+    SECTION("default writes opensim.log in the current directory") {
+        testCommand(cmd, EXIT_SUCCESS, printed);
+        CHECK(std::filesystem::exists("opensim.log"));
+    }
+
+    SECTION("--no-log-file writes no log file") {
+        // This also demonstrates that the library does not auto-create a file.
+        testCommand("--no-log-file " + cmd, EXIT_SUCCESS, printed);
+        CHECK_FALSE(std::filesystem::exists("opensim.log"));
+    }
+
+    SECTION("--log-file writes to the given path instead of opensim.log") {
+        testCommand("--log-file=testlogfile_custom.log " + cmd, EXIT_SUCCESS,
+                printed);
+        CHECK(std::filesystem::exists("testlogfile_custom.log"));
+        CHECK_FALSE(std::filesystem::exists("opensim.log"));
+    }
+
+    SECTION("--log-file also accepts a space-separated value") {
+        testCommand("--log-file testlogfile_spaced.log " + cmd, EXIT_SUCCESS,
+                printed);
+        CHECK(std::filesystem::exists("testlogfile_spaced.log"));
+        CHECK_FALSE(std::filesystem::exists("opensim.log"));
+    }
+
+    SECTION("--no-log-file overrides --log-file") {
+        // Even when a log-file location is given, --no-log-file wins and no
+        // file is created (neither the given path nor the default).
+        testCommand("--no-log-file --log-file=overridden.log " + cmd,
+                EXIT_SUCCESS, printed);
+        CHECK_FALSE(std::filesystem::exists("overridden.log"));
+        CHECK_FALSE(std::filesystem::exists("opensim.log"));
+    }
+
+    SECTION("--log-file that cannot be opened is an error") {
+        // Logger::addFileSink() merely warns when it cannot open the file.
+        // That is acceptable for the implicit default, but a log file the user
+        // asked for by name must not fail silently.
+        const std::string badPath = "testlogfile_no_such_dir/x.log";
+        REQUIRE_FALSE(std::filesystem::exists("testlogfile_no_such_dir"));
+        testCommand("--log-file=" + badPath + " " + cmd, EXIT_FAILURE,
+                ContainsSubstring("Could not open log file '" + badPath +
+                                  "' for writing."));
+        // The command exited before doing any work, so it printed nothing.
+        CHECK_FALSE(std::filesystem::exists("testlogfile_cmc_setup.xml"));
+        CHECK_FALSE(std::filesystem::exists("opensim.log"));
+    }
 }

--- a/Applications/versionUpdate/versionUpdate.cpp
+++ b/Applications/versionUpdate/versionUpdate.cpp
@@ -41,6 +41,10 @@ int main(int argc,char **argv)
     //----------------------
     try {
 
+    // The OpenSim library no longer creates 'opensim.log' on its own; opt in
+    // here so this application's logging behavior is unchanged.
+    Logger::addFileSink();
+
     // DEPRECATION NOTICE
     const std::string deprecationNotice = R"(
     THIS EXECUTABLE IS DEPRECATED AND WILL BE REMOVED IN A FUTURE RELEASE.

--- a/Bindings/Java/swig/java_common.i
+++ b/Bindings/Java/swig/java_common.i
@@ -216,6 +216,36 @@ using namespace SimTK;
       sink.markAdopted();
       private_addSink(sink);
   }
+
+  private static boolean defaultFileLogInitialized = false;
+  /**
+   * Restore the historical default of also writing OpenSim log messages to an
+   * 'opensim.log' file in the current working directory.
+   * The method is idempotent -- only the first call has an effect -- so it is
+   * safe to invoke it from the static initializer of every module's JNI class.
+   * <p>
+   * Deliberately not synchronized: it runs from class initializers, which hold
+   * the JVM's class-initialization locks, and taking another monitor there
+   * invites deadlock. Concurrent first calls are harmless -- the loser just
+   * gets Logger's "already logging to file" warning.
+   */
+  public static void enableDefaultFileLogOnce() {
+      if (defaultFileLogInitialized) {
+          return;
+      }
+      // Set the flag *before* calling addFileSink(): this method is invoked
+      // from the static initializer of every module's JNI class, and
+      // addFileSink() is itself a JNI call, so it re-enters this method while
+      // that initializer is still running. Setting the flag first is what
+      // terminates that recursion; do not move it below the call.
+      defaultFileLogInitialized = true;
+      try {
+          addFileSink("opensim.log");
+      } catch (Exception e) {
+          // Never let logging setup prevent the bindings from loading.
+          System.err.println("OpenSim: could not open 'opensim.log': " + e);
+      }
+  }
 %}
 
 %import "java_simbody.i"

--- a/Bindings/Java/swig/java_preliminaries.i
+++ b/Bindings/Java/swig/java_preliminaries.i
@@ -9,6 +9,7 @@ SWIG_JAVABODY_PROXY(public, public, SWIGTYPE)
       try{
           // All OpenSim classes required for GUI operation.
           System.loadLibrary("osimJavaJNI");
+          Logger.enableDefaultFileLogOnce();
       }
       catch(UnsatisfiedLinkError e){
           String OS = System.getProperty("os.name").toLowerCase();

--- a/Bindings/Python/__init__.py
+++ b/Bindings/Python/__init__.py
@@ -63,3 +63,12 @@ from .version import __version__
 geometry_path = os.path.join(curFolder, 'Geometry')
 if os.path.exists(geometry_path):
     ModelVisualizer.addDirToGeometrySearchPaths(geometry_path)
+
+# Restore the historical log-file behavior ('opensim.log' file in the current
+# working directory)
+try:
+    Logger.addFileSink()
+except Exception as e:
+    # Never let logging setup prevent importing the package.
+    import warnings
+    warnings.warn("OpenSim: could not set up file logging: {}".format(e))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 v4.6.1
 ======
+- File logging (e.g. `opensim.log`) is now controlled at runtime via `Logger::addFileSink()` instead of at compile-time using the `OPENSIM_DISABLE_LOG_FILE` CMake option. The OpenSim *library* now defaults to not logging to file, but the defaults for CLI, the GUI, and the language bindings (Python/Java) remain unchanged (`opensim.log` created in the current working directory). Two new CLI options were added to `opensim-cmd` to expand user control over file logging at runtime:
+  - `--log-file=<path>` sets an alternative log file location. If the file cannot be opened, `opensim-cmd` reports an error and exits rather than continuing without a log file.
+  - `--no-log-file` disables log-file creation entirely (overrides the `--log-file=<path>` option if present)
 - Added `CantileverFreeBeamJoint`, a joint type providing a lightweight way for modeling flexible structures (e.g., the bending of the spinal column in a human or animal skeleton). (#4227)
 - Added `ExponentialCoordinateLimitForce`, a force element for enforcing coordinate limits using exponential spring functions. (#4231)
 - Added `CoordinateLinearStopForce`, a force element for enforcing coordinate limits using a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,12 +168,13 @@ option(BUILD_API_ONLY "Build/install only headers, libraries,
 wrapping, tests; not applications (opensim, ik, rra, etc.)." OFF)
 
 option(OPENSIM_DISABLE_LOG_FILE
-"Disable OpenSim from automatically creating 'opensim.log'.
+"[DEPRECATED] Has no effect; file logging is now controlled at runtime.
 
-By default, any application linking to osimCommon will create an
-'opensim.log' file in the current working directory. All log messages
-written by OpenSim (incl. during static initialization) are written to
-both this file and the standard output streams." OFF)
+osimCommon no longer creates an 'opensim.log' file on its own, so there is
+nothing left for this option to disable. Applications that want a log file
+call `Logger::addFileSink()`; the bundled applications, the GUI, and the
+Python/Java bindings all do so, and write 'opensim.log' in the current
+working directory as before." OFF)
 
 option(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION
 "Disable OpenSim from registering bundled `Object` types at static
@@ -186,7 +187,9 @@ or by manually registering each type (e.g. `Object::registerType(PhysicalOffsetF
 mark_as_advanced(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION)
 
 if(OPENSIM_DISABLE_LOG_FILE)
-    add_definitions(-DOPENSIM_DISABLE_LOG_FILE=1)
+    message(DEPRECATION "OPENSIM_DISABLE_LOG_FILE is deprecated and has no "
+        "effect: the OpenSim library no longer creates a log file "
+        "automatically. Call `Logger::addFileSink()` to restore file logging.")
 endif()
 if(OPENSIM_DISABLE_STATIC_TYPE_REGISTRATION)
     add_definitions(-DOPENSIM_DISABLE_STATIC_TYPE_REGISTRATION=1)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -79,7 +79,6 @@
             "description": "Base build configuration settings for CI",
             "inherits": ["default"],
             "cacheVariables": {
-                "OPENSIM_DISABLE_LOG_FILE": "ON",
                 "OPENSIM_SIMBODY_DOXYGEN_LOCATION": "https://simbody.github.io/latest",
                 "OPENSIM_INSTALL_UNIX_FHS": "OFF",
                 "OPENSIM_DOXYGEN_USE_MATHJAX": "OFF",

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -69,51 +69,15 @@ static spdlog::logger& defaultLoggerInternal() {
     return *l;
 }
 
-// the file log sink (e.g. `opensim.log`) is lazily initialized.
-//
-// it is only initialized when the first log message is about to be written to
-// it. Users *may* disable this functionality before the first log message is
-// written (or disable it statically, by setting OPENSIM_DISABLE_LOG_FILE)
+// The file log sink (e.g. `opensim.log`) is only created when a caller
+// explicitly requests it (at runtime) via `Logger::addFileSink()`.
 static std::shared_ptr<spdlog::sinks::basic_file_sink_mt> m_filesink = nullptr;
 
-// if a user manually calls `Logger::(remove|add)FileSink`, auto-initialization
-// should be disabled. Manual usage "overrides" lazy auto-initialization.
-static bool fileSinkAutoInitDisabled = false;
-
-// attempt to auto-initialize the file log, if applicable
-static bool initFileLoggingAsNeeded() {
-#ifdef OPENSIM_DISABLE_LOG_FILE
-// software builders may want to statically ensure that automatic file logging
-// *cannot* happen - even during static initialization. This compiler define
-// outright disables the behavior, which is important in Windows applications
-// that run multiple instances of OpenSim-linked binaries. In Windows, the
-// logs files collide and cause a "multiple processes cannot open the same
-// file" error).
-return true;
-#else
-    static bool initialized = []() {
-        if (fileSinkAutoInitDisabled) {
-            return true;
-        }
-        Logger::addFileSink();
-        return true;
-    }();
-
-    return initialized;
-#endif
-}
-
-// this function is only called when the caller is about to log something, so
-// it should perform lazy initialization of the file sink
 spdlog::logger& Logger::getCoutLogger() {
-    initFileLoggingAsNeeded();
     return coutLoggerInternal();
 }
 
-// this function is only called when the caller is about to log something, so
-// it should perform lazy initialization of the file sink
 spdlog::logger& Logger::getDefaultLogger() {
-    initFileLoggingAsNeeded();
     return defaultLoggerInternal();
 }
 
@@ -230,13 +194,6 @@ bool Logger::shouldLog(Level level) {
 }
 
 void Logger::addFileSink(const std::string& filepath) {
-    // this method is either called by the file log auto-initializer, which
-    // should now be disabled, or by downstream code trying to manually specify
-    // a file sink
-    //
-    // downstream callers would find it quite surprising if the auto-initializer
-    // runs *after* they manually specify a log, so just disable it
-    fileSinkAutoInitDisabled = true;
     spdlog::logger& logger = defaultLoggerInternal();
 
     if (m_filesink) {
@@ -261,15 +218,6 @@ void Logger::addFileSink(const std::string& filepath) {
 }
 
 void Logger::removeFileSink() {
-    // if this method is called, then we are probably at a point in the
-    // application's lifetime where automatic log allocation is going to cause
-    // confusion.
-    //
-    // callers will be surpised if, after calling this method, auto
-    // initialization happens afterwards and the log file still exists - even
-    // if they called it to remove some manually-specified log
-    fileSinkAutoInitDisabled = true;
-
     if (m_filesink == nullptr) {
         return;
     }

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -167,8 +167,9 @@ public:
     }
 
     /// Use this function to log messages that would normally be sent to
-    /// std::cout. These messages always appear, and are also logged to the
-    /// filesink (addFileSink()) and any sinks added via addSink().
+    /// std::cout. These messages always appear, and are also logged to a file
+    /// sink (if one has been added via addFileSink()) and to any sinks added
+    /// via addSink().
     /// The main use case for this function is inside of functions whose intent
     /// is to print information (e.g., Component::printSubcomponentInfo()).
     /// Besides such use cases, this function should be used sparingly to
@@ -182,7 +183,9 @@ public:
     /// @}
 
     /// Log messages to a file at the level getLevel().
-    /// OpenSim logs messages to the file opensim.log by default.
+    /// OpenSim does not write log messages to any file unless this function is
+    /// called; "opensim.log" in the current working directory is the default
+    /// path used when no filepath is supplied.
     /// If we are already logging messages to a file, then this
     /// function issues a warning and returns; invoke removeFileSink() first.
     /// @note This function is not thread-safe. Do not invoke this function

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -72,10 +72,7 @@
             "hidden": true,
             "name": "ci",
             "description": "Base build configuration settings for CI",
-            "inherits": ["default"],
-            "cacheVariables": {
-                "OPENSIM_DISABLE_LOG_FILE": "ON"
-            }
+            "inherits": ["default"]
         },
         {
             "name": "dev-default",


### PR DESCRIPTION
@adamkewley 's PR #4367 inspired me to develop a proof-of-concept to solve a long-standing gripe of mine (and not just me based on [this comment](https://github.com/opensim-org/opensim-core/pull/4366#pullrequestreview-4778612555)). Fixes issue #3121.

Library provided functionality should generally require explicit use/action by consumer libraries/applications: linking against a library should not, by itself, produce observable side effects (outside of linking to e.g. a different allocator, etc). Similarly, the convention for a CLI is that diagnostics go to stdout/stderr (or to a standard OS location), and the user decides whether/where to persist them (e.g. redirecting to a file). However, the `osimCommon` library (and linked libraries/applications) always creates an "opensim.log" file in the current working directory (optionally disabled exclusively at build time with the `OPENSIM_DISABLE_LOG_FILE` option) when emitting logs.

The previous default behavior makes several assumptions that don't always hold:
- The user wants logs persisted to disk
- The current working directory is actually persistent (e.g. we are *not* running from a temporary directory)
- That directory is on a writable filesystem (and/or the current user has write permissions in the current directory).
- No other program is writing to `opensim.log`. Concurrent OpenSim processes started from the same directory contend for the same file; I have hit soft ~deadlocks from this in practice.

### Brief summary of changes

**tl;dr**: OpenSim library default was changed to only log to file on explicit request; all CLIs and language bindings (Python and Java/MATLAB) retain previous default behavior of logging to "opensim.log" file in current working directory.

`osimCommon` no longer creates a log file on its own; a file sink now exists only if someone calls `Logger::addFileSink()`.

Every entry point in opensim-core was updated to call `addFileSink`, so there shouldn't be any user-visible changes to defaults w.r.t. log files:

- `opensim-cmd` -- File sink initiated in `main()` (same for the individual apps), before plugin loading and before the log level is
  set, so those messages land in the file. Two new CLI options give users runtime control of file logging:
    - `--log-file=<path>` -- write the log somewhere other than `./opensim.log`.
    - `--no-log-file` -- disable log file (even if `--log-file` was given).
- Python -- File sink initiated in `Bindings/Python/__init__.py` at import time.
- Java/MATLAB/GUI -- File sink initiated in `Logger.enableDefaultFileLogOnce()` from the JNI class
  static initializer in `java_preliminaries.i`.

`OPENSIM_DISABLE_LOG_FILE` is kept as a no-op that emits a CMake deprecation
warning, so existing build scripts keep configuring.

`opensim-cmd` test harness converted to Catch2 while I'm at it.

### Testing I've completed

- testCommandLineInterface passes locally on Linux.
- Manually verified: default run creates `./opensim.log`; `--no-log-file` creates nothing; `--log-file run.log` writes to `run.log`; `--log-file no_such_dir/x.log` reports "Could not open log file" and exits 1; `--log-file` with no value reports that it requires an argument; `--help` and per-subcommand `-h` render correctly.

### Looking for feedback/approval on...

In addition to looking for feedback/approval on the general direction of this draft/PoC, specific areas of uncertainty are:

- The new Python log file init results in slightly different behavior, such that `import opensim` now creates `opensim.log` eagerly, whereas before it was created right before the first log message.
- I'm not familiar enough with Java to follow the comments/reasoning about the Java log file initialization.
- I made the new `--log-file=<path>` option error if the requested path/file isn't writable. Arguably that error-ing should happen in `Logger::addFileSink()` so that API callers benefit too: the current (pre-existing) behavior is to soft-fail and log the error, which (ironically) won't be found in the log file that couldn't be created. However, fixing that is probably out-of-scope for this PR.

### CHANGELOG.md

- updated.

AI disclosure: Anthropic's Claude generated large portions of these changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4377)
<!-- Reviewable:end -->
