### PR TITLE
Remove manylinux pin to use latest release with SWIG 4.5.0

### DIFF
--- a/.github/workflows/build_all_wheels.yml
+++ b/.github/workflows/build_all_wheels.yml
@@ -169,10 +169,7 @@ jobs:
   build_linux_wheels:
     runs-on: ubuntu-latest
     container:
-      # Note: a particular tag of manylinux is necessary because
-      # newer versions use a newer version of SWIG: drop the tag
-      # once SWIG is updated (#4436, #4435).
-      image: quay.io/pypa/manylinux_2_28_x86_64:2026.08.15-1
+      image: quay.io/pypa/manylinux_2_28_x86_64
 
     strategy:
       matrix:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -222,10 +222,7 @@ jobs:
     name: ManyLinux 2.28
     runs-on: ubuntu-latest
     container:
-      # Note: a particular tag of manylinux is necessary because
-      # newer versions use a newer version of SWIG: drop the tag
-      # once SWIG is updated (#4436, #4435).
-      image: quay.io/pypa/manylinux_2_28_x86_64:2026.08.15-1
+      image: quay.io/pypa/manylinux_2_28_x86_64
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Related: #4437 https://github.com/opensim-org/opensim-core/pull/4436 https://github.com/opensim-org/opensim-core/pull/4435

Removes the pin on the manylinux builds now that the bindings have been updated to remove Python 2 macros and support SWIG 4.5.0 (per #4436).

This would mean that the AlmaLinux CI builds will use 4.5.0 while the Windows and Mac builds are still pinned to 4.4.1. Per @alexbeattie42's comment on #4436, it is probably good to have a bleeding edge CI build as our canary in the coal mine, but we could also update Windows and Mac to use 4.5.0 as well if others would prefer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4439)
<!-- Reviewable:end -->
