### PR TITLE
remove unused ModelComponent overrides in GimbalJoint

### DIFF
--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.cpp
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.cpp
@@ -45,37 +45,4 @@ void GimbalJoint::extendAddToSystem(SimTK::MultibodySystem& system) const
     createMobilizedBody<MobilizedBody::Gimbal>(system);
 }
 
-void GimbalJoint::extendInitStateFromProperties(SimTK::State& s) const
-{
-    Super::extendInitStateFromProperties(s);
 
-    const MultibodySystem& system = _model->getMultibodySystem();
-    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
-    if (matter.getUseEulerAngles(s))
-        return;
-
-    double xangle = getCoordinate(GimbalJoint::Coord::Rotation1X).getDefaultValue();
-    double yangle = getCoordinate(GimbalJoint::Coord::Rotation2Y).getDefaultValue();
-    double zangle = getCoordinate(GimbalJoint::Coord::Rotation3Z).getDefaultValue();
-    Rotation r(BodyRotationSequence, xangle, XAxis, yangle, YAxis, zangle, ZAxis);
-
-    //GimbalJoint* mutableThis = const_cast<GimbalJoint*>(this);
-    getChildFrame().getMobilizedBody().setQToFitRotation(s, r);
-}
-
-void GimbalJoint::extendSetPropertiesFromState(const SimTK::State& state)
-{
-    Super::extendSetPropertiesFromState(state);
-
-    // Override default behavior in case of quaternions.
-    const MultibodySystem&        system = _model->getMultibodySystem();
-    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
-    if (!matter.getUseEulerAngles(state)) {
-        Rotation r = getChildFrame().getMobilizedBody().getBodyRotation(state);
-
-        Vec3 angles = r.convertRotationToBodyFixedXYZ();
-        updCoordinate(GimbalJoint::Coord::Rotation1X).setDefaultValue(angles[0]);
-        updCoordinate(GimbalJoint::Coord::Rotation2Y).setDefaultValue(angles[1]);
-        updCoordinate(GimbalJoint::Coord::Rotation3Z).setDefaultValue(angles[2]);
-    }
-}

--- a/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
+++ b/OpenSim/Simulation/SimbodyEngine/GimbalJoint.h
@@ -111,8 +111,6 @@ public:
 protected:
     // ModelComponent interface.
     void extendAddToSystem(SimTK::MultibodySystem& system) const override;
-    void extendInitStateFromProperties(SimTK::State& s) const override;
-    void extendSetPropertiesFromState(const SimTK::State& state) override;
 
 //=============================================================================
 };  // END of class GimbalJoint


### PR DESCRIPTION
Fixes issue #4300

### Brief summary of changes
- Removed the `extendInitStateFromProperties()` and `extendSetPropertiesFromState()` overrides from `GimbalJoint` (`GimbalJoint.h` and `GimbalJoint.cpp`).
- As noted in issue #4300 , `SimTK::MobilizedBody::Gimbal` only uses Euler angles and never uses quaternions. The quaternion handling in these overrides was unreachable dead code.
- `GimbalJoint` now safely uses the default implementation from the base `Joint` class.

### Testing I've completed
- Rebuilt `osimSimulation` with the methods removed.
- Ran `testJoints` locally to verify that joint initialization and simulations pass with zero regressions:

<img width="809" height="152" alt="image" src="https://github.com/user-attachments/assets/cfc6f73a-5675-43e4-a79c-9ea14d5a9cfb" />


### Looking for feedback on...
 If any additional tests are needed or if this cleanup is ready to merge.

### CHANGELOG.md (choose one)

- no need to update because...
- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4406)
<!-- Reviewable:end -->
