### PR TITLE
Copy `OpenSim/Common/Detail/` to installation directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The property `moment_arm_threshold` has been removed, and the methods `get/setMo
 - Added the property `use_warm_start` and accessors `set/getWarmStart()` in `Scholz2015GeometryPath` to enable toggling on and off warm starts, where the wrapping solver from the previous time step is an initial guess for the path at the next time step. Now, `Scholz2015GeometryPath` by default has warm starts disabled meaning that paths are always computed from wrap obstacle contact hints (previously, warm starts were always enabled). (#4342)
 - The `Vec` element-by-element constructor function now only accepts the correct
   number of elements (e.g. 2 elements for a `Vec2`, 3 for `Vec3`; #4416).
+- The `OpenSim/Common/Detail/` directory is now copied during installation. Fixes build failures related to compilation units
+  not finding the enclosed header files. (#4434)
 
 
 v4.6

--- a/OpenSim/Common/CMakeLists.txt
+++ b/OpenSim/Common/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB INCLUDES *.h gcvspl.h)
 file(GLOB SOURCES *.cpp gcvspl.c)
 
@@ -25,6 +24,12 @@ OpenSimAddLibrary(
     # see https://github.com/simbody/simbody/pull/815 for details
     EXTERNAL_DEPENDENCY_SYMBOL SWIG_PYTHON
     )
+
+# Copy the Detail directory so that compilation units can find the contained
+# headers in external projects.
+file(GLOB DETAIL_INCLUDES Detail/*.h)
+install(FILES ${DETAIL_INCLUDES}
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/OpenSim/Common/Detail")
 
 if(WIN32)
     # On Windows only, debug libraries cannot be mixed with release


### PR DESCRIPTION
Fixes issue #4433

### Brief summary of changes

Mostly self-explanatory: the `OpenSim/Common/Detail/` directory is now copied during installation so that these headers can be found by translation units when compiling external projects.

### Testing I've completed

Checked that the `Detail/` directory appeared in my local install directory.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4434)
<!-- Reviewable:end -->
