### PR TITLE
Gui cmake presets [build-gui]

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -105,6 +105,8 @@
         {
             "name": "msvc-dev-gui-default",
             "description": "Recommended MSVC development configuration for gui builds ",
+            "binaryDir": "${sourceDir}/bld/",
+            "installDir": "${sourceDir}/install",
             "inherits": [
                "dev-default",
                "windows"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -103,6 +103,19 @@
             ]
         },
         {
+            "name": "msvc-dev-gui-default",
+            "description": "Recommended MSVC development configuration for gui builds ",
+            "inherits": [
+               "dev-default",
+               "windows"
+            ],
+            "cacheVariables": {
+               "OPENSIM_WITH_CASADI": "OFF",
+               "BUILD_PYTHON_WRAPPING": "OFF",
+               "BUILD_API_EXAMPLES": "OFF"
+           }
+        },
+        {
             "name": "dev-minimal",
             "description": "Minimal development configuration that builds OpenSim without Moco, ezc3d, and bindings",
             "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -104,8 +104,8 @@
         },
         {
             "name": "msvc-dev-gui-default",
-            "description": "Recommended MSVC development configuration for gui builds ",
-            "binaryDir": "${sourceDir}/bld/",
+            "description": "Recommended MSVC development configuration for GUI builds ",
+            "binaryDir": "${sourceDir}/build/",
             "installDir": "${sourceDir}/install",
             "inherits": [
                "dev-default",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -96,7 +96,7 @@
         },
         {
             "name": "msvc-dev-default",
-            "description": "Recommended MSVC development configuration ",
+            "description": "Recommended MSVC development configuration",
             "inherits": [
                 "dev-default",
                 "windows"
@@ -104,7 +104,7 @@
         },
         {
             "name": "msvc-dev-gui-default",
-            "description": "Recommended MSVC development configuration for GUI builds ",
+            "description": "Recommended MSVC development configuration for GUI builds",
             "binaryDir": "${sourceDir}/build/",
             "installDir": "${sourceDir}/install",
             "inherits": [

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -101,7 +101,7 @@
         },
         {
           "name": "msvc-dev-gui-default",
-          "description": "Recommended MSVC development configuration for gui builds ",
+          "description": "Recommended MSVC development configuration for GUI builds ",
           "inherits": [
                 "dev-default",
                 "windows"

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -93,7 +93,7 @@
         },
         {
             "name": "msvc-dev-default",
-            "description": "Recommended MSVC development configuration ",
+            "description": "Recommended MSVC development configuration",
             "inherits": [
                 "dev-default",
                 "windows"
@@ -101,7 +101,7 @@
         },
         {
           "name": "msvc-dev-gui-default",
-          "description": "Recommended MSVC development configuration for GUI builds ",
+          "description": "Recommended MSVC development configuration for GUI builds",
           "inherits": [
                 "dev-default",
                 "windows"

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -100,6 +100,17 @@
             ]
         },
         {
+          "name": "msvc-dev-gui-default",
+          "description": "Recommended MSVC development configuration for gui builds ",
+          "inherits": [
+                "dev-default",
+                "windows"
+          ],
+          "cacheVariables": {
+            "OPENSIM_WITH_CASADI": "OFF"
+          }
+        },
+        {
             "name": "dev-minimal",
             "description": "Minimal development configuration that only build the dependencies necessary for a minimal build (no Moco, no ezc3d)",
             "inherits": ["dev-default"],


### PR DESCRIPTION
Fixes issue #4386 

### Brief summary of changes
Add 2 presets for building GUI (on windows) without python or casadi, also shorten build and install paths to work around path length limits on windows.

### Testing I've completed
Built locally and build succeeded while it failed due to long paths using existing presets.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4387)
<!-- Reviewable:end -->
