### PR TITLE
Some fixes: support of spdlog not bundled with fmt + correct target for casadi

### DIFF
--- a/OpenSim/Common/Array.h
+++ b/OpenSim/Common/Array.h
@@ -35,7 +35,11 @@
 #include <initializer_list>
 #include <iostream>
 #include <iterator>
+#if !defined(SPDLOG_FMT_EXTERNAL)
 #include <spdlog/fmt/bundled/ostream.h>
+#else
+#include <fmt/ostream.h>
+#endif
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/OpenSim/Common/Logger.cpp
+++ b/OpenSim/Common/Logger.cpp
@@ -26,7 +26,11 @@
 #include "IO.h"                              // for IO
 #include "LogSink.h"                         // for LogSink
 #include <algorithm>                         // for remove
+#if !defined(SPDLOG_FMT_EXTERNAL)
 #include <spdlog/fmt/bundled/format.h>       // for format
+#else
+#include <fmt/format.h>       // for format
+#endif
 #include <spdlog/sinks/basic_file_sink.h>    // for basic_file_sink_mt, bas...
 #include <spdlog/sinks/sink.h>               // for sink
 #include <spdlog/sinks/stdout_color_sinks.h> // for stdout_color_mt

--- a/OpenSim/Common/Logger.h
+++ b/OpenSim/Common/Logger.h
@@ -25,8 +25,13 @@
 #include "osimCommonDLL.h"              // for OSIMCOMMON_API
 #include <memory>                       // for shared_ptr
 #include <spdlog/common.h>              // for spdlog::format_string_t
+#if !defined(SPDLOG_FMT_EXTERNAL)
 #include <spdlog/fmt/bundled/base.h>    // for formatter
 #include <spdlog/fmt/bundled/ostream.h> // for ostream_formatter
+#else
+#include <fmt/base.h>    // for formatter
+#include <fmt/ostream.h> // for ostream_formatter
+#endif
 #include <spdlog/logger.h>              // for logger
 #include <string>                       // for basic_string, string
 #include <string_view>                  // for std::string_view

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -59,7 +59,7 @@ if(UNIX AND OPENSIM_COPY_DEPENDENCIES AND OPENSIM_WITH_CASADI)
     # is installed (add_subdirectory(cmake) must be after
     # add_subdirectory(Moco)).
     if (OPENSIM_WITH_CASADI)
-        get_target_property(CASADI_LIBRARY_LOCATION casadi LOCATION)
+        get_target_property(CASADI_LIBRARY_LOCATION casadi::casadi LOCATION)
         get_filename_component(CASADI_LIBDIR "${CASADI_LIBRARY_LOCATION}" DIRECTORY)
     endif()
 


### PR DESCRIPTION
When compiling opensim-core I encountered two issues:
- good packages do not bundle spdlog with fmt, and the headers spdlog/fmt/bundled/* do not exist;
- it was impossible to depend on casadi, caused by an invalid cmake target.
This PR fixes these issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4379)
<!-- Reviewable:end -->
