### PR TITLE
Replace Scale deprecated properties with property macros

### DIFF
--- a/OpenSim/Common/Scale.cpp
+++ b/OpenSim/Common/Scale.cpp
@@ -25,151 +25,35 @@
 
 using namespace OpenSim;
 using namespace std;
-using SimTK::Vec3;
 
 //=============================================================================
 // DESTRUCTOR AND CONSTRUCTORS
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Destructor.
- */
-Scale::~Scale(void)
-{
-}
-//_____________________________________________________________________________
-/**
  * Default constructor of an Scale
  */
-Scale::Scale():
-_scaleFactors(_propScaleFactors.getValueDblVec()),
-_segmentName(_propSegmentName.getValueStr()),
-_apply(_propApply.getValueBool())
-{
-    setNull();
-}
-//_____________________________________________________________________________
-/**
- * Copy constructor.
- *
- * @param an Scale to copy
- */
-Scale::Scale(const Scale &aScale) :
-Object(aScale),
-_scaleFactors(_propScaleFactors.getValueDblVec()),
-_segmentName(_propSegmentName.getValueStr()),
-_apply(_propApply.getValueBool())
-{
-    setNull();
+Scale::Scale() { constructProperties(); }
 
-    // ASSIGN
-    *this = aScale;
-}
 //_____________________________________________________________________________
 /**
  * Constructor of a scaleSet from a file.
  */
