### PR TITLE
Convert tests in `Applications/Analyze/` to the Catch2 testing framework

### DIFF
--- a/Applications/Analyze/tests/testAnalyzeTool.cpp
+++ b/Applications/Analyze/tests/testAnalyzeTool.cpp
@@ -42,85 +42,156 @@
 #include <OpenSim/Common/Constant.h>
 #include <OpenSim/Common/GCVSplineSet.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-void testTutorialOne();
-void testActuationAnalysisWithDisabledForce();
+namespace {
 
-// Test different default activations are respected when activation
-// states are not provided.
-void testTugOfWar(const string& dataFileName, const double& defaultAct);
+    // Test different default activations are respected when activation
+    // states are not provided.
+    void testTugOfWar(const string& dataFileName, const double& defaultAct) {
+        AnalyzeTool analyze("Tug_of_War_Setup_Analyze.xml");
+        analyze.setCoordinatesFileName("");
+        analyze.setStatesFileName("");
 
-void testBodyKinematics();
+        // Access the model and muscle being analyzed
+        Model& model = analyze.getModel();
+        Millard2012EquilibriumMuscle& muscle =
+            static_cast<Millard2012EquilibriumMuscle&>(model.updMuscles()[0]);
+        bool isCoordinatesOnly = true;
+        // Load in the States used to recompute the results of the Analysis
+        Storage dataStore(dataFileName);
+        if (dataStore.getColumnLabels().findIndex(muscle.getName() + ".activation") > 0) {
+            isCoordinatesOnly = false;
+            analyze.setStatesFileName(dataFileName);
+            // ramp input starts at 0.0
+            muscle.set_minimum_activation(0.0);
+        }
+        else {
+            analyze.setCoordinatesFileName(dataFileName);
+        }
 
-void testIMUDataReporter();
+        // Test that the default activation is taken into consideration by
+        // the Analysis and reflected in the AnalyzeTool solution
+        muscle.set_default_activation(defaultAct);
 
-void testMuscleAnalysisSerialization();
+        analyze.run();
 
-int main()
-{
-    SimTK::Array_<std::string> failures;
+        // Load the AnalyzTool results for the muscle's force through time
+        TimeSeriesTable_<double> results(
+            "Analyze_Tug_of_War/Tug_of_War_Millard_Iso_ForceReporter_forces.sto");
+        assert(results.getNumColumns() == 1);
+        SimTK::Vector forces = results.getDependentColumnAtIndex(0);
 
-    try { testTutorialOne(); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl; failures.push_back("testTutorialOne");
+        TimeSeriesTable_<double> outputs_table(
+            "Analyze_Tug_of_War/Tug_of_War_Millard_Iso_Outputs.sto");
+        SimTK::Vector tf_output = outputs_table.getDependentColumnAtIndex(1);
+
+        // Load input data as StatesTrajectory used to perform the Analysis
+        auto statesTraj = StatesTrajectory::createFromStatesStorage(
+            model, dataStore, true, false);
+        size_t nstates = statesTraj.getSize();
+
+        // muscle active, passive, total muscle and tendon force quantities
+        double af, pf, mf, tf, fl;
+        af= pf = mf = tf = fl = SimTK::NaN;
+
+        // Tolerance for muscle equilibrium solution
+        const double equilTol = muscle.getMaxIsometricForce()*SimTK::SqrtEps;
+
+        // The maximum acceptable change in force between two contiguous states
+        const double maxDelta = muscle.getMaxIsometricForce() / 10;
+
+        SimTK::State s = model.getWorkingState();
+        // Independently compute the active fiber force at every state
+        for (size_t i = 0; i < nstates; ++i) {
+            s = statesTraj[i];
+            // When the muscle states are not supplied in the input dataStore
+            // (isCoordinatesOnly == true), then set it to its default value.
+            if (isCoordinatesOnly) {
+                muscle.setActivation(s, muscle.get_default_activation());
+            }
+            // technically, fiber lengths could be supplied, but this test case
+            // (a typical use case) does not and therefore set to its default.
+            muscle.setFiberLength(s, muscle.get_default_fiber_length());
+            try {
+                muscle.computeEquilibrium(s);
+            }
+            catch (const MuscleCannotEquilibrate& x) {
+                // Write out the muscle equilibrium for error as a function of
+                // fiber-length.
+                reportTendonAndFiberForcesAcrossFiberLengths(muscle, s);
+                throw x;
+            }
+            model.realizeDynamics(s);
+
+            // Get the fiber-length
+            fl = muscle.getFiberLength(s);
+
+            cout << "t = " << s.getTime() << " | fiber_length = " << fl <<
+            " : default_fiber_length = " << muscle.get_default_fiber_length() << endl;
+
+            SimTK_ASSERT_ALWAYS(fl >= muscle.getMinimumFiberLength(),
+                "Equilibrium failed to compute valid fiber length.");
+
+            if (isCoordinatesOnly) {
+                // check that activation is not reset to zero or other value
+                SimTK_ASSERT_ALWAYS(muscle.getActivation(s) == defaultAct,
+                    "Test failed to correctly use the default activation value.");
+            }
+            else {
+                // check that activation used was that supplied by the dataStore
+                SimTK_ASSERT_ALWAYS(muscle.getActivation(s) == s.getTime(),
+                    "Test failed to correctly use the supplied activation values.");
+            }
+
+            // get active and passive forces given the default activation
+            af = muscle.getActiveFiberForceAlongTendon(s);
+            pf = muscle.getPassiveFiberForceAlongTendon(s);
+
+            // now the total muscle force is the active + passive
+            mf = af + pf;
+            tf = muscle.getTendonForce(s);
+
+            // equilibrium demands tendon and muscle fiber are equivalent
+            ASSERT_EQUAL<double>(tf, mf, equilTol);
+            // Verify that the current computed and AnalyzeTool reported force are
+            // equivalent for the provided motion file
+            cout << s.getTime() << " :: muscle-fiber-force: " << mf <<
+                " Analyze reported force: " << forces[int(i)] << endl;
+            ASSERT_EQUAL<double>(mf, forces[int(i)], equilTol, __FILE__, __LINE__,
+                "Total fiber force failed to match reported muscle force.");
+
+            cout << s.getTime() << " :: tendon-force: " << tf <<
+                " Analyze Output reported: " << tf_output[int(i)] << endl;
+            ASSERT_EQUAL<double>(tf, tf_output[int(i)], equilTol,
+                __FILE__, __LINE__,
+                "Output reported muscle-tendon force failed to match computed.");
+
+            double delta = (i > 0) ? abs(forces[int(i)]-forces[int(i-1)]) : 0;
+
+            SimTK_ASSERT_ALWAYS(delta < maxDelta,
+                "Force trajectory has unexplained discontinuity.");
+        }
     }
 
-    // produce passive force-length curve
-    try { testTugOfWar("Tug_of_War_ConstantVelocity.sto", 0.01); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testTugOfWar CoordinatesOnly: default_act = 0.01");
-    }
-
-    // produced passive + active muscle force-length
-    try { testTugOfWar("Tug_of_War_ConstantVelocity.sto", 1.0); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testTugOfWar CoordinatesOnly: default_act = 1.0");
-    }
-
-    // now supply activation states which should be used instead of the default
-    try { testTugOfWar("Tug_of_War_ConstantVelocity_RampActivation.sto", 0.0); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testTugOfWar with activation state provided");
-    }
-
-    try { testActuationAnalysisWithDisabledForce(); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testActuationAnalysisWithDisabledForce");
-    }
-    try { testBodyKinematics(); }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testBodyKinematics");
-    }
-    try {
-        testIMUDataReporter();
-    } catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testIMUDataReporter");
-    }
-    try {
-        testMuscleAnalysisSerialization();
-    } catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testMuscleAnalysisSerialization");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-    return 0;
 }
 
