### PR TITLE
CMake presets for Python wheels

### DIFF
--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -6,11 +6,11 @@ on:
 
 permissions:
   contents: read
- 
+
 jobs:
   build_windows_wheels:
 
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     strategy:
       matrix:
@@ -22,34 +22,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Doxygen
-      # choco install doxygen.portable # <-- too unreliable.
-      run: |
-        (New-Object System.Net.WebClient).DownloadFile("https://github.com/doxygen/doxygen/releases/download/Release_1_12_0/doxygen-1.12.0.windows.x64.bin.zip", "doxygen.zip")
-        7z x $env:GITHUB_WORKSPACE/doxygen.zip -odoxygen
-        echo "$env:GITHUB_WORKSPACE\\doxygen" >> $GITHUB_PATH
-
     - name: Install Python packages
       id: setup
       uses: actions/setup-python@v4
       with:
         python-version: '${{ matrix.python-version }}'
 
-    - name: Get Python root (sys.prefix)
-      id: pyroot
-      run: |
-          ROOT=$(python -c "import sys; print(sys.prefix)")
-          echo "root=$ROOT" >> "$GITHUB_OUTPUT"
-      shell: bash
-
     - name: Install numpy
-      #Need numpy to use SWIG numpy typemaps.
+      # Need numpy to use SWIG numpy typemaps.
       run: |
-        python3 -m pip install numpy==2.4.2
-        python3 -m pip install wheel
-        python3 -m pip install build
-        pip install --upgrade pip setuptools wheel
-        pip install delvewheel
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install numpy==2.4.2 wheel build
 
     - name: Install SWIG
       run: |
@@ -58,55 +41,36 @@ jobs:
 
     - name: Build dependencies
       run: |
-        echo $env:GITHUB_WORKSPACE\\build_deps
-        mkdir $env:GITHUB_WORKSPACE\\build_deps
-        chdir $env:GITHUB_WORKSPACE\\build_deps
-        # /W0 disables warnings.
-        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-        # TODO: CMake provides /W3, which overrides our /W0
-        cmake -E env CXXFLAGS="/W0 /MD" cmake $env:GITHUB_WORKSPACE/dependencies -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DSUPERBUILD_ezc3d=ON -DOPENSIM_WITH_CASADI=ON -DOPENSIM_PYTHON_STANDALONE=ON
-        cmake --build . --config Release -- /maxcpucount:4
+        chdir $env:GITHUB_WORKSPACE\\dependencies
+        cmake -G "Visual Studio 17 2022" . --preset wheels-msvc-windows-release -LAH
+        cmake --build --preset wheels-msvc-windows-release -j 4
 
     - name: Configure opensim-core
       id: configure
       run: |
-        mkdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE\\build
-        # TODO: Can remove /WX when we use that in CMakeLists.txt.
-        # Set the CXXFLAGS environment variable to turn warnings into errors.
-        # Skip timing test section included by default.
-        cmake -E env CXXFLAGS="/WX /MD -DSKIP_TIMING" cmake $env:GITHUB_WORKSPACE -LAH -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DOPENSIM_C3D_PARSER=ezc3d -DOPENSIM_WITH_CASADI=ON -DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=OFF -DBUILD_TESTING=OFF -DBUILD_PYTHON_WHEELS=ON -DPython3_ROOT_DIR=${{ steps.pyroot.outputs.root}}
-        $env:match = cmake -L . | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+        cmake -G "Visual Studio 17 2022" . --preset wheels-msvc-windows-release -LAH
+
+        $env:match = cmake -N -L build/wheels-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
         $version = $env:match.split('=')[1]
-        echo $version
-        echo "VERSION=$version" >> $GITHUB_ENV
         echo "version=$version" >> $env:GITHUB_OUTPUT
+        echo "CMAKE_INSTALL_PREFIX=$env:GITHUB_WORKSPACE\build\wheels-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
+        echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\build\dependencies\wheels-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
 
     - name: Build opensim-core
