### PR TITLE
Hotfix (pin) manylinux to a release with SWIG 4.4.1 (#4436)

### DIFF
--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -169,7 +169,10 @@ jobs:
   build_linux_wheels:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/pypa/manylinux_2_28_x86_64
+      # Note: a particular tag of manylinux is necessary because
+      # newer versions use a newer version of SWIG: drop the tag
+      # once SWIG is updated (#4436, #4435).
+      image: quay.io/pypa/manylinux_2_28_x86_64:2026.08.15-1
 
     strategy:
       matrix:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -222,7 +222,10 @@ jobs:
     name: ManyLinux 2.28
     runs-on: ubuntu-latest
     container:
-      image: quay.io/pypa/manylinux_2_28_x86_64
+      # Note: a particular tag of manylinux is necessary because
+      # newer versions use a newer version of SWIG: drop the tag
+      # once SWIG is updated (#4436, #4435).
+      image: quay.io/pypa/manylinux_2_28_x86_64:2026.08.15-1
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Related: #4436 #4435

CI build images were externally updated and now use a newer version of SWIG that cannot compile OpenSim. #4436 fixes this hollistically but, for now, we can pin the docker image so that all other CI builds go through while that change is being made.

manylinux doesn't pin packages like SWIG and instead uses pipx to install the latest one (as per the README). However, all builds are available on quay.io, and some messing around with:

- `docker run --pull=always --rm -it quay.io/pypa/manylinux_2_28_x86_64:2026.08.15-1`

Was enough to figure out the latest version that still has SWIG 4.4.1.

This is just a hotfix so if it makes CI pass again it will be merged until a more hollistic fix comes along.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4437)
<!-- Reviewable:end -->
