### PR TITLE
Convert `testCommandLineInterface.cpp` to Catch2 and standarize test directory

### DIFF
--- a/Applications/opensim-cmd/CMakeLists.txt
+++ b/Applications/opensim-cmd/CMakeLists.txt
@@ -9,5 +9,5 @@ OpenSimAddApplication(NAME opensim-cmd
 target_link_libraries(opensim-cmd osimdocopt osimMoco)
 
 if(BUILD_TESTING)
-    subdirs(test)
+    subdirs(tests)
 endif(BUILD_TESTING)

--- a/Applications/opensim-cmd/tests/CMakeLists.txt
+++ b/Applications/opensim-cmd/tests/CMakeLists.txt
@@ -1,9 +1,11 @@
+find_package(Catch2 REQUIRED
+        HINTS "${OPENSIM_DEPENDENCIES_DIR}/catch2")
 
 OpenSimAddTests(
     TESTPROGRAMS testCommandLineInterface.cpp
     # Don't need OpenSim since we only interact with OpenSim through the
     # command line tool. But we use Simbody for its Testing.h.
-    LINKLIBS SimTKcommon
+    LINKLIBS SimTKcommon Catch2::Catch2WithMain
     )
 
 add_dependencies(testCommandLineInterface opensim-cmd)

--- a/Applications/opensim-cmd/tests/testCommandLineInterface.cpp
+++ b/Applications/opensim-cmd/tests/testCommandLineInterface.cpp
@@ -22,6 +22,7 @@
  * -------------------------------------------------------------------------- */
 
 #include <SimTKcommon/Testing.h>
+#include <catch2/catch_all.hpp>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -46,151 +47,220 @@ const std::string COMMAND = MAKE_STRING(OSIM_CLI_PATH);
 
 // Helper code.
 // ============
+namespace {
 
-// The ?: says not to capture the group; should be slightly faster.
-// [\s\S]* escapes any amount of whitespace and non-whitespace; the
-// double \\ is to escape the slash.
-const std::string RE_ANY = "(?:[\\s\\S]*)";
+    // The ?: says not to capture the group; should be slightly faster.
+    // [\s\S]* escapes any amount of whitespace and non-whitespace; the
+    // double \\ is to escape the slash.
+    const std::string RE_ANY = "(?:[\\s\\S]*)";
 
-// For packaging the return code and the console output of a system command.
-struct CommandOutput {
-    CommandOutput(int returncode, std::string output)
-        : returncode(returncode), output(output) {}
-    int returncode;
-    std::string output;
-};
+    // For packaging the return code and the console output of a system command.
+    struct CommandOutput {
+        CommandOutput(int returncode, std::string output)
+            : returncode(returncode), output(output) {}
+        int returncode;
+        std::string output;
+    };
 
-// Cross-platform pipe, popen, pclose.
-// http://stackoverflow.com/questions/12402578/crossplatform-lightweight-wrapper-for-pipe-popen
-#ifdef _WIN32
-inline FILE* popen(const char* command, const char* type) {
-    return _popen(command, type);
-}
-inline int pclose(FILE* file) {
-    return _pclose(file);
-}
-#endif
-
-// Execute a system command and also grab its console output.
-CommandOutput system_output(std::string command) {
-    // http://stackoverflow.com/questions/478898/
-    // how-to-execute-a-command-and-get-output-of-command-within-c-using-posix
-    // The 2>& 1 redirects stderr to stdout.
-    std::string result = "";
+    // Cross-platform pipe, popen, pclose.
+    // http://stackoverflow.com/questions/12402578/crossplatform-lightweight-wrapper-for-pipe-popen
     #ifdef _WIN32
-        // To achieve proper quoting with cmd.exe, we must surround the
-        // entire command with quotes ("). See "cmd.exe /?" for more info.
-        command = "\"" + command + "\"";
+    inline FILE* popen(const char* command, const char* type) {
+        return _popen(command, type);
+    }
+    inline int pclose(FILE* file) {
+        return _pclose(file);
+    }
     #endif
-    FILE* pipe = popen((command + " 2>& 1").c_str(), "r");
-    try {
-        if (!pipe) return CommandOutput(-1, "Could not run command.");
-        char buffer[128];
-        while (!feof(pipe)) {
-            if (fgets(buffer, 128, pipe) != NULL)
-                result += buffer;
+
+    // Execute a system command and also grab its console output.
+    CommandOutput system_output(std::string command) {
+        // http://stackoverflow.com/questions/478898/
+        // how-to-execute-a-command-and-get-output-of-command-within-c-using-posix
+        // The 2>& 1 redirects stderr to stdout.
+        std::string result = "";
+        #ifdef _WIN32
+            // To achieve proper quoting with cmd.exe, we must surround the
+            // entire command with quotes ("). See "cmd.exe /?" for more info.
+            command = "\"" + command + "\"";
+        #endif
+        FILE* pipe = popen((command + " 2>& 1").c_str(), "r");
+        try {
+            if (!pipe) return CommandOutput(-1, "Could not run command.");
+            char buffer[128];
+            while (!feof(pipe)) {
+                if (fgets(buffer, 128, pipe) != NULL)
+                    result += buffer;
+            }
+        } catch (...) {
+            pclose(pipe);
+            throw std::runtime_error("Exception thrown while running command.");
         }
-    } catch (...) {
-        pclose(pipe);
-        throw std::runtime_error("Exception thrown while running command.");
+        int returncode = pclose(pipe);
+        // I was unable to actually get the correct return code on either OSX
+        // or Windows, so we will only do a binary check for failure/success.
+        // This is fine, considering that we only use two different return
+        // codes in the command line interface. -chrisdembia
+        if (returncode != 0) returncode = EXIT_FAILURE;
+        return CommandOutput(returncode, result);
     }
-    int returncode = pclose(pipe);
-    // I was unable to actually get the correct return code on either OSX
-    // or Windows, so we will only do a binary check for failure/success.
-    // This is fine, considering that we only use two different return
-    // codes in the command line interface. -chrisdembia
-    if (returncode != 0) returncode = EXIT_FAILURE;
-    return CommandOutput(returncode, result);
+
+    class StartsWith {
+    public:
+        StartsWith(std::string prefix) : prefixStr(prefix) {}
+        bool check(const std::string& str) const {
+            return std::equal(prefixStr.begin(), prefixStr.end(), str.begin());
+        }
+        const std::string prefixStr;
+    };
+
+    class ContainsSubstring {
+    public:
+        ContainsSubstring(std::string substr) : substring(substr) {}
+        bool check(const std::string& str) const {
+            return str.find(substring) != std::string::npos;
+        }
+        const std::string substring;
+    };
+
+    // Checks that the command produces exactly the expected output.
+    void checkCommandOutput(const std::string& arguments,
+            const std::string& output,
+            const std::string& expectedOutput) {
+        const bool outputIsEqual = (output == expectedOutput);
+        if (!outputIsEqual) {
+            std::string msg = "When testing arguments '" + arguments +
+                "' got the following output:\n" + output +
+                "\nExpected:\n" + expectedOutput;
+            throw std::runtime_error(msg);
+        }
+    }
+
+    // Checks that the command output starts with a given string.
+    // Created this because profiling indicated regexes were making the test
+    // slow; ended up not being true.
+    void checkCommandOutput(const std::string& arguments,
+            const std::string& output,
+            const StartsWith& expectedOutput) {
+        if (!expectedOutput.check(output)) {
+            std::string msg = "When testing arguments '" + arguments +
+                "' got the following output:\n" + output +
+                            "\nExpected it to start with:\n" +
+                            expectedOutput.prefixStr;
+            throw std::runtime_error(msg);
+        }
+    }
+
+    // Checks that the command output ends with a given string.
+    void checkCommandOutput(const std::string& arguments,
+            const std::string& output,
+            const ContainsSubstring& expectedOutput) {
+        if (!expectedOutput.check(output)) {
+            std::string msg = "When testing arguments '" + arguments +
+                            "' got the following output:\n" + output +
+                            "\nExpected it to contain:\n" +
+                            expectedOutput.substring;
+            throw std::runtime_error(msg);
+        }
+    }
+
+    // Checks that the command's output matches the given regular expression.
+    void checkCommandOutput(const std::string& arguments,
+            const std::string& output,
+            const std::regex& expectedOutput) {
+        if (!std::regex_match(output, expectedOutput)) {
+            std::string msg = "When testing arguments '" + arguments +
+                "' got the following unexpected output:\n" + output;
+            throw std::runtime_error(msg);
+        }
+    }
+
+    template <typename T>
+    void testCommand(const std::string& arguments,
+                    int expectedReturnCode,
+                    const T& expectedOutput) {
+        CommandOutput out = system_output(COMMAND + " " + arguments);
+
+        checkCommandOutput(arguments, out.output, expectedOutput);
+
+        const bool returnCodeIsCorrect = (out.returncode == expectedReturnCode);
+        if (!returnCodeIsCorrect) {
+            std::string msg = "When testing arguments '" + arguments +
+                "' got return code '" + std::to_string(out.returncode) +
+                "' but expected '" + std::to_string(expectedReturnCode) + "'.";
+            throw std::runtime_error(msg);
+        }
+    }
+
+    // http://stackoverflow.com/questions/5343190/how-do-i-replace-all-instances-of-a-string-with-another-string
+    std::string replaceString(std::string subject, const std::string& search,
+        const std::string& replace) {
+        size_t pos = 0;
+        while ((pos = subject.find(search, pos)) != std::string::npos) {
+            subject.replace(pos, search.length(), replace);
+            pos += replace.length();
+        }
+        return subject;
+    }
+
+    void testLoadPluginLibraries(const std::string& subcommand) {
+        const auto cmd = subcommand + " -h";
+
+        // Nonexistent file.
+        // =================
+        {
+            std::regex output(RE_ANY + "(Failed to load library x)\n");
+            // These are all valid ways of specifying libraries.
+            testCommand("-L x " + cmd, EXIT_FAILURE, output);
+            testCommand("-Lx " + cmd, EXIT_FAILURE, output);
+            testCommand("--library x " + cmd, EXIT_FAILURE, output);
+            testCommand("--library=x " + cmd, EXIT_FAILURE, output);
+            testCommand("-L x --library y " + cmd, EXIT_FAILURE, output);
+            testCommand("-Lx --library=y -L z " + cmd, EXIT_FAILURE, output);
+        }
+
+        // Load an actual library, including the file extension.
+        // =====================================================
+        // OSIM_ACTUATORS_LIB_PATH is a preprocessor definition that is defined
+        // when compiling this executable.
+        std::string lib = MAKE_STRING(OSIM_ACTUATORS_LIB_PATH);
+
+        // Get rid of the quotes surrounding `lib`.
+        std::string expectLib = lib.substr(1, lib.size() - 2);
+        #ifdef _WIN32
+            // When the library name gets printed back to us, the
+            // forward slashes are converted to backslashes. We have to
+            // escape backslash for the C++ parser, so '\\' is actually '\'.
+            expectLib = replaceString(expectLib, "/", "\\");
+        #endif
+        {
+            StartsWith output("[info] Loaded library " + expectLib);
+            testCommand("-L " + lib + " " + cmd, EXIT_SUCCESS, output);
+            testCommand("-L" + lib + " " + cmd, EXIT_SUCCESS, output);
+            testCommand("--library " + lib + " " + cmd, EXIT_SUCCESS, output);
+            testCommand("--library=" + lib + " " + cmd, EXIT_SUCCESS, output);
+        }
+
+        // Load multiple libraries.
+        // ========================
+        {
+            // Well, in this case, we just load the same library multiple times.
+            testCommand("-L " + lib + " --library " + lib + " " + cmd,
+                    EXIT_SUCCESS,
+                    StartsWith("[info] Loaded library " + expectLib + "\n"
+                            "[info] Loaded library " + expectLib + "\n"));
+            testCommand("-L" + lib +
+                        " --library=" + lib +
+                        " -L " + lib + " " + cmd, EXIT_SUCCESS,
+                    StartsWith("[info] Loaded library " + expectLib + "\n"
+                            "[info] Loaded library " + expectLib + "\n"
+                            "[info] Loaded library " + expectLib + "\n"));
+        }
+    }
+
 }
 
-class StartsWith {
-public:
-    StartsWith(std::string prefix) : prefixStr(prefix) {}
-    bool check(const std::string& str) const {
-        return std::equal(prefixStr.begin(), prefixStr.end(), str.begin());
-    }
-    const std::string prefixStr;
-};
-
-class ContainsSubstring {
-public:
-    ContainsSubstring(std::string substr) : substring(substr) {}
-    bool check(const std::string& str) const {
-        return str.find(substring) != std::string::npos;
-    }
-    const std::string substring;
-};
-
-// Checks that the command produces exactly the expected output.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const std::string& expectedOutput) {
-    const bool outputIsEqual = (output == expectedOutput);
-    if (!outputIsEqual) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following output:\n" + output +
-            "\nExpected:\n" + expectedOutput;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command output starts with a given string.
-// Created this because profiling indicated regexes were making the test slow;
-// ended up not being true.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const StartsWith& expectedOutput) {
-    if (!expectedOutput.check(output)) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following output:\n" + output +
-                          "\nExpected it to start with:\n" +
-                          expectedOutput.prefixStr;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command output ends with a given string.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const ContainsSubstring& expectedOutput) {
-    if (!expectedOutput.check(output)) {
-        std::string msg = "When testing arguments '" + arguments +
-                          "' got the following output:\n" + output +
-                          "\nExpected it to contain:\n" +
-                          expectedOutput.substring;
-        throw std::runtime_error(msg);
-    }
-}
-
-// Checks that the command's output matches the given regular expression.
-void checkCommandOutput(const std::string& arguments,
-        const std::string& output,
-        const std::regex& expectedOutput) {
-    if (!std::regex_match(output, expectedOutput)) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got the following unexpected output:\n" + output;
-        throw std::runtime_error(msg);
-    }
-}
-
-template <typename T>
-void testCommand(const std::string& arguments,
-                 int expectedReturnCode,
-                 const T& expectedOutput) {
-    CommandOutput out = system_output(COMMAND + " " + arguments);
-
-    checkCommandOutput(arguments, out.output, expectedOutput);
-
-    const bool returnCodeIsCorrect = (out.returncode == expectedReturnCode);
-    if (!returnCodeIsCorrect) {
-        std::string msg = "When testing arguments '" + arguments +
-            "' got return code '" + std::to_string(out.returncode) +
-            "' but expected '" + std::to_string(expectedReturnCode) + "'.";
-        throw std::runtime_error(msg);
-    }
-}
-
-void testNoCommand() {
+TEST_CASE("testNoCommand") {
     // Help.
     // =====
     {
@@ -237,74 +307,8 @@ void testNoCommand() {
             ContainsSubstring(str_bleepbloop));
 }
 
-// http://stackoverflow.com/questions/5343190/how-do-i-replace-all-instances-of-a-string-with-another-string
-std::string replaceString(std::string subject, const std::string& search,
-    const std::string& replace) {
-    size_t pos = 0;
-    while ((pos = subject.find(search, pos)) != std::string::npos) {
-        subject.replace(pos, search.length(), replace);
-        pos += replace.length();
-    }
-    return subject;
-}
+TEST_CASE("testRunTool") {
 
-void testLoadPluginLibraries(const std::string& subcommand) {
-
-    const auto cmd = subcommand + " -h";
-
-    // Nonexistent file.
-    // =================
-    {
-        std::regex output(RE_ANY + "(Failed to load library x)\n");
-        // These are all valid ways of specifying libraries.
-        testCommand("-L x " + cmd, EXIT_FAILURE, output);
-        testCommand("-Lx " + cmd, EXIT_FAILURE, output);
-        testCommand("--library x " + cmd, EXIT_FAILURE, output);
-        testCommand("--library=x " + cmd, EXIT_FAILURE, output);
-        testCommand("-L x --library y " + cmd, EXIT_FAILURE, output);
-        testCommand("-Lx --library=y -L z " + cmd, EXIT_FAILURE, output);
-    }
-
-    // Load an actual library, including the file extension.
-    // =====================================================
-    // OSIM_ACTUATORS_LIB_PATH is a preprocessor definition that is defined
-    // when compiling this executable.
-    std::string lib = MAKE_STRING(OSIM_ACTUATORS_LIB_PATH);
-
-    // Get rid of the quotes surrounding `lib`.
-    std::string expectLib = lib.substr(1, lib.size() - 2);
-    #ifdef _WIN32
-        // When the library name gets printed back to us, the
-        // forward slashes are converted to backslashes. We have to
-        // escape backslash for the C++ parser, so '\\' is actually '\'.
-        expectLib = replaceString(expectLib, "/", "\\");
-    #endif
-    {
-        StartsWith output("[info] Loaded library " + expectLib);
-        testCommand("-L " + lib + " " + cmd, EXIT_SUCCESS, output);
-        testCommand("-L" + lib + " " + cmd, EXIT_SUCCESS, output);
-        testCommand("--library " + lib + " " + cmd, EXIT_SUCCESS, output);
-        testCommand("--library=" + lib + " " + cmd, EXIT_SUCCESS, output);
-    }
-
-    // Load multiple libraries.
-    // ========================
-    {
-        // Well, in this case, we just load the same library multiple times.
-        testCommand("-L " + lib + " --library " + lib + " " + cmd,
-                EXIT_SUCCESS,
-                StartsWith("[info] Loaded library " + expectLib + "\n"
-                           "[info] Loaded library " + expectLib + "\n"));
-        testCommand("-L" + lib +
-                    " --library=" + lib +
-                    " -L " + lib + " " + cmd, EXIT_SUCCESS,
-                StartsWith("[info] Loaded library " + expectLib + "\n"
-                           "[info] Loaded library " + expectLib + "\n"
-                           "[info] Loaded library " + expectLib + "\n"));
-    }
-}
-
-void testRunTool() {
     // Help.
     // =====
     {
@@ -349,7 +353,7 @@ void testRunTool() {
     testLoadPluginLibraries("run-tool");
 }
 
-void testPrintXML() {
+TEST_CASE("testPrintXML") {
     // Help.
     // =====
     {
@@ -396,7 +400,8 @@ void testPrintXML() {
     testLoadPluginLibraries("print-xml");
 }
 
-void testInfo() {
+TEST_CASE("testInfo") {
+
     // Help.
     // =====
     {
@@ -430,7 +435,8 @@ void testInfo() {
     testLoadPluginLibraries("info");
 }
 
-void testUpdateFile() {
+TEST_CASE("testUpdateFile") {
+
     // Help.
     // =====
     {
@@ -488,14 +494,4 @@ void testUpdateFile() {
     // Library option.
     // ===============
     testLoadPluginLibraries("update-file");
-}
-
-int main() {
-    SimTK_START_TEST("testCommandLineInterface");
-        SimTK_SUBTEST(testNoCommand);
-        SimTK_SUBTEST(testRunTool);
-        SimTK_SUBTEST(testPrintXML);
-        SimTK_SUBTEST(testInfo);
-        SimTK_SUBTEST(testUpdateFile);
-    SimTK_END_TEST();
 }


### PR DESCRIPTION
Fixes issue #3555 #4393 

### Brief summary of changes

- Converts `testCommandLineInterface.cpp` to the Catch2 testing framework.
- Renames `Applications/opensim-cmd/test/` to `Applications/opensim-cmd/tests/`.
- Updates the `CMakeLists.txt` accordingly.

### Testing I've completed

Ran tests locally; CI.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because...internal update to tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4415)
<!-- Reviewable:end -->
