### PR TITLE
docs: update Moco CasADi test gating in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,13 +178,11 @@ can be used to specify platform-specific tests.
 Running Moco tests
 ------------------
 In general, Moco's tests depend on the CasADi library, whose use is determined 
-by the `OPENSIM_WITH_CASADI` and CMake variable. The CTests are designed to 
+by the `OPENSIM_WITH_CASADI` CMake variable. The CTests are designed to 
 succeed regardless of the value of the CMake variable: if `OPENSIM_WITH_CASADI` 
-is off, Moco's C++ tests are run with arguments `"~*MocoCasADiSolver*" "~[casadi]"`, 
-which excludes Catch2 templatized tests using MocoCasADiSolver and other tests that 
-are tagged as relying on CasADi. If the test executables are run without CTest (e.g., 
-debugging a project in Visual Studio), the tests will fail if `OPENSIM_WITH_CASADI` is 
-false; for the tests to pass, provide the argument `"~*MocoCasADiSolver*" "~[casadi]"`.
+is off, the Moco tests that rely on CasADi are marked `DISABLED` and are skipped 
+by CTest. If those test executables are run without CTest (e.g., debugging a 
+project in Visual Studio), they will fail when `OPENSIM_WITH_CASADI` is false.
 
 Building GUI
 -------------


### PR DESCRIPTION
### Brief summary of changes
CONTRIBUTING.md says that when `OPENSIM_WITH_CASADI` is off the Moco's tests are run with the arguments `"~*MocoCasADiSolver*" "~[casadi]"`. #4360 removed that so those tests are now marked `DISABLED` and skipped by CTest instead. Passing the arguments by hand no longer makes the test executables pass that advice too.

### Testing I've completed

On Linux with `OPENSIM_WITH_CASADI=OFF`: `ctest -N -R Moco` shows 11 of the 12 Moco tests as `(Disabled)`, and a full `ctest` run passes. Running `testMocoInterface` directly fails and still fails with the old arguments.

### Looking for feedback on...

1.The old arguments seem to fail because two test cases use CasADi but are not tagged `[casadi]` (`testMocoInterface.cpp:1256` and `:2207`). If we would rather tag those two instead the original wording should be become correct again. I only looked at `testMocoInterface` so there may be others.
2.I only checked this on Linux with CasADi off, not on Windows

### CHANGELOG.md (choose one)

- no need to update because it is a documentation change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4443)
<!-- Reviewable:end -->