-    # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        cmake --build . --config Release --target doxygen -- /maxcpucount:4
-        cmake --build . --config Release --target install -- /maxcpucount:4
-
-    - name: Install opensim-core
-    # TODO: This is where we wish to do the installing, but it's done above for now.
-      run: |
-        chdir $env:GITHUB_WORKSPACE\\build
-        chdir $env:GITHUB_WORKSPACE
-        Copy-Item -Path "~/opensim-core-install" -Destination "opensim-core-${{ steps.configure.outputs.version }}" -Recurse
-        7z a "opensim-core-${{ steps.configure.outputs.version }}.zip" "opensim-core-${{ steps.configure.outputs.version }}"
+        cmake --build --preset wheels-msvc-windows-release -j 4
+        cmake --build --preset wheels-msvc-windows-release --target install
 
     - name: Build wheel
       run: |
-        cd ~/opensim-core-install/sdk/Python
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         pip wheel . --wheel-dir dist
 
     - name: Capture wheel path
       id: wheel
       shell: pwsh
       run: |
-         cd ~/opensim-core-install/sdk/Python/dist
+         cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist
          $file = Get-ChildItem opensim*.whl | Select-Object -First 1
          echo "path=$($file.Name)" >> $env:GITHUB_OUTPUT
 
@@ -114,14 +78,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
          name: wheels-${{ matrix.python-version }}-windows
-         path: ~/opensim-core-install/sdk/Python/dist/opensim*.whl
+         path: ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist/opensim*.whl
          overwrite: true
 
     - name: Test Python bindings
       run: |
-        cd ~/opensim-core-install/sdk/Python
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         pip install dist/${{ steps.wheel.outputs.path }}
-        # Run the python tests, verbosely.
         # python3 -m unittest discover --start-directory opensim/tests --verbose
 
   build_osx_wheels:
@@ -143,7 +106,7 @@ jobs:
 
     - name: Install Homebrew packages
       run: |
-        brew install pkgconfig autoconf libtool automake wget pcre doxygen llvm
+        brew install pkgconfig autoconf libtool automake wget pcre llvm
         brew reinstall gcc
         pip3 install numpy==2.4.2
         pip3 install wheel
@@ -159,84 +122,48 @@ jobs:
 
     - name: Build dependencies
       run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