-void testTutorialOne() {
+TEST_CASE("testTugOfWar CoordinatesOnly: default_act = 0.01") {
+    testTugOfWar("Tug_of_War_ConstantVelocity.sto", 0.01);
+}
+
+TEST_CASE("testTugOfWar CoordinatesOnly: default_act = 1.0") {
+    testTugOfWar("Tug_of_War_ConstantVelocity.sto", 1.0);
+}
+
+TEST_CASE("testTugOfWar with activation state provided") {
+     testTugOfWar("Tug_of_War_ConstantVelocity_RampActivation.sto", 0.0);
+}
+
+TEST_CASE("testTutorialOne") {
     AnalyzeTool analyze1("PlotterTool.xml");
     analyze1.getModel().print("testAnalyzeTutorialOne.osim");
     analyze1.run();
@@ -145,131 +216,8 @@ void testTutorialOne() {
     cout << "testAnalyzeTutorialOne passed" << endl;
 }
 
-void testTugOfWar(const string& dataFileName, const double& defaultAct) {
-    AnalyzeTool analyze("Tug_of_War_Setup_Analyze.xml");
-    analyze.setCoordinatesFileName("");
-    analyze.setStatesFileName("");
 
-    // Access the model and muscle being analyzed
-    Model& model = analyze.getModel();
-    Millard2012EquilibriumMuscle& muscle =
-        static_cast<Millard2012EquilibriumMuscle&>(model.updMuscles()[0]);
-    bool isCoordinatesOnly = true;
-    // Load in the States used to recompute the results of the Analysis
-    Storage dataStore(dataFileName);
-    if (dataStore.getColumnLabels().findIndex(muscle.getName() + ".activation") > 0) {
-        isCoordinatesOnly = false;
-        analyze.setStatesFileName(dataFileName);
-        // ramp input starts at 0.0
-        muscle.set_minimum_activation(0.0);
-    }
-    else {
-        analyze.setCoordinatesFileName(dataFileName);
-    }
-
-    // Test that the default activation is taken into consideration by
-    // the Analysis and reflected in the AnalyzeTool solution
-    muscle.set_default_activation(defaultAct);
-
-    analyze.run();
-
-    // Load the AnalyzTool results for the muscle's force through time
-    TimeSeriesTable_<double> results("Analyze_Tug_of_War/Tug_of_War_Millard_Iso_ForceReporter_forces.sto");
-    assert(results.getNumColumns() == 1);
-    SimTK::Vector forces = results.getDependentColumnAtIndex(0);
-
-    TimeSeriesTable_<double> outputs_table("Analyze_Tug_of_War/Tug_of_War_Millard_Iso_Outputs.sto");
-    SimTK::Vector tf_output = outputs_table.getDependentColumnAtIndex(1);
-
-    // Load input data as StatesTrajectory used to perform the Analysis
-    auto statesTraj = StatesTrajectory::createFromStatesStorage(
-        model, dataStore, true, false);
-    size_t nstates = statesTraj.getSize();
-
-    // muscle active, passive, total muscle and tendon force quantities
-    double af, pf, mf, tf, fl;
-    af= pf = mf = tf = fl = SimTK::NaN;
-
-    // Tolerance for muscle equilibrium solution
-    const double equilTol = muscle.getMaxIsometricForce()*SimTK::SqrtEps;
-
-    // The maximum acceptable change in force between two contiguous states
-    const double maxDelta = muscle.getMaxIsometricForce() / 10;
-
-    SimTK::State s = model.getWorkingState();
-    // Independently compute the active fiber force at every state
-    for (size_t i = 0; i < nstates; ++i) {
-        s = statesTraj[i];
-        // When the muscle states are not supplied in the input dataStore
-        // (isCoordinatesOnly == true), then set it to its default value.
-        if (isCoordinatesOnly) {
-            muscle.setActivation(s, muscle.get_default_activation());
-        }
-        // technically, fiber lengths could be supplied, but this test case
-        // (a typical use case) does not and therefore set to its default.
-        muscle.setFiberLength(s, muscle.get_default_fiber_length());
-        try {
-            muscle.computeEquilibrium(s);
-        }
-        catch (const MuscleCannotEquilibrate& x) {
-            // Write out the muscle equilibrium for error as a function of
-            // fiber-length.
-            reportTendonAndFiberForcesAcrossFiberLengths(muscle, s);
-            throw x;
-        }
-        model.realizeDynamics(s);
-
-        // Get the fiber-length
-        fl = muscle.getFiberLength(s);
-
-        cout << "t = " << s.getTime() << " | fiber_length = " << fl <<
-           " : default_fiber_length = " << muscle.get_default_fiber_length() << endl;
-
-        SimTK_ASSERT_ALWAYS(fl >= muscle.getMinimumFiberLength(),
-            "Equilibrium failed to compute valid fiber length.");
-
-        if (isCoordinatesOnly) {
-            // check that activation is not reset to zero or other value
-            SimTK_ASSERT_ALWAYS(muscle.getActivation(s) == defaultAct,
-                "Test failed to correctly use the default activation value.");
-        }
-        else {
-            // check that activation used was that supplied by the dataStore
-            SimTK_ASSERT_ALWAYS(muscle.getActivation(s) == s.getTime(),
-                "Test failed to correctly use the supplied activation values.");
-        }
-
-        // get active and passive forces given the default activation
-        af = muscle.getActiveFiberForceAlongTendon(s);
-        pf = muscle.getPassiveFiberForceAlongTendon(s);
-
-        // now the total muscle force is the active + passive
-        mf = af + pf;
-        tf = muscle.getTendonForce(s);
-
-        // equilibrium demands tendon and muscle fiber are equivalent
-        ASSERT_EQUAL<double>(tf, mf, equilTol);
-        // Verify that the current computed and AnalyzeTool reported force are
-        // equivalent for the provided motion file
-        cout << s.getTime() << " :: muscle-fiber-force: " << mf <<
-            " Analyze reported force: " << forces[int(i)] << endl;
-        ASSERT_EQUAL<double>(mf, forces[int(i)], equilTol, __FILE__, __LINE__,
-            "Total fiber force failed to match reported muscle force.");
-
-        cout << s.getTime() << " :: tendon-force: " << tf <<
-            " Analyze Output reported: " << tf_output[int(i)] << endl;
-        ASSERT_EQUAL<double>(tf, tf_output[int(i)], equilTol,
-            __FILE__, __LINE__,
-            "Output reported muscle-tendon force failed to match computed.");
-
-        double delta = (i > 0) ? abs(forces[int(i)]-forces[int(i-1)]) : 0;
-
-        SimTK_ASSERT_ALWAYS(delta < maxDelta,
-            "Force trajectory has unexplained discontinuity.");
-    }
-}
-
-void testActuationAnalysisWithDisabledForce() {
+TEST_CASE("testActuationAnalysisWithDisabledForce") {
     AnalyzeTool analyze("PlotterTool.xml");
     Model& model = analyze.getModel();
     auto& muscle = model.updMuscles()[0];
@@ -290,7 +238,7 @@ void testActuationAnalysisWithDisabledForce() {
             (int)act_force_table.getNumColumns());
 }
 
-void testBodyKinematics() {
+TEST_CASE("testBodyKinematics") {
     Model model;
     model.setGravity(SimTK::Vec3(0));
     Body* body = new Body("body", 1, SimTK::Vec3(0), SimTK::Inertia(1));
@@ -364,7 +312,7 @@ void testBodyKinematics() {
     ASSERT_EQUAL<double>(groundPosY.getLast(), speedY * duration, tol);
 }
 
-void testIMUDataReporter() {
+TEST_CASE("testIMUDataReporter") {
     Model pendulum = ModelFactory::createNLinkPendulum(2);
 
     BodyKinematics* bodyKinematics = new BodyKinematics(&pendulum);
@@ -588,8 +536,8 @@ void testIMUDataReporter() {
         SimTK_TEST_EQ_TOL(integratedSumSquaredError, 0.0, 1e-5);
     }
 }
-void testMuscleAnalysisSerialization()
-{
+
+TEST_CASE("testMuscleAnalysisSerialization") {
     MuscleAnalysis m;
     m.setComputeMoments(true);
     m.print("manalysis.xml");

--- a/Applications/Analyze/tests/testInducedAccelerations.cpp
+++ b/Applications/Analyze/tests/testInducedAccelerations.cpp
@@ -30,44 +30,48 @@
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 #include <OpenSim/Analyses/InducedAccelerationsSolver.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace SimTK;
 using namespace std;
 
-// Prototypes
-void testDoublePendulumWithSolver();
-void testDoublePendulum();
-Vector calcDoublePendulumUdot(const Model &model, State &s, double Torq1, double Torq2, bool gravity, bool velocity);
+namespace {
+    Vector calcDoublePendulumUdot(const Model &model, State &s, double Torq1,
+            double Torq2, bool gravity, bool velocity) {
+        if(gravity)
+            model.getGravityForce().enable(s);
+        else
+            model.getGravityForce().disable(s);
 
-int main()
-{
-    try {
-        // First case is a simple torque driven double pendulum model
-        // Tool results compared directly Simbody model computed results
-        testDoublePendulumWithSolver();
 
-        // check that analysis version still works
-        testDoublePendulum();
+        if(!velocity)
+            s.updU() = 0.0;
 
-        AnalyzeTool analyze("subject02_Setup_IAA_02_232.xml");
-        analyze.run();
-        Storage result1("ResultsInducedAccelerations/subject02_running_arms_InducedAccelerations_center_of_mass.sto");
-        Storage standard1("std_subject02_running_arms_InducedAccelerations_CENTER_OF_MASS.sto");
-        CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
-            std::vector<double>(result1.getSmallestNumberOfStates(), 0.15),
-            __FILE__, __LINE__, "Induced Accelerations of Running failed");
-        cout << "Induced Accelerations of Running passed\n" << endl;
+        MultibodySystem &sys = model.updMultibodySystem();
+        Vector &mobilityForces = sys.updMobilityForces(s, Stage::Dynamics);
+        sys.realize(s, Stage::Dynamics);
+
+        mobilityForces[0] = Torq1;
+        mobilityForces[1] = Torq2;
+
+        sys.realize(s, Stage::Acceleration);
+
+        return s.getUDot();
     }
-    catch (const OpenSim::Exception& e) {
-        e.print(cerr);
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
 }
 
-void testDoublePendulumWithSolver()
-{
+TEST_CASE("Induced Accelerations of Running") {
+    AnalyzeTool analyze("subject02_Setup_IAA_02_232.xml");
+    analyze.run();
+    Storage result1("ResultsInducedAccelerations/subject02_running_arms_InducedAccelerations_center_of_mass.sto");
+    Storage standard1("std_subject02_running_arms_InducedAccelerations_CENTER_OF_MASS.sto");
+    CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
+        std::vector<double>(result1.getSmallestNumberOfStates(), 0.15),
+        __FILE__, __LINE__, "Induced Accelerations of Running failed");
+}
+
+TEST_CASE("testDoublePendulumWithSolver") {
     std::clock_t startTime = std::clock();
 
     double torq1 = 0.75;
@@ -161,12 +165,9 @@ void testDoublePendulumWithSolver()
         ASSERT_EQUAL(udot[0], udot_torq2[0], 1e-5, __FILE__, __LINE__, "Induced Accelerations of Torq2 for double pendulum q1 FAILED");
         ASSERT_EQUAL(udot[1], udot_torq2[1], 1e-5, __FILE__, __LINE__, "Induced Accelerations of Torq2 for double pendulum q2 FAILED");
     }
-    cout << "Induced Accelerations Solver on double pendulum passed\n" << endl;
-    cout << "Solver computed " << nt << " frames in " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n" << endl;
 }
 
-void testDoublePendulum()
-{
+TEST_CASE("testDoublePendulum") {
     std::clock_t startTime = std::clock();
     AnalyzeTool analyze("double_pendulum_Setup_IAA.xml");
     analyze.run();
@@ -224,30 +225,4 @@ void testDoublePendulum()
         ASSERT_EQUAL(udot[0], u1dot_torq2[i], 1e-5, __FILE__, __LINE__, "Induced Accelerations of Torq2 for double pendulum q1 FAILED");
         ASSERT_EQUAL(udot[1], u2dot_torq2[i], 1e-5, __FILE__, __LINE__, "Induced Accelerations of Torq2 for double pendulum q2 FAILED");
     }
-    cout << "Induced Accelerations of double pendulum passed\n" << endl;
-    cout << "Analysis computed " << nt << " frames in " << 1.e3*(std::clock()-startTime)/CLOCKS_PER_SEC << "ms\n" << endl;
-}
-
-
-Vector calcDoublePendulumUdot(const Model &model, State &s, double Torq1, double Torq2, bool gravity, bool velocity)
-{
-    if(gravity)
-        model.getGravityForce().enable(s);
-    else
-        model.getGravityForce().disable(s);
-
-
-    if(!velocity)
-        s.updU() = 0.0;
-
-    MultibodySystem &sys = model.updMultibodySystem();
-    Vector &mobilityForces = sys.updMobilityForces(s, Stage::Dynamics);
-    sys.realize(s, Stage::Dynamics);
-
-    mobilityForces[0] = Torq1;
-    mobilityForces[1] = Torq2;
-
-    sys.realize(s, Stage::Acceleration);
-
-    return s.getUDot();
 }

--- a/Applications/Analyze/tests/testJointReactions.cpp
+++ b/Applications/Analyze/tests/testJointReactions.cpp
@@ -25,12 +25,14 @@
 #include <OpenSim/OpenSim.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-int main()
-{
-    try {
+TEST_CASE("testJointReactions") {
+
+    SECTION("SinglePin") {
         AnalyzeTool analyze("SinglePin_Setup_JointReaction.xml");
         analyze.run();
         Storage result1("SinglePin_JointReaction_ReactionLoads.sto"),
@@ -38,8 +40,9 @@ int main()
         CHECK_STORAGE_AGAINST_STANDARD(result1, standard1,
             std::vector<double>(standard1.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
             "SinglePin failed");
-        cout << "SinglePin passed" << endl;
+    }
 
+    SECTION("DoublePendulum3D") {
         AnalyzeTool analyze2("DoublePendulum3D_Setup_JointReaction.xml");
         analyze2.run();
         Storage result2("DoublePendulum3D_JointReaction_ReactionLoads.sto"),
@@ -47,30 +50,25 @@ int main()
         CHECK_STORAGE_AGAINST_STANDARD(result2, standard2,
             std::vector<double>(standard2.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
             "DoublePendulum3D failed");
-        cout << "DoublePendulum3D passed" << endl;
+    }
 
+    SECTION("SinglePin_FrameKeyword") {
         AnalyzeTool analyze3("SinglePin_Setup_JointReaction_FrameKeyword.xml");
-        analyze.run();
+        analyze3.run();
         Storage result3("SinglePin_JointReaction_ReactionLoads.sto"),
             standard3("std_SinglePin_JointReaction_ReactionLoads_FrameKeyword.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result3, standard3,
             std::vector<double>(standard3.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
             "SinglePin_FrameKeyword failed");
-        cout << "SinglePin_FrameKeyword passed" << endl;
+    }
 
+    SECTION("DoublePendulum3D_FrameKeyword") {
         AnalyzeTool analyze4("DoublePendulum3D_Setup_JointReaction.xml");
-        analyze2.run();
+        analyze4.run();
         Storage result4("DoublePendulum3D_JointReaction_ReactionLoads.sto"),
             standard4("std_DoublePendulum3D_JointReaction_ReactionLoads_FrameKeyword.sto");
         CHECK_STORAGE_AGAINST_STANDARD(result4, standard4,
             std::vector<double>(standard4.getSmallestNumberOfStates(), 1e-5), __FILE__, __LINE__,
             "DoublePendulum3D_FrameKeyword failed");
-        cout << "DoublePendulum3D_FrameKeyword passed" << endl;
     }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        return 1;
-    }
-    cout << "Done" << endl;
-    return 0;
 }

--- a/Applications/Analyze/tests/testStaticOptimization.cpp
+++ b/Applications/Analyze/tests/testStaticOptimization.cpp
@@ -27,177 +27,106 @@
 #include <OpenSim/Analyses/StaticOptimization.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
-/** @param muscleModelClassName selects from:
-        Thelen2003Muscle_Deprecated
-        Thelen2003Muscle
-        Millard2012EquilibriumMuscle
-        Millard2012AccelerationMuscle
-*/
-void testArm26(const string& muscleModelClassName, double atol, double ftol);
+namespace {
+    void testArm26(const string& muscleModelClassName, double actTol,
+            double forceTol) {
+        Object::renameType( "Thelen2003Muscle", muscleModelClassName);
 
-void testArm26DisabledMuscles();
+        string std_force = "std_";
+        string std_activation = "std_";
+        string std_bounds_force = "std_";
+        string std_bounds_activation = "std_";
 
-void testLapackErrorDLASD4();
+        std_force.append(muscleModelClassName);
+        std_activation.append(muscleModelClassName);
+        std_bounds_force.append(muscleModelClassName);
+        std_bounds_activation.append(muscleModelClassName);
 
-void testModelWithPassiveForces();
+        std_force.append("_arm26_StaticOptimization_force.sto");
+        std_activation.append("_arm26_StaticOptimization_activation.sto");
+        std_bounds_force.append("_arm26_bounds_StaticOptimization_force.sto");
+        std_bounds_activation.append("_arm26_bounds_StaticOptimization_activation.sto");
 
-void testRelativePathInExternalLoads();
+        string resultsDir = "Results_"+muscleModelClassName;
+        const string& muscName = muscleModelClassName;
 
-int main()
-{
-    Array<string> muscleModelNames;
-    muscleModelNames.append("Thelen2003Muscle_Deprecated");
-    muscleModelNames.append("Thelen2003Muscle");
-    muscleModelNames.append("Millard2012EquilibriumMuscle");
-    //muscleModelNames.append("Millard2012AccelerationMuscle");
+        AnalyzeTool analyze1("arm26_Setup_StaticOptimization.xml");
+        analyze1.setResultsDir(resultsDir);
+        analyze1.run();
 
-    // Tolerances for the differences between the current models
-    // and the 'standard' solution, which was closest to using
-    // Thelen2003Muscle_Deprecated muscle formulation.
-    double actTols[4] = {0.005, 0.025, 0.04, 0.04};
-    double forceTols[4] = {1, 4, 5, 6};
+        Storage activations1(resultsDir+"/arm26_StaticOptimization_activation.sto");
+        Storage stdActivations1(std_activation);
+        // Uncomment to use muscle model specific standard
+        //Storage stdActivations1("std_arm26_"+muscName+"_SO_activation.sto");
 
-    SimTK::Array_<std::string> failures;
+        Storage forces1(resultsDir+"/arm26_StaticOptimization_force.sto");
+        Storage stdForces1(std_force);
+        // Uncomment to use muscle model specific standard
+        //Storage stdForces1("std_arm26_"+muscName+"_SO_force.sto");
 
-    for(int i=0; i< muscleModelNames.getSize(); ++i){
-        try { // regression test for the Thelen deprecate muscle
-           // otherwise verify that SO runs with the new models
-            testArm26(muscleModelNames[i], actTols[i], forceTols[i]);
-        }
-        catch (const std::exception& e) {
-            cout << e.what() <<endl;
-            failures.push_back("testArm26_"+muscleModelNames[i]);
-        }
+        CHECK_STORAGE_AGAINST_STANDARD(activations1, stdActivations1,
+                                    std::vector<double>(6, actTol),
+                                    __FILE__, __LINE__,
+                                    "Arm26 activations "+muscName+" failed");
+
+        CHECK_STORAGE_AGAINST_STANDARD(forces1, stdForces1,
+                                    std::vector<double>(6, forceTol),
+                                    __FILE__, __LINE__,
+                                    "Arm26 forces "+muscName+" failed.");
+
+
+        AnalyzeTool analyze2("arm26_bounds_Setup_StaticOptimization.xml");
+        analyze2.setResultsDir(resultsDir);
+        analyze2.run();
+
+        Storage activations2(
+            resultsDir+"/arm26_bounds_StaticOptimization_activation.sto");
+        Storage stdActivations2(std_bounds_activation);
+        // Uncomment to use muscle model specific standard
+        //Storage stdActivations2("std_arm26_bounds_"+muscName+"_SO_activation.sto");
+
+        Storage forces2(resultsDir+"/arm26_bounds_StaticOptimization_force.sto");
+        Storage stdForces2(std_bounds_force);
+        // Uncomment to use muscle model specific standard
+        //Storage stdForces2("std_arm26_bounds_"+muscName+"_SO_force.sto");
+
+        CHECK_STORAGE_AGAINST_STANDARD(activations2, stdActivations2,
+            std::vector<double>(6, actTol),
+            __FILE__, __LINE__,
+            "Arm26 activation "+muscName+" with bounds failed.");
+
+        CHECK_STORAGE_AGAINST_STANDARD(forces2, stdForces2,
+            std::vector<double>(6, forceTol),
+            __FILE__,  __LINE__,
+            "Arm26 forces "+muscName+" with bounds failed.");
     }
-
-    try {
-        testModelWithPassiveForces();
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testModelWithPassiveForces");
-    }
-
-    try {
-        testLapackErrorDLASD4();
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testLapackErrorDLASD4");
-    }
-
-    try {
-        testRelativePathInExternalLoads();
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testRelativePathInExternalLoads");
-    }
-
-    try {
-        testArm26DisabledMuscles();
-    }
-    catch (const std::exception& e) {
-        cout << e.what() << endl;
-        failures.push_back("testArm26DisabledMuscles");
-    }
-
-    if (!failures.empty()) {
-        cout << "Done, with failure(s): " << failures << endl;
-        return 1;
-    }
-
-    cout << "Done" << endl;
-    return 0;
 }
 
-void testArm26(const string& muscleModelClassName, double actTol, double forceTol)
-{
-    Object::renameType( "Thelen2003Muscle", muscleModelClassName);
 
-    cout << "==============================================" << endl;
-    cout << "       "<< muscleModelClassName << endl;
-    cout << "==============================================" << endl;
+TEST_CASE("testArm26") {
+    SECTION("Thelen2003Muscle_Deprecated") {
+        testArm26("Thelen2003Muscle_Deprecated", 0.005, 1.0);
+    }
 
-    string std_force = "std_";
-    string std_activation = "std_";
-    string std_bounds_force = "std_";
-    string std_bounds_activation = "std_";
+    SECTION("Thelen2003Muscle") {
+        testArm26("Thelen2003Muscle", 0.025, 4.0);
+    }
 
-    std_force.append(muscleModelClassName);
-    std_activation.append(muscleModelClassName);
-    std_bounds_force.append(muscleModelClassName);
-    std_bounds_activation.append(muscleModelClassName);
+    SECTION("Millard2012EquilibriumMuscle") {
+        testArm26("Millard2012EquilibriumMuscle", 0.04, 5.0);
+    }
 
-    std_force.append("_arm26_StaticOptimization_force.sto");
-    std_activation.append("_arm26_StaticOptimization_activation.sto");
-    std_bounds_force.append("_arm26_bounds_StaticOptimization_force.sto");
-    std_bounds_activation.append("_arm26_bounds_StaticOptimization_activation.sto");
-
-    string resultsDir = "Results_"+muscleModelClassName;
-    const string& muscName = muscleModelClassName;
-
-    AnalyzeTool analyze1("arm26_Setup_StaticOptimization.xml");
-    analyze1.setResultsDir(resultsDir);
-    analyze1.run();
-
-    Storage activations1(resultsDir+"/arm26_StaticOptimization_activation.sto");
-    Storage stdActivations1(std_activation);
-    // Uncomment to use muscle model specific standard
-    //Storage stdActivations1("std_arm26_"+muscName+"_SO_activation.sto");
-
-    Storage forces1(resultsDir+"/arm26_StaticOptimization_force.sto");
-    Storage stdForces1(std_force);
-    // Uncomment to use muscle model specific standard
-    //Storage stdForces1("std_arm26_"+muscName+"_SO_force.sto");
-
-    CHECK_STORAGE_AGAINST_STANDARD(activations1, stdActivations1,
-                                   std::vector<double>(6, actTol),
-                                   __FILE__, __LINE__,
-                                   "Arm26 activations "+muscName+" failed");
-
-    CHECK_STORAGE_AGAINST_STANDARD(forces1, stdForces1,
-                                   std::vector<double>(6, forceTol),
-                                   __FILE__, __LINE__,
-                                   "Arm26 forces "+muscName+" failed.");
-    cout << resultsDir <<": test Arm26 passed." << endl;
-
-
-    cout << "=============================================================\n" << endl;
-
-    AnalyzeTool analyze2("arm26_bounds_Setup_StaticOptimization.xml");
-    analyze2.setResultsDir(resultsDir);
-    analyze2.run();
-
-    Storage activations2(
-        resultsDir+"/arm26_bounds_StaticOptimization_activation.sto");
-    Storage stdActivations2(std_bounds_activation);
-    // Uncomment to use muscle model specific standard
-    //Storage stdActivations2("std_arm26_bounds_"+muscName+"_SO_activation.sto");
-
-    Storage forces2(resultsDir+"/arm26_bounds_StaticOptimization_force.sto");
-    Storage stdForces2(std_bounds_force);
-    // Uncomment to use muscle model specific standard
-    //Storage stdForces2("std_arm26_bounds_"+muscName+"_SO_force.sto");
-
-    CHECK_STORAGE_AGAINST_STANDARD(activations2, stdActivations2,
-        std::vector<double>(6, actTol),
-        __FILE__, __LINE__,
-        "Arm26 activation "+muscName+" with bounds failed.");
-
-    CHECK_STORAGE_AGAINST_STANDARD(forces2, stdForces2,
-        std::vector<double>(6, forceTol),
-        __FILE__,  __LINE__,
-        "Arm26 forces "+muscName+" with bounds failed.");
-
-    cout << resultsDir << ": testArm26 with bounds passed" << endl;
-    cout << "=============================================================\n" << endl;
+    // SECTION("Millard2012AccelerationMuscle") {
+    //     testArm26("Millard2012AccelerationMuscle", 0.04, 5.0);
+    // }
 }
 
-void testModelWithPassiveForces() {
+TEST_CASE("testModelWithPassiveForces") {
     AnalyzeTool analyze("staticoptimization_spring_Setup.xml");
     analyze.run();
     std::string resultsDir("ResultsSO_spring");
@@ -220,7 +149,7 @@ void testModelWithPassiveForces() {
 
 }
 
-void testLapackErrorDLASD4() {
+TEST_CASE("testLapackErrorDLASD4") {
     // With OpenSim 3.2 64bit, the 64 bit lapack library (in Simbody 3.3.1)
     // crashes with an error[1] if there are not enough actuators (or under
     // other similar circumstances). With Simbody 3.5.2, the 64 bit Windows lapack
@@ -240,7 +169,7 @@ void testLapackErrorDLASD4() {
     analyze.run();
 }
 
-void testRelativePathInExternalLoads() {
+TEST_CASE("testRelativePathInExternalLoads") {
     // Ensure that we can handle relative paths in the ExternalLoads XML file.
     // It's important that we do not run with the current working directory as
     // the location of Setup_SO.xml.
@@ -249,7 +178,7 @@ void testRelativePathInExternalLoads() {
     analyze.run();
 }
 
-void testArm26DisabledMuscles() {
+TEST_CASE("testArm26DisabledMuscles") {
     AnalyzeTool analyze("arm26_Setup_StaticOptimization.xml");
     analyze.setResultsDir("Results_arm26_StaticOptimization_Disabled");
     Model& model=analyze.getModel();
@@ -275,5 +204,4 @@ void testArm26DisabledMuscles() {
     int nt_d = statesDerivativeStore->getTimeColumn(time_d);
     ASSERT_EQUAL(nt, nt_d);
     ASSERT_EQUAL<Array<double>>(time, time_d, std::numeric_limits<double>::epsilon());
-
 }


### PR DESCRIPTION
Fixes issue #3555 

### Brief summary of changes

Converts the tests in `Applications/Analyze/` to the Catch2 test framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4408)
<!-- Reviewable:end -->