-Scale::Scale(const string& scaleFileName):
-Object(scaleFileName, false),
-_scaleFactors(_propScaleFactors.getValueDblVec()),
-_segmentName(_propSegmentName.getValueStr()),
-_apply(_propApply.getValueBool())
-{
-    setNull();
+Scale::Scale(const string& scaleFileName) : Object(scaleFileName, false) {
     updateFromXMLDocument();
 }
 
 //=============================================================================
 // OPERATORS
 //=============================================================================
-//-----------------------------------------------------------------------------
-// ASSIGNMENT
-//-----------------------------------------------------------------------------
-//_____________________________________________________________________________
-/**
- * Assign this object to the values of another.
- *
- * @return Reference to this object.
- */
-Scale& Scale::
-operator=(const Scale &aScale)
-{
-    // BASE CLASS
-    _segmentName = aScale.getSegmentName();
-    aScale.getScaleFactors(_scaleFactors);
-    _apply = aScale.getApply();
 
-    return(*this);
-}
-
-
-void Scale::setNull()
-{
-    setName("");
-    setupProperties();
-}
 //_____________________________________________________________________________
 /**
  * Set up the serialized member variables.  
  */
-void Scale::
-setupProperties()
-{
-    Vec3 one3(1.0); 
-
+void Scale::constructProperties() {
     // scale factors
-    _propScaleFactors.setName("scales");
-    _propScaleFactors.setValue(one3);
-    //_propScaleFactors.setAllowableListSize(3);
-    _propertySet.append( &_propScaleFactors );
-
-    // segment name
-    _propSegmentName.setName("segment");
-    _propSegmentName.setValue("unnamed_segment");
-    _propertySet.append( &_propSegmentName );
-
-    // whether or not to apply the scale
-    _propApply.setName("apply");
-    _propApply.setValue(true);
-    _propertySet.append(&_propApply);
-}
-//=============================================================================
-// GET AND SET
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Get segment name
- */
-const std::string& Scale::
-getSegmentName() const
-{
-    return _segmentName;
-}
-//_____________________________________________________________________________
-/**
- * Set the value of scale factors
- */
-void Scale::
-getScaleFactors(SimTK::Vec3& aScaleFactors) const
-{
-    aScaleFactors = _scaleFactors;
-}
-
-//_____________________________________________________________________________
-/**
- * Set segment name
- */
-void Scale::
-setSegmentName(const string& aSegmentName)
-{
-    _segmentName = aSegmentName;
-}
-//_____________________________________________________________________________
-/**
- * Set scale factors
- */
-void Scale::
-setScaleFactors(const SimTK::Vec3& aScaleFactors)
-{
-    _scaleFactors = aScaleFactors;
+    constructProperty_scales(SimTK::Vec3(1.0));
+    constructProperty_segment("unnamed_segment");
+    constructProperty_apply(true);
 }

--- a/OpenSim/Common/Scale.h
+++ b/OpenSim/Common/Scale.h
@@ -27,14 +27,9 @@
  * Author:  
  */
 
-
-#include "osimCommonDLL.h"
 #include "Object.h"
-#include "PropertyStr.h"
-#include "PropertyDblArray.h"
-#include "PropertyDbl.h"
-#include "PropertyBool.h"
-#include "PropertyDblVec.h"
+#include "Property.h"
+#include "osimCommonDLL.h"
 
 //=============================================================================
 /*
@@ -51,19 +46,10 @@ OpenSim_DECLARE_CONCRETE_OBJECT(Scale, Object);
 //=============================================================================
 // DATA
 //=============================================================================
-protected:
-    // PROPERTIES
-    /** A list of 3 scale factors */
-    PropertyDblVec3 _propScaleFactors;
-    /** Name of object to scale */
-    PropertyStr     _propSegmentName;
-    /** Whether or not to apply this scale */
-    PropertyBool        _propApply;
-
-    // REFERENCES
-    SimTK::Vec3&    _scaleFactors;
-    std::string&        _segmentName;
-    bool&                   _apply;
+public:
+OpenSim_DECLARE_PROPERTY(scales, SimTK::Vec3, "A list of 3 scale factors");
+OpenSim_DECLARE_PROPERTY(segment, std::string, "Name of object to scale");
+OpenSim_DECLARE_PROPERTY(apply, bool, "Whether or not to apply this scale");
 
 //=============================================================================
 // METHODS
@@ -73,32 +59,29 @@ public:
     // CONSTRUCTION
     //--------------------------------------------------------------------------
     Scale();
-    Scale(const Scale &aMarker);
-    Scale( const std::string& scaleFileName);
-    virtual ~Scale(void);
+    Scale(const std::string& scaleFileName);
 
-    //--------------------------------------------------------------------------
-    // OPERATORS
-    //--------------------------------------------------------------------------
-#ifndef SWIG
-    Scale& operator=(const Scale &aMarker);
-#endif  
 private:
-    void setNull();
-    void setupProperties();
+    void constructProperties();
 
 public:
     //--------------------------------------------------------------------------
     // SET AND GET
     //--------------------------------------------------------------------------
-    const std::string& getSegmentName() const;
-    void setSegmentName(const std::string& aSegmentName);
+    const std::string& getSegmentName() const { return get_segment(); };
+    void setSegmentName(const std::string& aSegmentName) {
+        set_segment(aSegmentName);
+    };
 
-    void getScaleFactors(SimTK::Vec3& aScaleFactors) const;
-    SimTK::Vec3& getScaleFactors() { return _scaleFactors; }
-    void setScaleFactors(const SimTK::Vec3& aScaleFactors);
-    bool getApply(void) const { return _apply; }
-    void setApply(bool state) { _apply = state; }
+    void getScaleFactors(SimTK::Vec3& aScaleFactors) const {
+        aScaleFactors = get_scales();
+    };
+    SimTK::Vec3& getScaleFactors() { return upd_scales(); }
+    void setScaleFactors(const SimTK::Vec3& aScaleFactors) {
+        set_scales(aScaleFactors);
+    };
+    bool getApply(void) const { return get_apply(); }
+    void setApply(bool state) { set_apply(state); }
 };
 
 }; //namespace

--- a/OpenSim/Simulation/Model/Geometry.cpp
+++ b/OpenSim/Simulation/Model/Geometry.cpp
@@ -28,6 +28,7 @@
 
 #include "Frame.h"
 #include "Model.h"
+#include "OpenSim/Common/PropertyStr.h"
 
 #include <filesystem>
 #include <fstream>

--- a/OpenSim/Tools/ModelScaler.h
+++ b/OpenSim/Tools/ModelScaler.h
@@ -23,10 +23,12 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-
 // INCLUDE
-#include <OpenSim/Common/ScaleSet.h>
 #include "MeasurementSet.h"
+
+#include <OpenSim/Common/PropertyDblArray.h>
+#include <OpenSim/Common/PropertyStr.h>
+#include <OpenSim/Common/ScaleSet.h>
 
 namespace SimTK {
 class State;


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-core/issues/4074
Step 3 of breaking the [previous PR](https://github.com/opensim-org/opensim-core/pull/4351) into smaller chunks.

### Brief summary of changes
Replaces the Scale and BodyScale deprecated properties with property macros.

### Testing I've completed
Tested locally

### Looking for feedback on...
@adamkewley and @nickbianco could you take a look?

### CHANGELOG.md (choose one)

- no need to update because it removes deprecated code without changing existing functionality or interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4422)
<!-- Reviewable:end -->