-        DEP_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3)
-
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
+        cd $GITHUB_WORKSPACE/dependencies
+        cmake . --preset wheels-make-macos-release -LAH
+        cmake --build --preset wheels-make-macos-release -j 4
 
     - name: Configure opensim-core
       id: configure
       run: |
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=13.3)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=ON -DBUILD_JAVA_WRAPPING=OFF)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WHEELS=ON)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        OSIM_CMAKE_ARGS+=(-DBUILD_TESTING=OFF)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=$HOME/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=OFF)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror, -Wdeprecated-copy")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        cmake -S $GITHUB_WORKSPACE --preset wheels-make-macos-release -LAH \
+            -DSWIG_EXECUTABLE=$HOME/swig/bin/swig
+
+        VERSION=`cmake -N -L $GITHUB_WORKSPACE/build/wheels-make-macos-release | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
         echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/wheels-make-macos-release/install" >> $GITHUB_OUTPUT
+        echo "OPENSIM_DEPENDENCIES_DIR=$GITHUB_WORKSPACE/build/dependencies/wheels-make-macos-release/install" >> $GITHUB_OUTPUT
 
     - name: Build opensim-core
       run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
-
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}.zip opensim-core-${{ steps.configure.outputs.version }}
-        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+        cmake --build --preset wheels-make-macos-release -j 4
+        cmake --build --preset wheels-make-macos-release --target install
 
     - name: Build wheel
       run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-        pip3 wheel . --wheel-dir dist
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
+        python3 -m build --wheel
+
     - name: Capture wheel path
       id: wheel
       run: |
-         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python/dist
+         cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist
          echo "path=$(ls -1 opensim*.whl | head -n1)" >> $GITHUB_OUTPUT
+
     - name: Upload osx wheel
       uses: actions/upload-artifact@v4
       with:
          name: wheels-${{ matrix.python-version }}-osx
-         path: /Users/runner/work/opensim-core/opensim-core-install/sdk/python/dist/opensim*.whl
+         path: ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist/${{ steps.wheel.outputs.path }}
          overwrite: true
 
     - name: Test Python bindings
       run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-        pip3 install /Users/runner/work/opensim-core/opensim-core-install/sdk/python/dist/${{ steps.wheel.outputs.path }}
-        # Run the python tests, verbosely.
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
+        pip3 install ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist/${{ steps.wheel.outputs.path }}
         python3 -m unittest discover --start-directory opensim/tests --verbose
 
   build_linux_wheels:
@@ -259,24 +186,31 @@ jobs:
         $PY -m pip install numpy==2.4.2
         $PY -m pip install build
         $PY -m pip install wheel
-        $PY -m pip install "cibuildwheel==2.9.0"
         $PY -m pip install auditwheel
 
     - name: Install packages
       run: |
         yum -y update
         yum -y install \
-        gcc gcc-c++ make \
-        libtool autoconf automake pkgconfig \
+        gcc \
+        gcc-c++ \
+        make \
+        libtool \
+        autoconf \
+        automake \
+        pkgconfig \
         pcre2-devel \
         gcc-gfortran \
-        openblas-devel lapack-devel \
-        freeglut-devel libXi-devel libXmu-devel \
-        doxygen wget tar gzip patchelf
-        PYVER=$($PY -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')")
-    - name: Install zip
-      run: yum install -y zip
-      
+        openblas-devel \
+        lapack-devel \
+        freeglut-devel \
+        libXi-devel \
+        libXmu-devel \
+        wget \
+        tar \
+        gzip \
+        patchelf
+
     - name: Install SWIG
       run: |
         mkdir ~/swig-source && cd ~/swig-source
@@ -292,122 +226,74 @@ jobs:
 
     - name: Build dependencies
       run: |
-        mkdir $GITHUB_WORKSPACE/../build_deps
-        cd $GITHUB_WORKSPACE/../build_deps
-        DEP_CMAKE_ARGS=($GITHUB_WORKSPACE/dependencies -LAH)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim_dependencies_install)
-        DEP_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        DEP_CMAKE_ARGS+=(-DCMAKE_INSTALL_LIBDIR=lib)
-        DEP_CMAKE_ARGS+=(-DSUPERBUILD_ezc3d=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        DEP_CMAKE_ARGS+=(-DOPENSIM_DISABLE_LOG_FILE=ON)
-        printf '%s\n' "${DEP_CMAKE_ARGS[@]}"
-        cmake "${DEP_CMAKE_ARGS[@]}"
-        make --jobs 4
+        cd $GITHUB_WORKSPACE/dependencies
+        cmake . --preset wheels-make-linux-release -LAH
+        cmake --build --preset wheels-make-linux-release -j 4
 
     - name: Configure opensim-core
       id: configure
       run: |
-        PY_PREFIX=$(dirname $(dirname $PY))
-        PY_INCLUDE=$($PY -c "import sysconfig; print(sysconfig.get_path('include'))")
-        mkdir $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
-        OSIM_CMAKE_ARGS=($GITHUB_WORKSPACE -LAH)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/../opensim-core-install)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_BUILD_TYPE=Release)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DEPENDENCIES_DIR=$GITHUB_WORKSPACE/../opensim_dependencies_install)
-        #OSIM_CMAKE_ARGS+=(-DOPENSIM_C3D_PARSER=ezc3d)
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WRAPPING=ON)
-        OSIM_CMAKE_ARGS+=(-DPython3_EXECUTABLE=$PY)
-        OSIM_CMAKE_ARGS+=(-DPython3_ROOT_DIR=$PY_PREFIX)
-        OSIM_CMAKE_ARGS+=(-DPython3_NumPy_INCLUDE_DIRS=$($PY -c "import numpy; print(numpy.get_include())"))
-        OSIM_CMAKE_ARGS+=(-DBUILD_PYTHON_WHEELS=ON)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_WITH_CASADI=ON)
-        OSIM_CMAKE_ARGS+=(-Dcasadi_DIR=$GITHUB_WORKSPACE/../opensim_dependencies_install/casadi/lib/cmake/casadi)
-        OSIM_CMAKE_ARGS+=(-DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/../opensim_dependencies_install/ipopt)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DIR=~/swig/share/swig)
-        OSIM_CMAKE_ARGS+=(-DSWIG_EXECUTABLE=~/swig/bin/swig)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_INSTALL_UNIX_FHS=OFF)
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_DOXYGEN_USE_MATHJAX=OFF)
-        #OSIM_CMAKE_ARGS+=(-DCMAKE_INSTALL_LIBDIR=lib)
-        OSIM_CMAKE_ARGS+=(-DBUILD_TESTING=OFF)
-        OSIM_CMAKE_ARGS+=(-DSWIG_DOXYGEN=OFF)
-        # TODO: Update to simbody.github.io/latest
-        OSIM_CMAKE_ARGS+=(-DOPENSIM_SIMBODY_DOXYGEN_LOCATION="https://simbody.github.io/simtk.org/api_docs/simbody/latest/")
-        OSIM_CMAKE_ARGS+=(-DCMAKE_CXX_FLAGS="-Werror")
-        printf '%s\n' "${OSIM_CMAKE_ARGS[@]}"
-        cmake "${OSIM_CMAKE_ARGS[@]}"
-        VERSION=`cmake -L . | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
-        echo $VERSION
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
+        cmake -S $GITHUB_WORKSPACE --preset wheels-make-linux-release -LAH \
+            -DSWIG_DIR=$HOME/swig/share/swig \
+            -DSWIG_EXECUTABLE=$HOME/swig/bin/swig \
+            -DPython3_EXECUTABLE=$PY
+
+        VERSION=`cmake -N -L $GITHUB_WORKSPACE/build/wheels-make-linux-release | grep OPENSIM_QUALIFIED_VERSION | cut -d "=" -f2`
         echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "CMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/wheels-make-linux-release/install" >> $GITHUB_OUTPUT
