### PR TITLE
Fix: 'InverseKinemtaticsTool' typo in IK test resources

### DIFF
--- a/Applications/IK/tests/resources/subject01_Setup_InverseKinematics.xml
+++ b/Applications/IK/tests/resources/subject01_Setup_InverseKinematics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSimDocument Version="20302">
-  <InverseKinemtaticsTool name="subject01">
+  <InverseKinematicsTool name="subject01">
 	  <!--Name of the .osim file used to construct a model.-->
 	  <model_file> subject01_simbody.osim </model_file>
     <!-- A positive scalar that is used to weight the importance of satisfying constraints."
@@ -42,6 +42,6 @@
     <report_errors> false </report_errors>
     <!--Flag indicating whether or not to report model marker locations in ground.-->
     <report_marker_locations> true </report_marker_locations>
-  </InverseKinemtaticsTool>
+  </InverseKinematicsTool>
 </OpenSimDocument>
 

--- a/Applications/IK/tests/resources/subject01_Setup_InverseKinematics_NoModel.xml
+++ b/Applications/IK/tests/resources/subject01_Setup_InverseKinematics_NoModel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InverseKinemtaticsTool name="subject01">
+<InverseKinematicsTool name="subject01">
 	<!--Name of the .osim file used to construct a model.-->
 	<model_file> </model_file>
 	<!--Task set used to specify IK weights.-->
@@ -33,5 +33,5 @@
 		  A weighting of 'Infinity' or if it is unassigned results in the constraints being strictly enforced-->
   <constraint_weight> 100.0 </constraint_weight>
   <accuracy>1e-5</accuracy>
-</InverseKinemtaticsTool>
+</InverseKinematicsTool>
 


### PR DESCRIPTION
### Brief summary of changes
Minor typo fix in subject01 inverse kinematics files.

### Testing I've completed
- Verified `opensim-cmd run-tool` now registers the obj and initialises the tool.
### Looking for feedback on...
The typo is not visible as C++ unit tests instantiate from the concrete class directly (XML root tags are bypassed), but throws `Object not registered` error when we try through `opensim-cmd run-tool` . I think this would have also been the same in case of GUI but I have not tested that though .
### CHANGELOG.md (choose one)

- no need to update because typo fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4440)
<!-- Reviewable:end -->
