### PR TITLE
Convert CMC tests to the Catch2 framework

### DIFF
--- a/Applications/CMC/tests/testCMCArm26_Millard.cpp
+++ b/Applications/CMC/tests/testCMCArm26_Millard.cpp
@@ -20,12 +20,13 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
+
+#include <catch2/catch_all.hpp>
 
 #include <fstream>
 #include <thread>
@@ -33,10 +34,9 @@
 using namespace OpenSim;
 using namespace std;
 
-void testCMCArm26() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                     testCMCArm26_Millard                          *" << endl;
-    cout << "******************************************************************\n" << endl;
+TEST_CASE("testCMCArm26_Millard") {
+    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+
     CMCTool cmc("arm26_Setup_CMC.xml");
     cmc.setResultsDir("Results_Arm26_Millard");
     cmc.run();
@@ -58,31 +58,4 @@ void testCMCArm26() {
 
     CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__, __LINE__,
         base+" failed");
-
-
-    cout << "\n" << base <<" passed\n" << endl;
 }
-
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
-
-    try{
-        testCMCArm26();
-    }catch (const std::exception& e) {
-        cout << e.what() <<endl; failures.push_back("testCMCArm26_Millard");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-

--- a/Applications/CMC/tests/testCMCArm26_Thelen.cpp
+++ b/Applications/CMC/tests/testCMCArm26_Thelen.cpp
@@ -20,20 +20,18 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testCMCArm26() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                      testCMCArm26_Thelen                          *" << endl;
-    cout << "******************************************************************\n" << endl;
+TEST_CASE("testCMCArm26_Thelen") {
     CMCTool cmc("arm26_Setup_CMC.xml");
     cmc.run();
 
@@ -48,29 +46,4 @@ void testCMCArm26() {
 
     CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__, __LINE__,
         base+" failed");
-
-
-    cout << "\n" << base <<" passed\n" << endl;
 }
-
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    try{
-        testCMCArm26();
-    } catch(const std::exception& e) {
-        cout << e.what() <<endl; failures.push_back("testCMCArm26");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-

--- a/Applications/CMC/tests/testCMCEMGDrivenArm_Millard.cpp
+++ b/Applications/CMC/tests/testCMCEMGDrivenArm_Millard.cpp
@@ -20,20 +20,20 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testCMCEMGDrivenArm() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                 testCMCEMGDrivenArm_Millard                    *" << endl;
-    cout << "******************************************************************\n" << endl;
+TEST_CASE("testCMCEMGDrivenArm_Millard") {
+    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+
     CMCTool cmc("arm26_Setup_ComputedMuscleControl_EMG.xml");
     cmc.setResultsDir("Results_Arm26_EMG_Millard");
     cmc.run();
@@ -49,31 +49,6 @@ void testCMCEMGDrivenArm() {
     rms_tols[10] = 0.50;  // biceps long normally low but because of EMG tracking should be on more
     rms_tols[12] = 0.50;  // biceps short normally on but because of EMG tracking should be lower
 
-    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols, __FILE__, __LINE__, "testCMCEMGDrivenArm failed");
-
-    const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
-    cout << "\ntestCMCEMGDrivenArm_ "+muscleType+ " passed\n" << endl;
+    CHECK_STORAGE_AGAINST_STANDARD(results, standard, rms_tols,
+        __FILE__, __LINE__, "testCMCEMGDrivenArm_Millard failed");
 }
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
-
-    try{
-        testCMCEMGDrivenArm();
-    } catch (const std::exception& e) {
-        cout << e.what() <<endl; failures.push_back("testCMCEMGDrivenArm_Millard");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-

--- a/Applications/CMC/tests/testCMCEMGDrivenArm_Thelen.cpp
+++ b/Applications/CMC/tests/testCMCEMGDrivenArm_Thelen.cpp
@@ -20,20 +20,18 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testCMCEMGDrivenArm() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*               testCMCEMGDrivenArm_Thelen                       *" << endl;
-    cout << "******************************************************************\n" << endl;
+TEST_CASE("testCMCEMGDrivenArm_Thelen") {
     CMCTool cmc("arm26_Setup_ComputedMuscleControl_EMG.xml");
     cmc.setResultsDir("Results_Arm26_EMG_Thelen");
     cmc.run();
@@ -54,28 +52,4 @@ void testCMCEMGDrivenArm() {
     CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols,
                                     __FILE__, __LINE__,
                                     "testCMCEMGDrivenArm_Thelen failed");
-
-    const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
-    cout << "\ntestCMCEMGDrivenArm_"+muscleType+ " passed\n" << endl;
 }
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    try{
-        testCMCEMGDrivenArm();
-    } catch(const std::exception& e) {
-        cout << e.what() <<endl; failures.push_back("testCMCEMGDrivenArm");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-

--- a/Applications/CMC/tests/testCMCGait10dof18musc.cpp
+++ b/Applications/CMC/tests/testCMCGait10dof18musc.cpp
@@ -20,7 +20,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Common/GCVSplineSet.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Tools/CMCTool.h>

--- a/Applications/CMC/tests/testCMCLeg6Dof9Musc.cpp
+++ b/Applications/CMC/tests/testCMCLeg6Dof9Musc.cpp
@@ -20,58 +20,20 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testLeg6Dof9MuscSwing();
-void testLeg6Dof9MuscStance();
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    try {
-        testLeg6Dof9MuscSwing();
-    } catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testLeg6Dof9MuscSwing");
-    }
-    try {
-        testLeg6Dof9MuscStance();
-    } catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testLeg6Dof9MuscStance");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-
 // Perform regression test with standard generated from Leg6Dof9Musc
 // example in OpenSim 4.1
-void testLeg6Dof9MuscSwing() {
-    cout << "\n****************************************************************"
-            "**"
-         << endl;
-    cout << "*                      testLeg6Dof9Musc Swing                     "
-            "*"
-         << endl;
-    cout << "******************************************************************"
-            "\n"
-         << endl;
+TEST_CASE("testLeg6Dof9MuscSwing") {
     CMCTool cmc("leg6dof9musc_setup_Swing.xml");
     CoordinateSet& coordSet = cmc.getModel().updCoordinateSet();
     // Lock pelvis coordinates per tutorial
@@ -93,19 +55,9 @@ void testLeg6Dof9MuscSwing() {
 
     CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__,
             __LINE__, "testLeg6Dof9Musc Swing failed");
-
-    cout << "\ntestLeg6Dof9Musc Swing passed\n" << endl;
 }
-void testLeg6Dof9MuscStance() {
-    cout << "\n****************************************************************"
-            "**"
-         << endl;
-    cout << "*                      testLeg6Dof9Musc Stance                     "
-            "*"
-         << endl;
-    cout << "******************************************************************"
-            "\n"
-         << endl;
+
+TEST_CASE("testLeg6Dof9MuscStance") {
     CMCTool cmc("leg69_Setup_CMC_Stance.xml");
 
     if (!cmc.run())
@@ -125,8 +77,6 @@ void testLeg6Dof9MuscStance() {
 
     CHECK_STORAGE_AGAINST_STANDARD(results, *standard, rms_tols, __FILE__,
             __LINE__, "testLeg6Dof9Musc Stance failed");
-
-    cout << "\ntestLeg6Dof9Musc Stance passed\n" << endl;
 }
 
 

--- a/Applications/CMC/tests/testCMCSingleMuscle.cpp
+++ b/Applications/CMC/tests/testCMCSingleMuscle.cpp
@@ -20,81 +20,63 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testSingleMuscle();
+namespace {
 
-int main() {
+    void testSingleMuscle() {
 
-    SimTK::Array_<std::string> failures;
+        ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
+        CMCTool cmc("block_hanging_from_muscle_Setup_CMC.xml");
 
-    try {testSingleMuscle();}
-    catch (const std::exception& e)
-        {  cout << e.what() <<endl; failures.push_back("testSingleMuscle"); }
+        const string& muscleType =
+            cmc.getModel().getMuscles()[0].getConcreteClassName();
+        string base = "testSingleMuscle_" + muscleType;
 
-    // redo with the Millard2012EquilibriumMuscle
-    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+        // test MUST fail if forward simulation fails to run to completion.
+        OPENSIM_THROW_IF(!forward.run(), Exception, base + ": Failed running ForwardTool.");
+        // test MUST fail if CMC fails to track to completion.
+        OPENSIM_THROW_IF(!cmc.run(), Exception, base + ": Failed running CMCTool.");
 
-    try { testSingleMuscle();}
-    catch (const std::exception& e)
-        {   cout << e.what() <<endl;
-            failures.push_back("testSingleMuscle_Millard"); }
+        Storage fwd_controls("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_controls.sto");
+        Storage cmc_controls("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_controls.sto");
 
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
+        Storage fwd_force("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_ForceReporter_forces.sto");
+        Storage cmc_force("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_Actuation_force.sto");
+
+        Storage fwd_states("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
+        Storage cmc_states("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
+
+        std::vector<double> control_tols(1, 4.0e-3); // peak control is 0.2 so this is 2% of peak
+        std::vector<double> force_tols(1, 1.0e-1);   // 0.1 N
+        std::vector<double> state_tols(4, 1.0e-3);   // errors: q<1mm, u<1mm/s, a<0.001, fl<1mm
+
+        CHECK_STORAGE_AGAINST_STANDARD(cmc_controls, fwd_controls, control_tols,
+            __FILE__, __LINE__, base + " controls failed");
+
+        CHECK_STORAGE_AGAINST_STANDARD(cmc_force, fwd_force, force_tols,
+            __FILE__, __LINE__, base + " forces failed");
+
+        CHECK_STORAGE_AGAINST_STANDARD(fwd_states, cmc_states, state_tols,
+            __FILE__, __LINE__, base+" states failed");
     }
 
-    cout << "Done" << endl;
-
-    return 0;
 }
 
-void testSingleMuscle() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                         testSingleMuscle                       *" << endl;
-    cout << "******************************************************************\n" << endl;
-    ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
-    CMCTool cmc("block_hanging_from_muscle_Setup_CMC.xml");
+TEST_CASE("testSingleMuscle_Thelen") {
+    testSingleMuscle();
+}
 
-    const string& muscleType =
-        cmc.getModel().getMuscles()[0].getConcreteClassName();
-    string base = "testSingleMuscle_" + muscleType;
-
-    // test MUST fail if forward simulation fails to run to completion.
-    OPENSIM_THROW_IF(!forward.run(), Exception, base + ": Failed running ForwardTool.");
-    // test MUST fail if CMC fails to track to completion.
-    OPENSIM_THROW_IF(!cmc.run(), Exception, base + ": Failed running CMCTool.");
-
-    Storage fwd_controls("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_controls.sto");
-    Storage cmc_controls("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_controls.sto");
-
-    Storage fwd_force("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_ForceReporter_forces.sto");
-    Storage cmc_force("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_Actuation_force.sto");
-
-    Storage fwd_states("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
-    Storage cmc_states("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
-
-    std::vector<double> control_tols(1, 4.0e-3); // peak control is 0.2 so this is 2% of peak
-    std::vector<double> force_tols(1, 1.0e-1);   // 0.1 N
-    std::vector<double> state_tols(4, 1.0e-3);   // errors: q<1mm, u<1mm/s, a<0.001, fl<1mm
-
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_controls, fwd_controls, control_tols,
-        __FILE__, __LINE__, base + " controls failed");
-
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_force, fwd_force, force_tols,
-        __FILE__, __LINE__, base + " forces failed");
-
-    CHECK_STORAGE_AGAINST_STANDARD(fwd_states, cmc_states, state_tols,
-        __FILE__, __LINE__, base+" states failed");
-
-    cout << "\n" << base << " passed\n" << endl;
+TEST_CASE("testSingleMuscle_Millard") {
+    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+    testSingleMuscle();
 }

--- a/Applications/CMC/tests/testCMCSingleRigidTendonMuscle.cpp
+++ b/Applications/CMC/tests/testCMCSingleRigidTendonMuscle.cpp
@@ -20,50 +20,18 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testSingleRigidTendonMuscle();
-void testSingleMillardRigidTendonMuscle();
-
-int main() {
-
-    SimTK::Array_<std::string> failures;
-
-    try {testSingleRigidTendonMuscle();}
-    catch (const std::exception& e)
-        {  cout << e.what() <<endl; failures.push_back("testSingleRigidTendonMuscle"); }
-
-    // redo with the Millard2012EquilibriumMuscle
-    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
-
-    try {testSingleMillardRigidTendonMuscle();}
-    catch (const std::exception& e)
-        {   cout << e.what() <<endl;
-            failures.push_back("testSingleMillardRigidTendonMuscle"); }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-
-void testSingleRigidTendonMuscle() {
-    cout << "\n******************************************************************" << endl;
-    cout << "*                   testSingleRigidTendonMuscle                  *" << endl;
-    cout << "******************************************************************\n" << endl;
-
+TEST_CASE("testSingleRigidTendonMuscle") {
     ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
     forward.setResultsDir("block_hanging_from_rigid_thelen_muscle_ForwardResults");
     forward.run();
@@ -84,15 +52,12 @@ void testSingleRigidTendonMuscle() {
     CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result,
         std::vector<double>(4, 0.002), __FILE__, __LINE__,
         "testSingleRigidTendonMuscle failed");
-
-    cout << "testSingleRigidTendonMuscle passed\n" << endl;
 }
 
 
-void testSingleMillardRigidTendonMuscle() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*               testSingleMillardRigidTendonMuscle               *" << endl;
-    cout << "******************************************************************\n" << endl;
+TEST_CASE("testSingleMillardRigidTendonMuscle") {
+    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+
     ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
     forward.setResultsDir("block_hanging_from_rigid_millard_muscle_ForwardResults");
     Model& fwdModel = forward.getModel();
@@ -114,6 +79,4 @@ void testSingleMillardRigidTendonMuscle() {
     CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result,
         std::vector<double>(3, 0.002), __FILE__, __LINE__,
         "testSingleMillardRigidTendonMuscle failed");
-
-    cout << "testSingleMillardRigidTendonMuscle passed\n" << endl;
 }

--- a/Applications/CMC/tests/testCMCTwoMusclesOnBlock.cpp
+++ b/Applications/CMC/tests/testCMCTwoMusclesOnBlock.cpp
@@ -20,126 +20,47 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// INCLUDE
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/AnalysisSet.h>
 #include <OpenSim/Tools/CMCTool.h>
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testTwoMusclesOnBlock();
+namespace {
 
-int main() {
+    void testTwoMusclesOnBlock() {
+        ForwardTool forward("twoMusclesOnBlock_Setup_Forward.xml");
+        forward.run();
 
-    SimTK::Array_<std::string> failures;
+        CMCTool cmc("twoMusclesOnBlock_Setup_CMC.xml");
+        cmc.run();
 
-    try {testTwoMusclesOnBlock();}
-    catch (const std::exception& e)
-        {  cout << e.what() <<endl; failures.push_back("testTwoMusclesOnBlock"); }
+        Storage fwd_result("twoMusclesOnBlock_ForwardResults/twoMusclesOnBlock_forward_states.sto");
+        Storage cmc_result("twoMusclesOnBlock_ResultsCMC/twoMusclesOnBlock_tugOfWar_states.sto");
 
-    // redo with the Millard2012EquilibriumMuscle
-    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+        std::vector<double> rms_tols(6, 0.001);
+        rms_tols[1] = 0.0025; // block_u
+        rms_tols[2] = 0.05;  // muscle 1 activation
+        rms_tols[4] = 0.05;  // muscle 2 activation
 
-    try {testTwoMusclesOnBlock();}
-    catch (const std::exception& e)
-        {   cout << e.what() <<endl;
-            failures.push_back("testTwoMusclesOnBlock_Millard"); }
+        const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
+        string base = "testTwoMusclesOnBlock "+ muscleType;
 
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
+        CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, rms_tols,
+            __FILE__, __LINE__, base+" failed");
     }
-
-    cout << "Done" << endl;
-
-    return 0;
 }
 
-void testSingleRigidTendonMuscle() {
-    cout << "\n******************************************************************" << endl;
-    cout << "*                   testSingleRigidTendonMuscle                  *" << endl;
-    cout << "******************************************************************\n" << endl;
-
-    Model model("block_hanging_RigidTendonMuscle.osim");
-    Model* modelCopy = model.clone();
-    modelCopy->setup();
-    ASSERT(model == *modelCopy);
-
-    ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
-    forward.setModel(model);
-    forward.run();
-
-    // Use copy of the model because forward adds a ControlSetController to the model and the controls from CMC
-    // are added in with those "feedforward" controls. Instead we want to verify that CMC can compute these
-    // same controls
-    CMCTool cmc("block_hanging_from_muscle_Setup_CMC.xml");
-    cmc.setModel(*modelCopy);
-    cmc.run();
-
-    Storage fwd_result("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
-    Storage cmc_result("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
-
-    // Tolerance of 2mm or position error and 2mm/s translational velocity of the block
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result,
-        std::vector<double>(4, 0.0025), __FILE__, __LINE__,
-        "testSingleRigidTendonMuscle failed");
-
-    cout << "testSingleRigidTendonMuscle passed\n" << endl;
+TEST_CASE("testTwoMusclesOnBlock_Thelen") {
+    testTwoMusclesOnBlock();
 }
 
-
-void testSingleMillardRigidTendonMuscle() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*               testSingleMillardRigidTendonMuscle               *" << endl;
-    cout << "******************************************************************\n" << endl;
-    ForwardTool forward("block_hanging_from_muscle_Setup_Forward.xml");
-    Model& fwdModel = forward.getModel();
-    fwdModel.getMuscles()[0].set_ignore_tendon_compliance(true); //make tendon rigid
-    forward.run();
-
-    CMCTool cmc("block_hanging_from_muscle_Setup_CMC.xml");
-    Model& cmcModel = cmc.getModel();
-    cmcModel.getMuscles()[0].set_ignore_tendon_compliance(true); //make tendon rigid
-    cmc.run();
-
-    Storage fwd_result("block_hanging_from_muscle_ForwardResults/block_hanging_from_muscle_states.sto");
-    Storage cmc_result("block_hanging_from_muscle_ResultsCMC/block_hanging_from_muscle_states.sto");
-
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result,
-        std::vector<double>(3, 0.002), __FILE__, __LINE__,
-        "testSingleMillardRigidTendonMuscle failed");
-
-    cout << "testSingleMillardRigidTendonMuscle passed\n" << endl;
+TEST_CASE("testTwoMusclesOnBlock_Millard") {
+    Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
+    testTwoMusclesOnBlock();
 }
-
-void testTwoMusclesOnBlock() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                       testTwoMusclesOnBlock                    *" << endl;
-    cout << "******************************************************************\n" << endl;
-
-    ForwardTool forward("twoMusclesOnBlock_Setup_Forward.xml");
-    forward.run();
-
-    CMCTool cmc("twoMusclesOnBlock_Setup_CMC.xml");
-    cmc.run();
-
-    Storage fwd_result("twoMusclesOnBlock_ForwardResults/twoMusclesOnBlock_forward_states.sto");
-    Storage cmc_result("twoMusclesOnBlock_ResultsCMC/twoMusclesOnBlock_tugOfWar_states.sto");
-
-    std::vector<double> rms_tols(6, 0.001);
-    rms_tols[1] = 0.0025; // block_u
-    rms_tols[2] = 0.05;  // muscle 1 activation
-    rms_tols[4] = 0.05;  // muscle 2 activation
-
-    const string& muscleType = cmc.getModel().getMuscles()[0].getConcreteClassName();
-    string base = "testTwoMusclesOnBlock "+ muscleType;
-
-    CHECK_STORAGE_AGAINST_STANDARD(cmc_result, fwd_result, rms_tols,
-        __FILE__, __LINE__, base+" failed");
-
-    cout << "\n" << base << " passed\n" << endl;
-}
-

--- a/Applications/CMC/tests/testCMCWithControlConstraintsGait2354.cpp
+++ b/Applications/CMC/tests/testCMCWithControlConstraintsGait2354.cpp
@@ -27,35 +27,15 @@
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testGait2354();
-
-int main() {
+TEST_CASE("testGait2354") {
     Object::renameType("Thelen2003Muscle", "Thelen2003Muscle_Deprecated");
     //Object::renameType("Thelen2003Muscle", "Millard2012AccelerationMuscle");
     //Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
-    SimTK::Array_<std::string> failures;
-
-    try {testGait2354();}
-    catch (const std::exception& e)
-        {  cout << e.what() <<endl; failures.push_back("testGait2354"); }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-
-void testGait2354() {
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                          testGait2354                          *" << endl;
-    cout << "******************************************************************\n" << endl;
 
     CMCTool cmc("subject01_Setup_CMC.xml");
     cmc.run();
@@ -87,6 +67,4 @@ void testGait2354() {
 
     CHECK_STORAGE_AGAINST_STANDARD(results2, standard2, rms_tols2,
         __FILE__, __LINE__, "testGait2354 states failed");
-
-    cout << "\n testGait2354 passed\n" << endl;
 }

--- a/Applications/CMC/tests/testCMCWithControlConstraintsRunningModel.cpp
+++ b/Applications/CMC/tests/testCMCWithControlConstraintsRunningModel.cpp
@@ -27,37 +27,17 @@
 #include <OpenSim/Tools/ForwardTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testRunningModel();
 
-int main() {
-
+TEST_CASE("testRunningModel") {
     Object::renameType("Thelen2003Muscle", "Thelen2003Muscle_Deprecated");
     //Object::renameType("Thelen2003Muscle", "Millard2012AccelerationMuscle");
     //Object::renameType("Thelen2003Muscle", "Millard2012EquilibriumMuscle");
-    SimTK::Array_<std::string> failures;
 
-    try {testRunningModel();}
-    catch (const std::exception& e)
-        {  cout << e.what() <<endl; failures.push_back("testRunningModel"); }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-
-    return 0;
-}
-
-void testRunningModel()
-{
-    cout<<"\n******************************************************************" << endl;
-    cout << "*                     testRunningModel                     *" << endl;
-    cout << "******************************************************************\n" << endl;
     CMCTool cmc("runningModel_Setup_CMC_test.xml");
     cmc.run();
 


### PR DESCRIPTION
Fixes issue #3555 

### Brief summary of changes

Converts the tests in `Applications/CMC/` to the Catch2 test framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4403)
<!-- Reviewable:end -->