+        echo "OPENSIM_DEPENDENCIES_DIR=$GITHUB_WORKSPACE/build/dependencies/wheels-make-linux-release/install" >> $GITHUB_OUTPUT
 
     - name: Build opensim-core
       run: |
-        cd $GITHUB_WORKSPACE/../build
-        make --jobs 4
-
-    - name: Install opensim-core
-      run: |
-        cd $GITHUB_WORKSPACE/../build
-        make doxygen
-        make --jobs 4 install
-        cd $GITHUB_WORKSPACE
-        mv $GITHUB_WORKSPACE/../opensim-core-install opensim-core-${{ steps.configure.outputs.version }}
-        zip --symlinks --recurse-paths --quiet opensim-core-${{ steps.configure.outputs.version }}-ubuntu22.zip opensim-core-${{ steps.configure.outputs.version }}
-        mv opensim-core-${{ steps.configure.outputs.version }} $GITHUB_WORKSPACE/../opensim-core-install
+        cmake --build --preset wheels-make-linux-release -j 4
+        cmake --build --preset wheels-make-linux-release --target install
 
     - name: Test Python bindings
       run: |
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/../opensim_dependencies_install/simbody/lib
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-        # Run the python tests, verbosely
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ steps.configure.outputs.OPENSIM_DEPENDENCIES_DIR }}/simbody/lib
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         $PY -m unittest discover --start-directory opensim/tests --verbose
 
     - name: Build wheel
-      env:
-        CIBW_CONTAINER_ENGINE: none
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
       run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
