### PR TITLE
Replace the deprecated properties in the MarkerPair and Measurement classes

### DIFF
--- a/OpenSim/Tools/IKTaskSet.h
+++ b/OpenSim/Tools/IKTaskSet.h
@@ -24,10 +24,11 @@
  * -------------------------------------------------------------------------- */
 
 #include "osimToolsDLL.h"
+
 #include <OpenSim/Common/Set.h>
-#include "IKTask.h"
-#include "IKMarkerTask.h"
 #include <OpenSim/Simulation/MarkersReference.h>
+#include <OpenSim/Tools/IKMarkerTask.h>
+#include <OpenSim/Tools/IKTask.h>
 
 namespace OpenSim {
 
@@ -47,10 +48,11 @@ public:
     IKTaskSet(const IKTaskSet &aIKTaskSet) : Set<IKTask>(aIKTaskSet) { }
     IKTaskSet(const std::string &aFileName) : Set<IKTask>(aFileName) { }
     void createMarkerWeightSet(Set<MarkerWeight>& aWeights) const {
-        for(int i=0; i< getSize(); i++){
-            if(IKMarkerTask *nextTask = dynamic_cast<IKMarkerTask *>(&get(i))){
+        for (int i = 0; i < getSize(); ++i) {
+            if (auto* nextTask = dynamic_cast<IKMarkerTask*>(&get(i))) {
                 if(nextTask->getApply()){
-                    aWeights.cloneAndAppend(*(new MarkerWeight(nextTask->getName(), nextTask->getWeight())));
+                    aWeights.cloneAndAppend(MarkerWeight(
+                            nextTask->getName(), nextTask->getWeight()));
                 }
             }
         }

--- a/OpenSim/Tools/MarkerPair.cpp
+++ b/OpenSim/Tools/MarkerPair.cpp
@@ -42,85 +42,29 @@ using namespace std;
 /**
  * Default constructor.
  */
-MarkerPair::MarkerPair() :
-    _markerNames(_markerNamesProp.getValueStrArray())
-{
-    setNull();
-}
-
-//_____________________________________________________________________________
-/**
- * Destructor.
- */
-MarkerPair::~MarkerPair()
-{
-}
-
-//_____________________________________________________________________________
-/**
- * Copy constructor.
- *
- * @param aMarkerPair MarkerPair to be copied.
- */
-MarkerPair::MarkerPair(const MarkerPair &aMarkerPair) :
-   Object(aMarkerPair),
-    _markerNames(_markerNamesProp.getValueStrArray())
-{
-    setNull();
-    copyData(aMarkerPair);
-}
+MarkerPair::MarkerPair() { constructProperties(); }
 //_____________________________________________________________________________
 /**
  */
-MarkerPair::MarkerPair(const std::string &aName1, const std::string &aName2) :
-    _markerNames(_markerNamesProp.getValueStrArray())
-{
-    setNull();
-    _markerNames.append(aName1);
-    _markerNames.append(aName2);
+MarkerPair::MarkerPair(const std::string& aName1, const std::string& aName2) {
+    setMarkerName(0, aName1);
+    setMarkerName(1, aName2);
 }
-
-
-void MarkerPair::copyData(const MarkerPair &aMarkerPair)
-{
-    _markerNames = aMarkerPair._markerNames;
-}
-
 
 //=============================================================================
 // CONSTRUCTION
 //=============================================================================
 //_____________________________________________________________________________
-/**
- * Set the data members of this MarkerPair to their null values.
- */
-void MarkerPair::setNull()
-{
-    setupProperties();
-}
 //_____________________________________________________________________________
 /**
  * Connect properties to local pointers.
  */
-void MarkerPair::setupProperties()
-{
-    _markerNamesProp.setComment("Names of two markers, the distance between which is used to compute a body scale factor.");
-    _markerNamesProp.setName("markers");
-    _propertySet.append(&_markerNamesProp);
-}
-
-MarkerPair& MarkerPair::operator=(const MarkerPair &aMarkerPair)
-{
-    // BASE CLASS
-    Object::operator=(aMarkerPair);
-
-    copyData(aMarkerPair);
-
-    return(*this);
+void MarkerPair::constructProperties() {
+    constructProperty_markers(Array<std::string>{"", ""});
 }
 
 void MarkerPair::getMarkerNames(string& aName1, string& aName2) const
 {
-    aName1 = _markerNames[0];
-    aName2 = _markerNames[1];
+    aName1 = get_markers(0);
+    aName2 = get_markers(1);
 }

--- a/OpenSim/Tools/MarkerPair.h
+++ b/OpenSim/Tools/MarkerPair.h
@@ -26,9 +26,9 @@
 
 // INCLUDE
 #include "osimToolsDLL.h"
-#include <OpenSim/Common/Object.h>
-#include <OpenSim/Common/PropertyStrArray.h>
 
+#include <OpenSim/Common/Object.h>
+#include <OpenSim/Common/Property.h>
 //=============================================================================
 //=============================================================================
 namespace OpenSim {
@@ -49,8 +49,9 @@ OpenSim_DECLARE_CONCRETE_OBJECT(MarkerPair, Object);
 private:
 
 protected:
-    PropertyStrArray _markerNamesProp;
-    Array<std::string>& _markerNames;
+    OpenSim_DECLARE_LIST_PROPERTY_SIZE(markers, std::string, 2,
+            "Names of two markers, the distance between which is used to "
+            "compute a body scale factor.");
 
 //=============================================================================
 // METHODS
@@ -60,29 +61,23 @@ protected:
     //--------------------------------------------------------------------------
 public:
     MarkerPair();
-    MarkerPair(const MarkerPair &aMarkerPair);
-    MarkerPair(const std::string &aName1, const std::string &aName2);
-    virtual ~MarkerPair();
-
-#ifndef SWIG
-    MarkerPair& operator=(const MarkerPair &aMarkerPair);
-#endif
-    void copyData(const MarkerPair &aMarkerPair);
+    MarkerPair(const std::string& aName1, const std::string& aName2);
 
     void getMarkerNames(std::string& aName1, std::string& aName2) const;
-    const std::string &getMarkerName(int i) const { 
-        if (_markerNames.getSize() < i+1)
+    const std::string& getMarkerName(int i) const {
+        if (getProperty_markers().size() < i + 1)
             throw Exception("MarkerPair: ERROR- Pair has incorrect number of Marker names, 2 required.",
                              __FILE__,__LINE__);
-        return _markerNames.get(i); 
+        return get_markers(i);
     }
-    void setMarkerName(int i, const std::string &aName) { _markerNames.set(i,aName); }
+    void setMarkerName(int i, const std::string& aName) {
+        upd_markers(i) = aName;
+    }
 
 protected:
 
 private:
-    void setNull();
-    void setupProperties();
+    void constructProperties();
 //=============================================================================
 };  // END of class MarkerPair
 

--- a/OpenSim/Tools/Measurement.cpp
+++ b/OpenSim/Tools/Measurement.cpp
@@ -25,15 +25,21 @@
 // INCLUDES
 //=============================================================================
 #include "Measurement.h"
+
+#include <OpenSim/Common/Logger.h>
+#include <OpenSim/Common/Scale.h>
 #include <OpenSim/Common/ScaleSet.h>
+#include <OpenSim/Common/XMLDocument.h>
+#include <OpenSim/Simulation/Model/BodyScale.h>
 #include <OpenSim/Simulation/Model/BodyScaleSet.h>
+#include <OpenSim/Tools/MarkerPair.h>
+#include <OpenSim/Tools/MarkerPairSet.h>
 
 //=============================================================================
 // STATICS
 //=============================================================================
 using namespace std;
 using namespace OpenSim;
-using SimTK::Vec3;
 
 //=============================================================================
 // CONSTRUCTOR(S) AND DESTRUCTOR
@@ -42,86 +48,19 @@ using SimTK::Vec3;
 /**
  * Default constructor.
  */
-Measurement::Measurement() :
-    _markerPairSetProp(PropertyObj("", MarkerPairSet())),
-    _markerPairSet((MarkerPairSet&)_markerPairSetProp.getValueObj()),
-    _bodyScaleSetProp(PropertyObj("", BodyScaleSet())),
-    _bodyScaleSet((BodyScaleSet&)_bodyScaleSetProp.getValueObj()),
-    _apply(_applyProp.getValueBool())
-{
-    setNull();
-    setupProperties();
-}
-
-//_____________________________________________________________________________
-/**
- * Destructor.
- */
-Measurement::~Measurement()
-{
-}
-
-//_____________________________________________________________________________
-/**
- * Copy constructor.
- *
- * @param aMeasurement Measurement to be copied.
- */
-Measurement::Measurement(const Measurement &aMeasurement) :
-   Object(aMeasurement),
-    _markerPairSetProp(PropertyObj("", MarkerPairSet())),
-    _markerPairSet((MarkerPairSet&)_markerPairSetProp.getValueObj()),
-    _bodyScaleSetProp(PropertyObj("", BodyScaleSet())),
-    _bodyScaleSet((BodyScaleSet&)_bodyScaleSetProp.getValueObj()),
-    _apply(_applyProp.getValueBool())
-{
-    setNull();
-    setupProperties();
-    copyData(aMeasurement);
-}
-
+Measurement::Measurement() { constructProperties(); }
 //=============================================================================
 // CONSTRUCTION METHODS
 //=============================================================================
 //_____________________________________________________________________________
 /**
- * Copy data members from one Measurement to another.
- *
- * @param aMeasurement Measurement to be copied.
- */
-void Measurement::copyData(const Measurement &aMeasurement)
-{
-    _markerPairSet = aMeasurement._markerPairSet;
-    _bodyScaleSet = aMeasurement._bodyScaleSet;
-    _apply = aMeasurement._apply;
-}
-
-//_____________________________________________________________________________
-/**
- * Set the data members of this Measurement to their null values.
- */
-void Measurement::setNull()
-{
-}
-
-//_____________________________________________________________________________
-/**
  * Connect properties to local pointers.
  */
-void Measurement::setupProperties()
-{
-    _applyProp.setComment("Flag to turn on and off scaling for this measurement.");
-    _applyProp.setName("apply");
-    _applyProp.setValue(true);
-    _propertySet.append(&_applyProp);
+void Measurement::constructProperties() {
+    constructProperty_MarkerPairSet(MarkerPairSet());
+    constructProperty_BodyScaleSet(BodyScaleSet());
 
-    _markerPairSetProp.setComment("Set of marker pairs used to determine the scale factors.");
-    _markerPairSetProp.setName("MarkerPairSet");
-    _propertySet.append(&_markerPairSetProp);
-
-    _bodyScaleSetProp.setComment("Set of bodies to be scaled by this measurement.");
-    _bodyScaleSetProp.setName("BodyScaleSet");
-    _propertySet.append(&_bodyScaleSetProp);
+    constructProperty_apply(true);
 }
 
 //_____________________________________________________________________________
@@ -134,29 +73,6 @@ void Measurement::registerTypes()
     Object::registerType(BodyScale());
 }
 
-//=============================================================================
-// OPERATORS
-//=============================================================================
-//_____________________________________________________________________________
-/**
- * Assignment operator.
- *
- * @return Reference to this object.
- */
-Measurement& Measurement::operator=(const Measurement &aMeasurement)
-{
-    // BASE CLASS
-    Object::operator=(aMeasurement);
-
-    copyData(aMeasurement);
-
-    return(*this);
-}
-
-/* Apply a scale factor to a scale set, according to the elements of
- * the Measurement's BodyScaleSet.
- */
-//_____________________________________________________________________________
 /**
  * Apply a scale factor to a scale set, according to the elements of
  * the Measurement's _bodyScaleSet.
@@ -164,21 +80,16 @@ Measurement& Measurement::operator=(const Measurement &aMeasurement)
  * @param aFactor the scale factor to apply
  * @param aScaleSet the set of scale factors to modify
  */
-void Measurement::applyScaleFactor(double aFactor, ScaleSet& aScaleSet)
-{
-    for (int i = 0; i < _bodyScaleSet.getSize(); i++)
-    {
-        const string& bodyName = _bodyScaleSet[i].getName();
-        for (int j = 0; j < aScaleSet.getSize(); j++)
-        {
+void Measurement::applyScaleFactor(double aFactor, ScaleSet& aScaleSet) {
+    for (int i = 0; i < get_BodyScaleSet().getSize(); ++i) {
+        const auto& bodyScale = get_BodyScaleSet()[i];
+        const string& bodyName = bodyScale.getName();
+        const auto& axisNames = bodyScale.getAxisNames();
+        for (int j = 0; j < aScaleSet.getSize(); ++j) {
             if (aScaleSet[j].getSegmentName() == bodyName)
             {
-                const Array<std::string>& axisNames = _bodyScaleSet[i].getAxisNames();
-                Vec3 factors(1.0);
-                aScaleSet[j].getScaleFactors(factors);
-
-                for (int k = 0; k < axisNames.getSize(); k++)
-                {
+                auto& factors = aScaleSet[j].upd_scales();
+                for (int k = 0; k < axisNames.getSize(); ++k) {
                     if (axisNames[k] == "x" || axisNames[k] == "X")
                         factors[0] = aFactor;
                     else if (axisNames[k] == "y" || axisNames[k] == "Y")
@@ -186,7 +97,6 @@ void Measurement::applyScaleFactor(double aFactor, ScaleSet& aScaleSet)
                     else if (axisNames[k] == "z" || axisNames[k] == "Z")
                         factors[2] = aFactor;
                 }
-                aScaleSet[j].setScaleFactors(factors);
             }
         }
     }

--- a/OpenSim/Tools/Measurement.h
+++ b/OpenSim/Tools/Measurement.h
@@ -26,9 +26,11 @@
 
 // INCLUDE
 #include "osimToolsDLL.h"
-#include <OpenSim/Common/PropertyObj.h>
-#include <OpenSim/Common/PropertyBool.h>
-#include "MarkerPairSet.h"
+
+#include <OpenSim/Common/Object.h>
+#include <OpenSim/Common/Property.h>
+#include <OpenSim/Simulation/Model/BodyScaleSet.h>
+#include <OpenSim/Tools/MarkerPairSet.h>
 
 #ifdef SWIG
     #ifdef OSIMTOOLS_API
@@ -39,7 +41,7 @@
 
 namespace OpenSim {
 
-class BodyScaleSet;
+class MarkerPair;
 class ScaleSet;
 
 //=============================================================================
@@ -57,15 +59,13 @@ OpenSim_DECLARE_CONCRETE_OBJECT(Measurement, Object);
 //=============================================================================
 // DATA
 //=============================================================================
-protected:
-    PropertyObj _markerPairSetProp;
-    MarkerPairSet &_markerPairSet;
-
-    PropertyObj _bodyScaleSetProp;
-    BodyScaleSet &_bodyScaleSet;
-
-    PropertyBool _applyProp;
-    bool &_apply;
+public:
+OpenSim_DECLARE_UNNAMED_PROPERTY(MarkerPairSet,
+        "Set of marker pairs used to determine the scale factors.");
+OpenSim_DECLARE_UNNAMED_PROPERTY(
+        BodyScaleSet, "Set of bodies to be scaled by this measurement.");
+OpenSim_DECLARE_PROPERTY(
+        apply, bool, "Flag to turn on and off scaling for this measurement.");
 
 //=============================================================================
 // METHODS
@@ -75,25 +75,15 @@ protected:
     //--------------------------------------------------------------------------
 public:
     Measurement();
-    Measurement(const Measurement &aMeasurement);
-    virtual ~Measurement();
 
-#ifndef SWIG
-    Measurement& operator=(const Measurement &aMeasurement);
-#endif
-   void copyData(const Measurement &aMeasurement);
+    BodyScaleSet& getBodyScaleSet() { return upd_BodyScaleSet(); }
+    MarkerPairSet& getMarkerPairSet() { return upd_MarkerPairSet(); }
 
-    BodyScaleSet &getBodyScaleSet() { return _bodyScaleSet; }
+    int getNumMarkerPairs() const {return get_MarkerPairSet().getSize();};
+    const MarkerPair& getMarkerPair(int aIndex) const { return get_MarkerPairSet()[aIndex]; };
 
-    MarkerPairSet& getMarkerPairSet() { return _markerPairSet; }
-    int getNumMarkerPairs() const { return _markerPairSet.getSize(); }
-    const MarkerPair& getMarkerPair(int aIndex) const { return _markerPairSet[aIndex]; }
-
-    bool getApply() const { return _apply; }
-    void setApply(bool aApply) { 
-        _apply = aApply;
-        _applyProp.setValueIsDefault(false);
-    }
+    bool getApply() const { return get_apply(); }
+    void setApply(bool aApply) { set_apply(aApply); }
 
     void applyScaleFactor(double aFactor, ScaleSet& aScaleSet);
 
@@ -101,8 +91,7 @@ public:
     static void registerTypes();
 
 private:
-    void setNull();
-    void setupProperties();
+    void constructProperties();
 //=============================================================================
 };  // END of class Measurement
 //=============================================================================


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-core/issues/4074
Step 8 of breaking the [previous PR](https://github.com/opensim-org/opensim-core/pull/4351) into smaller chunks.
This is the last one in the series :partying_face:.
### Brief summary of changes
Replace the deprecated properties in the MarkerPair and Measurement classes.
Also fixes a memory leak in the `IKTaskSet` so that the scale tool now runs leak free (checked with libasan).
Prior to the fix, that specific leak alone caused a 33000 byte leak with 385 allocation(s) in my very small, single subject test program. 

For reference (for all the PRs thus far):
- ASAN leaks before all the related PRs: SUMMARY: AddressSanitizer: 687650 byte(s) leaked in 5587 allocation(s).
- ASAN leaks after this PR: No leaks

### Testing I've completed
Tested locally

### Looking for feedback on...


### CHANGELOG.md (choose one)

- no need to update because it removes deprecated code without changing existing functionality or interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensim-org/opensim-core/4450)
<!-- Reviewable:end -->
