### PR TITLE
DataQueue pop_front now supports generic typing.

### DIFF
--- a/OpenSim/Common/DataQueue.h
+++ b/OpenSim/Common/DataQueue.h
@@ -108,7 +108,7 @@ public:
     void pop_front(double& time, SimTK::RowVector_<T>& data) { 
         std::unique_lock<std::mutex> mlock(m_mutex);
         while (m_data_queue.empty()) { m_cond.wait(mlock); }
-        DataQueueEntry_<SimTK::Rotation> frontEntry = m_data_queue.front();
+        DataQueueEntry_<T> frontEntry = m_data_queue.front();
         m_data_queue.pop();
         mlock.unlock(); 
         time = frontEntry.getTimeStamp();


### PR DESCRIPTION
Fix a hardcoded `SimTK::Rotation` type in `DataQueue` 

Fixes issue #4211

### Brief summary of changes

Fixes an issue where in the `DataQueue` objects `pop_front` method, there is a hard-coded `SimTK::Rotation` type, even though the `DataQueue` objects support arbitrary types. `pop_front` has been updated to support multiple types, mimicing the correct behavior in `push_back`.

### Testing I've completed

### Looking for feedback on...
@nickbianco  & @aymanhab would you be able to review this?

### CHANGELOG.md (choose one)
unsure if a mention in the change log is needed, this doesn't add any new intended functionality, only fixes previous behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4411)
<!-- Reviewable:end -->
