### PR TITLE
Convert `testOpenSense.cpp` to the Catch2 testing framework

### DIFF
--- a/Applications/opensense/tests/CMakeLists.txt
+++ b/Applications/opensense/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 file(GLOB TEST_PROGS "test*.cpp")
 file(GLOB TEST_FILES resources/*.osim
@@ -7,5 +9,5 @@ file(GLOB TEST_FILES resources/*.osim
 OpenSimAddTests(
     TESTPROGRAMS ${TEST_PROGS}
     DATAFILES ${TEST_FILES}
-    LINKLIBS osimTools
+    LINKLIBS osimTools Catch2::Catch2WithMain
     )

--- a/Applications/opensense/tests/testOpenSense.cpp
+++ b/Applications/opensense/tests/testOpenSense.cpp
@@ -21,8 +21,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-
-// INCLUDES
 #include <OpenSim/Common/STOFileAdapter.h>
 #include <OpenSim/Simulation/OpenSense/OpenSenseUtilities.h>
 #include <OpenSim/Simulation/OpenSense/IMUPlacer.h>
@@ -30,12 +28,13 @@
 #include <OpenSim/Tools/IMUInverseKinematicsTool.h>
 #include <OpenSim/Auxiliary/auxiliaryTestFunctions.h>
 
+#include <catch2/catch_all.hpp>
+
 using namespace OpenSim;
 using namespace std;
 
 
-int main()
-{
+TEST_CASE("testOpenSense") {
 
     // Calibrate model and compare result to standard
     IMUPlacer imuPlacer("imuPlacer.xml");
@@ -114,6 +113,4 @@ int main()
     SimTK::Real angularDifference = acos(~pelvisXInGround * pelvisIMUZInGround);
     // Angle less than 30 would be reasonable goal to maintain
     assert(angularDifference < SimTK::Pi/6);
-    std::cout << "Done. All testOpensense cases passed." << endl;
-    return 0;
 }


### PR DESCRIPTION
Fixes issue #3555 

### Brief summary of changes

Converts `testOpenSense.cpp` to the Catch2 test framework.

### Testing I've completed

Ran locally and CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal test updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4412)
<!-- Reviewable:end -->
