### PR TITLE
Docs: clarify forces_to_exclude `All` behavior with external loads

### DIFF
--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -123,8 +123,9 @@ void DynamicsTool::setupProperties()
             "List of forces by individual or grouping name "
             "(e.g. All, actuators, muscles, ...)"
             " to be excluded when computing model dynamics. "
-            "Please note that 'All' does not exclude external loads added "
-            "via 'external_loads_file'.");
+            "'All' does not exclude external loads added "
+            "via 'external_loads_file' (i.e., they will be "
+            "applied to the model when computing dynamics).");
     _excludedForcesProp.setName("forces_to_exclude");
     _propertySet.append(&_excludedForcesProp);
 

--- a/OpenSim/Tools/DynamicsTool.cpp
+++ b/OpenSim/Tools/DynamicsTool.cpp
@@ -123,7 +123,7 @@ void DynamicsTool::setupProperties()
             "List of forces by individual or grouping name "
             "(e.g. All, actuators, muscles, ...)"
             " to be excluded when computing model dynamics. "
-            "'All' also excludes external loads added "
+            "Please note that 'All' does not exclude external loads added "
             "via 'external_loads_file'.");
     _excludedForcesProp.setName("forces_to_exclude");
     _propertySet.append(&_excludedForcesProp);


### PR DESCRIPTION
Fixes issue #4161 

### Brief summary of changes
Updated the comment for `forces_to_exclude` in `DynamicsTool.cpp` to make it clear that 'ALL' does not exclude external loads.

### Testing I've completed
- Checked `DynamicsTool::disableModelForces()` in the source code to confirm the behavior.
- Built the tools module locally.

### CHANGELOG.md (choose one)
- no need to update since its a minor docs clarification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4423)
<!-- Reviewable:end -->