-        CIBW_MANYLINUX_X86_64_IMAGE=manylinux_2_28
-        CIBW_BUILD="${{ matrix.python }}-*"
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         $PY -m build --wheel .
 
     - name: Twine and audit check
       run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         $PY -m pip install --upgrade twine
         $PY -m twine check dist/*
         for whl in dist/*.whl; do
             echo "=== $whl ==="
             $PY -m auditwheel show "$whl"
           done
+
     - name: Repair wheels
       run: |
-          cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+          cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
           mkdir -p dist/repaired
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/../opensim_dependencies_install/simbody/lib
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ steps.configure.outputs.OPENSIM_DEPENDENCIES_DIR }}/simbody/lib
           for whl in dist/*.whl; do
             echo "Repairing $whl"
             auditwheel repair "$whl" -w dist/repaired/
           done
+
     - name: Capture wheel path
       id: wheel
       run: |
-         cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python/dist/repaired
+         cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist/repaired
          echo "path=$(ls -1 opensim*.whl | head -n1)" >> $GITHUB_OUTPUT
 
     - name: Upload linux wheel
       uses: actions/upload-artifact@v4
       with:
          name: wheels-${{ matrix.python }}-linux
-         path: /__w/opensim-core/opensim-core-install/sdk/Python/dist/repaired/opensim*.whl
+         path: ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python/dist/repaired/opensim*.whl
          overwrite: true
 
     - name: Test Python bindings
       run: |
-        cd $GITHUB_WORKSPACE/../opensim-core-install/sdk/Python
+        cd ${{ steps.configure.outputs.CMAKE_INSTALL_PREFIX }}/sdk/Python
         $PY -m pip install dist/repaired/${{ steps.wheel.outputs.path }}
-        # Run the python tests, verbosely.
         $PY -m unittest discover --start-directory opensim/tests --verbose

--- a/Bindings/Python/CMakeLists.txt
+++ b/Bindings/Python/CMakeLists.txt
@@ -122,6 +122,7 @@ macro(OpenSimAddPythonModule)
         $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
             -O0
             -Wno-deprecated-declarations
+            -Wno-error=missing-field-initializers
         >
 
         $<$<CXX_COMPILER_ID:MSVC>:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -162,6 +162,45 @@
                 "CMAKE_CXX_FLAGS_RELEASE": "-DNDEBUG -O2 -funroll-loops",
                 "CMAKE_C_FLAGS_RELEASE": "-DNDEBUG -O2 -funroll-loops"
             }
+        },
+        {
+            "hidden": true,
+            "name": "wheels",
+            "description": "Base build configuration settings for Python wheels",
+            "inherits": ["ci"],
+            "cacheVariables": {
+                "BUILD_JAVA_WRAPPING": "OFF",
+                "BUILD_TESTING": "OFF",
+                "BUILD_API_EXAMPLES": "OFF",
+                "SWIG_DOXYGEN": "OFF"
+            }
+        },
+        {
+            "name": "wheels-msvc-windows-release",
+            "displayName": "Windows Python wheels default",
+            "description": "Default Python wheels configuration for Windows",
+            "inherits": [
+                "wheels",
+                "windows"
+            ]
+        },
+        {
+            "name": "wheels-make-macos-release",
+            "displayName": "MacOS Python wheels default",
+            "description": "Default Python wheels configuration for MacOS",
+            "inherits": [
+                "wheels",
+                "macos"
+            ]
+        },
+        {
+            "name": "wheels-make-linux-release",
+            "displayName": "Linux Python wheels default",
+            "description": "Default Python wheels configuration for Linux",
+            "inherits": [
+                "wheels",
+                "linux"
+            ]
         }
     ],
     "buildPresets": [
@@ -230,6 +269,22 @@
         {
             "name": "ci-make-linux-release",
             "configurePreset": "ci-make-linux-release",
+            "inherits": "linux"
+        },
+        {
+            "name": "wheels-msvc-windows-release",
+            "configurePreset": "wheels-msvc-windows-release",
+            "inherits": "windows",
+            "configuration": "Release"
+        },
+        {
+            "name": "wheels-make-macos-release",
+            "configurePreset": "wheels-make-macos-release",
+            "inherits": "macos"
+        },
+        {
+            "name": "wheels-make-linux-release",
+            "configurePreset": "wheels-make-linux-release",
             "inherits": "linux"
         }
     ],
@@ -326,6 +381,31 @@
         },
         {
             "name": "ci-make-linux-release",
+            "configurePreset": "ci-make-linux-release",
+            "inherits": [
+                "base",
+                "linux"
+            ]
+        },
+        {
+            "name": "wheels-msvc-windows-release",
+            "configurePreset": "wheels-msvc-windows-release",
+            "inherits": [
+                "base",
+                "windows"
+            ],
+            "configuration": "Release"
+        },
+        {
+            "name": "wheels-make-macos-release",
+            "configurePreset": "wheels-make-macos-release",
+            "inherits": [
+                "base",
+                "macos"
+            ]
+        },
+        {
+            "name": "wheels-make-linux-release",
             "configurePreset": "ci-make-linux-release",
             "inherits": [
                 "base",

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -143,6 +143,9 @@ function(AddDependency)
         if(SWIG_EXECUTABLE)
             list(APPEND CMAKE_ARGS -DSWIG_EXECUTABLE:FILEPATH=${SWIG_EXECUTABLE})
         endif()
+        if(CMAKE_INSTALL_LIBDIR)
+            list(APPEND CMAKE_ARGS -DCMAKE_INSTALL_LIBDIR:STRING=${CMAKE_INSTALL_LIBDIR})
+        endif()
 
         # Append the dependency-specific CMake arguments.
         list(APPEND CMAKE_ARGS ${DEP_CMAKE_ARGS})

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -35,6 +35,9 @@
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Linux"
+            },
+            "cacheVariables": {
+                "CMAKE_INSTALL_LIBDIR": "lib"
             }
         },
         {
@@ -140,6 +143,42 @@
                 "ci",
                 "linux"
             ]
+        },
+        {
+            "hidden": true,
+            "name": "wheels",
+            "description": "Base build configuration settings for Python wheels",
+            "inherits": ["default"]
+        },
+        {
+            "name": "wheels-msvc-windows-release",
+            "displayName": "Windows Python wheels default",
+            "description": "Default Python wheels configuration for Windows",
+            "inherits": [
+                "ci",
+                "windows"
+            ],
+            "environment": {
+                "CXXFLAGS": "/w"
+            }
+        },
+        {
+            "name": "wheels-make-macos-release",
+            "displayName": "MacOS Python wheels default",
+            "description": "Default Python wheels configuration for MacOS",
+            "inherits": [
+                "ci",
+                "macos"
+            ]
+        },
+        {
+            "name": "wheels-make-linux-release",
+            "displayName": "Linux Python wheels default",
+            "description": "Default Python wheels configuration for Linux",
+            "inherits": [
+                "ci",
+                "linux"
+            ]
         }
     ],
     "buildPresets": [
@@ -208,6 +247,22 @@
         {
             "name": "ci-make-linux-release",
             "configurePreset": "ci-make-linux-release",
+             "inherits": "linux"
+        },
+        {
+            "name": "wheels-msvc-windows-release",
+            "configurePreset": "wheels-msvc-windows-release",
+            "inherits": "windows",
+            "configuration": "Release"
+        },
+        {
+            "name": "wheels-make-macos-release",
+            "configurePreset": "wheels-make-macos-release",
+             "inherits": "macos"
+        },
+        {
+            "name": "wheels-make-linux-release",
+            "configurePreset": "wheels-make-linux-release",
              "inherits": "linux"
         }
     ],


### PR DESCRIPTION
Fixes issue #4372

### Brief summary of changes

Adds the presets to `wheels-msvc-windows-release`, `wheels-make-macos-release`, and `wheels-make-linux-release` to the `CMakePresets.json` files to provide configurations specific to building Python wheels. These presets are then applied to simplify/unify the jobs in `build_all_wheels.yml`. 

Various cleanups and improvements (some related, some drive-bys) to the `build_all_wheels.yml` were also made:
- Removed the installation of Doxygen in all jobs (unused in wheels).
- Removed unused wheels building packages and related code (e.g., `delvewheel` and `cibuildwheel`).
- Similarly to `continuous_integration.yml`, `CMAKE_INSTALL_PREFIX` and `OPENSIM_DEPENDENCIES_DIR` are cached in the configuration step and applied where necessary in following steps.

### Testing I've completed

Launched the "Build Python wheels" GH Actions job off this branch and plugged my ears Wile-E-Coyote-style.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...wheels build workflow changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4385)
<!-- Reviewable:end -->
