### PR TITLE
Fix Ipopt plugin failing to load in the macOS Python wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ The property `moment_arm_threshold` has been removed, and the methods `get/setMo
   a fixed scene graph (#4286).
 - The `ModelScaler` tool was refactored from the legacy property system (`PropertyDblArray`,
   `PropertyStr`) to the newer `Property<T>` system (#4438).
+- Fixed the Ipopt plugin failing to load in the macOS Python wheels. `libipopt` and `libcoinmumps`
+  referenced `libgfortran`/`libquadmath` by the absolute path those libraries had on the build
+  machine, so `MocoStudy.solve()` failed with "Plugin 'ipopt' is not found" on any macOS machine
+  without GCC installed at that prefix (#4447).
 
 
 v4.6

--- a/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
+++ b/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
@@ -63,6 +63,16 @@ if (OPENSIM_WITH_CASADI)
     install_name_tool_add_rpath(coinmumps.3)
     install_name_tool_change(ipopt.3 coinmumps.3 "@IPOPT_LIBDIR@")
 
+    # libipopt and libcoinmumps link against the Fortran runtime themselves, so
+    # they need the same treatment as the CasADi plugin below. Without this,
+    # their references to libgfortran/libquadmath keep pointing at the absolute
+    # path those libraries had on the build machine, and loading the Ipopt
+    # plugin fails on any machine that does not have them there (#4445).
+    install_name_tool_change_gfortran(ipopt.3)
+    install_name_tool_change_quadmath(ipopt.3)
+    install_name_tool_change_gfortran(coinmumps.3)
+    install_name_tool_change_quadmath(coinmumps.3)
+
     install_name_tool_change(casadi_nlpsol_ipopt.3.7 ipopt.3 "@IPOPT_LIBDIR@")
     install_name_tool_change(casadi_nlpsol_ipopt.3.7 coinmumps.3 "@IPOPT_LIBDIR@")
     install_name_tool_change(casadi_nlpsol_ipopt.3.7 metis "@IPOPT_LIBDIR@")

--- a/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
+++ b/cmake/OpenSimMocoInstallMacDependencyLibraries.cmake.in
@@ -61,6 +61,10 @@ if (OPENSIM_WITH_CASADI)
 
     install_name_tool_add_rpath(ipopt.3)
     install_name_tool_add_rpath(coinmumps.3)
+    # Ipopt's and MUMPS's install names are absolute build-machine paths; use
+    # @rpath like the other bundled libraries.
+    install_name_tool_id(ipopt.3)
+    install_name_tool_id(coinmumps.3)
     install_name_tool_change(ipopt.3 coinmumps.3 "@IPOPT_LIBDIR@")
 
     # libipopt and libcoinmumps link against the Fortran runtime themselves, so


### PR DESCRIPTION
Fixes #4445.

## What was wrong

`OpenSimMocoInstallMacDependencyLibraries.cmake.in` already rewrites the CasADi Ipopt
plugin's references to the Fortran runtime, but not those of the two libraries the plugin
loads. `libipopt` and `libcoinmumps` were left pointing at `libgfortran`/`libquadmath` by
the absolute path they had on the build machine:

```
$ otool -L site-packages/opensim/libipopt.3.dylib
  /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib
  /opt/homebrew/opt/gcc/lib/gcc/current/libquadmath.0.dylib
```

while the plugin itself is correct (`@rpath/libipopt.3.dylib`). On any macOS machine
without GCC at that exact prefix, `dlopen` of the plugin fails and CasADi surfaces it as
`Plugin 'ipopt' is not found`, so every `MocoStudy.solve()` fails. `initCasADiSolver()`
succeeds, which is why the failure only shows up at solve time.

CI does not catch it because `build_osx_wheels` runs `brew reinstall gcc`, which puts the
libraries at exactly the hardcoded path on the runner.

## What this changes

Four calls to macros that already exist in the file, applied to `ipopt.3` and
`coinmumps.3`. Both already get `@loader_path` added to their rpath a few lines above, so
nothing else is needed.

This sits in the install step rather than in the wheel packaging itself, which fixes
both cases: `add_subdirectory(cmake)` registers this script before
`install(SCRIPT buildWheel.cmake)` runs, so the libraries copied into the Python
package are the already-rewritten ones, and a plain macOS install gets the fix too.

## How this was verified

I could not build opensim-core on macOS to run the install step end to end, so I verified
the two halves separately.

**1. The macros produce the right commands.** Running the `otool | grep | perl` pipeline
from `install_name_tool_change_gfortran` / `_quadmath` against the `libipopt.3.dylib`
shipped in `opensim-4.6-2-cp311-cp311-macosx_15_0_universal2.whl` yields:

```
libgfortran_dir  = /opt/homebrew/opt/gcc/lib/gcc/current
libgfortran_name = gfortran.5
libquadmath_dir  = /opt/homebrew/opt/gcc/lib/gcc/current
libquadmath_name = quadmath.0
```

i.e. exactly the `-change <abs>/libgfortran.5.dylib @rpath/libgfortran.5.dylib` calls
intended.

**2. Those commands fix the shipped wheel.** Applying them to the published wheel, on a
machine with no Homebrew GCC installed:

| | before | after |
|---|---|---|
| `libipopt.3.dylib` → gfortran/quadmath | `/opt/homebrew/opt/gcc/...` | `@rpath/...` |
| `exampleSlidingMass.py` | `Plugin 'ipopt' is not found` | solves |
| `Bindings/Python/tests/test_moco.py` | 5 of 12 fail | 12/12 pass |

Environment: macOS 26.6.2, Apple Silicon, Python 3.11, `opensim` 4.6 from PyPI.

What remains untested locally is the install step itself running in the wheels build —
that is what CI here exercises.

## A note on code signing

An earlier version of my analysis in #4445 said any fix would need to re-sign the
libraries. That is only true if you modify `libgfortran`/`libquadmath`/`libgcc_s`
themselves: those arrive signed by Homebrew, and `install_name_tool` invalidates the
signature, after which arm64 macOS kills the process on load. `libipopt` and
`libcoinmumps` are linker-signed and `install_name_tool` re-signs them ad-hoc on its own.
This change only touches the latter two, so no `codesign` step is required — verified by
checking `codesign -v` on all four libraries after the rewrite.

## Follow-ups, if wanted

- A CHANGELOG entry, once this has a number.
- The packaging test you floated in #4445 — failing the build if any binary in the wheel
  has a load command outside it, e.g.
  `otool -L opensim/*.dylib opensim/*.so | grep -v '@rpath\|@loader_path\|/usr/lib\|/System'`.
  Happy to add it here or as a separate PR.
- Unrelated to this fix, but noticed while investigating: the macOS wheels are tagged
  `macosx_15_0_universal2` while the binaries are arm64-only.

*(Investigation done with the help of Claude; every claim above was verified
empirically on the machine described.)*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4447)
<!-- Reviewable:end -->
