### PR TITLE
add cmake presets to build stack in debug mode in msvc

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -134,6 +134,24 @@
             }
         },
         {
+            "name": "dev-minimal-msvc-debug",
+            "description": "Recommended MSVC Debug development configuration",
+            "inherits": [
+                "dev-default",
+                "windows"
+            ],
+            "cacheVariables": {
+                "CMAKE_COMPILE_WARNING_AS_ERROR": false,
+                "OPENSIM_WITH_CASADI": "OFF",
+                "BUILD_JAVA_WRAPPING": "OFF",
+                "BUILD_PYTHON_WRAPPING": "OFF",
+                "BUILD_API_EXAMPLES": "OFF",
+                "OPENSIM_C3D_PARSER": "None",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDebugDLL"
+            }
+        },        
+        {
             "hidden": true,
             "name": "ci",
             "description": "Base build configuration settings for CI",
@@ -286,6 +304,10 @@
             "name": "ci-make-macos-release",
             "configurePreset": "ci-make-macos-release",
             "inherits": "macos"
+        },
+        {
+            "name": "dev-minimal-msvc-debug",
+            "configurePreset": "dev-minimal-msvc-debug"
         },
         {
             "name": "ci-make-linux-release",
@@ -475,6 +497,13 @@
             "steps": [
                 { "type": "configure", "name": "dev-minimal" },
                 { "type": "build",     "name": "dev-minimal" }
+            ]
+        },
+        {
+            "name": "dev-minimal-msvc-debug",
+            "steps": [
+                { "type": "configure", "name": "dev-minimal-msvc-debug" },
+                { "type": "build",     "name": "dev-minimal-msvc-debug" }
             ]
         }
     ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,7 +150,7 @@
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDebugDLL"
             }
-        },        
+        },
         {
             "hidden": true,
             "name": "ci",

--- a/dependencies/CMakePresets.json
+++ b/dependencies/CMakePresets.json
@@ -138,6 +138,20 @@
             }
         },
         {
+            "name": "dev-minimal-msvc-debug",
+            "description": "Minimal development configuration that only build the dependencies necessary for a minimal build (no Moco, no ezc3d)",
+            "inherits": ["dev-default"],
+            "cacheVariables": {
+                "OPENSIM_WITH_CASADI": "OFF",
+                "SUPERBUILD_ezc3d": "OFF",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreadedDebugDLL"
+            },
+            "environment": {
+                "CXXFLAGS": "/w"
+            }
+        },
+        {
             "name": "ci-make-macos-release",
             "displayName": "MacOS CI default",
             "description": "Default CI configuration for MacOS",
@@ -251,6 +265,10 @@
             "configurePreset": "dev-minimal"
         },
         {
+            "name": "dev-minimal-msvc-debug",
+            "configurePreset": "dev-minimal-msvc-debug"
+        },
+        {
             "name": "ci-msvc-windows-release",
             "configurePreset": "ci-msvc-windows-release",
             "inherits": "windows",
@@ -324,6 +342,13 @@
             "steps": [
                 { "type": "configure", "name": "dev-minimal" },
                 { "type": "build",     "name": "dev-minimal" }
+            ]
+        },
+        {
+            "name": "dev-minimal-msvc-debug",
+            "steps": [
+                { "type": "configure", "name": "dev-minimal-msvc-debug" },
+                { "type": "build",     "name": "dev-minimal-msvc-debug" }
             ]
         }
     ]


### PR DESCRIPTION
minimal build without moco, c3d, or wrapping

Fixes issue #0

### Brief summary of changes

### Testing I've completed
built and ran locally, a few test failures were exposed.

### Looking for feedback on...

### CHANGELOG.md (choose one)

- no need to update because internal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4442)
<!-- Reviewable:end -->
