### PR TITLE
Upgrade SWIG to 4.2.1 for python wheels

### DIFF
--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install SWIG
       run: |
-        choco install swig --version 4.1.1 --yes --limit-output --allow-downgrade
+        choco install swig --version 4.2.1 --yes --limit-output --allow-downgrade
         swig -swiglib
 
     - name: Build dependencies
@@ -106,8 +106,9 @@ jobs:
 
     - name: Install Homebrew packages
       run: |
-        brew install pkgconfig autoconf libtool automake wget pcre llvm
+        brew install pkgconfig autoconf libtool automake wget pcre llvm bison
         brew reinstall gcc
+        echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
         pip3 install numpy==2.4.2
         pip3 install wheel
         pip3 install build
@@ -115,8 +116,8 @@ jobs:
     - name: Install SWIG
       run: |
         mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        wget https://github.com/swig/swig/archive/refs/tags/v4.2.1.tar.gz
+        tar xzf v4.2.1.tar.gz && cd swig-4.2.1
         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
         make && make -j4 install
 
@@ -211,11 +212,17 @@ jobs:
         gzip \
         patchelf
 
+        wget https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz
+        tar -xzf bison-3.8.2.tar.gz
+        cd bison-3.8.2
+        ./configure --prefix=/usr/local
+        make -j"$(nproc)"
+        make install
     - name: Install SWIG
       run: |
         mkdir ~/swig-source && cd ~/swig-source
-        wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
-        tar xzf v4.1.1.tar.gz && cd swig-4.1.1
+        wget https://github.com/swig/swig/archive/refs/tags/v4.2.1.tar.gz
+        tar xzf v4.2.1.tar.gz && cd swig-4.2.1
         sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
         make && make -j4 install
 

--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -108,7 +108,6 @@ jobs:
       run: |
         brew install pkgconfig autoconf libtool automake wget pcre llvm bison
         brew reinstall gcc
-        echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
         pip3 install numpy==2.4.2
         pip3 install wheel
         pip3 install build
@@ -118,7 +117,7 @@ jobs:
         mkdir ~/swig-source && cd ~/swig-source
         wget https://github.com/swig/swig/archive/refs/tags/v4.2.1.tar.gz
         tar xzf v4.2.1.tar.gz && cd swig-4.2.1
-        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        sh autogen.sh && BISON="$(brew --prefix bison)/bin/bison" ./configure --prefix=$HOME/swig --disable-ccache
         make && make -j4 install
 
     - name: Build dependencies
@@ -218,6 +217,7 @@ jobs:
         ./configure --prefix=/usr/local
         make -j"$(nproc)"
         make install
+
     - name: Install SWIG
       run: |
         mkdir ~/swig-source && cd ~/swig-source


### PR DESCRIPTION
Fixes issue #4404 

### Brief summary of changes

The bulk of the work to make the code base compatible with SWIG > 4.1.1 was done in https://github.com/opensim-org/opensim-core/pull/4028. The wheels that are generated for the python bindings use SWIG 4.2 though which is missing some critical features like correctly wrapping the `using` declaration. This updates the SWIG version to 4.2 for generating these wheels. 

SWIG 4.2.1 requires a modern version of bison, so I upgraded it for the linux and OSX builds. This involved making sure that the installed SWIG version was before the bundle version for OSX, so that is why we do `echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"`

### Testing I've completed

You can see the run here: https://github.com/RTnhN/opensim-core/actions/runs/32312066274

I also installed the wheel for my linux machine, and tested the features that were missing between SWIG 4.1.1 and SWIG 4.2.1, and they work great. 

### Looking for feedback on...


### CHANGELOG.md (choose one)

- I have not changed the CHANGELOG.md yet. After I get feedback on the change, I can make the change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4407)
<!-- Reviewable:end -->
